### PR TITLE
Calculate the payload length on every update.

### DIFF
--- a/sample_apps/subscribe_publish_sample/subscribe_publish_sample.c
+++ b/sample_apps/subscribe_publish_sample/subscribe_publish_sample.c
@@ -200,6 +200,8 @@ int main(int argc, char** argv) {
 		INFO("-->sleep");
 		sleep(1);
 		sprintf(cPayload, "%s : %d ", "hello from SDK", i++);
+		Msg.PayloadLen = strlen(cPayload) + 1;
+
 		rc = aws_iot_mqtt_publish(&Params);
 		if(publishCount > 0){
 			publishCount--;


### PR DESCRIPTION
The publish sample doesn't calculate the payload's length during each loop, after the counter reaches 10 the original length is going to result in minor data truncation.