### PR TITLE
Added additional input parameter pThingName to aws_iot_shadow_registe…

### DIFF
--- a/aws_iot_src/shadow/aws_iot_shadow.c
+++ b/aws_iot_src/shadow/aws_iot_shadow.c
@@ -97,14 +97,14 @@ IoT_Error_t aws_iot_shadow_connect(MQTTClient_t *pClient, ShadowParameters_t *pP
 	return rc;
 }
 
-IoT_Error_t aws_iot_shadow_register_delta(MQTTClient_t *pClient, jsonStruct_t *pStruct) {
+IoT_Error_t aws_iot_shadow_register_delta(MQTTClient_t *pClient, const char *pThingName, jsonStruct_t *pStruct) {
 	IoT_Error_t rc = NONE_ERROR;
 
 	if (!(pClient->isConnected())) {
 		return CONNECTION_ERROR;
 	}
 
-	rc = registerJsonTokenOnDelta(pStruct);
+	rc = registerJsonTokenOnDelta(pThingName, pStruct);
 
 	return rc;
 }

--- a/aws_iot_src/shadow/aws_iot_shadow_interface.h
+++ b/aws_iot_src/shadow/aws_iot_shadow_interface.h
@@ -201,15 +201,16 @@ IoT_Error_t aws_iot_shadow_delete(MQTTClient_t *pClient, const char *pThingName,
 		void *pContextData, uint8_t timeout_seconds, bool isPersistentSubscriptions);
 
 /**
- * @brief This function is used to listen on the delta topic of #AWS_IOT_MY_THING_NAME mentioned in the aws_iot_config.h file.
+ * @brief This function is used to listen on the delta topic of pThingName passed as input parameter
  *
  * Any time a delta is published the Json document will be delivered to the pStruct->cb. If you don't want the parsing done by the SDK then use the jsonStruct_t key set to "state". A good example of this is displayed in the sample_apps/shadow_console_echo.c
  *
  * @param pClient MQTT Client used as the protocol layer
+ * @param pThingName Thing Name of the Shadow to listen on delta topic
  * @param pStruct The struct used to parse JSON value
  * @return An IoT Error Type defining successful/failed delta registering
  */
-IoT_Error_t aws_iot_shadow_register_delta(MQTTClient_t *pClient, jsonStruct_t *pStruct);
+IoT_Error_t aws_iot_shadow_register_delta(MQTTClient_t *pClient, const char *pThingName, jsonStruct_t *pStruct);
 
 /**
  * @brief Reset the last received version number to zero.
@@ -219,7 +220,7 @@ IoT_Error_t aws_iot_shadow_register_delta(MQTTClient_t *pClient, jsonStruct_t *p
  */
 void aws_iot_shadow_reset_last_received_version(void);
 /**
- * @brief Version of a document is received with every accepted/rejected and the SDK keeps track of the last received version of the JSON document of #AWS_IOT_MY_THING_NAME shadow
+ * @brief Version of a document is received with every accepted/rejected and the SDK keeps track of the last received version of the JSON document of the configured thingname shadow
  *
  * One exception to this version tracking is that, the SDK will ignore the version from update/accepted topic. Rest of the responses will be scanned to update the version number.
  * Accepting version change for update/accepted may cause version conflicts for delta message if the update message is received before the delta.

--- a/aws_iot_src/shadow/aws_iot_shadow_records.h
+++ b/aws_iot_src/shadow/aws_iot_shadow_records.h
@@ -37,6 +37,6 @@ void addToAckWaitList(uint8_t indexAckWaitList, const char *pThingName, ShadowAc
 bool getNextFreeIndexOfAckWaitList(uint8_t *pIndex);
 void HandleExpiredResponseCallbacks(void);
 void initDeltaTokens(void);
-IoT_Error_t registerJsonTokenOnDelta(jsonStruct_t *pStruct);
+IoT_Error_t registerJsonTokenOnDelta(const char *pThingName, jsonStruct_t *pStruct);
 
 #endif /* SRC_SHADOW_AWS_IOT_SHADOW_RECORDS_H_ */

--- a/sample_apps/shadow_sample/shadow_sample.c
+++ b/sample_apps/shadow_sample/shadow_sample.c
@@ -202,7 +202,7 @@ int main(int argc, char** argv) {
 		ERROR("Shadow Connection Error %d", rc);
 	}
 
-	rc = aws_iot_shadow_register_delta(&mqttClient, &windowActuator);
+	rc = aws_iot_shadow_register_delta(&mqttClient, AWS_IOT_MY_THING_NAME, &windowActuator);
 
 	if (NONE_ERROR != rc) {
 		ERROR("Shadow Register Delta Error");

--- a/sample_apps/shadow_sample_console_echo/shadow_console_echo.c
+++ b/sample_apps/shadow_sample_console_echo/shadow_console_echo.c
@@ -132,7 +132,7 @@ int main(int argc, char** argv) {
 	/*
 	 * Register the jsonStruct object
 	 */
-	rc = aws_iot_shadow_register_delta(&mqttClient, &deltaObject);
+	rc = aws_iot_shadow_register_delta(&mqttClient, AWS_IOT_MY_THING_NAME, &deltaObject);
 
 	// Now wait in the loop to receive any message sent from the console
 	while (rc == NONE_ERROR) {


### PR DESCRIPTION
…r_delta api.

With this implentation, flexibility is given to the application developer to
accept thingname from the user during initial setup and then configure it by
passing it to the shadow subscribe API.

Problem: Thingname used in shadow subscribe API is hardcoded compile time using
macro AWS_IOT_MY_THING_NAME which reduces flexibilty.
Also all other shadow APIs have thingname as the input parameter and can be
configured compile time.

Signed-off-by: Nikita Nerkar <nikitan@marvell.com>