### PR TITLE
Add disconnectHandler to ShadowParameters_t

### DIFF
--- a/aws_iot_src/shadow/aws_iot_shadow.c
+++ b/aws_iot_src/shadow/aws_iot_shadow.c
@@ -27,7 +27,8 @@ const ShadowParameters_t ShadowParametersDefault = {
 		.port = AWS_IOT_MQTT_PORT,
 		.pRootCA = NULL,
 		.pClientCRT = NULL,
-		.pClientKey = NULL
+		.pClientKey = NULL,
+		.disconnectHandler = NULL
 };
 
 void aws_iot_shadow_reset_last_received_version(void) {
@@ -86,7 +87,7 @@ IoT_Error_t aws_iot_shadow_connect(MQTTClient_t *pClient, ShadowParameters_t *pP
 	ConnectParams.pUserName = NULL;
 	ConnectParams.pHostURL = pParams->pHost;
 	ConnectParams.port = pParams->port;
-	ConnectParams.disconnectHandler = NULL;
+	ConnectParams.disconnectHandler = pParams->disconnectHandler;
 
 	rc = pClient->connect(&ConnectParams);
 

--- a/aws_iot_src/shadow/aws_iot_shadow_interface.h
+++ b/aws_iot_src/shadow/aws_iot_shadow_interface.h
@@ -53,6 +53,7 @@ typedef struct {
 	char *pRootCA; ///< Location with the Filename of the Root CA
 	char *pClientCRT; ///< Location of Device certs signed by AWS IoT service
 	char *pClientKey; ///< Location of Device private key
+ 	iot_disconnect_handler disconnectHandler; ///< Callback to be invoked upon connection loss.
 } ShadowParameters_t;
 
 /*!


### PR DESCRIPTION
Issue: `aws_iot_shadow_connect` defaults the `MQTTClientParameters.disconnectHandler` to `NULL` with no way to override through the `ShadowParameters_t pParams` argument.  Cases where `aws_iot_shadow_connect` is used to connect the MQTT Client should be able to specify a disconnect handler.

This PR adds `disconnectHandler` to `ShadowParameters_t` with a `NULL` default value for `ShadowParametersDefault` so no change is required to sample apps or existing implementations.  This same approach could be applied to other parameters in `MQTTConnectParams` as well, if needed.

Alternately, we could change `ShadowParameters_t` to take `MQTTConnectParams` directly to avoid this overlap, but that would be a breaking change.