### PR TITLE
Fixed compiler error with mbedtls library

### DIFF
--- a/platform/linux/mbedtls/network_platform.h
+++ b/platform/linux/mbedtls/network_platform.h
@@ -17,6 +17,7 @@
 
 #include "mbedtls/config.h"
 
+#include "mbedtls/platform.h"
 #include "mbedtls/net.h"
 #include "mbedtls/ssl.h"
 #include "mbedtls/entropy.h"


### PR DESCRIPTION
Trying to compile the sample programs result in the following error:

In file included from ../../../external_libs/mbedTLS/include/mbedtls/net.h:32:0,
                 from ../../../platform/linux/mbedtls/network_platform.h:20,
                 from ../../../include/network_interface.h:31,
                 from ../../../platform/linux/mbedtls/network_mbedtls_wrapper.c:19:
../../../external_libs/mbedTLS/include/mbedtls/ssl.h:545:5: error: unknown type name ‘mbedtls_time_t’
     mbedtls_time_t start;       /*!< starting time      */

Including mbedtls/platform.h defines mbedtls_time_t and fixes the error.