### PR TITLE
Constify string parameters

### DIFF
--- a/include/aws_iot_mqtt_client.h
+++ b/include/aws_iot_mqtt_client.h
@@ -131,15 +131,15 @@ extern const IoT_MQTT_Will_Options iotMqttWillOptionsDefault;
 typedef struct {
 	char struct_id[4];			///< The eyecatcher for this structure.  must be MQTC
 	MQTT_Ver_t MQTTVersion;			///< Desired MQTT version used during connection
-	char *pClientID;                	///< Pointer to a string defining the MQTT client ID (this needs to be unique \b per \b device across your AWS account)
+	const char *pClientID;                	///< Pointer to a string defining the MQTT client ID (this needs to be unique \b per \b device across your AWS account)
 	uint16_t clientIDLen;			///< Client Id Length. 16 bit unsigned integer
 	uint16_t keepAliveIntervalInSec;	///< MQTT keep alive interval in seconds.  Defines inactivity time allowed before determining the connection has been lost.
 	bool isCleanSession;			///< MQTT clean session.  True = this session is to be treated as clean.  Previous server state is cleared and no stated is retained from this connection.
 	bool isWillMsgPresent;			///< Is there a LWT associated with this connection?
 	IoT_MQTT_Will_Options will;		///< MQTT LWT parameters.
-	char *pUsername;			///< Not used in the AWS IoT Service, will need to be cstring if used
+	const char *pUsername;			///< Not used in the AWS IoT Service, will need to be cstring if used
 	uint16_t usernameLen;			///< Username Length. 16 bit unsigned integer
-	char *pPassword;			///< Not used in the AWS IoT Service, will need to be cstring if used
+	const char *pPassword;			///< Not used in the AWS IoT Service, will need to be cstring if used
 	uint16_t passwordLen;			///< Password Length. 16 bit unsigned integer
 } IoT_Client_Connect_Params;
 extern const IoT_Client_Connect_Params iotClientConnectParamsDefault;
@@ -164,11 +164,11 @@ typedef void (*iot_disconnect_handler)(AWS_IoT_Client *, void *);
  */
 typedef struct {
 	bool enableAutoReconnect;			///< Set to true to enable auto reconnect
-	char *pHostURL;					///< Pointer to a string defining the endpoint for the MQTT service
+	const char *pHostURL;				///< Pointer to a string defining the endpoint for the MQTT service
 	uint16_t port;					///< MQTT service listening port
-	char *pRootCALocation;				///< Pointer to a string defining the Root CA file (full file, not path)
-	char *pDeviceCertLocation;			///< Pointer to a string defining the device identity certificate file (full file, not path)
-	char *pDevicePrivateKeyLocation;        	///< Pointer to a string defining the device private key file (full file, not path)
+	const char *pRootCALocation;			///< Pointer to a string defining the Root CA file (full file, not path)
+	const char *pDeviceCertLocation;		///< Pointer to a string defining the device identity certificate file (full file, not path)
+	const char *pDevicePrivateKeyLocation;        	///< Pointer to a string defining the device private key file (full file, not path)
 	uint32_t mqttCommandTimeout_ms;			///< Timeout for MQTT blocking calls. In milliseconds
 	uint32_t tlsHandshakeTimeout_ms;		///< TLS handshake timeout.  In milliseconds
 	bool isSSLHostnameVerify;			///< Client should perform server certificate hostname validation

--- a/include/aws_iot_shadow_interface.h
+++ b/include/aws_iot_shadow_interface.h
@@ -50,11 +50,11 @@ extern "C" {
  *
  */
 typedef struct {
-	char *pHost; ///< This will be unique to a customer and can be retrieved from the console
+	const char *pHost; ///< This will be unique to a customer and can be retrieved from the console
 	uint16_t port; ///< By default the port is 8883
-	char *pRootCA; ///< Location with the Filename of the Root CA
-	char *pClientCRT; ///< Location of Device certs signed by AWS IoT service
-	char *pClientKey; ///< Location of Device private key
+	const char *pRootCA; ///< Location with the Filename of the Root CA
+	const char *pClientCRT; ///< Location of Device certs signed by AWS IoT service
+	const char *pClientKey; ///< Location of Device private key
 	bool enableAutoReconnect;        ///< Set to true to enable auto reconnect
 	iot_disconnect_handler disconnectHandler;    ///< Callback to be invoked upon connection loss.
 } ShadowInitParameters_t;
@@ -69,8 +69,8 @@ typedef struct {
  *
  */
 typedef struct {
-	char *pMyThingName; ///< Every device has a Thing Shadow and this is the placeholder for name
-	char *pMqttClientId; ///< Currently the Shadow uses MQTT to connect and it is important to ensure we have unique client id
+	const char *pMyThingName; ///< Every device has a Thing Shadow and this is the placeholder for name
+	const char *pMqttClientId; ///< Currently the Shadow uses MQTT to connect and it is important to ensure we have unique client id
 	uint16_t mqttClientIdLen; ///< Currently the Shadow uses MQTT to connect and it is important to ensure we have unique client id
 	pApplicationHandler_t deleteActionHandler;	///< Callback to be invoked when Thing shadow for this device is deleted
 } ShadowConnectParameters_t;

--- a/include/network_interface.h
+++ b/include/network_interface.h
@@ -48,13 +48,13 @@ typedef struct Network Network;
  * TLS networking layer to create a TLS secured socket.
  */
 typedef struct {
-	char *pRootCALocation;                ///< Pointer to string containing the filename (including path) of the root CA file.
-	char *pDeviceCertLocation;            ///< Pointer to string containing the filename (including path) of the device certificate.
-	char *pDevicePrivateKeyLocation;    ///< Pointer to string containing the filename (including path) of the device private key file.
-	char *pDestinationURL;                ///< Pointer to string containing the endpoint of the MQTT service.
-	uint16_t DestinationPort;            ///< Integer defining the connection port of the MQTT service.
-	uint32_t timeout_ms;                ///< Unsigned integer defining the TLS handshake timeout value in milliseconds.
-	bool ServerVerificationFlag;        ///< Boolean.  True = perform server certificate hostname validation.  False = skip validation \b NOT recommended.
+	const char *pRootCALocation;           ///< Pointer to string containing the filename (including path) of the root CA file.
+	const char *pDeviceCertLocation;       ///< Pointer to string containing the filename (including path) of the device certificate.
+	const char *pDevicePrivateKeyLocation; ///< Pointer to string containing the filename (including path) of the device private key file.
+	const char *pDestinationURL;           ///< Pointer to string containing the endpoint of the MQTT service.
+	uint16_t DestinationPort;              ///< Integer defining the connection port of the MQTT service.
+	uint32_t timeout_ms;                   ///< Unsigned integer defining the TLS handshake timeout value in milliseconds.
+	bool ServerVerificationFlag;           ///< Boolean.  True = perform server certificate hostname validation.  False = skip validation \b NOT recommended.
 } TLSConnectParams;
 
 /**
@@ -93,8 +93,8 @@ struct Network {
  *
  * @return IoT_Error_t - successful initialization or TLS error
  */
-IoT_Error_t iot_tls_init(Network *pNetwork, char *pRootCALocation, char *pDeviceCertLocation,
-						 char *pDevicePrivateKeyLocation, char *pDestinationURL,
+IoT_Error_t iot_tls_init(Network *pNetwork, const char *pRootCALocation, const char *pDeviceCertLocation,
+						 const char *pDevicePrivateKeyLocation, const char *pDestinationURL,
 						 uint16_t DestinationPort, uint32_t timeout_ms, bool ServerVerificationFlag);
 
 /**

--- a/platform/linux/mbedtls/network_mbedtls_wrapper.c
+++ b/platform/linux/mbedtls/network_mbedtls_wrapper.c
@@ -52,8 +52,8 @@ static int _iot_tls_verify_cert(void *data, mbedtls_x509_crt *crt, int depth, ui
 	return 0;
 }
 
-void _iot_tls_set_connect_params(Network *pNetwork, char *pRootCALocation, char *pDeviceCertLocation,
-								 char *pDevicePrivateKeyLocation, char *pDestinationURL,
+void _iot_tls_set_connect_params(Network *pNetwork, const char *pRootCALocation, const char *pDeviceCertLocation,
+								 const char *pDevicePrivateKeyLocation, const char *pDestinationURL,
 								 uint16_t destinationPort, uint32_t timeout_ms, bool ServerVerificationFlag) {
 	pNetwork->tlsConnectParams.DestinationPort = destinationPort;
 	pNetwork->tlsConnectParams.pDestinationURL = pDestinationURL;
@@ -64,8 +64,8 @@ void _iot_tls_set_connect_params(Network *pNetwork, char *pRootCALocation, char 
 	pNetwork->tlsConnectParams.ServerVerificationFlag = ServerVerificationFlag;
 }
 
-IoT_Error_t iot_tls_init(Network *pNetwork, char *pRootCALocation, char *pDeviceCertLocation,
-						 char *pDevicePrivateKeyLocation, char *pDestinationURL,
+IoT_Error_t iot_tls_init(Network *pNetwork, const char *pRootCALocation, const char *pDeviceCertLocation,
+						 const char *pDevicePrivateKeyLocation, const char *pDestinationURL,
 						 uint16_t destinationPort, uint32_t timeout_ms, bool ServerVerificationFlag) {
 	_iot_tls_set_connect_params(pNetwork, pRootCALocation, pDeviceCertLocation, pDevicePrivateKeyLocation,
 								pDestinationURL, destinationPort, timeout_ms, ServerVerificationFlag);

--- a/tests/unit/tls_mock/aws_iot_tests_unit_mock_tls.c
+++ b/tests/unit/tls_mock/aws_iot_tests_unit_mock_tls.c
@@ -18,8 +18,8 @@ void _iot_tls_set_connect_params(Network *pNetwork, char *pRootCALocation, char 
 	pNetwork->tlsConnectParams.ServerVerificationFlag = ServerVerificationFlag;
 }
 
-IoT_Error_t iot_tls_init(Network *pNetwork, char *pRootCALocation, char *pDeviceCertLocation,
-						 char *pDevicePrivateKeyLocation, char *pDestinationURL,
+IoT_Error_t iot_tls_init(Network *pNetwork, const char *pRootCALocation, const char *pDeviceCertLocation,
+						 const char *pDevicePrivateKeyLocation, const char *pDestinationURL,
 						 uint16_t destinationPort, uint32_t timeout_ms, bool ServerVerificationFlag) {
 	_iot_tls_set_connect_params(pNetwork, pRootCALocation, pDeviceCertLocation, pDevicePrivateKeyLocation,
 								pDestinationURL, destinationPort, timeout_ms, ServerVerificationFlag);


### PR DESCRIPTION
String literals, such as "Hello world" need to be const char \* pointers;
as such, using AWS_IOT_MQTT_HOST produce compiler warnings when the
pHost variable is assigned directly to this.

Since the library does not need to modify these string constants, modify
the interfaces to be const char pointers instead of char pointers.

Signed-off-by: Tim Nordell tim.nordell@nimbelink.com
