### PR TITLE
Added Win32 support to aws-iot-device-sdk-embedded-c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+platform/win32/aws-iot-sdk-dll/.vs
+platform/win32/aws-iot-sdk-dll/Debug
+platform/win32/aws-iot-sdk-dll/Release
+platform/win32/aws-iot-sdk-dll/*.VC.db
+platform/win32/aws-iot-sdk-dll/*.user

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,18 @@
+certs
+external_libs/mbedTLS
+
 platform/win32/aws-iot-sdk-dll/.vs
 platform/win32/aws-iot-sdk-dll/Debug
 platform/win32/aws-iot-sdk-dll/Release
 platform/win32/aws-iot-sdk-dll/*.VC.db
+platform/win32/aws-iot-sdk-dll/*.VC.opendb
 platform/win32/aws-iot-sdk-dll/*.user
 
 samples/win32/shadow_sample/shadow_sample_console/Debug
 samples/win32/shadow_sample/shadow_sample_console/Release
+
+samples/win32/subscribe_publish_sample/subscribe_publish_sample_console/Debug
+samples/win32/subscribe_publish_sample/subscribe_publish_sample_console/Release
+
+
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ platform/win32/aws-iot-sdk-dll/Debug
 platform/win32/aws-iot-sdk-dll/Release
 platform/win32/aws-iot-sdk-dll/*.VC.db
 platform/win32/aws-iot-sdk-dll/*.user
+
+samples/win32/shadow_sample/shadow_sample_console/Debug
+samples/win32/shadow_sample/shadow_sample_console/Release
+

--- a/include/aws_iot_config.h
+++ b/include/aws_iot_config.h
@@ -23,13 +23,21 @@
 
 // Get from console
 // =================================================
-#define AWS_IOT_MQTT_HOST              "" ///< Customer specific MQTT HOST. The same will be used for Thing Shadow
-#define AWS_IOT_MQTT_PORT              8883 ///< default port for MQTT/S
-#define AWS_IOT_MQTT_CLIENT_ID         "c-sdk-client-id" ///< MQTT client ID should be unique for every device
-#define AWS_IOT_MY_THING_NAME 		   "AWS-IoT-C-SDK" ///< Thing Name of the Shadow this device is associated with
-#define AWS_IOT_ROOT_CA_FILENAME       "rootCA.crt" ///< Root CA file name
-#define AWS_IOT_CERTIFICATE_FILENAME   "cert.pem" ///< device signed certificate file name
-#define AWS_IOT_PRIVATE_KEY_FILENAME   "privkey.pem" ///< Device private key filename
+//#define AWS_IOT_MQTT_HOST              "" ///< Customer specific MQTT HOST. The same will be used for Thing Shadow
+//#define AWS_IOT_MQTT_PORT              8883 ///< default port for MQTT/S
+//#define AWS_IOT_MQTT_CLIENT_ID         "c-sdk-client-id" ///< MQTT client ID should be unique for every device
+//#define AWS_IOT_MY_THING_NAME 		   "AWS-IoT-C-SDK" ///< Thing Name of the Shadow this device is associated with
+//#define AWS_IOT_ROOT_CA_FILENAME       "rootCA.crt" ///< Root CA file name
+//#define AWS_IOT_CERTIFICATE_FILENAME   "cert.pem" ///< device signed certificate file name
+//#define AWS_IOT_PRIVATE_KEY_FILENAME   "privkey.pem" ///< Device private key filename
+
+#define AWS_IOT_MQTT_HOST              "a5hmya0iyo4an.iot.us-east-1.amazonaws.com"
+#define AWS_IOT_MQTT_PORT              8883
+#define AWS_IOT_MQTT_CLIENT_ID         "AVR-CAN"
+#define AWS_IOT_MY_THING_NAME          "AVR-CAN"
+#define AWS_IOT_ROOT_CA_FILENAME       "root-CA.crt"
+#define AWS_IOT_CERTIFICATE_FILENAME   "f8d1e12571-certificate.pem.crt"
+#define AWS_IOT_PRIVATE_KEY_FILENAME   "f8d1e12571-private.pem.key"
 
 // =================================================
 

--- a/include/aws_iot_config.h
+++ b/include/aws_iot_config.h
@@ -23,21 +23,13 @@
 
 // Get from console
 // =================================================
-//#define AWS_IOT_MQTT_HOST              "" ///< Customer specific MQTT HOST. The same will be used for Thing Shadow
-//#define AWS_IOT_MQTT_PORT              8883 ///< default port for MQTT/S
-//#define AWS_IOT_MQTT_CLIENT_ID         "c-sdk-client-id" ///< MQTT client ID should be unique for every device
-//#define AWS_IOT_MY_THING_NAME 		   "AWS-IoT-C-SDK" ///< Thing Name of the Shadow this device is associated with
-//#define AWS_IOT_ROOT_CA_FILENAME       "rootCA.crt" ///< Root CA file name
-//#define AWS_IOT_CERTIFICATE_FILENAME   "cert.pem" ///< device signed certificate file name
-//#define AWS_IOT_PRIVATE_KEY_FILENAME   "privkey.pem" ///< Device private key filename
-
-#define AWS_IOT_MQTT_HOST              "a5hmya0iyo4an.iot.us-east-1.amazonaws.com"
-#define AWS_IOT_MQTT_PORT              8883
-#define AWS_IOT_MQTT_CLIENT_ID         "AVR-CAN"
-#define AWS_IOT_MY_THING_NAME          "AVR-CAN"
-#define AWS_IOT_ROOT_CA_FILENAME       "root-CA.crt"
-#define AWS_IOT_CERTIFICATE_FILENAME   "f8d1e12571-certificate.pem.crt"
-#define AWS_IOT_PRIVATE_KEY_FILENAME   "f8d1e12571-private.pem.key"
+#define AWS_IOT_MQTT_HOST              "" ///< Customer specific MQTT HOST. The same will be used for Thing Shadow
+#define AWS_IOT_MQTT_PORT              8883 ///< default port for MQTT/S
+#define AWS_IOT_MQTT_CLIENT_ID         "c-sdk-client-id" ///< MQTT client ID should be unique for every device
+#define AWS_IOT_MY_THING_NAME 		   "AWS-IoT-C-SDK" ///< Thing Name of the Shadow this device is associated with
+#define AWS_IOT_ROOT_CA_FILENAME       "rootCA.crt" ///< Root CA file name
+#define AWS_IOT_CERTIFICATE_FILENAME   "cert.pem" ///< device signed certificate file name
+#define AWS_IOT_PRIVATE_KEY_FILENAME   "privkey.pem" ///< Device private key filename
 
 // =================================================
 

--- a/include/aws_iot_config.h
+++ b/include/aws_iot_config.h
@@ -1,0 +1,65 @@
+/*
+* Copyright 2010-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+/**
+* @file aws_iot_config.h
+* @brief AWS IoT specific configuration file
+*/
+
+#ifndef SRC_SHADOW_IOT_SHADOW_CONFIG_H_
+#define SRC_SHADOW_IOT_SHADOW_CONFIG_H_
+
+// Get from console
+// =================================================
+//#define AWS_IOT_MQTT_HOST              "" ///< Customer specific MQTT HOST. The same will be used for Thing Shadow
+//#define AWS_IOT_MQTT_PORT              8883 ///< default port for MQTT/S
+//#define AWS_IOT_MQTT_CLIENT_ID         "c-sdk-client-id" ///< MQTT client ID should be unique for every device
+//#define AWS_IOT_MY_THING_NAME 		   "AWS-IoT-C-SDK" ///< Thing Name of the Shadow this device is associated with
+//#define AWS_IOT_ROOT_CA_FILENAME       "rootCA.crt" ///< Root CA file name
+//#define AWS_IOT_CERTIFICATE_FILENAME   "cert.pem" ///< device signed certificate file name
+//#define AWS_IOT_PRIVATE_KEY_FILENAME   "privkey.pem" ///< Device private key filename
+
+#define AWS_IOT_MQTT_HOST              "a5hmya0iyo4an.iot.us-east-1.amazonaws.com"
+#define AWS_IOT_MQTT_PORT              8883
+#define AWS_IOT_MQTT_CLIENT_ID         "AVR-CAN"
+#define AWS_IOT_MY_THING_NAME          "AVR-CAN"
+#define AWS_IOT_ROOT_CA_FILENAME       "root-CA.crt"
+#define AWS_IOT_CERTIFICATE_FILENAME   "f8d1e12571-certificate.pem.crt"
+#define AWS_IOT_PRIVATE_KEY_FILENAME   "f8d1e12571-private.pem.key"
+
+// =================================================
+
+// MQTT PubSub
+#define AWS_IOT_MQTT_TX_BUF_LEN 512 ///< Any time a message is sent out through the MQTT layer. The message is copied into this buffer anytime a publish is done. This will also be used in the case of Thing Shadow
+#define AWS_IOT_MQTT_RX_BUF_LEN 512 ///< Any message that comes into the device should be less than this buffer size. If a received message is bigger than this buffer size the message will be dropped.
+#define AWS_IOT_MQTT_NUM_SUBSCRIBE_HANDLERS 5 ///< Maximum number of topic filters the MQTT client can handle at any given time. This should be increased appropriately when using Thing Shadow
+
+// Thing Shadow specific configs
+#define SHADOW_MAX_SIZE_OF_RX_BUFFER AWS_IOT_MQTT_RX_BUF_LEN+1 ///< Maximum size of the SHADOW buffer to store the received Shadow message
+#define MAX_SIZE_OF_UNIQUE_CLIENT_ID_BYTES 80  ///< Maximum size of the Unique Client Id. For More info on the Client Id refer \ref response "Acknowledgments"
+#define MAX_SIZE_CLIENT_ID_WITH_SEQUENCE MAX_SIZE_OF_UNIQUE_CLIENT_ID_BYTES + 10 ///< This is size of the extra sequence number that will be appended to the Unique client Id
+#define MAX_SIZE_CLIENT_TOKEN_CLIENT_SEQUENCE MAX_SIZE_CLIENT_ID_WITH_SEQUENCE + 20 ///< This is size of the the total clientToken key and value pair in the JSON
+#define MAX_ACKS_TO_COMEIN_AT_ANY_GIVEN_TIME 10 ///< At Any given time we will wait for this many responses. This will correlate to the rate at which the shadow actions are requested
+#define MAX_THINGNAME_HANDLED_AT_ANY_GIVEN_TIME 10 ///< We could perform shadow action on any thing Name and this is maximum Thing Names we can act on at any given time
+#define MAX_JSON_TOKEN_EXPECTED 120 ///< These are the max tokens that is expected to be in the Shadow JSON document. Include the metadata that gets published
+#define MAX_SHADOW_TOPIC_LENGTH_WITHOUT_THINGNAME 60 ///< All shadow actions have to be published or subscribed to a topic which is of the format $aws/things/{thingName}/shadow/update/accepted. This refers to the size of the topic without the Thing Name
+#define MAX_SIZE_OF_THING_NAME 20 ///< The Thing Name should not be bigger than this value. Modify this if the Thing Name needs to be bigger
+#define MAX_SHADOW_TOPIC_LENGTH_BYTES MAX_SHADOW_TOPIC_LENGTH_WITHOUT_THINGNAME + MAX_SIZE_OF_THING_NAME ///< This size includes the length of topic with Thing Name
+
+// Auto Reconnect specific config
+#define AWS_IOT_MQTT_MIN_RECONNECT_WAIT_INTERVAL 1000 ///< Minimum time before the First reconnect attempt is made as part of the exponential back-off algorithm
+#define AWS_IOT_MQTT_MAX_RECONNECT_WAIT_INTERVAL 128000 ///< Maximum time interval after which exponential back-off will stop attempting to reconnect.
+
+#endif /* SRC_SHADOW_IOT_SHADOW_CONFIG_H_ */

--- a/include/aws_iot_mqtt_client.h
+++ b/include/aws_iot_mqtt_client.h
@@ -152,7 +152,12 @@ typedef struct {
 	char *pPassword;			///< Not used in the AWS IoT Service, will need to be cstring if used
 	uint16_t passwordLen;			///< Password Length. 16 bit unsigned integer
 } IoT_Client_Connect_Params;
+
+#ifndef WIN32
 extern const IoT_Client_Connect_Params iotClientConnectParamsDefault;
+#else
+const IoT_Client_Connect_Params iotClientConnectParamsDefault;
+#endif
 
 #define IoT_Client_Connect_Params_initializer { {'M', 'Q', 'T', 'C'}, MQTT_3_1_1, NULL, 0, 60, true, false, \
         IoT_MQTT_Will_Options_Initializer, NULL, 0, NULL, 0 }
@@ -189,7 +194,12 @@ typedef struct {
 	bool isBlockOnThreadLockEnabled;		///< Timeout for Thread blocking calls. Set to 0 to block until lock is obtained. In milliseconds
 #endif
 } IoT_Client_Init_Params;
+
+#ifndef WIN32
 extern const IoT_Client_Init_Params iotClientInitParamsDefault;
+#else
+const IoT_Client_Init_Params iotClientInitParamsDefault;
+#endif
 
 #ifdef _ENABLE_THREAD_SUPPORT_
 #define IoT_Client_Init_Params_initializer { true, NULL, 0, NULL, NULL, NULL, 2000, 20000, 5000, true, NULL, NULL, false }

--- a/include/aws_iot_mqtt_client.h
+++ b/include/aws_iot_mqtt_client.h
@@ -43,6 +43,16 @@
 extern "C" {
 #endif
 
+#ifndef WIN32
+#define AWSIOTSDK_API
+#else
+#ifdef AWSIOTSDK_EXPORTS
+#define AWSIOTSDK_API __declspec(dllexport)
+#else
+#define AWSIOTSDK_API __declspec(dllimport)
+#endif
+#endif
+
 /* Library Header files */
 #include "stdio.h"
 #include "stdbool.h"
@@ -362,7 +372,7 @@ ClientState aws_iot_mqtt_get_client_state(AWS_IoT_Client *pClient);
  *
  * @return true = enabled, false = disabled
  */
-bool aws_iot_is_autoreconnect_enabled(AWS_IoT_Client *pClient);
+AWSIOTSDK_API bool aws_iot_is_autoreconnect_enabled(AWS_IoT_Client *pClient);
 
 /**
  * @brief Set the IoT Client disconnect handler
@@ -389,7 +399,7 @@ IoT_Error_t aws_iot_mqtt_set_disconnect_handler(AWS_IoT_Client *pClient, iot_dis
  *
  * @return IoT_Error_t Type defining successful/failed API call
  */
-IoT_Error_t aws_iot_mqtt_autoreconnect_set_status(AWS_IoT_Client *pClient, bool newStatus);
+AWSIOTSDK_API IoT_Error_t aws_iot_mqtt_autoreconnect_set_status(AWS_IoT_Client *pClient, bool newStatus);
 
 /**
  * @brief Get count of Network Disconnects

--- a/include/aws_iot_mqtt_client_interface.h
+++ b/include/aws_iot_mqtt_client_interface.h
@@ -68,7 +68,7 @@ extern "C" {
  *
  * @return IoT_Error_t Type defining successful/failed API call
  */
-IoT_Error_t aws_iot_mqtt_init(AWS_IoT_Client *pClient, IoT_Client_Init_Params *pInitParams);
+AWSIOTSDK_API IoT_Error_t aws_iot_mqtt_init(AWS_IoT_Client *pClient, IoT_Client_Init_Params *pInitParams);
 
 /**
  * @brief MQTT Connection Function
@@ -80,7 +80,7 @@ IoT_Error_t aws_iot_mqtt_init(AWS_IoT_Client *pClient, IoT_Client_Init_Params *p
  *
  * @return An IoT Error Type defining successful/failed connection
  */
-IoT_Error_t aws_iot_mqtt_connect(AWS_IoT_Client *pClient, IoT_Client_Connect_Params *pConnectParams);
+AWSIOTSDK_API IoT_Error_t aws_iot_mqtt_connect(AWS_IoT_Client *pClient, IoT_Client_Connect_Params *pConnectParams);
 
 /**
  * @brief Publish an MQTT message on a topic
@@ -97,7 +97,7 @@ IoT_Error_t aws_iot_mqtt_connect(AWS_IoT_Client *pClient, IoT_Client_Connect_Par
  *
  * @return An IoT Error Type defining successful/failed publish
  */
-IoT_Error_t aws_iot_mqtt_publish(AWS_IoT_Client *pClient, const char *pTopicName, uint16_t topicNameLen,
+AWSIOTSDK_API IoT_Error_t aws_iot_mqtt_publish(AWS_IoT_Client *pClient, const char *pTopicName, uint16_t topicNameLen,
 								 IoT_Publish_Message_Params *pParams);
 
 /**
@@ -115,7 +115,7 @@ IoT_Error_t aws_iot_mqtt_publish(AWS_IoT_Client *pClient, const char *pTopicName
  *
  * @return An IoT Error Type defining successful/failed subscription
  */
-IoT_Error_t aws_iot_mqtt_subscribe(AWS_IoT_Client *pClient, const char *pTopicName, uint16_t topicNameLen,
+AWSIOTSDK_API IoT_Error_t aws_iot_mqtt_subscribe(AWS_IoT_Client *pClient, const char *pTopicName, uint16_t topicNameLen,
 								   QoS qos, pApplicationHandler_t pApplicationHandler, void *pApplicationHandlerData);
 
 /**
@@ -130,7 +130,7 @@ IoT_Error_t aws_iot_mqtt_subscribe(AWS_IoT_Client *pClient, const char *pTopicNa
  *
  * @return An IoT Error Type defining successful/failed subscription
  */
-IoT_Error_t aws_iot_mqtt_resubscribe(AWS_IoT_Client *pClient);
+AWSIOTSDK_API IoT_Error_t aws_iot_mqtt_resubscribe(AWS_IoT_Client *pClient);
 
 /**
  * @brief Unsubscribe to an MQTT topic.
@@ -145,7 +145,7 @@ IoT_Error_t aws_iot_mqtt_resubscribe(AWS_IoT_Client *pClient);
  *
  * @return An IoT Error Type defining successful/failed unsubscribe call
  */
-IoT_Error_t aws_iot_mqtt_unsubscribe(AWS_IoT_Client *pClient, const char *pTopicFilter, uint16_t topicFilterLen);
+AWSIOTSDK_API IoT_Error_t aws_iot_mqtt_unsubscribe(AWS_IoT_Client *pClient, const char *pTopicFilter, uint16_t topicFilterLen);
 
 /**
  * @brief Disconnect an MQTT Connection
@@ -156,7 +156,7 @@ IoT_Error_t aws_iot_mqtt_unsubscribe(AWS_IoT_Client *pClient, const char *pTopic
  *
  * @return An IoT Error Type defining successful/failed send of the disconnect control packet.
  */
-IoT_Error_t aws_iot_mqtt_disconnect(AWS_IoT_Client *pClient);
+AWSIOTSDK_API IoT_Error_t aws_iot_mqtt_disconnect(AWS_IoT_Client *pClient);
 
 /**
  * @brief Yield to the MQTT client
@@ -175,7 +175,7 @@ IoT_Error_t aws_iot_mqtt_disconnect(AWS_IoT_Client *pClient);
  *         If this call results in an error it is likely the MQTT connection has dropped.
  *         iot_is_mqtt_connected can be called to confirm.
  */
-IoT_Error_t aws_iot_mqtt_yield(AWS_IoT_Client *pClient, uint32_t timeout_ms);
+AWSIOTSDK_API IoT_Error_t aws_iot_mqtt_yield(AWS_IoT_Client *pClient, uint32_t timeout_ms);
 
 /**
  * @brief MQTT Manual Re-Connection Function
@@ -190,7 +190,39 @@ IoT_Error_t aws_iot_mqtt_yield(AWS_IoT_Client *pClient, uint32_t timeout_ms);
  *
  * @return An IoT Error Type defining successful/failed connection
  */
-IoT_Error_t aws_iot_mqtt_attempt_reconnect(AWS_IoT_Client *pClient);
+AWSIOTSDK_API IoT_Error_t aws_iot_mqtt_attempt_reconnect(AWS_IoT_Client *pClient);
+
+
+
+
+/**
+*  For dynamically linking this DLL
+*
+* EXAMPLE:
+*
+*    HMODULE hModule = ::LoadLibraryA("AwsIotSdk.dll");
+*
+*    AWS_IOT_MQTT_INIT aws_iot_mqtt_init_ptr = (AWS_IOT_MQTT_INIT)::GetProcAddress(hModule, "aws_iot_mqtt_init");
+*
+*    IoT_Client_Init_Params iotInitParams;
+*    AWS_IoT_Client client;
+*
+*    IoT_Error_t res = (aws_iot_mqtt_init_ptr)(&client, &iotInitParams);
+*
+*/
+#ifdef WIN32
+typedef IoT_Error_t(__cdecl *AWS_IOT_MQTT_INIT)(AWS_IoT_Client *pClient, IoT_Client_Init_Params *pInitParams);
+typedef IoT_Error_t(__cdecl *AWS_IOT_MQTT_CONNECT)(AWS_IoT_Client *pClient, IoT_Client_Connect_Params *pConnectParams);
+typedef IoT_Error_t(__cdecl *AWS_IOT_MQTT_PUBLISH)(AWS_IoT_Client *pClient, const char *pTopicName, uint16_t topicNameLen, IoT_Publish_Message_Params *pParams);
+typedef IoT_Error_t(__cdecl *AWS_IOT_MQTT_SUBSCRIBE)(AWS_IoT_Client *pClient, const char *pTopicName, uint16_t topicNameLen, QoS qos, pApplicationHandler_t pApplicationHandler, void *pApplicationHandlerData);
+typedef IoT_Error_t(__cdecl *AWS_IOT_MQTT_RESUBSCRIBE)(AWS_IoT_Client *pClient);
+typedef IoT_Error_t(__cdecl *AWS_IOT_MQTT_UNSUBSCRIBE)(AWS_IoT_Client *pClient, const char *pTopicFilter, uint16_t topicFilterLen);;
+typedef IoT_Error_t(__cdecl *AWS_IOT_MQTT_DISCONNECT)(AWS_IoT_Client *pClient);
+typedef IoT_Error_t(__cdecl *AWS_IOT_MQTT_YIELD)(AWS_IoT_Client *pClient, uint32_t timeout_ms);
+typedef IoT_Error_t(__cdecl *AWS_IOT_MQTT_ATTEMPT_RECONNECT)(AWS_IoT_Client *pClient);
+typedef bool(__cdecl *AWS_IOT_MQTT_AUTORECONNECT_ENABLED)(AWS_IoT_Client *pClient);
+typedef IoT_Error_t(__cdecl *AWS_IOT_MQTT_AUTORECONNECT_SET_STATUS)(AWS_IoT_Client *pClient, bool newStatus);
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/aws_iot_shadow_interface.h
+++ b/include/aws_iot_shadow_interface.h
@@ -102,7 +102,7 @@ extern const ShadowConnectParameters_t ShadowConnectParametersDefault;
  * @param pClient A new MQTT Client to be used as the protocol layer. Will be initialized with pParams.
  * @return An IoT Error Type defining successful/failed Initialization
  */
-IoT_Error_t aws_iot_shadow_init(AWS_IoT_Client *pClient, ShadowInitParameters_t *pParams);
+AWSIOTSDK_API IoT_Error_t aws_iot_shadow_init(AWS_IoT_Client *pClient, ShadowInitParameters_t *pParams);
 
 /**
  * @brief Connect to the AWS IoT Thing Shadow service over MQTT
@@ -113,7 +113,7 @@ IoT_Error_t aws_iot_shadow_init(AWS_IoT_Client *pClient, ShadowInitParameters_t 
  * @param pParams	Shadow Conenction parameters like TLS cert location
  * @return An IoT Error Type defining successful/failed Connection
  */
-IoT_Error_t aws_iot_shadow_connect(AWS_IoT_Client *pClient, ShadowConnectParameters_t *pParams);
+AWSIOTSDK_API IoT_Error_t aws_iot_shadow_connect(AWS_IoT_Client *pClient, ShadowConnectParameters_t *pParams);
 
 /**
  * @brief Yield function to let the background tasks of MQTT and Shadow
@@ -126,7 +126,7 @@ IoT_Error_t aws_iot_shadow_connect(AWS_IoT_Client *pClient, ShadowConnectParamet
  * @param timeout	in milliseconds, This is the maximum time the yield function will wait for a message and/or read the messages from the TLS buffer
  * @return An IoT Error Type defining successful/failed Yield
  */
-IoT_Error_t aws_iot_shadow_yield(AWS_IoT_Client *pClient, uint32_t timeout);
+AWSIOTSDK_API IoT_Error_t aws_iot_shadow_yield(AWS_IoT_Client *pClient, uint32_t timeout);
 
 /**
  * @brief Disconnect from the AWS IoT Thing Shadow service over MQTT
@@ -136,7 +136,7 @@ IoT_Error_t aws_iot_shadow_yield(AWS_IoT_Client *pClient, uint32_t timeout);
  * @param pClient	MQTT Client used as the protocol layer
  * @return An IoT Error Type defining successful/failed disconnect status
  */
-IoT_Error_t aws_iot_shadow_disconnect(AWS_IoT_Client *pClient);
+AWSIOTSDK_API IoT_Error_t aws_iot_shadow_disconnect(AWS_IoT_Client *pClient);
 
 /**
  * @brief Thing Shadow Acknowledgment enum
@@ -197,7 +197,7 @@ typedef void (*fpActionCallback_t)(const char *pThingName, ShadowActions_t actio
  * @param isPersistentSubscribe As mentioned above, every  time if a device updates the same shadow then this should be set to true to avoid repeated subscription and unsubscription. If the Thing Name is one off update then this should be set to false
  * @return An IoT Error Type defining successful/failed update action
  */
-IoT_Error_t aws_iot_shadow_update(AWS_IoT_Client *pClient, const char *pThingName, char *pJsonString,
+AWSIOTSDK_API IoT_Error_t aws_iot_shadow_update(AWS_IoT_Client *pClient, const char *pThingName, char *pJsonString,
 								  fpActionCallback_t callback, void *pContextData, uint8_t timeout_seconds,
 								  bool isPersistentSubscribe);
 
@@ -215,7 +215,7 @@ IoT_Error_t aws_iot_shadow_update(AWS_IoT_Client *pClient, const char *pThingNam
  * @param isPersistentSubscribe As mentioned above, every  time if a device gets the same Sahdow (JSON document) then this should be set to true to avoid repeated subscription and un-subscription. If the Thing Name is one off get then this should be set to false
  * @return An IoT Error Type defining successful/failed get action
  */
-IoT_Error_t aws_iot_shadow_get(AWS_IoT_Client *pClient, const char *pThingName, fpActionCallback_t callback,
+AWSIOTSDK_API IoT_Error_t aws_iot_shadow_get(AWS_IoT_Client *pClient, const char *pThingName, fpActionCallback_t callback,
 							   void *pContextData, uint8_t timeout_seconds, bool isPersistentSubscribe);
 
 /**
@@ -232,7 +232,7 @@ IoT_Error_t aws_iot_shadow_get(AWS_IoT_Client *pClient, const char *pThingName, 
  * @param isPersistentSubscribe As mentioned above, every  time if a device deletes the same Shadow (JSON document) then this should be set to true to avoid repeated subscription and un-subscription. If the Thing Name is one off delete then this should be set to false
  * @return An IoT Error Type defining successful/failed delete action
  */
-IoT_Error_t aws_iot_shadow_delete(AWS_IoT_Client *pClient, const char *pThingName, fpActionCallback_t callback,
+AWSIOTSDK_API IoT_Error_t aws_iot_shadow_delete(AWS_IoT_Client *pClient, const char *pThingName, fpActionCallback_t callback,
 								  void *pContextData, uint8_t timeout_seconds, bool isPersistentSubscriptions);
 
 /**
@@ -244,7 +244,7 @@ IoT_Error_t aws_iot_shadow_delete(AWS_IoT_Client *pClient, const char *pThingNam
  * @param pStruct The struct used to parse JSON value
  * @return An IoT Error Type defining successful/failed delta registering
  */
-IoT_Error_t aws_iot_shadow_register_delta(AWS_IoT_Client *pClient, jsonStruct_t *pStruct);
+AWSIOTSDK_API IoT_Error_t aws_iot_shadow_register_delta(AWS_IoT_Client *pClient, jsonStruct_t *pStruct);
 
 /**
  * @brief Reset the last received version number to zero.
@@ -287,7 +287,39 @@ void aws_iot_shadow_disable_discard_old_delta_msgs(void);
  *
  * @return An IoT Error Type defining successful/failed operation
  */
-IoT_Error_t aws_iot_shadow_set_autoreconnect_status(AWS_IoT_Client *pClient, bool newStatus);
+AWSIOTSDK_API IoT_Error_t aws_iot_shadow_set_autoreconnect_status(AWS_IoT_Client *pClient, bool newStatus);
+
+
+/**
+*  For dynamically linking this DLL
+*
+* EXAMPLE:
+*
+*    HMODULE hModule = ::LoadLibraryA("AwsIotSdk.dll");
+*
+*    AWS_IOT_SHADOW_INIT aws_iot_shadow_init_ptr = (AWS_IOT_SHADOW_INIT)::GetProcAddress(hModule, "aws_iot_shadow_init");
+*
+*    ShadowInitParameters_t parms;
+*    AWS_IoT_Client client;
+*
+*    IoT_Error_t res = (aws_iot_shadow_init_ptr)(&client, &parms);
+*
+*/
+#ifdef WIN32
+typedef IoT_Error_t(__cdecl *AWS_IOT_SHADOW_INIT)(AWS_IoT_Client *pClient, ShadowInitParameters_t *pParams);
+typedef IoT_Error_t(__cdecl *AWS_IOT_SHADOW_CONNECT)(AWS_IoT_Client *pClient, ShadowConnectParameters_t *pParams);
+typedef IoT_Error_t(__cdecl *AWS_IOT_SHADOW_YIELD)(AWS_IoT_Client *pClient, uint32_t timeout);
+typedef IoT_Error_t(__cdecl *AWS_IOT_SHADOW_DISCONNECT)(AWS_IoT_Client *pClient);
+typedef IoT_Error_t(__cdecl *AWS_IOT_SHADOW_UPDATE)(AWS_IoT_Client *pClient, const char *pThingName, char *pJsonString, fpActionCallback_t callback, void *pContextData, uint8_t timeout_seconds, bool isPersistentSubscribe);
+typedef IoT_Error_t(__cdecl *AWS_IOT_SHADOW_GET)(AWS_IoT_Client *pClient, const char *pThingName, fpActionCallback_t callback, void *pContextData, uint8_t timeout_seconds, bool isPersistentSubscribe);
+typedef IoT_Error_t(__cdecl *AWS_IOT_SHADOW_DELETE)(AWS_IoT_Client *pClient, const char *pThingName, fpActionCallback_t callback, void *pContextData, uint8_t timeout_seconds, bool isPersistentSubscriptions);
+typedef IoT_Error_t(__cdecl *AWS_IOT_SHADOW_REGISTER_DELTA)(AWS_IoT_Client *pClient, jsonStruct_t *pStruct);
+typedef void(__cdecl *AWS_IOT_SHADOW_RESET_LAST_RECEIVED_VERSION)();
+typedef uint32_t(__cdecl *AWS_IOT_SHADOW_GET_LAST_RECEIVED_VERSION)();
+typedef void(__cdecl *AWS_IOT_SHADOW_ENABLE_DISCARD_OLD_DELTA_MSGS)();
+typedef void(__cdecl *AWS_IOT_SHADOW_DISABLE_DISCARD_OLD_DELTA_MSGS)();
+typedef IoT_Error_t(__cdecl *AWS_IOT_SHADOW_SET_AUTORECONNECT_STATUS)(AWS_IoT_Client *pClient, bool newStatus);
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/aws_iot_shadow_interface.h
+++ b/include/aws_iot_shadow_interface.h
@@ -81,7 +81,11 @@ typedef struct {
  *
  * \relates ShadowInitParameters_t
  */
+#ifndef WIN32
 extern const ShadowInitParameters_t ShadowInitParametersDefault;
+#else
+const ShadowInitParameters_t ShadowInitParametersDefault;
+#endif
 
 /*!
  * @brief This is set to defaults from the configuration file
@@ -91,8 +95,11 @@ extern const ShadowInitParameters_t ShadowInitParametersDefault;
  *
  * \relates ShadowConnectParameters_t
  */
+#ifndef WIN32
 extern const ShadowConnectParameters_t ShadowConnectParametersDefault;
-
+#else
+const ShadowConnectParameters_t ShadowConnectParametersDefault;
+#endif
 
 /**
  * @brief Initialize the Thing Shadow before use

--- a/include/aws_iot_shadow_json_data.h
+++ b/include/aws_iot_shadow_json_data.h
@@ -20,6 +20,16 @@
 extern "C" {
 #endif
 
+#ifndef WIN32
+#define AWSIOTSDK_API
+#else
+#ifdef AWSIOTSDK_EXPORTS
+#define AWSIOTSDK_API __declspec(dllexport)
+#else
+#define AWSIOTSDK_API __declspec(dllimport)
+#endif
+#endif
+
 /**
  * @file aws_iot_shadow_json_data.h
  * @brief This file is the interface for all the Shadow related JSON functions.
@@ -81,7 +91,7 @@ struct jsonStruct {
  * @param maxSizeOfJsonDocument maximum size of the pJsonDocument that can be used to fill the JSON document
  * @return An IoT Error Type defining if the buffer was null or the entire string was not filled up
  */
-IoT_Error_t aws_iot_shadow_init_json_document(char *pJsonDocument, size_t maxSizeOfJsonDocument);
+AWSIOTSDK_API IoT_Error_t aws_iot_shadow_init_json_document(char *pJsonDocument, size_t maxSizeOfJsonDocument);
 
 /**
  * @brief Add the reported section of the JSON document of jsonStruct_t
@@ -97,7 +107,7 @@ IoT_Error_t aws_iot_shadow_init_json_document(char *pJsonDocument, size_t maxSiz
  * @param count total number of arguments(jsonStruct_t object) passed in the arguments
  * @return An IoT Error Type defining if the buffer was null or the entire string was not filled up
  */
-IoT_Error_t aws_iot_shadow_add_reported(char *pJsonDocument, size_t maxSizeOfJsonDocument, uint8_t count, ...);
+AWSIOTSDK_API IoT_Error_t aws_iot_shadow_add_reported(char *pJsonDocument, size_t maxSizeOfJsonDocument, uint8_t count, ...);
 
 /**
  * @brief Add the desired section of the JSON document of jsonStruct_t
@@ -113,7 +123,7 @@ IoT_Error_t aws_iot_shadow_add_reported(char *pJsonDocument, size_t maxSizeOfJso
  * @param count total number of arguments(jsonStruct_t object) passed in the arguments
  * @return An IoT Error Type defining if the buffer was null or the entire string was not filled up
  */
-IoT_Error_t aws_iot_shadow_add_desired(char *pJsonDocument, size_t maxSizeOfJsonDocument, uint8_t count, ...);
+AWSIOTSDK_API IoT_Error_t aws_iot_shadow_add_desired(char *pJsonDocument, size_t maxSizeOfJsonDocument, uint8_t count, ...);
 
 /**
  * @brief Finalize the JSON document with Shadow expected client Token.
@@ -127,7 +137,7 @@ IoT_Error_t aws_iot_shadow_add_desired(char *pJsonDocument, size_t maxSizeOfJson
  * @param maxSizeOfJsonDocument maximum size of the pJsonDocument that can be used to fill the JSON document
  * @return An IoT Error Type defining if the buffer was null or the entire string was not filled up
  */
-IoT_Error_t aws_iot_finalize_json_document(char *pJsonDocument, size_t maxSizeOfJsonDocument);
+AWSIOTSDK_API IoT_Error_t aws_iot_finalize_json_document(char *pJsonDocument, size_t maxSizeOfJsonDocument);
 
 /**
  * @brief Fill the given buffer with client token for tracking the Repsonse.
@@ -140,7 +150,30 @@ IoT_Error_t aws_iot_finalize_json_document(char *pJsonDocument, size_t maxSizeOf
  * @return An IoT Error Type defining if the buffer was null or the entire string was not filled up
  */
 
-IoT_Error_t aws_iot_fill_with_client_token(char *pBufferToBeUpdatedWithClientToken, size_t maxSizeOfJsonDocument);
+AWSIOTSDK_API IoT_Error_t aws_iot_fill_with_client_token(char *pBufferToBeUpdatedWithClientToken, size_t maxSizeOfJsonDocument);
+
+/**
+*  For dynamically linking this DLL
+*
+* EXAMPLE:
+*
+*    HMODULE hModule = ::LoadLibraryA("AwsIotSdk.dll");
+*
+*    AWS_IOT_SHADOW_INIT_JSON_DOCUMENT aws_iot_shadow_init_json_document_ptr = (AWS_IOT_SHADOW_INIT_JSON_DOCUMENT)::GetProcAddress(hModule, "aws_iot_shadow_init_json_document");
+*
+*    char JsonDocumentBuffer[MAX_LENGTH_OF_UPDATE_JSON_BUFFER];
+*    size_t sizeOfJsonDocumentBuffer = sizeof(JsonDocumentBuffer) / sizeof(JsonDocumentBuffer[0]);
+*
+*    IoT_Error_t res = (aws_iot_shadow_init_json_document_ptr)(&JsonDocumentBuffer, sizeOfJsonDocumentBuffer);
+*
+*/
+#ifdef WIN32
+typedef IoT_Error_t(__cdecl *AWS_IOT_SHADOW_INIT_JSON_DOCUMENT)(char *pJsonDocument, size_t maxSizeOfJsonDocument);
+typedef IoT_Error_t(__cdecl *AWS_IOT_SHADOW_ADD_DESIRED)(char *pJsonDocument, size_t maxSizeOfJsonDocument, uint8_t count, ...);
+typedef IoT_Error_t(__cdecl *AWS_IOT_SHADOW_ADD_REPORTED)(char *pJsonDocument, size_t maxSizeOfJsonDocument, uint8_t count, ...);
+typedef IoT_Error_t(__cdecl *AWS_IOT_FINALIZE_JSON_DOCUMENT)(char *pJsonDocument, size_t maxSizeOfJsonDocument);
+typedef IoT_Error_t(__cdecl *AWS_IOT_FILL_WITH_CLIENT_TOKEN)(char *pBufferToBeUpdatedWithClientToken, size_t maxSizeOfJsonDocument);
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/timer_interface.h
+++ b/include/timer_interface.h
@@ -47,7 +47,9 @@ extern "C" {
  * in "timer_<platform>.h" and include that file above.
  *
  */
+#ifndef WIN32
 typedef struct Timer Timer;
+#endif
 
 /**
  * @brief Check if a timer is expired

--- a/platform/win32/aws-iot-sdk-dll/aws-iot-sdk.sln
+++ b/platform/win32/aws-iot-sdk-dll/aws-iot-sdk.sln
@@ -10,6 +10,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "shadow_sample_console", "..
 		{A7390FB7-2E36-4B8A-A794-F69D2BB7BFA1} = {A7390FB7-2E36-4B8A-A794-F69D2BB7BFA1}
 	EndProjectSection
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "subscribe_publish_sample_console", "..\..\..\samples\win32\subscribe_publish_sample\subscribe_publish_sample_console\subscribe_publish_sample_console.vcxproj", "{4367393A-0814-476A-B13B-ABCD6C16EFCA}"
+	ProjectSection(ProjectDependencies) = postProject
+		{A7390FB7-2E36-4B8A-A794-F69D2BB7BFA1} = {A7390FB7-2E36-4B8A-A794-F69D2BB7BFA1}
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -34,6 +39,14 @@ Global
 		{602AFFEB-E907-425A-955E-35E0344915CB}.Release|x64.Build.0 = Release|x64
 		{602AFFEB-E907-425A-955E-35E0344915CB}.Release|x86.ActiveCfg = Release|Win32
 		{602AFFEB-E907-425A-955E-35E0344915CB}.Release|x86.Build.0 = Release|Win32
+		{4367393A-0814-476A-B13B-ABCD6C16EFCA}.Debug|x64.ActiveCfg = Debug|x64
+		{4367393A-0814-476A-B13B-ABCD6C16EFCA}.Debug|x64.Build.0 = Debug|x64
+		{4367393A-0814-476A-B13B-ABCD6C16EFCA}.Debug|x86.ActiveCfg = Debug|Win32
+		{4367393A-0814-476A-B13B-ABCD6C16EFCA}.Debug|x86.Build.0 = Debug|Win32
+		{4367393A-0814-476A-B13B-ABCD6C16EFCA}.Release|x64.ActiveCfg = Release|x64
+		{4367393A-0814-476A-B13B-ABCD6C16EFCA}.Release|x64.Build.0 = Release|x64
+		{4367393A-0814-476A-B13B-ABCD6C16EFCA}.Release|x86.ActiveCfg = Release|Win32
+		{4367393A-0814-476A-B13B-ABCD6C16EFCA}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/platform/win32/aws-iot-sdk-dll/aws-iot-sdk.sln
+++ b/platform/win32/aws-iot-sdk-dll/aws-iot-sdk.sln
@@ -5,6 +5,11 @@ VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "aws-iot-sdk", "aws-iot-sdk.vcxproj", "{A7390FB7-2E36-4B8A-A794-F69D2BB7BFA1}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "shadow_sample_console", "..\..\..\samples\win32\shadow_sample\shadow_sample_console\shadow_sample_console.vcxproj", "{602AFFEB-E907-425A-955E-35E0344915CB}"
+	ProjectSection(ProjectDependencies) = postProject
+		{A7390FB7-2E36-4B8A-A794-F69D2BB7BFA1} = {A7390FB7-2E36-4B8A-A794-F69D2BB7BFA1}
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -21,6 +26,14 @@ Global
 		{A7390FB7-2E36-4B8A-A794-F69D2BB7BFA1}.Release|x64.Build.0 = Release|x64
 		{A7390FB7-2E36-4B8A-A794-F69D2BB7BFA1}.Release|x86.ActiveCfg = Release|Win32
 		{A7390FB7-2E36-4B8A-A794-F69D2BB7BFA1}.Release|x86.Build.0 = Release|Win32
+		{602AFFEB-E907-425A-955E-35E0344915CB}.Debug|x64.ActiveCfg = Debug|x64
+		{602AFFEB-E907-425A-955E-35E0344915CB}.Debug|x64.Build.0 = Debug|x64
+		{602AFFEB-E907-425A-955E-35E0344915CB}.Debug|x86.ActiveCfg = Debug|Win32
+		{602AFFEB-E907-425A-955E-35E0344915CB}.Debug|x86.Build.0 = Debug|Win32
+		{602AFFEB-E907-425A-955E-35E0344915CB}.Release|x64.ActiveCfg = Release|x64
+		{602AFFEB-E907-425A-955E-35E0344915CB}.Release|x64.Build.0 = Release|x64
+		{602AFFEB-E907-425A-955E-35E0344915CB}.Release|x86.ActiveCfg = Release|Win32
+		{602AFFEB-E907-425A-955E-35E0344915CB}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/platform/win32/aws-iot-sdk-dll/aws-iot-sdk.sln
+++ b/platform/win32/aws-iot-sdk-dll/aws-iot-sdk.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "aws-iot-sdk", "aws-iot-sdk.vcxproj", "{A7390FB7-2E36-4B8A-A794-F69D2BB7BFA1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A7390FB7-2E36-4B8A-A794-F69D2BB7BFA1}.Debug|x64.ActiveCfg = Debug|x64
+		{A7390FB7-2E36-4B8A-A794-F69D2BB7BFA1}.Debug|x64.Build.0 = Debug|x64
+		{A7390FB7-2E36-4B8A-A794-F69D2BB7BFA1}.Debug|x86.ActiveCfg = Debug|Win32
+		{A7390FB7-2E36-4B8A-A794-F69D2BB7BFA1}.Debug|x86.Build.0 = Debug|Win32
+		{A7390FB7-2E36-4B8A-A794-F69D2BB7BFA1}.Release|x64.ActiveCfg = Release|x64
+		{A7390FB7-2E36-4B8A-A794-F69D2BB7BFA1}.Release|x64.Build.0 = Release|x64
+		{A7390FB7-2E36-4B8A-A794-F69D2BB7BFA1}.Release|x86.ActiveCfg = Release|Win32
+		{A7390FB7-2E36-4B8A-A794-F69D2BB7BFA1}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/platform/win32/aws-iot-sdk-dll/aws-iot-sdk.vcxproj
+++ b/platform/win32/aws-iot-sdk-dll/aws-iot-sdk.vcxproj
@@ -1,0 +1,363 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{A7390FB7-2E36-4B8A-A794-F69D2BB7BFA1}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>awsiotsdkdll</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <ProjectName>aws-iot-sdk</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;AWSIOTSDK_EXPORTS;_CRT_SECURE_NO_WARNINGS;_DEBUG;_WINDOWS;_USRDLL;AWSIOTSDKDLL_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <ExceptionHandling>false</ExceptionHandling>
+      <PrecompiledHeaderFile />
+      <PrecompiledHeaderOutputFile />
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <AdditionalIncludeDirectories>..\..\..\include;..\..\..\external_libs;..\..\..\external_libs\mbedTLS;..\..\..\external_libs\jsmn;..\..\..\external_libs\CppUTest;..\..\win32\pthread;..\..\win32\mbedtls;..\..\win32\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;AWSIOTSDKDLL_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;AWSIOTSDK_EXPORTS;_CRT_SECURE_NO_WARNINGS;NDEBUG;_WINDOWS;_USRDLL;AWSIOTSDKDLL_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <ExceptionHandling>false</ExceptionHandling>
+      <PrecompiledHeaderFile />
+      <PrecompiledHeaderOutputFile />
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalIncludeDirectories>..\..\..\include;..\..\..\external_libs;..\..\..\external_libs\mbedTLS;..\..\..\external_libs\jsmn;..\..\..\external_libs\CppUTest;..\..\win32\pthread;..\..\win32\mbedtls;..\..\win32\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;AWSIOTSDKDLL_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\external_libs\jsmn\jsmn.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\aes.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\aesni.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\arc4.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\asn1.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\asn1write.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\base64.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\bignum.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\blowfish.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\bn_mul.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\camellia.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ccm.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\certs.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\check_config.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\cipher.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\cipher_internal.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\cmac.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\compat-1.3.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\config.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ctr_drbg.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\debug.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\des.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\dhm.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ecdh.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ecdsa.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ecjpake.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ecp.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\entropy.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\entropy_poll.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\error.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\gcm.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\havege.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\hmac_drbg.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\md.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\md2.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\md4.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\md5.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\md_internal.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\memory_buffer_alloc.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\net.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\net_sockets.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\oid.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\padlock.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\pem.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\pk.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\pkcs11.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\pkcs12.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\pkcs5.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\pk_internal.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\platform.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\platform_time.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ripemd160.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\rsa.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\sha1.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\sha256.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\sha512.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ssl.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ssl_cache.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ssl_ciphersuites.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ssl_cookie.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ssl_internal.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ssl_ticket.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\threading.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\timing.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\version.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\x509.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\x509_crl.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\x509_crt.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\x509_csr.h" />
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\xtea.h" />
+    <ClInclude Include="..\..\..\include\aws_iot_config.h" />
+    <ClInclude Include="..\..\..\include\aws_iot_error.h" />
+    <ClInclude Include="..\..\..\include\aws_iot_json_utils.h" />
+    <ClInclude Include="..\..\..\include\aws_iot_log.h" />
+    <ClInclude Include="..\..\..\include\aws_iot_mqtt_client.h" />
+    <ClInclude Include="..\..\..\include\aws_iot_mqtt_client_common_internal.h" />
+    <ClInclude Include="..\..\..\include\aws_iot_mqtt_client_interface.h" />
+    <ClInclude Include="..\..\..\include\aws_iot_shadow_actions.h" />
+    <ClInclude Include="..\..\..\include\aws_iot_shadow_interface.h" />
+    <ClInclude Include="..\..\..\include\aws_iot_shadow_json.h" />
+    <ClInclude Include="..\..\..\include\aws_iot_shadow_json_data.h" />
+    <ClInclude Include="..\..\..\include\aws_iot_shadow_key.h" />
+    <ClInclude Include="..\..\..\include\aws_iot_shadow_records.h" />
+    <ClInclude Include="..\..\..\include\aws_iot_version.h" />
+    <ClInclude Include="..\..\..\include\network_interface.h" />
+    <ClInclude Include="..\..\..\include\threads_interface.h" />
+    <ClInclude Include="..\..\..\include\timer_interface.h" />
+    <ClInclude Include="..\common\timer_platform.h" />
+    <ClInclude Include="..\mbedtls\network_platform.h" />
+    <ClInclude Include="..\pthread\threads_platform.h" />
+    <ClInclude Include="targetver.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\external_libs\jsmn\jsmn.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\aes.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\aesni.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\arc4.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\asn1parse.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\asn1write.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\base64.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\bignum.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\blowfish.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\camellia.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ccm.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\certs.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\cipher.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\cipher_wrap.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\cmac.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ctr_drbg.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\debug.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\des.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\dhm.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ecdh.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ecdsa.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ecjpake.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ecp.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ecp_curves.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\entropy.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\entropy_poll.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\error.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\gcm.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\havege.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\hmac_drbg.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\md.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\md2.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\md4.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\md5.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\md_wrap.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\memory_buffer_alloc.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\net_sockets.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\oid.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\padlock.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\pem.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\pk.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\pkcs11.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\pkcs12.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\pkcs5.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\pkparse.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\pkwrite.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\pk_wrap.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\platform.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ripemd160.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\rsa.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\sha1.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\sha256.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\sha512.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ssl_cache.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ssl_ciphersuites.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ssl_cli.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ssl_cookie.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ssl_srv.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ssl_ticket.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ssl_tls.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\threading.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\timing.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\version.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\version_features.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\x509.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\x509write_crt.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\x509write_csr.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\x509_create.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\x509_crl.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\x509_crt.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\x509_csr.c" />
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\xtea.c" />
+    <ClCompile Include="..\..\..\src\aws_iot_json_utils.c" />
+    <ClCompile Include="..\..\..\src\aws_iot_mqtt_client.c" />
+    <ClCompile Include="..\..\..\src\aws_iot_mqtt_client_common_internal.c" />
+    <ClCompile Include="..\..\..\src\aws_iot_mqtt_client_connect.c" />
+    <ClCompile Include="..\..\..\src\aws_iot_mqtt_client_publish.c" />
+    <ClCompile Include="..\..\..\src\aws_iot_mqtt_client_subscribe.c" />
+    <ClCompile Include="..\..\..\src\aws_iot_mqtt_client_unsubscribe.c" />
+    <ClCompile Include="..\..\..\src\aws_iot_mqtt_client_yield.c" />
+    <ClCompile Include="..\..\..\src\aws_iot_shadow.c" />
+    <ClCompile Include="..\..\..\src\aws_iot_shadow_actions.c" />
+    <ClCompile Include="..\..\..\src\aws_iot_shadow_json.c" />
+    <ClCompile Include="..\..\..\src\aws_iot_shadow_records.c" />
+    <ClCompile Include="..\common\timer.c" />
+    <ClCompile Include="..\mbedtls\network_mbedtls_wrapper.c" />
+    <ClCompile Include="..\pthread\threads_pthread_wrapper.c" />
+    <ClCompile Include="dllmain.c">
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsManaged>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+      </PrecompiledHeader>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsManaged>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+      </PrecompiledHeader>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsManaged>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+      </PrecompiledHeader>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsManaged>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+      </PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="..\..\..\external_libs\CppUTest\README.txt">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </Text>
+    <Text Include="..\..\..\external_libs\mbedTLS\README.txt" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/platform/win32/aws-iot-sdk-dll/aws-iot-sdk.vcxproj.filters
+++ b/platform/win32/aws-iot-sdk-dll/aws-iot-sdk.vcxproj.filters
@@ -1,0 +1,583 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClInclude Include="targetver.h" />
+    <ClInclude Include="..\common\timer_platform.h">
+      <Filter>platform\win32\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mbedtls\network_platform.h">
+      <Filter>platform\win32\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\pthread\threads_platform.h">
+      <Filter>platform\win32\pthread</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\aws_iot_error.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\aws_iot_json_utils.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\aws_iot_log.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\aws_iot_mqtt_client.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\aws_iot_mqtt_client_common_internal.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\aws_iot_mqtt_client_interface.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\aws_iot_shadow_actions.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\aws_iot_shadow_interface.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\aws_iot_shadow_json.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\aws_iot_shadow_json_data.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\aws_iot_shadow_key.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\aws_iot_shadow_records.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\aws_iot_version.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\network_interface.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\threads_interface.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\timer_interface.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\aws_iot_config.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\jsmn\jsmn.h">
+      <Filter>external_libs\jsmn</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\aes.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\aesni.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\arc4.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\asn1.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\asn1write.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\base64.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\bignum.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\blowfish.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\bn_mul.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\camellia.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ccm.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\certs.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\check_config.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\cipher.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\cipher_internal.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\cmac.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\compat-1.3.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\config.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ctr_drbg.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\debug.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\des.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\dhm.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ecdh.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ecdsa.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ecjpake.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ecp.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\entropy.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\entropy_poll.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\error.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\gcm.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\havege.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\hmac_drbg.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\md.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\md_internal.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\md2.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\md4.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\md5.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\memory_buffer_alloc.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\net.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\net_sockets.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\oid.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\padlock.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\pem.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\pk.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\pk_internal.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\pkcs5.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\pkcs11.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\pkcs12.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\platform.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\platform_time.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ripemd160.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\rsa.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\sha1.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\sha256.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\sha512.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ssl.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ssl_cache.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ssl_ciphersuites.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ssl_cookie.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ssl_internal.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\ssl_ticket.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\threading.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\timing.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\version.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\x509.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\x509_crl.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\x509_crt.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\x509_csr.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external_libs\mbedTLS\xtea.h">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="dllmain.c" />
+    <ClCompile Include="..\..\..\src\aws_iot_json_utils.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\aws_iot_mqtt_client.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\aws_iot_mqtt_client_common_internal.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\aws_iot_mqtt_client_connect.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\aws_iot_mqtt_client_publish.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\aws_iot_mqtt_client_subscribe.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\aws_iot_mqtt_client_unsubscribe.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\aws_iot_mqtt_client_yield.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\aws_iot_shadow.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\aws_iot_shadow_actions.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\aws_iot_shadow_json.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\aws_iot_shadow_records.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\common\timer.c">
+      <Filter>platform\win32\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mbedtls\network_mbedtls_wrapper.c">
+      <Filter>platform\win32\mbedtls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\pthread\threads_pthread_wrapper.c">
+      <Filter>platform\win32\pthread</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\jsmn\jsmn.c">
+      <Filter>external_libs\jsmn</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\aes.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\aesni.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\arc4.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\asn1parse.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\asn1write.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\base64.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\bignum.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\blowfish.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\camellia.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ccm.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\certs.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\cipher.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\cipher_wrap.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\cmac.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ctr_drbg.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\debug.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\des.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\dhm.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ecdh.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ecdsa.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ecjpake.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ecp.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ecp_curves.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\entropy.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\entropy_poll.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\error.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\gcm.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\havege.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\hmac_drbg.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\md.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\md_wrap.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\md2.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\md4.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\md5.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\memory_buffer_alloc.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\net_sockets.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\oid.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\padlock.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\pem.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\pk.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\pk_wrap.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\pkcs5.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\pkcs11.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\pkcs12.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\pkparse.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\pkwrite.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\platform.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ripemd160.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\rsa.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\sha1.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\sha256.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\sha512.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ssl_cache.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ssl_ciphersuites.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ssl_cli.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ssl_cookie.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ssl_srv.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ssl_ticket.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\ssl_tls.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\threading.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\timing.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\version.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\version_features.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\x509.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\x509_create.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\x509_crl.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\x509_crt.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\x509_csr.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\x509write_crt.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\x509write_csr.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external_libs\mbedTLS\xtea.c">
+      <Filter>external_libs\mbedTLS</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="src">
+      <UniqueIdentifier>{cb160a44-38f8-4a8d-9c08-d667b74be0fb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="platform">
+      <UniqueIdentifier>{e5161367-0549-477d-9a76-bda1813312a3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="platform\win32">
+      <UniqueIdentifier>{bb8b779b-8c4b-4366-985f-da0f2eadf20d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="platform\win32\common">
+      <UniqueIdentifier>{bc8fa089-9224-45e7-8c2d-1199c9d591b5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="platform\win32\mbedtls">
+      <UniqueIdentifier>{40dc14e0-3e5b-4887-be87-e9d1dce76a10}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="platform\win32\pthread">
+      <UniqueIdentifier>{710199de-1935-4d48-b9ec-e8557295503d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="include">
+      <UniqueIdentifier>{5ba441ce-a2c9-4706-b9de-6dcee4b675f1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="external_libs">
+      <UniqueIdentifier>{9c978f7e-dcc6-4535-aec9-04aae65f2a0a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="external_libs\CppUTest">
+      <UniqueIdentifier>{f659f6fb-9283-44e2-9c85-6607c247fc55}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="external_libs\jsmn">
+      <UniqueIdentifier>{0d446823-b490-4a52-942c-bb1c01706f95}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="external_libs\mbedTLS">
+      <UniqueIdentifier>{fbf86946-c476-466f-a8dd-0a0f923290b5}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="..\..\..\external_libs\mbedTLS\README.txt">
+      <Filter>external_libs\mbedTLS</Filter>
+    </Text>
+    <Text Include="..\..\..\external_libs\CppUTest\README.txt">
+      <Filter>external_libs\CppUTest</Filter>
+    </Text>
+  </ItemGroup>
+</Project>

--- a/platform/win32/aws-iot-sdk-dll/dllmain.c
+++ b/platform/win32/aws-iot-sdk-dll/dllmain.c
@@ -1,0 +1,18 @@
+#include "targetver.h"
+
+#define WIN32_LEAN_AND_MEAN             
+#include <windows.h>
+
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)
+{
+	switch (ul_reason_for_call)
+	{
+		case DLL_PROCESS_ATTACH:
+		case DLL_THREAD_ATTACH:
+		case DLL_THREAD_DETACH:
+		case DLL_PROCESS_DETACH:
+			break;
+	}
+	return TRUE;
+}
+

--- a/platform/win32/aws-iot-sdk-dll/dllmain.c
+++ b/platform/win32/aws-iot-sdk-dll/dllmain.c
@@ -1,3 +1,18 @@
+/*
+* Copyright 2010-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
 #include "targetver.h"
 
 #define WIN32_LEAN_AND_MEAN             

--- a/platform/win32/aws-iot-sdk-dll/targetver.h
+++ b/platform/win32/aws-iot-sdk-dll/targetver.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// Including SDKDDKVer.h defines the highest available Windows platform.
+
+// If you wish to build your application for a previous Windows platform, include WinSDKVer.h and
+// set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
+
+#include <SDKDDKVer.h>

--- a/platform/win32/aws-iot-sdk-dll/targetver.h
+++ b/platform/win32/aws-iot-sdk-dll/targetver.h
@@ -1,4 +1,20 @@
-#pragma once
+/*
+* Copyright 2010-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+#ifndef _TARGETVER_H
+#define _TARGETVER_H
 
 // Including SDKDDKVer.h defines the highest available Windows platform.
 
@@ -6,3 +22,6 @@
 // set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
 
 #include <SDKDDKVer.h>
+
+#endif // _TARGETVER_H
+

--- a/platform/win32/common/timer.c
+++ b/platform/win32/common/timer.c
@@ -1,5 +1,5 @@
 /*
-* Copyright 2010-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* Copyright 2010-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License").
 * You may not use this file except in compliance with the License.

--- a/platform/win32/common/timer.c
+++ b/platform/win32/common/timer.c
@@ -1,0 +1,77 @@
+/*
+* Copyright 2010-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "timer_platform.h"
+
+// Timeout if 'now' greater than 'endTime'
+bool has_timer_expired(Timer *timer) 
+{	
+	LARGE_INTEGER now;
+	QueryPerformanceCounter(&now);
+
+	return (now.QuadPart > timer->endTime.QuadPart);
+}
+
+// Calculate a new 'endTime' given the 'timeout' passed in by the client
+// TODO:: Check for timer rollover.
+void countdown_ms(Timer *timer, unsigned __int32 timeout) 
+{
+	LARGE_INTEGER freq, now;
+	QueryPerformanceFrequency(&freq);
+
+	// Convert 'timeout' to ticks
+	LARGE_INTEGER timeoutTicks;
+	timeoutTicks.QuadPart = (timeout * freq.QuadPart) / 1000LL;
+	
+	// Calculate 'endTime' 
+	QueryPerformanceCounter(&now);
+	timer->endTime.QuadPart = now.QuadPart + timeoutTicks.QuadPart;
+}
+
+unsigned __int32 left_ms(Timer *timer) 
+{
+	_int32 leftMilliseconds = 0;
+
+	LARGE_INTEGER now;
+	QueryPerformanceCounter(&now);
+
+	LONGLONG delta = timer->endTime.QuadPart - now.QuadPart;
+	if (delta > 0)
+	{
+		LARGE_INTEGER freq;
+		QueryPerformanceFrequency(&freq);
+		leftMilliseconds = (__int32)((1000LL * delta) / freq.QuadPart);
+	}
+	
+	return leftMilliseconds;
+}
+
+void countdown_sec(Timer *timer, unsigned __int32 timeout) 
+{
+	countdown_ms(timer, timeout * 1000);
+}
+
+void init_timer(Timer *timer) 
+{	
+	timer->endTime.QuadPart = 0LL;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/platform/win32/common/timer_platform.h
+++ b/platform/win32/common/timer_platform.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2010-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* Copyright 2010-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License").
 * You may not use this file except in compliance with the License.

--- a/platform/win32/common/timer_platform.h
+++ b/platform/win32/common/timer_platform.h
@@ -1,0 +1,40 @@
+/*
+* Copyright 2010-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+#ifndef _TIMER_PLATFORM_H_
+#define _TIMER_PLATFORM_H_
+
+#include <Windows.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+	LARGE_INTEGER endTime;
+} Timer;
+
+extern bool has_timer_expired(Timer *timer);
+extern void countdown_ms(Timer *timer, unsigned __int32 timeout);
+extern void countdown_sec(Timer *timer, unsigned __int32 timeout);
+extern unsigned __int32 left_ms(Timer *timer);
+extern void init_timer(Timer *timer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _TIMER_PLATFORM_H_ */

--- a/platform/win32/mbedtls/network_mbedtls_wrapper.c
+++ b/platform/win32/mbedtls/network_mbedtls_wrapper.c
@@ -1,0 +1,363 @@
+/*
+ * Copyright 2010-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <string.h>
+#include <timer_platform.h>
+#include <network_interface.h>
+
+#include "aws_iot_error.h"
+#include "aws_iot_log.h"
+#include "network_interface.h"
+#include "network_platform.h"
+
+/* This is the value used for ssl read timeout */
+#define IOT_SSL_READ_TIMEOUT 10
+
+/*
+ * This is a function to do further verification if needed on the cert received
+ */
+
+static int _iot_tls_verify_cert(void *data, mbedtls_x509_crt *crt, int depth, uint32_t *flags) {
+	char buf[1024];
+	((void) data);
+
+	IOT_DEBUG("\nVerify requested for (Depth %d):\n", depth);
+	mbedtls_x509_crt_info(buf, sizeof(buf) - 1, "", crt);
+	IOT_DEBUG("%s", buf);
+
+	if((*flags) == 0) {
+		IOT_DEBUG("  This certificate has no flags\n");
+	} else {
+		IOT_DEBUG(buf, sizeof(buf), "  ! ", *flags);
+		IOT_DEBUG("%s\n", buf);
+	}
+
+	return 0;
+}
+
+void _iot_tls_set_connect_params(Network *pNetwork, char *pRootCALocation, char *pDeviceCertLocation,
+								 char *pDevicePrivateKeyLocation, char *pDestinationURL,
+								 uint16_t destinationPort, uint32_t timeout_ms, bool ServerVerificationFlag) {
+	pNetwork->tlsConnectParams.DestinationPort = destinationPort;
+	pNetwork->tlsConnectParams.pDestinationURL = pDestinationURL;
+	pNetwork->tlsConnectParams.pDeviceCertLocation = pDeviceCertLocation;
+	pNetwork->tlsConnectParams.pDevicePrivateKeyLocation = pDevicePrivateKeyLocation;
+	pNetwork->tlsConnectParams.pRootCALocation = pRootCALocation;
+	pNetwork->tlsConnectParams.timeout_ms = timeout_ms;
+	pNetwork->tlsConnectParams.ServerVerificationFlag = ServerVerificationFlag;
+}
+
+IoT_Error_t iot_tls_init(Network *pNetwork, char *pRootCALocation, char *pDeviceCertLocation,
+						 char *pDevicePrivateKeyLocation, char *pDestinationURL,
+						 uint16_t destinationPort, uint32_t timeout_ms, bool ServerVerificationFlag) {
+	_iot_tls_set_connect_params(pNetwork, pRootCALocation, pDeviceCertLocation, pDevicePrivateKeyLocation,
+								pDestinationURL, destinationPort, timeout_ms, ServerVerificationFlag);
+
+	pNetwork->connect = iot_tls_connect;
+	pNetwork->read = iot_tls_read;
+	pNetwork->write = iot_tls_write;
+	pNetwork->disconnect = iot_tls_disconnect;
+	pNetwork->isConnected = iot_tls_is_connected;
+	pNetwork->destroy = iot_tls_destroy;
+
+	pNetwork->tlsDataParams.flags = 0;
+
+	return SUCCESS;
+}
+
+IoT_Error_t iot_tls_is_connected(Network *pNetwork) {
+	/* Use this to add implementation which can check for physical layer disconnect */
+	return NETWORK_PHYSICAL_LAYER_CONNECTED;
+}
+
+IoT_Error_t iot_tls_connect(Network *pNetwork, TLSConnectParams *params) {
+	int ret = 0;
+	const char *pers = "aws_iot_tls_wrapper";
+	TLSDataParams *tlsDataParams = NULL;
+	char portBuffer[6];
+	char vrfy_buf[512];
+#ifdef IOT_DEBUG
+	unsigned char buf[MBEDTLS_SSL_MAX_CONTENT_LEN + 1];
+#endif
+
+	if(NULL == pNetwork) {
+		return NULL_VALUE_ERROR;
+	}
+
+	if(NULL != params) {
+		_iot_tls_set_connect_params(pNetwork, params->pRootCALocation, params->pDeviceCertLocation,
+									params->pDevicePrivateKeyLocation, params->pDestinationURL,
+									params->DestinationPort, params->timeout_ms, params->ServerVerificationFlag);
+	}
+
+	tlsDataParams = &(pNetwork->tlsDataParams);
+
+	mbedtls_net_init(&(tlsDataParams->server_fd));
+	mbedtls_ssl_init(&(tlsDataParams->ssl));
+	mbedtls_ssl_config_init(&(tlsDataParams->conf));
+	mbedtls_ctr_drbg_init(&(tlsDataParams->ctr_drbg));
+	mbedtls_x509_crt_init(&(tlsDataParams->cacert));
+	mbedtls_x509_crt_init(&(tlsDataParams->clicert));
+	mbedtls_pk_init(&(tlsDataParams->pkey));
+
+	IOT_DEBUG("\n  . Seeding the random number generator...");
+	mbedtls_entropy_init(&(tlsDataParams->entropy));
+	if((ret = mbedtls_ctr_drbg_seed(&(tlsDataParams->ctr_drbg), mbedtls_entropy_func, &(tlsDataParams->entropy),
+									(const unsigned char *) pers, strlen(pers))) != 0) {
+		IOT_ERROR(" failed\n  ! mbedtls_ctr_drbg_seed returned -0x%x\n", -ret);
+		return NETWORK_MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED;
+	}
+
+	IOT_DEBUG("  . Loading the CA root certificate ...");
+	ret = mbedtls_x509_crt_parse_file(&(tlsDataParams->cacert), pNetwork->tlsConnectParams.pRootCALocation);
+	if(ret < 0) {
+		IOT_ERROR(" failed\n  !  mbedtls_x509_crt_parse returned -0x%x while parsing root cert\n\n", -ret);
+		return NETWORK_X509_ROOT_CRT_PARSE_ERROR;
+	}
+	IOT_DEBUG(" ok (%d skipped)\n", ret);
+
+	IOT_DEBUG("  . Loading the client cert. and key...");
+	ret = mbedtls_x509_crt_parse_file(&(tlsDataParams->clicert), pNetwork->tlsConnectParams.pDeviceCertLocation);
+	if(ret != 0) {
+		IOT_ERROR(" failed\n  !  mbedtls_x509_crt_parse returned -0x%x while parsing device cert\n\n", -ret);
+		return NETWORK_X509_DEVICE_CRT_PARSE_ERROR;
+	}
+
+	ret = mbedtls_pk_parse_keyfile(&(tlsDataParams->pkey), pNetwork->tlsConnectParams.pDevicePrivateKeyLocation, "");
+	if(ret != 0) {
+		IOT_ERROR(" failed\n  !  mbedtls_pk_parse_key returned -0x%x while parsing private key\n\n", -ret);
+		IOT_DEBUG(" path : %s ", pNetwork->tlsConnectParams.pDevicePrivateKeyLocation);
+		return NETWORK_PK_PRIVATE_KEY_PARSE_ERROR;
+	}
+	IOT_DEBUG(" ok\n");
+	snprintf(portBuffer, 6, "%d", pNetwork->tlsConnectParams.DestinationPort);
+	IOT_DEBUG("  . Connecting to %s/%s...", pNetwork->tlsConnectParams.pDestinationURL, portBuffer);
+	if((ret = mbedtls_net_connect(&(tlsDataParams->server_fd), pNetwork->tlsConnectParams.pDestinationURL,
+								  portBuffer, MBEDTLS_NET_PROTO_TCP)) != 0) {
+		IOT_ERROR(" failed\n  ! mbedtls_net_connect returned -0x%x\n\n", -ret);
+		switch(ret) {
+			case MBEDTLS_ERR_NET_SOCKET_FAILED:
+				return NETWORK_ERR_NET_SOCKET_FAILED;
+			case MBEDTLS_ERR_NET_UNKNOWN_HOST:
+				return NETWORK_ERR_NET_UNKNOWN_HOST;
+			case MBEDTLS_ERR_NET_CONNECT_FAILED:
+			default:
+				return NETWORK_ERR_NET_CONNECT_FAILED;
+		};
+	}
+
+	ret = mbedtls_net_set_block(&(tlsDataParams->server_fd));
+	if(ret != 0) {
+		IOT_ERROR(" failed\n  ! net_set_(non)block() returned -0x%x\n\n", -ret);
+		return SSL_CONNECTION_ERROR;
+	} IOT_DEBUG(" ok\n");
+
+	IOT_DEBUG("  . Setting up the SSL/TLS structure...");
+	if((ret = mbedtls_ssl_config_defaults(&(tlsDataParams->conf), MBEDTLS_SSL_IS_CLIENT, MBEDTLS_SSL_TRANSPORT_STREAM,
+										  MBEDTLS_SSL_PRESET_DEFAULT)) != 0) {
+		IOT_ERROR(" failed\n  ! mbedtls_ssl_config_defaults returned -0x%x\n\n", -ret);
+		return SSL_CONNECTION_ERROR;
+	}
+
+	mbedtls_ssl_conf_verify(&(tlsDataParams->conf), _iot_tls_verify_cert, NULL);
+	if(pNetwork->tlsConnectParams.ServerVerificationFlag == true) {
+		mbedtls_ssl_conf_authmode(&(tlsDataParams->conf), MBEDTLS_SSL_VERIFY_REQUIRED);
+	} else {
+		mbedtls_ssl_conf_authmode(&(tlsDataParams->conf), MBEDTLS_SSL_VERIFY_OPTIONAL);
+	}
+	mbedtls_ssl_conf_rng(&(tlsDataParams->conf), mbedtls_ctr_drbg_random, &(tlsDataParams->ctr_drbg));
+
+	mbedtls_ssl_conf_ca_chain(&(tlsDataParams->conf), &(tlsDataParams->cacert), NULL);
+	if((ret = mbedtls_ssl_conf_own_cert(&(tlsDataParams->conf), &(tlsDataParams->clicert), &(tlsDataParams->pkey))) !=
+	   0) {
+		IOT_ERROR(" failed\n  ! mbedtls_ssl_conf_own_cert returned %d\n\n", ret);
+		return SSL_CONNECTION_ERROR;
+	}
+
+	mbedtls_ssl_conf_read_timeout(&(tlsDataParams->conf), pNetwork->tlsConnectParams.timeout_ms);
+
+	if((ret = mbedtls_ssl_setup(&(tlsDataParams->ssl), &(tlsDataParams->conf))) != 0) {
+		IOT_ERROR(" failed\n  ! mbedtls_ssl_setup returned -0x%x\n\n", -ret);
+		return SSL_CONNECTION_ERROR;
+	}
+	if((ret = mbedtls_ssl_set_hostname(&(tlsDataParams->ssl), pNetwork->tlsConnectParams.pDestinationURL)) != 0) {
+		IOT_ERROR(" failed\n  ! mbedtls_ssl_set_hostname returned %d\n\n", ret);
+		return SSL_CONNECTION_ERROR;
+	}
+	IOT_DEBUG("\n\nSSL state connect : %d ", tlsDataParams->ssl.state);
+	mbedtls_ssl_set_bio(&(tlsDataParams->ssl), &(tlsDataParams->server_fd), mbedtls_net_send, NULL,
+						mbedtls_net_recv_timeout);
+	IOT_DEBUG(" ok\n");
+
+	IOT_DEBUG("\n\nSSL state connect : %d ", tlsDataParams->ssl.state);
+	IOT_DEBUG("  . Performing the SSL/TLS handshake...");
+	while((ret = mbedtls_ssl_handshake(&(tlsDataParams->ssl))) != 0) {
+		if(ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
+			IOT_ERROR(" failed\n  ! mbedtls_ssl_handshake returned -0x%x\n", -ret);
+			if(ret == MBEDTLS_ERR_X509_CERT_VERIFY_FAILED) {
+				IOT_ERROR("    Unable to verify the server's certificate. "
+							  "Either it is invalid,\n"
+							  "    or you didn't set ca_file or ca_path "
+							  "to an appropriate value.\n"
+							  "    Alternatively, you may want to use "
+							  "auth_mode=optional for testing purposes.\n");
+			}
+			return SSL_CONNECTION_ERROR;
+		}
+	}
+
+	IOT_DEBUG(" ok\n    [ Protocol is %s ]\n    [ Ciphersuite is %s ]\n", mbedtls_ssl_get_version(&(tlsDataParams->ssl)),
+		  mbedtls_ssl_get_ciphersuite(&(tlsDataParams->ssl)));
+	if((ret = mbedtls_ssl_get_record_expansion(&(tlsDataParams->ssl))) >= 0) {
+		IOT_DEBUG("    [ Record expansion is %d ]\n", ret);
+	} else {
+		IOT_DEBUG("    [ Record expansion is unknown (compression) ]\n");
+	}
+
+	IOT_DEBUG("  . Verifying peer X.509 certificate...");
+
+	if(pNetwork->tlsConnectParams.ServerVerificationFlag == true) {
+		if((tlsDataParams->flags = mbedtls_ssl_get_verify_result(&(tlsDataParams->ssl))) != 0) {
+			IOT_ERROR(" failed\n");
+			mbedtls_x509_crt_verify_info(vrfy_buf, sizeof(vrfy_buf), "  ! ", tlsDataParams->flags);
+			IOT_ERROR("%s\n", vrfy_buf);
+			ret = SSL_CONNECTION_ERROR;
+		} else {
+			IOT_DEBUG(" ok\n");
+			ret = SUCCESS;
+		}
+	} else {
+		IOT_DEBUG(" Server Verification skipped\n");
+		ret = SUCCESS;
+	}
+
+#ifdef IOT_DEBUG
+	if (mbedtls_ssl_get_peer_cert(&(tlsDataParams->ssl)) != NULL) {
+		IOT_DEBUG("  . Peer certificate information    ...\n");
+		mbedtls_x509_crt_info((char *) buf, sizeof(buf) - 1, "      ", mbedtls_ssl_get_peer_cert(&(tlsDataParams->ssl)));
+		IOT_DEBUG("%s\n", buf);
+	}
+#endif
+
+	mbedtls_ssl_conf_read_timeout(&(tlsDataParams->conf), IOT_SSL_READ_TIMEOUT);
+
+	return (IoT_Error_t) ret;
+}
+
+IoT_Error_t iot_tls_write(Network *pNetwork, unsigned char *pMsg, size_t len, Timer *timer, size_t *written_len) {
+	size_t written_so_far;
+	bool isErrorFlag = false;
+	int frags, ret;
+	TLSDataParams *tlsDataParams = &(pNetwork->tlsDataParams);
+
+	for(written_so_far = 0, frags = 0;
+		written_so_far < len && !has_timer_expired(timer); written_so_far += ret, frags++) {
+		while(!has_timer_expired(timer) &&
+			  (ret = mbedtls_ssl_write(&(tlsDataParams->ssl), pMsg + written_so_far, len - written_so_far)) <= 0) {
+			if(ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
+				IOT_ERROR(" failed\n  ! mbedtls_ssl_write returned -0x%x\n\n", -ret);
+				/* All other negative return values indicate connection needs to be reset.
+		 		* Will be caught in ping request so ignored here */
+				isErrorFlag = true;
+				break;
+			}
+		}
+		if(isErrorFlag) {
+			break;
+		}
+	}
+
+	*written_len = written_so_far;
+
+	if(isErrorFlag) {
+		return NETWORK_SSL_WRITE_ERROR;
+	} else if(has_timer_expired(timer) && written_so_far != len) {
+		return NETWORK_SSL_WRITE_TIMEOUT_ERROR;
+	}
+
+	return SUCCESS;
+}
+
+IoT_Error_t iot_tls_read(Network *pNetwork, unsigned char *pMsg, size_t len, Timer *timer, size_t *read_len) {
+	mbedtls_ssl_context *ssl = &(pNetwork->tlsDataParams.ssl);
+	size_t rxLen = 0;
+	int ret;
+
+	while (len > 0) {
+		// This read will timeout after IOT_SSL_READ_TIMEOUT if there's no data to be read
+		ret = mbedtls_ssl_read(ssl, pMsg, len);
+		if (ret > 0) {
+			rxLen += ret;
+			pMsg += ret;
+			len -= ret;
+		} else if (ret == 0 || (ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE && ret != MBEDTLS_ERR_SSL_TIMEOUT)) {
+			return NETWORK_SSL_READ_ERROR;
+		}
+
+		// Evaluate timeout after the read to make sure read is done at least once
+		if (has_timer_expired(timer)) {
+			break;
+		}
+	}
+
+	if (len == 0) {
+		*read_len = rxLen;
+		return SUCCESS;
+	}
+
+	if (rxLen == 0) {
+		return NETWORK_SSL_NOTHING_TO_READ;
+	} else {
+		return NETWORK_SSL_READ_TIMEOUT_ERROR;
+	}
+}
+
+IoT_Error_t iot_tls_disconnect(Network *pNetwork) {
+	mbedtls_ssl_context *ssl = &(pNetwork->tlsDataParams.ssl);
+	int ret = 0;
+	do {
+		ret = mbedtls_ssl_close_notify(ssl);
+	} while(ret == MBEDTLS_ERR_SSL_WANT_WRITE);
+
+	/* All other negative return values indicate connection needs to be reset.
+	 * No further action required since this is disconnect call */
+
+	return SUCCESS;
+}
+
+IoT_Error_t iot_tls_destroy(Network *pNetwork) {
+	TLSDataParams *tlsDataParams = &(pNetwork->tlsDataParams);
+
+	mbedtls_net_free(&(tlsDataParams->server_fd));
+
+	mbedtls_x509_crt_free(&(tlsDataParams->clicert));
+	mbedtls_x509_crt_free(&(tlsDataParams->cacert));
+	mbedtls_pk_free(&(tlsDataParams->pkey));
+	mbedtls_ssl_free(&(tlsDataParams->ssl));
+	mbedtls_ssl_config_free(&(tlsDataParams->conf));
+	mbedtls_ctr_drbg_free(&(tlsDataParams->ctr_drbg));
+	mbedtls_entropy_free(&(tlsDataParams->entropy));
+
+	return SUCCESS;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/platform/win32/mbedtls/network_platform.h
+++ b/platform/win32/mbedtls/network_platform.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2010-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#ifndef IOTSDKC_NETWORK_MBEDTLS_PLATFORM_H_H
+
+#include "mbedtls/config.h"
+
+#include "mbedtls/platform.h"
+#include "mbedtls/net.h"
+#include "mbedtls/ssl.h"
+#include "mbedtls/entropy.h"
+#include "mbedtls/ctr_drbg.h"
+#include "mbedtls/certs.h"
+#include "mbedtls/x509.h"
+#include "mbedtls/error.h"
+#include "mbedtls/debug.h"
+#include "mbedtls/timing.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief TLS Connection Parameters
+ *
+ * Defines a type containing TLS specific parameters to be passed down to the
+ * TLS networking layer to create a TLS secured socket.
+ */
+typedef struct _TLSDataParams {
+	mbedtls_entropy_context entropy;
+	mbedtls_ctr_drbg_context ctr_drbg;
+	mbedtls_ssl_context ssl;
+	mbedtls_ssl_config conf;
+	uint32_t flags;
+	mbedtls_x509_crt cacert;
+	mbedtls_x509_crt clicert;
+	mbedtls_pk_context pkey;
+	mbedtls_net_context server_fd;
+}TLSDataParams;
+
+#define IOTSDKC_NETWORK_MBEDTLS_PLATFORM_H_H
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //IOTSDKC_NETWORK_MBEDTLS_PLATFORM_H_H

--- a/platform/win32/pthread/threads_platform.h
+++ b/platform/win32/pthread/threads_platform.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2010-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "threads_interface.h"
+#ifdef _ENABLE_THREAD_SUPPORT_
+#ifndef IOTSDKC_THREADS_PLATFORM_H_H
+#define IOTSDKC_THREADS_PLATFORM_H_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <pthread.h>
+
+/**
+ * @brief Mutex Type
+ *
+ * definition of the Mutex	 struct. Platform specific
+ *
+ */
+struct _IoT_Mutex_t {
+	pthread_mutex_t lock;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* IOTSDKC_THREADS_PLATFORM_H_H */
+#endif /* _ENABLE_THREAD_SUPPORT_ */
+

--- a/platform/win32/pthread/threads_pthread_wrapper.c
+++ b/platform/win32/pthread/threads_pthread_wrapper.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2010-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "threads_platform.h"
+#ifdef _ENABLE_THREAD_SUPPORT_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Initialize the provided mutex
+ *
+ * Call this function to initialize the mutex
+ *
+ * @param IoT_Mutex_t - pointer to the mutex to be initialized
+ * @return IoT_Error_t - error code indicating result of operation
+ */
+IoT_Error_t aws_iot_thread_mutex_init(IoT_Mutex_t *pMutex) {
+	if(0 != pthread_mutex_init(&(pMutex->lock), NULL)) {
+		return MUTEX_INIT_ERROR;
+	}
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Lock the provided mutex
+ *
+ * Call this function to lock the mutex before performing a state change
+ * Blocking, thread will block until lock request fails
+ *
+ * @param IoT_Mutex_t - pointer to the mutex to be locked
+ * @return IoT_Error_t - error code indicating result of operation
+ */
+IoT_Error_t aws_iot_thread_mutex_lock(IoT_Mutex_t *pMutex) {
+int rc = pthread_mutex_lock(&(pMutex->lock));
+	if(0 != rc) {
+		return MUTEX_LOCK_ERROR;
+	}
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Try to lock the provided mutex
+ *
+ * Call this function to attempt to lock the mutex before performing a state change
+ * Non-Blocking, immediately returns with failure if lock attempt fails
+ *
+ * @param IoT_Mutex_t - pointer to the mutex to be locked
+ * @return IoT_Error_t - error code indicating result of operation
+ */
+IoT_Error_t aws_iot_thread_mutex_trylock(IoT_Mutex_t *pMutex) {
+int rc = pthread_mutex_trylock(&(pMutex->lock));
+	if(0 != rc) {
+		return MUTEX_LOCK_ERROR;
+	}
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Unlock the provided mutex
+ *
+ * Call this function to unlock the mutex before performing a state change
+ *
+ * @param IoT_Mutex_t - pointer to the mutex to be unlocked
+ * @return IoT_Error_t - error code indicating result of operation
+ */
+IoT_Error_t aws_iot_thread_mutex_unlock(IoT_Mutex_t *pMutex) {
+	if(0 != pthread_mutex_unlock(&(pMutex->lock))) {
+		return MUTEX_UNLOCK_ERROR;
+	}
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Destroy the provided mutex
+ *
+ * Call this function to destroy the mutex
+ *
+ * @param IoT_Mutex_t - pointer to the mutex to be destroyed
+ * @return IoT_Error_t - error code indicating result of operation
+ */
+IoT_Error_t aws_iot_thread_mutex_destroy(IoT_Mutex_t *pMutex) {
+	if(0 != pthread_mutex_destroy(&(pMutex->lock))) {
+		return MUTEX_DESTROY_ERROR;
+	}
+
+	return SUCCESS;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ENABLE_THREAD_SUPPORT_ */
+

--- a/samples/win32/shadow_sample/shadow_sample_console/shadow_sample_console.c
+++ b/samples/win32/shadow_sample/shadow_sample_console/shadow_sample_console.c
@@ -129,7 +129,8 @@ int main()
 
 	IOT_INFO("Shadow Init");
 	rc = aws_iot_shadow_init_ptr(&mqttClient, &sp);
-	if (SUCCESS != rc) {
+	if (SUCCESS != rc) 
+	{
 		IOT_ERROR("Shadow Connection Error");
 		return rc;
 	}
@@ -141,7 +142,8 @@ int main()
 
 	IOT_INFO("Shadow Connect");
 	rc = aws_iot_shadow_connect_ptr(&mqttClient, &scp);
-	if (SUCCESS != rc) {
+	if (SUCCESS != rc) 
+	{
 		IOT_ERROR("Shadow Connection Error");
 		return rc;
 	}
@@ -152,37 +154,46 @@ int main()
 	*  #AWS_IOT_MQTT_MAX_RECONNECT_WAIT_INTERVAL
 	*/
 	rc = aws_iot_shadow_set_autoreconnect_status_ptr(&mqttClient, true);
-	if (SUCCESS != rc) {
+	if (SUCCESS != rc) 
+	{
 		IOT_ERROR("Unable to set Auto Reconnect to true - %d", rc);
 		return rc;
 	}
 
 	rc = aws_iot_shadow_register_delta_ptr(&mqttClient, &windowActuator);
 
-	if (SUCCESS != rc) {
+	if (SUCCESS != rc) 
+	{
 		IOT_ERROR("Shadow Register Delta Error");
 	}
 	temperature = STARTING_ROOMTEMPERATURE;
 
 	// loop and publish a change in temperature
-	while (NETWORK_ATTEMPTING_RECONNECT == rc || NETWORK_RECONNECTED == rc || SUCCESS == rc) {
+	while (NETWORK_ATTEMPTING_RECONNECT == rc || NETWORK_RECONNECTED == rc || SUCCESS == rc) 
+	{
 		rc = aws_iot_shadow_yield_ptr(&mqttClient, 200);
-		if (NETWORK_ATTEMPTING_RECONNECT == rc) {
+		if (NETWORK_ATTEMPTING_RECONNECT == rc) 
+		{
 			Sleep(1);
 			// If the client is attempting to reconnect we will skip the rest of the loop.
 			continue;
 		}
+
 		IOT_INFO("\n=======================================================================================\n");
 		IOT_INFO("On Device: window state %s", windowOpen ? "true" : "false");
+
 		simulateRoomTemperature(&temperature);
 
 		rc = aws_iot_shadow_init_json_document_ptr(JsonDocumentBuffer, sizeOfJsonDocumentBuffer);
-		if (SUCCESS == rc) {
+		if (SUCCESS == rc) 
+		{
 			rc = aws_iot_shadow_add_reported_ptr(JsonDocumentBuffer, sizeOfJsonDocumentBuffer, 2, &temperatureHandler,
 				&windowActuator);
-			if (SUCCESS == rc) {
+			if (SUCCESS == rc) 
+			{
 				rc = aws_iot_finalize_json_document_ptr(JsonDocumentBuffer, sizeOfJsonDocumentBuffer);
-				if (SUCCESS == rc) {
+				if (SUCCESS == rc) 
+				{
 					IOT_INFO("Update Shadow: %s", JsonDocumentBuffer);
 					rc = aws_iot_shadow_update_ptr(&mqttClient, AWS_IOT_MY_THING_NAME, JsonDocumentBuffer, shadowUpdateStatusCallback, NULL, 4, true);
 				}
@@ -192,14 +203,16 @@ int main()
 		Sleep(3 * 1000);
 	}
 
-	if (SUCCESS != rc) {
+	if (SUCCESS != rc) 
+	{
 		IOT_ERROR("An error occurred in the loop %d", rc);
 	}
 
 	IOT_INFO("Disconnecting");
 	rc = aws_iot_shadow_disconnect_ptr(&mqttClient);
 
-	if (SUCCESS != rc) {
+	if (SUCCESS != rc) 
+	{
 		IOT_ERROR("Disconnect error %d", rc);
 	}
 
@@ -214,13 +227,16 @@ static void shadowUpdateStatusCallback(const char *pThingName, ShadowActions_t a
 	IOT_UNUSED(pReceivedJsonDocument);
 	IOT_UNUSED(pContextData);
 
-	if (SHADOW_ACK_TIMEOUT == status) {
+	if (SHADOW_ACK_TIMEOUT == status) 
+	{
 		IOT_INFO("Update Timeout--");
 	}
-	else if (SHADOW_ACK_REJECTED == status) {
+	else if (SHADOW_ACK_REJECTED == status) 
+	{
 		IOT_INFO("Update RejectedXX");
 	}
-	else if (SHADOW_ACK_ACCEPTED == status) {
+	else if (SHADOW_ACK_ACCEPTED == status) 
+	{
 		IOT_INFO("Update Accepted !!");
 	}
 }
@@ -228,10 +244,12 @@ static void shadowUpdateStatusCallback(const char *pThingName, ShadowActions_t a
 static void simulateRoomTemperature(float *pRoomTemperature) {
 	static float deltaChange;
 
-	if (*pRoomTemperature >= ROOMTEMPERATURE_UPPERLIMIT) {
+	if (*pRoomTemperature >= ROOMTEMPERATURE_UPPERLIMIT) 
+	{
 		deltaChange = -0.5f;
 	}
-	else if (*pRoomTemperature <= ROOMTEMPERATURE_LOWERLIMIT) {
+	else if (*pRoomTemperature <= ROOMTEMPERATURE_LOWERLIMIT) 
+	{
 		deltaChange = 0.5f;
 	}
 
@@ -242,7 +260,8 @@ static void windowActuate_Callback(const char *pJsonString, uint32_t JsonStringD
 	IOT_UNUSED(pJsonString);
 	IOT_UNUSED(JsonStringDataLen);
 
-	if (pContext != NULL) {
+	if (pContext != NULL) 
+	{
 		IOT_INFO("Delta - Window state changed to %d", *(bool *)(pContext->pData));
 	}
 }

--- a/samples/win32/shadow_sample/shadow_sample_console/shadow_sample_console.c
+++ b/samples/win32/shadow_sample/shadow_sample_console/shadow_sample_console.c
@@ -1,0 +1,248 @@
+/*
+* Copyright 2010-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+#include "targetver.h" 
+#define WIN32_LEAN_AND_MEAN 
+#include <windows.h>
+#include <stdio.h>
+#include <tchar.h>
+
+#include "aws_iot_config.h"
+#include "aws_iot_log.h"
+#include "aws_iot_version.h"
+#include "aws_iot_mqtt_client_interface.h"
+#include "aws_iot_mqtt_client.h"
+#include "aws_iot_shadow_interface.h"
+#include "aws_iot_shadow_json_data.h"
+
+#define ROOMTEMPERATURE_UPPERLIMIT 32.0f
+#define ROOMTEMPERATURE_LOWERLIMIT 25.0f
+#define STARTING_ROOMTEMPERATURE ROOMTEMPERATURE_LOWERLIMIT
+
+#define MAX_LENGTH_OF_UPDATE_JSON_BUFFER 200
+
+/*
+*  Function prototypes
+*/
+static void simulateRoomTemperature(float *pRoomTemperature);
+static void shadowUpdateStatusCallback(const char *pThingName, ShadowActions_t action, Shadow_Ack_Status_t status, const char *pReceivedJsonDocument, void *pContextData);
+static void windowActuate_Callback(const char *pJsonString, uint32_t JsonStringDataLen, jsonStruct_t *pContext);
+
+static AWS_IOT_SHADOW_INIT aws_iot_shadow_init_ptr = NULL;
+static AWS_IOT_SHADOW_CONNECT aws_iot_shadow_connect_ptr = NULL;
+static AWS_IOT_SHADOW_YIELD aws_iot_shadow_yield_ptr = NULL;
+static AWS_IOT_SHADOW_DISCONNECT aws_iot_shadow_disconnect_ptr = NULL;
+static AWS_IOT_SHADOW_UPDATE aws_iot_shadow_update_ptr = NULL;
+static AWS_IOT_SHADOW_GET aws_iot_shadow_get_ptr = NULL;
+static AWS_IOT_SHADOW_DELETE aws_iot_shadow_delete_ptr = NULL;
+static AWS_IOT_SHADOW_REGISTER_DELTA aws_iot_shadow_register_delta_ptr = NULL;
+static AWS_IOT_SHADOW_SET_AUTORECONNECT_STATUS aws_iot_shadow_set_autoreconnect_status_ptr = NULL;
+static AWS_IOT_SHADOW_INIT_JSON_DOCUMENT aws_iot_shadow_init_json_document_ptr = NULL;
+static AWS_IOT_SHADOW_ADD_DESIRED aws_iot_shadow_add_desired_ptr = NULL;
+static AWS_IOT_SHADOW_ADD_REPORTED aws_iot_shadow_add_reported_ptr = NULL;
+static AWS_IOT_FINALIZE_JSON_DOCUMENT aws_iot_finalize_json_document_ptr = NULL;
+
+enum { PATH_MAX = 512 };
+
+static char certDirectory[PATH_MAX + 1] = "..\\..\\..\\..\\certs";
+static char HostAddress[255] = AWS_IOT_MQTT_HOST;
+static uint32_t port = AWS_IOT_MQTT_PORT;
+static uint8_t numPubs = 5;
+
+int main()
+{
+	IoT_Error_t rc = FAILURE;
+	int32_t i = 0;
+
+	char JsonDocumentBuffer[MAX_LENGTH_OF_UPDATE_JSON_BUFFER];
+	size_t sizeOfJsonDocumentBuffer = sizeof(JsonDocumentBuffer) / sizeof(JsonDocumentBuffer[0]);
+	float temperature = 0.0;
+
+	bool windowOpen = false;
+	jsonStruct_t windowActuator;
+	windowActuator.cb = windowActuate_Callback;
+	windowActuator.pData = &windowOpen;
+	windowActuator.pKey = "windowOpen";
+	windowActuator.type = SHADOW_JSON_BOOL;
+
+	jsonStruct_t temperatureHandler;
+	temperatureHandler.cb = NULL;
+	temperatureHandler.pKey = "temperature";
+	temperatureHandler.pData = &temperature;
+	temperatureHandler.type = SHADOW_JSON_FLOAT;
+
+	char rootCA[PATH_MAX + 1];
+	char clientCRT[PATH_MAX + 1];
+	char clientKey[PATH_MAX + 1];
+	char CurrentWD[PATH_MAX + 1];
+
+	IOT_INFO("\nAWS IoT SDK Version %d.%d.%d-%s\n", VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH, VERSION_TAG);
+
+	GetCurrentDirectoryA(sizeof(CurrentWD), CurrentWD);
+	snprintf(rootCA, PATH_MAX + 1, "%s/%s/%s", CurrentWD, certDirectory, AWS_IOT_ROOT_CA_FILENAME);
+	snprintf(clientCRT, PATH_MAX + 1, "%s/%s/%s", CurrentWD, certDirectory, AWS_IOT_CERTIFICATE_FILENAME);
+	snprintf(clientKey, PATH_MAX + 1, "%s/%s/%s", CurrentWD, certDirectory, AWS_IOT_PRIVATE_KEY_FILENAME);
+
+	IOT_DEBUG("rootCA %s", rootCA);
+	IOT_DEBUG("clientCRT %s", clientCRT);
+	IOT_DEBUG("clientKey %s", clientKey);
+
+	HMODULE hModule = LoadLibraryA("aws-iot-sdk.dll");
+
+	aws_iot_shadow_init_ptr = (AWS_IOT_SHADOW_INIT)GetProcAddress(hModule, "aws_iot_shadow_init");;
+	aws_iot_shadow_connect_ptr = (AWS_IOT_SHADOW_CONNECT)GetProcAddress(hModule, "aws_iot_shadow_connect");;
+	aws_iot_shadow_yield_ptr = (AWS_IOT_SHADOW_YIELD)GetProcAddress(hModule, "aws_iot_shadow_yield");;
+	aws_iot_shadow_disconnect_ptr = (AWS_IOT_SHADOW_DISCONNECT)GetProcAddress(hModule, "aws_iot_shadow_disconnect");;
+	aws_iot_shadow_update_ptr = (AWS_IOT_SHADOW_UPDATE)GetProcAddress(hModule, "aws_iot_shadow_update");;
+	aws_iot_shadow_get_ptr = (AWS_IOT_SHADOW_GET)GetProcAddress(hModule, "aws_iot_shadow_get");;
+	aws_iot_shadow_delete_ptr = (AWS_IOT_SHADOW_DELETE)GetProcAddress(hModule, "aws_iot_shadow_delete");;
+	aws_iot_shadow_register_delta_ptr = (AWS_IOT_SHADOW_REGISTER_DELTA)GetProcAddress(hModule, "aws_iot_shadow_register_delta");
+	aws_iot_shadow_set_autoreconnect_status_ptr = (AWS_IOT_SHADOW_SET_AUTORECONNECT_STATUS)GetProcAddress(hModule, "aws_iot_shadow_set_autoreconnect_status");
+	aws_iot_shadow_init_json_document_ptr = (AWS_IOT_SHADOW_INIT_JSON_DOCUMENT)GetProcAddress(hModule, "aws_iot_shadow_init_json_document");
+	aws_iot_shadow_add_desired_ptr = (AWS_IOT_SHADOW_ADD_DESIRED)GetProcAddress(hModule, "aws_iot_shadow_add_desired");
+	aws_iot_shadow_add_reported_ptr = (AWS_IOT_SHADOW_ADD_REPORTED)GetProcAddress(hModule, "aws_iot_shadow_add_reported");
+	aws_iot_finalize_json_document_ptr = (AWS_IOT_FINALIZE_JSON_DOCUMENT)GetProcAddress(hModule, "aws_iot_finalize_json_document");
+
+	// initialize the mqtt client
+	AWS_IoT_Client mqttClient;
+
+	ShadowInitParameters_t sp = ShadowInitParametersDefault;
+	sp.pHost = AWS_IOT_MQTT_HOST;
+	sp.port = AWS_IOT_MQTT_PORT;
+	sp.pClientCRT = clientCRT;
+	sp.pClientKey = clientKey;
+	sp.pRootCA = rootCA;
+	sp.enableAutoReconnect = false;
+	sp.disconnectHandler = NULL;
+
+	IOT_INFO("Shadow Init");
+	rc = aws_iot_shadow_init_ptr(&mqttClient, &sp);
+	if (SUCCESS != rc) {
+		IOT_ERROR("Shadow Connection Error");
+		return rc;
+	}
+
+	ShadowConnectParameters_t scp = ShadowConnectParametersDefault;
+	scp.pMyThingName = AWS_IOT_MY_THING_NAME;
+	scp.pMqttClientId = AWS_IOT_MQTT_CLIENT_ID;
+	scp.mqttClientIdLen = (uint16_t)strlen(AWS_IOT_MQTT_CLIENT_ID);
+
+	IOT_INFO("Shadow Connect");
+	rc = aws_iot_shadow_connect_ptr(&mqttClient, &scp);
+	if (SUCCESS != rc) {
+		IOT_ERROR("Shadow Connection Error");
+		return rc;
+	}
+
+	/*
+	* Enable Auto Reconnect functionality. Minimum and Maximum time of Exponential backoff are set in aws_iot_config.h
+	*  #AWS_IOT_MQTT_MIN_RECONNECT_WAIT_INTERVAL
+	*  #AWS_IOT_MQTT_MAX_RECONNECT_WAIT_INTERVAL
+	*/
+	rc = aws_iot_shadow_set_autoreconnect_status_ptr(&mqttClient, true);
+	if (SUCCESS != rc) {
+		IOT_ERROR("Unable to set Auto Reconnect to true - %d", rc);
+		return rc;
+	}
+
+	rc = aws_iot_shadow_register_delta_ptr(&mqttClient, &windowActuator);
+
+	if (SUCCESS != rc) {
+		IOT_ERROR("Shadow Register Delta Error");
+	}
+	temperature = STARTING_ROOMTEMPERATURE;
+
+	// loop and publish a change in temperature
+	while (NETWORK_ATTEMPTING_RECONNECT == rc || NETWORK_RECONNECTED == rc || SUCCESS == rc) {
+		rc = aws_iot_shadow_yield_ptr(&mqttClient, 200);
+		if (NETWORK_ATTEMPTING_RECONNECT == rc) {
+			Sleep(1);
+			// If the client is attempting to reconnect we will skip the rest of the loop.
+			continue;
+		}
+		IOT_INFO("\n=======================================================================================\n");
+		IOT_INFO("On Device: window state %s", windowOpen ? "true" : "false");
+		simulateRoomTemperature(&temperature);
+
+		rc = aws_iot_shadow_init_json_document_ptr(JsonDocumentBuffer, sizeOfJsonDocumentBuffer);
+		if (SUCCESS == rc) {
+			rc = aws_iot_shadow_add_reported_ptr(JsonDocumentBuffer, sizeOfJsonDocumentBuffer, 2, &temperatureHandler,
+				&windowActuator);
+			if (SUCCESS == rc) {
+				rc = aws_iot_finalize_json_document_ptr(JsonDocumentBuffer, sizeOfJsonDocumentBuffer);
+				if (SUCCESS == rc) {
+					IOT_INFO("Update Shadow: %s", JsonDocumentBuffer);
+					rc = aws_iot_shadow_update_ptr(&mqttClient, AWS_IOT_MY_THING_NAME, JsonDocumentBuffer, shadowUpdateStatusCallback, NULL, 4, true);
+				}
+			}
+		}
+		IOT_INFO("*****************************************************************************************\n");
+		Sleep(3 * 1000);
+	}
+
+	if (SUCCESS != rc) {
+		IOT_ERROR("An error occurred in the loop %d", rc);
+	}
+
+	IOT_INFO("Disconnecting");
+	rc = aws_iot_shadow_disconnect_ptr(&mqttClient);
+
+	if (SUCCESS != rc) {
+		IOT_ERROR("Disconnect error %d", rc);
+	}
+
+	FreeLibrary(hModule);
+
+	return 0;
+}
+
+static void shadowUpdateStatusCallback(const char *pThingName, ShadowActions_t action, Shadow_Ack_Status_t status, const char *pReceivedJsonDocument, void *pContextData) {
+	IOT_UNUSED(pThingName);
+	IOT_UNUSED(action);
+	IOT_UNUSED(pReceivedJsonDocument);
+	IOT_UNUSED(pContextData);
+
+	if (SHADOW_ACK_TIMEOUT == status) {
+		IOT_INFO("Update Timeout--");
+	}
+	else if (SHADOW_ACK_REJECTED == status) {
+		IOT_INFO("Update RejectedXX");
+	}
+	else if (SHADOW_ACK_ACCEPTED == status) {
+		IOT_INFO("Update Accepted !!");
+	}
+}
+
+static void simulateRoomTemperature(float *pRoomTemperature) {
+	static float deltaChange;
+
+	if (*pRoomTemperature >= ROOMTEMPERATURE_UPPERLIMIT) {
+		deltaChange = -0.5f;
+	}
+	else if (*pRoomTemperature <= ROOMTEMPERATURE_LOWERLIMIT) {
+		deltaChange = 0.5f;
+	}
+
+	*pRoomTemperature += deltaChange;
+}
+
+static void windowActuate_Callback(const char *pJsonString, uint32_t JsonStringDataLen, jsonStruct_t *pContext) {
+	IOT_UNUSED(pJsonString);
+	IOT_UNUSED(JsonStringDataLen);
+
+	if (pContext != NULL) {
+		IOT_INFO("Delta - Window state changed to %d", *(bool *)(pContext->pData));
+	}
+}

--- a/samples/win32/shadow_sample/shadow_sample_console/shadow_sample_console.vcxproj
+++ b/samples/win32/shadow_sample/shadow_sample_console/shadow_sample_console.vcxproj
@@ -1,0 +1,159 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{602AFFEB-E907-425A-955E-35E0344915CB}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>shadow_sample_console</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;ENABLE_IOT_INFO;ENABLE_IOT_WARN;ENABLE_IOT_ERROR;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeaderFile />
+      <PrecompiledHeaderOutputFile />
+      <AdditionalIncludeDirectories>..\..\..\..\external_libs;..\..\..\..\external_libs\mbedTLS;..\..\..\..\external_libs\jsmn;..\..\..\..\platform\win32\common;..\..\..\..\platform\win32\mbedtls;..\..\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\..\..\..\platform\win32\aws-iot-sdk-dll\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeaderFile />
+      <PrecompiledHeaderOutputFile />
+      <AdditionalIncludeDirectories>..\..\..\..\external_libs;..\..\..\..\external_libs\mbedTLS;..\..\..\..\external_libs\jsmn;..\..\..\..\platform\win32\common;..\..\..\..\platform\win32\mbedtls;..\..\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\..\..\..\platform\win32\aws-iot-sdk-dll\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="targetver.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="shadow_sample_console.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/samples/win32/shadow_sample/shadow_sample_console/shadow_sample_console.vcxproj.filters
+++ b/samples/win32/shadow_sample/shadow_sample_console/shadow_sample_console.vcxproj.filters
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClInclude Include="targetver.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="shadow_sample_console.c" />
+  </ItemGroup>
+</Project>

--- a/samples/win32/shadow_sample/shadow_sample_console/targetver.h
+++ b/samples/win32/shadow_sample/shadow_sample_console/targetver.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// Including SDKDDKVer.h defines the highest available Windows platform.
+
+// If you wish to build your application for a previous Windows platform, include WinSDKVer.h and
+// set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
+
+#include <SDKDDKVer.h>

--- a/samples/win32/shadow_sample/shadow_sample_console/targetver.h
+++ b/samples/win32/shadow_sample/shadow_sample_console/targetver.h
@@ -1,4 +1,20 @@
-#pragma once
+/*
+* Copyright 2010-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+#ifndef _TARGETVER_H
+#define _TARGETVER_H
 
 // Including SDKDDKVer.h defines the highest available Windows platform.
 
@@ -6,3 +22,6 @@
 // set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
 
 #include <SDKDDKVer.h>
+
+#endif // _TARGETVER_H
+

--- a/samples/win32/subscribe_publish_sample/subscribe_publish_sample_console/subscribe_publish_sample_console.c
+++ b/samples/win32/subscribe_publish_sample/subscribe_publish_sample_console/subscribe_publish_sample_console.c
@@ -1,0 +1,255 @@
+/*
+* Copyright 2010-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+#include "targetver.h" 
+#define WIN32_LEAN_AND_MEAN 
+#include <windows.h>
+#include <stdio.h>
+#include <tchar.h>
+
+#include "aws_iot_config.h"
+#include "aws_iot_log.h"
+#include "aws_iot_version.h"
+#include "aws_iot_mqtt_client_interface.h"
+#include "aws_iot_mqtt_client.h"
+
+/*
+*  Function prototypes
+*/
+static void iot_subscribe_callback_handler(AWS_IoT_Client *pClient, char *topicName, uint16_t topicNameLen, IoT_Publish_Message_Params *params, void *pData);
+static void disconnectCallbackHandler(AWS_IoT_Client *pClient, void *data);
+
+static AWS_IOT_MQTT_INIT aws_iot_mqtt_init_ptr = NULL;
+static AWS_IOT_MQTT_CONNECT aws_iot_mqtt_connect_ptr = NULL;
+static AWS_IOT_MQTT_PUBLISH aws_iot_mqtt_publish_ptr = NULL;
+static AWS_IOT_MQTT_SUBSCRIBE aws_iot_mqtt_subscribe_ptr = NULL;
+static AWS_IOT_MQTT_RESUBSCRIBE aws_iot_mqtt_resubscribe_ptr = NULL;
+static AWS_IOT_MQTT_UNSUBSCRIBE aws_iot_mqtt_unsubscribe_ptr = NULL;
+static AWS_IOT_MQTT_DISCONNECT aws_iot_mqtt_disconnect_ptr = NULL;
+static AWS_IOT_MQTT_YIELD aws_iot_mqtt_yield_ptr = NULL;
+static AWS_IOT_MQTT_ATTEMPT_RECONNECT aws_iot_mqtt_attempt_reconnect_ptr = NULL;
+static AWS_IOT_MQTT_AUTORECONNECT_ENABLED aws_iot_is_autoreconnect_enabled_ptr = NULL;
+static AWS_IOT_MQTT_AUTORECONNECT_SET_STATUS aws_iot_mqtt_autoreconnect_set_status_ptr = NULL;
+
+enum { PATH_MAX = 512 };
+
+static char certDirectory[PATH_MAX + 1] = "..\\..\\..\\..\\certs";
+static char HostAddress[255] = AWS_IOT_MQTT_HOST;
+static uint32_t port = AWS_IOT_MQTT_PORT;
+static uint8_t numPubs = 5;
+
+int main()
+{
+	IoT_Error_t rc = FAILURE;
+	int32_t i = 0;
+
+	AWS_IoT_Client client;
+	IoT_Client_Init_Params mqttInitParams = iotClientInitParamsDefault;
+	IoT_Client_Connect_Params connectParams = iotClientConnectParamsDefault;
+
+	IoT_Publish_Message_Params paramsQOS0;
+	IoT_Publish_Message_Params paramsQOS1;
+
+	uint32_t publishCount = 2;
+	bool infinitePublishFlag = true;
+
+	char rootCA[PATH_MAX + 1];
+	char clientCRT[PATH_MAX + 1];
+	char clientKey[PATH_MAX + 1];
+	char CurrentWD[PATH_MAX + 1];
+	char cPayload[100];
+
+	IOT_INFO("\nAWS IoT SDK Version %d.%d.%d-%s\n", VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH, VERSION_TAG);
+
+	GetCurrentDirectoryA(sizeof(CurrentWD), CurrentWD);
+	snprintf(rootCA, PATH_MAX + 1, "%s/%s/%s", CurrentWD, certDirectory, AWS_IOT_ROOT_CA_FILENAME);
+	snprintf(clientCRT, PATH_MAX + 1, "%s/%s/%s", CurrentWD, certDirectory, AWS_IOT_CERTIFICATE_FILENAME);
+	snprintf(clientKey, PATH_MAX + 1, "%s/%s/%s", CurrentWD, certDirectory, AWS_IOT_PRIVATE_KEY_FILENAME);
+
+	IOT_DEBUG("rootCA %s", rootCA);
+	IOT_DEBUG("clientCRT %s", clientCRT);
+	IOT_DEBUG("clientKey %s", clientKey);
+
+	mqttInitParams.enableAutoReconnect = false; // We enable this later below
+	mqttInitParams.pHostURL = HostAddress;
+	mqttInitParams.port = port;
+	mqttInitParams.pRootCALocation = rootCA;
+	mqttInitParams.pDeviceCertLocation = clientCRT;
+	mqttInitParams.pDevicePrivateKeyLocation = clientKey;
+	mqttInitParams.mqttCommandTimeout_ms = 20000;
+	mqttInitParams.tlsHandshakeTimeout_ms = 5000;
+	mqttInitParams.isSSLHostnameVerify = true;
+	mqttInitParams.disconnectHandler = disconnectCallbackHandler;
+	mqttInitParams.disconnectHandlerData = NULL;
+
+	HMODULE hModule = LoadLibraryA("aws-iot-sdk.dll");
+
+	aws_iot_mqtt_init_ptr = (AWS_IOT_MQTT_INIT)GetProcAddress(hModule, "aws_iot_mqtt_init");
+	aws_iot_mqtt_connect_ptr = (AWS_IOT_MQTT_CONNECT)GetProcAddress(hModule, "aws_iot_mqtt_connect");
+	aws_iot_mqtt_publish_ptr = (AWS_IOT_MQTT_PUBLISH)GetProcAddress(hModule, "aws_iot_mqtt_publish");
+	aws_iot_mqtt_subscribe_ptr = (AWS_IOT_MQTT_SUBSCRIBE)GetProcAddress(hModule, "aws_iot_mqtt_subscribe");
+	aws_iot_mqtt_resubscribe_ptr = (AWS_IOT_MQTT_RESUBSCRIBE)GetProcAddress(hModule, "aws_iot_mqtt_resubscribe");
+	aws_iot_mqtt_unsubscribe_ptr = (AWS_IOT_MQTT_UNSUBSCRIBE)GetProcAddress(hModule, "aws_iot_mqtt_unsubscribe");
+	aws_iot_mqtt_disconnect_ptr = (AWS_IOT_MQTT_DISCONNECT)GetProcAddress(hModule, "aws_iot_mqtt_disconnect");
+	aws_iot_mqtt_yield_ptr = (AWS_IOT_MQTT_YIELD)GetProcAddress(hModule, "aws_iot_mqtt_yield");
+	aws_iot_mqtt_attempt_reconnect_ptr = (AWS_IOT_MQTT_ATTEMPT_RECONNECT)GetProcAddress(hModule, "aws_iot_mqtt_attempt_reconnect");
+	aws_iot_is_autoreconnect_enabled_ptr = (AWS_IOT_MQTT_AUTORECONNECT_ENABLED)GetProcAddress(hModule, "aws_iot_is_autoreconnect_enabled");
+	aws_iot_mqtt_autoreconnect_set_status_ptr = (AWS_IOT_MQTT_AUTORECONNECT_SET_STATUS)GetProcAddress(hModule, "aws_iot_mqtt_autoreconnect_set_status");
+
+	rc = aws_iot_mqtt_init_ptr(&client, &mqttInitParams);
+	if (SUCCESS != rc) 
+	{
+		IOT_ERROR("aws_iot_mqtt_init returned error : %d ", rc);
+		return rc;
+	}
+
+	connectParams.keepAliveIntervalInSec = 10;
+	connectParams.isCleanSession = true;
+	connectParams.MQTTVersion = MQTT_3_1_1;
+	connectParams.pClientID = AWS_IOT_MQTT_CLIENT_ID;
+	connectParams.clientIDLen = (uint16_t)strlen(AWS_IOT_MQTT_CLIENT_ID);
+	connectParams.isWillMsgPresent = false;
+
+	IOT_INFO("Connecting...");
+	rc = aws_iot_mqtt_connect_ptr(&client, &connectParams);
+	if (SUCCESS != rc) 
+	{
+		IOT_ERROR("Error(%d) connecting to %s:%d", rc, mqttInitParams.pHostURL, mqttInitParams.port);
+		return rc;
+	}
+
+	/*
+	* Enable Auto Reconnect functionality. Minimum and Maximum time of Exponential backoff are set in aws_iot_config.h
+	*  #AWS_IOT_MQTT_MIN_RECONNECT_WAIT_INTERVAL
+	*  #AWS_IOT_MQTT_MAX_RECONNECT_WAIT_INTERVAL
+	*/
+	rc = aws_iot_mqtt_autoreconnect_set_status_ptr(&client, true);
+	if (SUCCESS != rc) 
+	{
+		IOT_ERROR("Unable to set Auto Reconnect to true - %d", rc);
+		return rc;
+	}
+
+	//IOT_INFO("Subscribing...");
+	//rc = aws_iot_mqtt_subscribe_ptr(&client, "AVR-CAN", 11, QOS0, iot_subscribe_callback_handler, NULL);
+	//if (SUCCESS != rc) {
+	//	IOT_ERROR("Error subscribing : %d ", rc);
+	//	return rc;
+	//}
+
+	sprintf_s(cPayload, 100, "%s : %d ", "Hello from Win32 subscribe_publish_sample", i);
+
+	paramsQOS0.qos = QOS0;
+	paramsQOS0.payload = (void *)cPayload;
+	paramsQOS0.isRetained = 0;
+
+	paramsQOS1.qos = QOS1;
+	paramsQOS1.payload = (void *)cPayload;
+	paramsQOS1.isRetained = 0;
+
+	if (publishCount != 0) 
+	{
+		infinitePublishFlag = false;
+	}
+
+	while ((NETWORK_ATTEMPTING_RECONNECT == rc || NETWORK_RECONNECTED == rc || SUCCESS == rc)
+		&& (publishCount > 0 || infinitePublishFlag)) 
+	{
+		//Max time the yield function will wait for read messages
+		rc = aws_iot_mqtt_yield_ptr(&client, 100);
+		if (NETWORK_ATTEMPTING_RECONNECT == rc) 
+		{
+			// If the client is attempting to reconnect we will skip the rest of the loop.
+			continue;
+		}
+
+		IOT_INFO("-->sleep");
+		Sleep(1);
+		sprintf_s(cPayload, 100, "%s : %d ", "Hello from Win32 subscribe_publish_sample QOS0", i++);
+		IOT_INFO(cPayload);
+		paramsQOS0.payloadLen = strlen(cPayload);
+		rc = aws_iot_mqtt_publish_ptr(&client, "WIN32_SUB_PUB", 11, &paramsQOS0);
+		if (publishCount > 0) 
+		{
+			publishCount--;
+		}
+
+		sprintf_s(cPayload, 100, "%s : %d ", "Hello from Win32 subscribe_publish_sample QOS1", i++);
+		paramsQOS1.payloadLen = strlen(cPayload);
+		rc = aws_iot_mqtt_publish_ptr(&client, "WIN32_SUB-_PUB", 11, &paramsQOS1);
+		if (rc == MQTT_REQUEST_TIMEOUT_ERROR) 
+		{
+			IOT_WARN("QOS1 publish ack not received.\n");
+			rc = SUCCESS;
+		}
+		if (publishCount > 0) 
+		{
+			publishCount--;
+		}
+	}
+
+	if (SUCCESS != rc) 
+	{
+		IOT_ERROR("An error occurred in the loop.\n");
+	}
+	else {
+		IOT_INFO("Publish done\n");
+	}
+
+	FreeLibrary(hModule);
+
+	return 0;
+}
+
+void iot_subscribe_callback_handler(AWS_IoT_Client *pClient, char *topicName, uint16_t topicNameLen,
+	IoT_Publish_Message_Params *params, void *pData) 
+{
+	IOT_UNUSED(pData);
+	IOT_UNUSED(pClient);
+	IOT_INFO("Subscribe callback");
+	IOT_INFO("%.*s\t%.*s", topicNameLen, topicName, (int)params->payloadLen, (char*)params->payload);
+}
+
+void disconnectCallbackHandler(AWS_IoT_Client *pClient, void *data) 
+{
+	IOT_WARN("MQTT Disconnect");
+	IoT_Error_t rc = FAILURE;
+
+	if (NULL == pClient)
+	{
+		return;
+	}
+
+	IOT_UNUSED(data);
+
+	if (aws_iot_is_autoreconnect_enabled_ptr(pClient))
+	{
+		IOT_INFO("Auto Reconnect is enabled, Reconnecting attempt will start now");
+	}
+	else
+	{
+		IOT_WARN("Auto Reconnect not enabled. Starting manual reconnect...");
+		rc = aws_iot_mqtt_attempt_reconnect_ptr(pClient);
+		if (NETWORK_RECONNECTED == rc)
+		{
+			IOT_WARN("Manual Reconnect Successful");
+		}
+		else
+		{
+			IOT_WARN("Manual Reconnect Failed - %d", rc);
+		}
+	}
+}
+

--- a/samples/win32/subscribe_publish_sample/subscribe_publish_sample_console/subscribe_publish_sample_console.c
+++ b/samples/win32/subscribe_publish_sample/subscribe_publish_sample_console/subscribe_publish_sample_console.c
@@ -62,7 +62,7 @@ int main()
 	IoT_Publish_Message_Params paramsQOS0;
 	IoT_Publish_Message_Params paramsQOS1;
 
-	uint32_t publishCount = 2;
+	uint32_t publishCount = 0;
 	bool infinitePublishFlag = true;
 
 	char rootCA[PATH_MAX + 1];
@@ -176,19 +176,20 @@ int main()
 		}
 
 		IOT_INFO("-->sleep");
-		Sleep(1);
+		Sleep(1000);
 		sprintf_s(cPayload, 100, "%s : %d ", "Hello from Win32 subscribe_publish_sample QOS0", i++);
 		IOT_INFO(cPayload);
 		paramsQOS0.payloadLen = strlen(cPayload);
-		rc = aws_iot_mqtt_publish_ptr(&client, "WIN32_SUB_PUB", 11, &paramsQOS0);
+		rc = aws_iot_mqtt_publish_ptr(&client, "WIN32_SUB_PUB", 13, &paramsQOS0);
 		if (publishCount > 0) 
 		{
 			publishCount--;
 		}
 
 		sprintf_s(cPayload, 100, "%s : %d ", "Hello from Win32 subscribe_publish_sample QOS1", i++);
+		IOT_INFO(cPayload);
 		paramsQOS1.payloadLen = strlen(cPayload);
-		rc = aws_iot_mqtt_publish_ptr(&client, "WIN32_SUB-_PUB", 11, &paramsQOS1);
+		rc = aws_iot_mqtt_publish_ptr(&client, "WIN32_SUB_PUB", 13, &paramsQOS1);
 		if (rc == MQTT_REQUEST_TIMEOUT_ERROR) 
 		{
 			IOT_WARN("QOS1 publish ack not received.\n");

--- a/samples/win32/subscribe_publish_sample/subscribe_publish_sample_console/subscribe_publish_sample_console.vcxproj
+++ b/samples/win32/subscribe_publish_sample/subscribe_publish_sample_console/subscribe_publish_sample_console.vcxproj
@@ -19,9 +19,9 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{602AFFEB-E907-425A-955E-35E0344915CB}</ProjectGuid>
+    <ProjectGuid>{4367393A-0814-476A-B13B-ABCD6C16EFCA}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <RootNamespace>shadow_sample_console</RootNamespace>
+    <RootNamespace>subscribe_publish_sample_console</RootNamespace>
     <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -87,15 +87,14 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;ENABLE_IOT_INFO;ENABLE_IOT_WARN;ENABLE_IOT_ERROR;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PrecompiledHeaderFile />
-      <PrecompiledHeaderOutputFile />
+      <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\..\..\..\external_libs;..\..\..\..\external_libs\mbedTLS;..\..\..\..\external_libs\jsmn;..\..\..\..\platform\win32\common;..\..\..\..\platform\win32\mbedtls;..\..\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>..\..\..\..\platform\win32\aws-iot-sdk-dll\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\platform\win32\aws-iot-sdk-dll\Debug</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -105,6 +104,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -119,8 +119,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PrecompiledHeaderFile />
-      <PrecompiledHeaderOutputFile />
+      <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\..\..\..\external_libs;..\..\..\..\external_libs\mbedTLS;..\..\..\..\external_libs\jsmn;..\..\..\..\platform\win32\common;..\..\..\..\platform\win32\mbedtls;..\..\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
@@ -129,7 +128,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>..\..\..\..\platform\win32\aws-iot-sdk-dll\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\platform\win32\aws-iot-sdk-dll\Release</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -141,6 +140,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -153,7 +153,7 @@
     <ClInclude Include="targetver.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="shadow_sample_console.c" />
+    <ClCompile Include="subscribe_publish_sample_console.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/samples/win32/subscribe_publish_sample/subscribe_publish_sample_console/subscribe_publish_sample_console.vcxproj.filters
+++ b/samples/win32/subscribe_publish_sample/subscribe_publish_sample_console/subscribe_publish_sample_console.vcxproj.filters
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClInclude Include="targetver.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="subscribe_publish_sample_console.c" />
+  </ItemGroup>
+</Project>

--- a/samples/win32/subscribe_publish_sample/subscribe_publish_sample_console/targetver.h
+++ b/samples/win32/subscribe_publish_sample/subscribe_publish_sample_console/targetver.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// Including SDKDDKVer.h defines the highest available Windows platform.
+
+// If you wish to build your application for a previous Windows platform, include WinSDKVer.h and
+// set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
+
+#include <SDKDDKVer.h>

--- a/src/aws_iot_mqtt_client.c
+++ b/src/aws_iot_mqtt_client.c
@@ -152,7 +152,7 @@ IoT_Error_t aws_iot_mqtt_set_connect_params(AWS_IoT_Client *pClient, IoT_Client_
 	FUNC_EXIT_RC(SUCCESS);
 }
 
-IoT_Error_t aws_iot_mqtt_init(AWS_IoT_Client *pClient, IoT_Client_Init_Params *pInitParams) {
+AWSIOTSDK_API IoT_Error_t aws_iot_mqtt_init(AWS_IoT_Client *pClient, IoT_Client_Init_Params *pInitParams) {
 	uint32_t i;
 	IoT_Error_t rc;
 	IoT_Client_Connect_Params default_options = IoT_Client_Connect_Params_initializer;
@@ -265,7 +265,7 @@ bool aws_iot_mqtt_is_client_connected(AWS_IoT_Client *pClient) {
 	FUNC_EXIT_RC(isConnected);
 }
 
-bool aws_iot_is_autoreconnect_enabled(AWS_IoT_Client *pClient) {
+AWSIOTSDK_API bool aws_iot_is_autoreconnect_enabled(AWS_IoT_Client *pClient) {
 	FUNC_ENTRY;
 	if(NULL == pClient) {
 		IOT_WARN(" Client is null! ");
@@ -275,7 +275,7 @@ bool aws_iot_is_autoreconnect_enabled(AWS_IoT_Client *pClient) {
 	FUNC_EXIT_RC(pClient->clientStatus.isAutoReconnectEnabled);
 }
 
-IoT_Error_t aws_iot_mqtt_autoreconnect_set_status(AWS_IoT_Client *pClient, bool newStatus) {
+AWSIOTSDK_API IoT_Error_t aws_iot_mqtt_autoreconnect_set_status(AWS_IoT_Client *pClient, bool newStatus) {
 	FUNC_ENTRY;
 	if(NULL == pClient) {
 		FUNC_EXIT_RC(NULL_VALUE_ERROR);

--- a/src/aws_iot_mqtt_client_common_internal.c
+++ b/src/aws_iot_mqtt_client_common_internal.c
@@ -41,7 +41,9 @@ extern "C" {
 #endif
 
 #include <aws_iot_mqtt_client.h>
+#ifndef WIN32
 #include <unistd.h>
+#endif
 #include "aws_iot_mqtt_client_common_internal.h"
 
 /* Max length of packet header */

--- a/src/aws_iot_mqtt_client_connect.c
+++ b/src/aws_iot_mqtt_client_connect.c
@@ -448,7 +448,7 @@ static IoT_Error_t _aws_iot_mqtt_internal_connect(AWS_IoT_Client *pClient, IoT_C
  *
  * @return An IoT Error Type defining successful/failed connection
  */
-IoT_Error_t aws_iot_mqtt_connect(AWS_IoT_Client *pClient, IoT_Client_Connect_Params *pConnectParams) {
+AWSIOTSDK_API IoT_Error_t aws_iot_mqtt_connect(AWS_IoT_Client *pClient, IoT_Client_Connect_Params *pConnectParams) {
 	IoT_Error_t rc, disconRc;
 	ClientState clientState;
 
@@ -540,7 +540,7 @@ IoT_Error_t _aws_iot_mqtt_internal_disconnect(AWS_IoT_Client *pClient) {
  *
  * @return An IoT Error Type defining successful/failed send of the disconnect control packet.
  */
-IoT_Error_t aws_iot_mqtt_disconnect(AWS_IoT_Client *pClient) {
+AWSIOTSDK_API IoT_Error_t aws_iot_mqtt_disconnect(AWS_IoT_Client *pClient) {
 	ClientState clientState;
 	IoT_Error_t rc;
 
@@ -586,7 +586,7 @@ IoT_Error_t aws_iot_mqtt_disconnect(AWS_IoT_Client *pClient) {
  *
  * @return An IoT Error Type defining successful/failed connection
  */
-IoT_Error_t aws_iot_mqtt_attempt_reconnect(AWS_IoT_Client *pClient) {
+AWSIOTSDK_API IoT_Error_t aws_iot_mqtt_attempt_reconnect(AWS_IoT_Client *pClient) {
 	IoT_Error_t rc;
 
 	FUNC_ENTRY;

--- a/src/aws_iot_mqtt_client_publish.c
+++ b/src/aws_iot_mqtt_client_publish.c
@@ -259,7 +259,7 @@ static IoT_Error_t _aws_iot_mqtt_internal_publish(AWS_IoT_Client *pClient, const
  *
  * @return An IoT Error Type defining successful/failed publish
  */
-IoT_Error_t aws_iot_mqtt_publish(AWS_IoT_Client *pClient, const char *pTopicName, uint16_t topicNameLen,
+AWSIOTSDK_API IoT_Error_t aws_iot_mqtt_publish(AWS_IoT_Client *pClient, const char *pTopicName, uint16_t topicNameLen,
 								 IoT_Publish_Message_Params *pParams) {
 	IoT_Error_t rc, pubRc;
 	ClientState clientState;

--- a/src/aws_iot_mqtt_client_subscribe.c
+++ b/src/aws_iot_mqtt_client_subscribe.c
@@ -285,7 +285,7 @@ static IoT_Error_t _aws_iot_mqtt_internal_subscribe(AWS_IoT_Client *pClient, con
  *
  * @return An IoT Error Type defining successful/failed subscription
  */
-IoT_Error_t aws_iot_mqtt_subscribe(AWS_IoT_Client *pClient, const char *pTopicName, uint16_t topicNameLen,
+AWSIOTSDK_API IoT_Error_t aws_iot_mqtt_subscribe(AWS_IoT_Client *pClient, const char *pTopicName, uint16_t topicNameLen,
 								   QoS qos, pApplicationHandler_t pApplicationHandler, void *pApplicationHandlerData) {
 	ClientState clientState;
 	IoT_Error_t rc, subRc;
@@ -397,7 +397,7 @@ static IoT_Error_t _aws_iot_mqtt_internal_resubscribe(AWS_IoT_Client *pClient) {
  *
  * @return An IoT Error Type defining successful/failed subscription
  */
-IoT_Error_t aws_iot_mqtt_resubscribe(AWS_IoT_Client *pClient) {
+AWSIOTSDK_API IoT_Error_t aws_iot_mqtt_resubscribe(AWS_IoT_Client *pClient) {
 	IoT_Error_t rc, resubRc;
 
 	FUNC_ENTRY;

--- a/src/aws_iot_mqtt_client_unsubscribe.c
+++ b/src/aws_iot_mqtt_client_unsubscribe.c
@@ -210,7 +210,7 @@ static IoT_Error_t _aws_iot_mqtt_internal_unsubscribe(AWS_IoT_Client *pClient, c
  *
  * @return An IoT Error Type defining successful/failed unsubscribe call
  */
-IoT_Error_t aws_iot_mqtt_unsubscribe(AWS_IoT_Client *pClient, const char *pTopicFilter, uint16_t topicFilterLen) {
+AWSIOTSDK_API IoT_Error_t aws_iot_mqtt_unsubscribe(AWS_IoT_Client *pClient, const char *pTopicFilter, uint16_t topicFilterLen) {
 	IoT_Error_t rc, unsubRc;
 	ClientState clientState;
 

--- a/src/aws_iot_mqtt_client_yield.c
+++ b/src/aws_iot_mqtt_client_yield.c
@@ -258,7 +258,7 @@ static IoT_Error_t _aws_iot_mqtt_internal_yield(AWS_IoT_Client *pClient, uint32_
  *         If this call results in an error it is likely the MQTT connection has dropped.
  *         iot_is_mqtt_connected can be called to confirm.
  */
-IoT_Error_t aws_iot_mqtt_yield(AWS_IoT_Client *pClient, uint32_t timeout_ms) {
+AWSIOTSDK_API IoT_Error_t aws_iot_mqtt_yield(AWS_IoT_Client *pClient, uint32_t timeout_ms) {
 	IoT_Error_t rc, yieldRc;
 	ClientState clientState;
 

--- a/src/aws_iot_shadow.c
+++ b/src/aws_iot_shadow.c
@@ -54,7 +54,7 @@ void aws_iot_shadow_disable_discard_old_delta_msgs(void) {
 	shadowDiscardOldDeltaFlag = false;
 }
 
-IoT_Error_t aws_iot_shadow_init(AWS_IoT_Client *pClient, ShadowInitParameters_t *pParams) {
+AWSIOTSDK_API IoT_Error_t aws_iot_shadow_init(AWS_IoT_Client *pClient, ShadowInitParameters_t *pParams) {
 	IoT_Client_Init_Params mqttInitParams;
 	IoT_Error_t rc;
 
@@ -87,7 +87,7 @@ IoT_Error_t aws_iot_shadow_init(AWS_IoT_Client *pClient, ShadowInitParameters_t 
 	FUNC_EXIT_RC(SUCCESS);
 }
 
-IoT_Error_t aws_iot_shadow_connect(AWS_IoT_Client *pClient, ShadowConnectParameters_t *pParams) {
+AWSIOTSDK_API IoT_Error_t aws_iot_shadow_connect(AWS_IoT_Client *pClient, ShadowConnectParameters_t *pParams) {
 	IoT_Error_t rc = SUCCESS;
 	char deleteAcceptedTopic[MAX_SHADOW_TOPIC_LENGTH_BYTES];
 	uint16_t deleteAcceptedTopicLen;
@@ -128,7 +128,7 @@ IoT_Error_t aws_iot_shadow_connect(AWS_IoT_Client *pClient, ShadowConnectParamet
 	FUNC_EXIT_RC(rc);
 }
 
-IoT_Error_t aws_iot_shadow_register_delta(AWS_IoT_Client *pMqttClient, jsonStruct_t *pStruct) {
+AWSIOTSDK_API IoT_Error_t aws_iot_shadow_register_delta(AWS_IoT_Client *pMqttClient, jsonStruct_t *pStruct) {
 	if(NULL == pMqttClient || NULL == pStruct) {
 		return NULL_VALUE_ERROR;
 	}
@@ -140,7 +140,7 @@ IoT_Error_t aws_iot_shadow_register_delta(AWS_IoT_Client *pMqttClient, jsonStruc
 	return registerJsonTokenOnDelta(pStruct);
 }
 
-IoT_Error_t aws_iot_shadow_yield(AWS_IoT_Client *pClient, uint32_t timeout) {
+AWSIOTSDK_API IoT_Error_t aws_iot_shadow_yield(AWS_IoT_Client *pClient, uint32_t timeout) {
 	if(NULL == pClient) {
 		return NULL_VALUE_ERROR;
 	}
@@ -149,11 +149,11 @@ IoT_Error_t aws_iot_shadow_yield(AWS_IoT_Client *pClient, uint32_t timeout) {
 	return aws_iot_mqtt_yield(pClient, timeout);
 }
 
-IoT_Error_t aws_iot_shadow_disconnect(AWS_IoT_Client *pClient) {
+AWSIOTSDK_API IoT_Error_t aws_iot_shadow_disconnect(AWS_IoT_Client *pClient) {
 	return aws_iot_mqtt_disconnect(pClient);
 }
 
-IoT_Error_t aws_iot_shadow_update(AWS_IoT_Client *pClient, const char *pThingName, char *pJsonString,
+AWSIOTSDK_API IoT_Error_t aws_iot_shadow_update(AWS_IoT_Client *pClient, const char *pThingName, char *pJsonString,
 								  fpActionCallback_t callback, void *pContextData, uint8_t timeout_seconds,
 								  bool isPersistentSubscribe) {
 	IoT_Error_t rc;
@@ -172,7 +172,7 @@ IoT_Error_t aws_iot_shadow_update(AWS_IoT_Client *pClient, const char *pThingNam
 	FUNC_EXIT_RC(rc);
 }
 
-IoT_Error_t aws_iot_shadow_delete(AWS_IoT_Client *pClient, const char *pThingName, fpActionCallback_t callback,
+AWSIOTSDK_API IoT_Error_t aws_iot_shadow_delete(AWS_IoT_Client *pClient, const char *pThingName, fpActionCallback_t callback,
 								  void *pContextData, uint8_t timeout_seconds, bool isPersistentSubscribe) {
 	char deleteRequestJsonBuf[MAX_SIZE_CLIENT_TOKEN_CLIENT_SEQUENCE];
 	IoT_Error_t rc;
@@ -194,7 +194,7 @@ IoT_Error_t aws_iot_shadow_delete(AWS_IoT_Client *pClient, const char *pThingNam
 	FUNC_EXIT_RC(rc);
 }
 
-IoT_Error_t aws_iot_shadow_get(AWS_IoT_Client *pClient, const char *pThingName, fpActionCallback_t callback,
+AWSIOTSDK_API IoT_Error_t aws_iot_shadow_get(AWS_IoT_Client *pClient, const char *pThingName, fpActionCallback_t callback,
 							   void *pContextData, uint8_t timeout_seconds, bool isPersistentSubscribe) {
 	char getRequestJsonBuf[MAX_SIZE_CLIENT_TOKEN_CLIENT_SEQUENCE];
 	IoT_Error_t rc;
@@ -215,7 +215,7 @@ IoT_Error_t aws_iot_shadow_get(AWS_IoT_Client *pClient, const char *pThingName, 
 	FUNC_EXIT_RC(rc);
 }
 
-IoT_Error_t aws_iot_shadow_set_autoreconnect_status(AWS_IoT_Client *pClient, bool newStatus) {
+AWSIOTSDK_API IoT_Error_t aws_iot_shadow_set_autoreconnect_status(AWS_IoT_Client *pClient, bool newStatus) {
 	return aws_iot_mqtt_autoreconnect_set_status(pClient, newStatus);
 }
 


### PR DESCRIPTION
Added ability to use aws-iot-device-sdk-embedded-c library on Win32 platforms by compiling library into a Win32 DLL.  

win32 folder created under both platform and samples folder.

platform/win32 also has aws-iot-sdk-dll folder to host Visual Studio 2015 solution and project files for aws-iot-sdk.dll.  aws-iot-sdk.dll uses existing mbedTLS library for TLS communications and NOT Win32 libraries.

samples/win32 contains two sample projects - subscribe_publish_sample and shadow_sample.  Both samples are Win32 console applications.  These applications dynamically load the Win32 aws-iot-sdk.dll and do not compile against a static library. 

Solution file in platform/win32/aws-iot-sdk-dll contains all three projects - aws-iot-sdk DLL, subscribe_publish_sample console application, shadow_sample console application.  Build dependencies are configured to build in proper order, and project include paths are configured to find both aws-iot-device-sdk-embedded-c source and aws-iot-sdk DLL.

