### PR TITLE
Fixed warning when compiling

### DIFF
--- a/src/aws_iot_mqtt_client_publish.c
+++ b/src/aws_iot_mqtt_client_publish.c
@@ -350,7 +350,6 @@ IoT_Error_t aws_iot_mqtt_internal_deserialize_publish(uint8_t *dup, QoS *qos,
 	rc = aws_iot_mqtt_internal_decode_remaining_length_from_buffer(curData, &decodedLen, &readBytesLen);
 	if(SUCCESS != rc) {
 		FUNC_EXIT_RC(rc);
-		return rc;
 	}
 	curData += (readBytesLen);
 	endData = curData + decodedLen;


### PR DESCRIPTION
"aws-iot-device-sdk-embedded-C/src/aws_iot_mqtt_client_publish.c", line 353: warning #112-D: statement is unreachable
Using TI 16.9.3LTS compiler, the above message is generated.  The "return rc;" line is redundant as the FUNC_EXIT_RC macro on the line before returns as well.