### PR TITLE
Allow keepAliveIntervalInSec to be configured when calling aws_iot_shadow_connect

### DIFF
--- a/include/aws_iot_shadow_interface.h
+++ b/include/aws_iot_shadow_interface.h
@@ -73,6 +73,7 @@ typedef struct {
 	char *pMqttClientId; ///< Currently the Shadow uses MQTT to connect and it is important to ensure we have unique client id
 	uint16_t mqttClientIdLen; ///< Currently the Shadow uses MQTT to connect and it is important to ensure we have unique client id
 	pApplicationHandler_t deleteActionHandler;	///< Callback to be invoked when Thing shadow for this device is deleted
+	uint16_t keepAliveIntervalInSec;	///< MQTT keep alive interval in seconds.  Defines inactivity time allowed before determining the connection has been lost.
 } ShadowConnectParameters_t;
 
 /*!

--- a/src/aws_iot_shadow.c
+++ b/src/aws_iot_shadow.c
@@ -33,10 +33,10 @@ extern "C" {
 #include "aws_iot_shadow_records.h"
 
 const ShadowInitParameters_t ShadowInitParametersDefault = {(char *) AWS_IOT_MQTT_HOST, AWS_IOT_MQTT_PORT, NULL, NULL,
-															NULL, false, NULL};
+															NULL, false};
 
 const ShadowConnectParameters_t ShadowConnectParametersDefault = {(char *) AWS_IOT_MY_THING_NAME,
-								  (char *) AWS_IOT_MQTT_CLIENT_ID, 0, NULL};
+								  (char *) AWS_IOT_MQTT_CLIENT_ID, 0, NULL, 600};
 
 static char deleteAcceptedTopic[MAX_SHADOW_TOPIC_LENGTH_BYTES];
 
@@ -103,7 +103,7 @@ IoT_Error_t aws_iot_shadow_connect(AWS_IoT_Client *pClient, ShadowConnectParamet
 	snprintf(myThingName, MAX_SIZE_OF_THING_NAME, "%s", pParams->pMyThingName);
 	snprintf(mqttClientID, MAX_SIZE_OF_UNIQUE_CLIENT_ID_BYTES, "%s", pParams->pMqttClientId);
 
-	ConnectParams.keepAliveIntervalInSec = 600; // NOTE: Temporary fix
+	ConnectParams.keepAliveIntervalInSec = pParams->keepAliveIntervalInSec; // NOTE: Temporary fix 600 seconds does not always work.  Adjust as necessary
 	ConnectParams.MQTTVersion = MQTT_3_1_1;
 	ConnectParams.isCleanSession = true;
 	ConnectParams.isWillMsgPresent = false;


### PR DESCRIPTION
I have issues with the keep alive interval being "too long" which causes my SSL tunnel to close down.

It would be nicer to have keepAliveIntervalInSec be configurable even when using shadows.

