### PR TITLE
Initialise msgParams.isRetained to 0 in publishToShadowAction()

### DIFF
--- a/src/aws_iot_shadow_records.c
+++ b/src/aws_iot_shadow_records.c
@@ -412,6 +412,7 @@ IoT_Error_t publishToShadowAction(const char *pThingName, ShadowActions_t action
 	topicNameFromThingAndAction(TemporaryTopicName, pThingName, action, SHADOW_ACTION);
 
 	msgParams.qos = QOS0;
+	msgParams.isRetained = 0;
 	msgParams.payloadLen = strlen(pJsonDocumentToBeSent);
 	msgParams.payload = (char *) pJsonDocumentToBeSent;
 	ret_val = aws_iot_mqtt_publish(pMqttClient, TemporaryTopicName, (uint16_t) strlen(TemporaryTopicName), &msgParams);


### PR DESCRIPTION
       publishToShadowAction() was violating the MQTT spec by sending publish requests with
       will = 0, and retain = 1, due to msgParams.isRetained not being initialised.

      [MQTT-3.1.2-11]   If the Will Flag is set to 0 the Will QoS and Will Retain fields in the Connect Flags
                                   MUST be set to zero and the Will Topic and Will Message fields MUST NOT be
                                   present in the payload.