### PR TITLE
mbedtls_wrap: Fix unintialized variable usage

### DIFF
--- a/platform/linux/mbedtls/network_mbedtls_wrapper.c
+++ b/platform/linux/mbedtls/network_mbedtls_wrapper.c
@@ -273,7 +273,8 @@ IoT_Error_t iot_tls_connect(Network *pNetwork, TLSConnectParams *params) {
 IoT_Error_t iot_tls_write(Network *pNetwork, unsigned char *pMsg, size_t len, Timer *timer, size_t *written_len) {
 	size_t written_so_far;
 	bool isErrorFlag = false;
-	int frags, ret;
+	int frags;
+	int ret = 0;
 	TLSDataParams *tlsDataParams = &(pNetwork->tlsDataParams);
 
 	for(written_so_far = 0, frags = 0;


### PR DESCRIPTION
Hello,

Thank you for your library as it really helps a lot.
I would like to propose a small fix that allows applications that utilize AWS library to be built correctly with `-Wall -Werror` flags.

The root of issue is uninitialized variable `ret` that lead to the following error:

```c
../../../platform/linux/mbedtls/network_mbedtls_wrapper.c:280:69: error: ‘ret’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   written_so_far < len && !has_timer_expired(timer); written_so_far += ret, frags++) {
                                                                     ^~
cc1: all warnings being treated as errors
```

I have not digged through the context of usage of that method, but it seems that it might be a problem if `has_timer_expired` evaluates to `true`.