### PR TITLE
Use AWS IoT Core support for MQTT over port 443

### DIFF
--- a/include/aws_iot_shadow_interface.h
+++ b/include/aws_iot_shadow_interface.h
@@ -51,7 +51,7 @@ extern "C" {
  */
 typedef struct {
 	char *pHost; ///< This will be unique to a customer and can be retrieved from the console
-	uint16_t port; ///< By default the port is 8883
+	uint16_t port; ///< Network port for TCP/IP socket
 	char *pRootCA; ///< Location with the Filename of the Root CA
 	char *pClientCRT; ///< Location of Device certs signed by AWS IoT service
 	char *pClientKey; ///< Location of Device private key

--- a/samples/linux/jobs_sample/aws_iot_config.h
+++ b/samples/linux/jobs_sample/aws_iot_config.h
@@ -24,7 +24,7 @@
 // Get from console
 // =================================================
 #define AWS_IOT_MQTT_HOST              "" ///< Customer specific MQTT HOST. The same will be used for Thing Shadow
-#define AWS_IOT_MQTT_PORT              8883 ///< default port for MQTT/S
+#define AWS_IOT_MQTT_PORT              443 ///< default port for MQTT/S
 #define AWS_IOT_MQTT_CLIENT_ID         "c-sdk-client-id" ///< MQTT client ID should be unique for every device
 #define AWS_IOT_MY_THING_NAME          "AWS-IoT-C-SDK" ///< Thing Name of the Shadow this device is associated with
 #define AWS_IOT_ROOT_CA_FILENAME       "rootCA.crt" ///< Root CA file name

--- a/samples/linux/shadow_sample/aws_iot_config.h
+++ b/samples/linux/shadow_sample/aws_iot_config.h
@@ -24,7 +24,7 @@
 // Get from console
 // =================================================
 #define AWS_IOT_MQTT_HOST              "" ///< Customer specific MQTT HOST. The same will be used for Thing Shadow
-#define AWS_IOT_MQTT_PORT              8883 ///< default port for MQTT/S
+#define AWS_IOT_MQTT_PORT              443 ///< default port for MQTT/S
 #define AWS_IOT_MQTT_CLIENT_ID         "c-sdk-client-id" ///< MQTT client ID should be unique for every device
 #define AWS_IOT_MY_THING_NAME 		   "AWS-IoT-C-SDK" ///< Thing Name of the Shadow this device is associated with
 #define AWS_IOT_ROOT_CA_FILENAME       "rootCA.crt" ///< Root CA file name

--- a/samples/linux/shadow_sample_console_echo/aws_iot_config.h
+++ b/samples/linux/shadow_sample_console_echo/aws_iot_config.h
@@ -24,7 +24,7 @@
 // Get from console
 // =================================================
 #define AWS_IOT_MQTT_HOST              "" ///< Customer specific MQTT HOST. The same will be used for Thing Shadow
-#define AWS_IOT_MQTT_PORT              8883 ///< default port for MQTT/S
+#define AWS_IOT_MQTT_PORT              443 ///< default port for MQTT/S
 #define AWS_IOT_MQTT_CLIENT_ID         "c-sdk-client-id" ///< MQTT client ID should be unique for every device
 #define AWS_IOT_MY_THING_NAME 		   "AWS-IoT-C-SDK" ///< Thing Name of the Shadow this device is associated with
 #define AWS_IOT_ROOT_CA_FILENAME       "rootCA.crt" ///< Root CA file name

--- a/samples/linux/subscribe_publish_cpp_sample/aws_iot_config.h
+++ b/samples/linux/subscribe_publish_cpp_sample/aws_iot_config.h
@@ -24,7 +24,7 @@
 // Get from console
 // =================================================
 #define AWS_IOT_MQTT_HOST              "" ///< Customer specific MQTT HOST. The same will be used for Thing Shadow
-#define AWS_IOT_MQTT_PORT              8883 ///< default port for MQTT/S
+#define AWS_IOT_MQTT_PORT              443 ///< default port for MQTT/S
 #define AWS_IOT_MQTT_CLIENT_ID         "c-sdk-client-id" ///< MQTT client ID should be unique for every device
 #define AWS_IOT_MY_THING_NAME 		   "AWS-IoT-C-SDK" ///< Thing Name of the Shadow this device is associated with
 #define AWS_IOT_ROOT_CA_FILENAME       "rootCA.crt" ///< Root CA file name

--- a/samples/linux/subscribe_publish_cpp_sample/subscribe_publish_cpp_sample.cpp
+++ b/samples/linux/subscribe_publish_cpp_sample/subscribe_publish_cpp_sample.cpp
@@ -62,7 +62,7 @@ void iot_subscribe_callback_handler(AWS_IoT_Client *pClient, char *topicName, ui
 	IOT_UNUSED(pData);
 	IOT_UNUSED(pClient);
 	IOT_INFO("Subscribe callback");
-	IOT_INFO("%.*s\t%.*s", topicNameLen, topicName, (int) params->payloadLen, params->payload);
+	IOT_INFO("%.*s\t%.*s", topicNameLen, topicName, (int) params->payloadLen, (char *) params->payload);
 }
 
 void disconnectCallbackHandler(AWS_IoT_Client *pClient, void *data) {

--- a/samples/linux/subscribe_publish_library_sample/aws_iot_config.h
+++ b/samples/linux/subscribe_publish_library_sample/aws_iot_config.h
@@ -24,7 +24,7 @@
 // Get from console
 // =================================================
 #define AWS_IOT_MQTT_HOST              "" ///< Customer specific MQTT HOST. The same will be used for Thing Shadow
-#define AWS_IOT_MQTT_PORT              8883 ///< default port for MQTT/S
+#define AWS_IOT_MQTT_PORT              443 ///< default port for MQTT/S
 #define AWS_IOT_MQTT_CLIENT_ID         "c-sdk-client-id" ///< MQTT client ID should be unique for every device
 #define AWS_IOT_MY_THING_NAME 		   "AWS-IoT-C-SDK" ///< Thing Name of the Shadow this device is associated with
 #define AWS_IOT_ROOT_CA_FILENAME       "rootCA.crt" ///< Root CA file name

--- a/samples/linux/subscribe_publish_library_sample/subscribe_publish_library_sample.c
+++ b/samples/linux/subscribe_publish_library_sample/subscribe_publish_library_sample.c
@@ -62,7 +62,7 @@ void iot_subscribe_callback_handler(AWS_IoT_Client *pClient, char *topicName, ui
 	IOT_UNUSED(pData);
 	IOT_UNUSED(pClient);
 	IOT_INFO("Subscribe callback");
-	IOT_INFO("%.*s\t%.*s", topicNameLen, topicName, (int) params->payloadLen, params->payload);
+	IOT_INFO("%.*s\t%.*s", topicNameLen, topicName, (int) params->payloadLen, (char *) params->payload);
 }
 
 void disconnectCallbackHandler(AWS_IoT_Client *pClient, void *data) {

--- a/samples/linux/subscribe_publish_sample/aws_iot_config.h
+++ b/samples/linux/subscribe_publish_sample/aws_iot_config.h
@@ -24,7 +24,7 @@
 // Get from console
 // =================================================
 #define AWS_IOT_MQTT_HOST              "" ///< Customer specific MQTT HOST. The same will be used for Thing Shadow
-#define AWS_IOT_MQTT_PORT              8883 ///< default port for MQTT/S
+#define AWS_IOT_MQTT_PORT              443 ///< default port for MQTT/S
 #define AWS_IOT_MQTT_CLIENT_ID         "c-sdk-client-id" ///< MQTT client ID should be unique for every device
 #define AWS_IOT_MY_THING_NAME 		   "AWS-IoT-C-SDK" ///< Thing Name of the Shadow this device is associated with
 #define AWS_IOT_ROOT_CA_FILENAME       "rootCA.crt" ///< Root CA file name

--- a/samples/linux/subscribe_publish_sample/subscribe_publish_sample.c
+++ b/samples/linux/subscribe_publish_sample/subscribe_publish_sample.c
@@ -62,7 +62,7 @@ void iot_subscribe_callback_handler(AWS_IoT_Client *pClient, char *topicName, ui
 	IOT_UNUSED(pData);
 	IOT_UNUSED(pClient);
 	IOT_INFO("Subscribe callback");
-	IOT_INFO("%.*s\t%.*s", topicNameLen, topicName, (int) params->payloadLen, params->payload);
+	IOT_INFO("%.*s\t%.*s", topicNameLen, topicName, (int) params->payloadLen, (char *) params->payload);
 }
 
 void disconnectCallbackHandler(AWS_IoT_Client *pClient, void *data) {

--- a/tests/integration/include/aws_iot_config.h
+++ b/tests/integration/include/aws_iot_config.h
@@ -19,7 +19,7 @@
 // Get from console
 // =================================================
 #define AWS_IOT_MQTT_HOST              "" ///< Customer specific MQTT HOST. The same will be used for Thing Shadow
-#define AWS_IOT_MQTT_PORT              8883 ///< default port for MQTT/S
+#define AWS_IOT_MQTT_PORT              443 ///< default port for MQTT/S
 #define AWS_IOT_MQTT_CLIENT_ID         "c-sdk-client-id" ///< MQTT client ID should be unique for every device
 #define AWS_IOT_MY_THING_NAME          "AWS-IoT-C-SDK" ///< Thing Name of the Shadow this device is associated with
 #define AWS_IOT_ROOT_CA_FILENAME       "rootCA.crt" ///< Root CA file name

--- a/tests/integration/multithreadingTest/aws_iot_test_multithreading_validation.c
+++ b/tests/integration/multithreadingTest/aws_iot_test_multithreading_validation.c
@@ -226,7 +226,7 @@ int aws_iot_mqtt_tests_multi_threading_validation() {
 
 		IOT_DEBUG(" Root CA Path : %s\n clientCRT : %s\n clientKey : %s\n", root_CA, clientCRT, clientKey);
 		initParams.pHostURL = AWS_IOT_MQTT_HOST;
-		initParams.port = 8883;
+		initParams.port =  AWS_IOT_MQTT_PORT;
 		initParams.pRootCALocation = root_CA;
 		initParams.pDeviceCertLocation = clientCRT;
 		initParams.pDevicePrivateKeyLocation = clientKey;

--- a/tests/integration/src/aws_iot_test_auto_reconnect.c
+++ b/tests/integration/src/aws_iot_test_auto_reconnect.c
@@ -101,7 +101,7 @@ int aws_iot_mqtt_tests_auto_reconnect() {
 	printf(" Root CA Path : %s\n clientCRT : %s\n clientKey : %s\n", root_CA, clientCRT, clientKey);
 	IoT_Client_Init_Params initParams;
 	initParams.pHostURL = AWS_IOT_MQTT_HOST;
-	initParams.port = 8883;
+	initParams.port = AWS_IOT_MQTT_PORT;
 	initParams.pRootCALocation = root_CA;
 	initParams.pDeviceCertLocation = clientCRT;
 	initParams.pDevicePrivateKeyLocation = clientKey;

--- a/tests/integration/src/aws_iot_test_basic_connectivity.c
+++ b/tests/integration/src/aws_iot_test_basic_connectivity.c
@@ -190,7 +190,7 @@ int aws_iot_mqtt_tests_basic_connectivity() {
 
 		IOT_DEBUG("Root CA Path : %s\n clientCRT : %s\n clientKey : %s\n", root_CA, clientCRT, clientKey);
 		initParams.pHostURL = AWS_IOT_MQTT_HOST;
-		initParams.port = 8883;
+		initParams.port = AWS_IOT_MQTT_PORT;
 		initParams.pRootCALocation = root_CA;
 		initParams.pDeviceCertLocation = clientCRT;
 		initParams.pDevicePrivateKeyLocation = clientKey;

--- a/tests/integration/src/aws_iot_test_jobs_api.c
+++ b/tests/integration/src/aws_iot_test_jobs_api.c
@@ -191,7 +191,7 @@ int aws_iot_jobs_basic_test() {
 
 		IOT_DEBUG("Root CA Path : %s\n clientCRT : %s\n clientKey : %s\n", root_CA, clientCRT, clientKey);
 		initParams.pHostURL = AWS_IOT_MQTT_HOST;
-		initParams.port = 8883;
+		initParams.port = AWS_IOT_MQTT_PORT;
 		initParams.pRootCALocation = root_CA;
 		initParams.pDeviceCertLocation = clientCRT;
 		initParams.pDevicePrivateKeyLocation = clientKey;

--- a/tests/integration/src/aws_iot_test_multiple_clients.c
+++ b/tests/integration/src/aws_iot_test_multiple_clients.c
@@ -66,7 +66,7 @@ static IoT_Error_t aws_iot_mqtt_tests_connect_client_to_service(AWS_IoT_Client *
 	struct timeval start, end;
 
 	initParams.pHostURL = AWS_IOT_MQTT_HOST;
-	initParams.port = 8883;
+	initParams.port = AWS_IOT_MQTT_PORT;
 	initParams.pRootCALocation = rootCA;
 	initParams.pDeviceCertLocation = clientCRT;
 	initParams.pDevicePrivateKeyLocation = clientKey;

--- a/tests/unit/include/aws_iot_config.h
+++ b/tests/unit/include/aws_iot_config.h
@@ -24,7 +24,7 @@
 // Get from console
 // =================================================
 #define AWS_IOT_MQTT_HOST              "localhost"
-#define AWS_IOT_MQTT_PORT              8883
+#define AWS_IOT_MQTT_PORT              443
 #define AWS_IOT_MQTT_CLIENT_ID         "C-SDK_UnitTestClient"
 #define AWS_IOT_MY_THING_NAME          "C-SDK_UnitTestThing"
 #define AWS_IOT_ROOT_CA_FILENAME       "rootCA.crt"

--- a/tests/unit/src/aws_iot_tests_unit_disconnect_helper.c
+++ b/tests/unit/src/aws_iot_tests_unit_disconnect_helper.c
@@ -179,7 +179,7 @@ TEST_C(DisconnectTests, SetHandlerAndInvokedOnDisconnect) {
 	IOT_DEBUG("-->Running Disconnect Tests - F:7 - Disconnect, with set handler and invoked on disconnect \n");
 
 	handlerInvoked = false;
-	InitMQTTParamsSetup(&initParams, "localhost", 8883, false, NULL);
+	InitMQTTParamsSetup(&initParams, "localhost", AWS_IOT_MQTT_PORT, false, NULL);
 	rc = aws_iot_mqtt_init(&iotClient, &initParams);
 	CHECK_EQUAL_C_INT(SUCCESS, rc);
 


### PR DESCRIPTION
Use ALPN during TLS negotiation in the five sample projects. Also, fix a compiler warning in the three subscribe/publish projects.

https://aws.amazon.com/about-aws/whats-new/2018/02/aws-iot-core-now-supports-mqtt-connections-with-certificate-based-client-authentication-on-port-443/
https://docs.aws.amazon.com/iot/latest/developerguide/protocols.html
