### PR TITLE
Added @warning comments about using API with parameters from stack

### DIFF
--- a/include/aws_iot_mqtt_client_interface.h
+++ b/include/aws_iot_mqtt_client_interface.h
@@ -117,12 +117,15 @@ IoT_Error_t aws_iot_mqtt_publish(AWS_IoT_Client *pClient, const char *pTopicName
  * Called to send a subscribe message to the broker requesting a subscription
  * to an MQTT topic.
  * @note Call is blocking.  The call returns after the receipt of the SUBACK control packet.
+ * @warning pTopicName and pApplicationHandlerData need to be static in memory.
  *
  * @param pClient Reference to the IoT Client
- * @param pTopicName Topic Name to publish to
+ * @param pTopicName Topic Name to publish to. pTopicName needs to be static in memory since 
+ *     no malloc are performed by the SDK
  * @param topicNameLen Length of the topic name
  * @param pApplicationHandler_t Reference to the handler function for this subscription
- * @param pApplicationHandlerData Data to be passed as argument to the application handler callback
+ * @param pApplicationHandlerData Point to data passed to the callback. 
+ *    pApplicationHandlerData also needs to be static in memory  since no malloc are performed by the SDK
  *
  * @return An IoT Error Type defining successful/failed subscription
  */

--- a/src/aws_iot_mqtt_client_subscribe.c
+++ b/src/aws_iot_mqtt_client_subscribe.c
@@ -192,11 +192,15 @@ static uint32_t _aws_iot_mqtt_get_free_message_handler_index(AWS_IoT_Client *pCl
  * subscribe API to perform the operation. Not meant to be called directly as
  * it doesn't do validations or client state changes
  * @note Call is blocking.  The call returns after the receipt of the SUBACK control packet.
+ * @warning pTopicName and pApplicationHandlerData need to be static in memory.
  *
  * @param pClient Reference to the IoT Client
- * @param pTopicName Topic Name to publish to
+ * @param pTopicName Topic Name to publish to. pTopicName needs to be static in memory since 
+ *     no malloc are performed by the SDK
  * @param topicNameLen Length of the topic name
  * @param pApplicationHandler_t Reference to the handler function for this subscription
+ * @param pApplicationHandlerData Point to data passed to the callback. 
+ *    pApplicationHandlerData also needs to be static in memory  since no malloc are performed by the SDK
  *
  * @return An IoT Error Type defining successful/failed subscription
  */
@@ -277,11 +281,15 @@ static IoT_Error_t _aws_iot_mqtt_internal_subscribe(AWS_IoT_Client *pClient, con
  * calls the internal subscribe above to perform the actual operation.
  * It is also responsible for client state changes
  * @note Call is blocking.  The call returns after the receipt of the SUBACK control packet.
+ * @warning pTopicName and pApplicationHandlerData need to be static in memory.
  *
  * @param pClient Reference to the IoT Client
- * @param pTopicName Topic Name to publish to
+ * @param pTopicName Topic Name to publish to. pTopicName needs to be static in memory since 
+ *     no malloc are performed by the SDK
  * @param topicNameLen Length of the topic name
  * @param pApplicationHandler_t Reference to the handler function for this subscription
+ * @param pApplicationHandlerData Point to data passed to the callback. 
+ *    pApplicationHandlerData also needs to be static in memory  since no malloc are performed by the SDK
  *
  * @return An IoT Error Type defining successful/failed subscription
  */

--- a/src/aws_iot_mqtt_client_unsubscribe.c
+++ b/src/aws_iot_mqtt_client_unsubscribe.c
@@ -149,6 +149,7 @@ static IoT_Error_t _aws_iot_mqtt_internal_unsubscribe(AWS_IoT_Client *pClient, c
 		if(pClient->clientData.messageHandlers[i].topicName != NULL &&
 		   (strcmp(pClient->clientData.messageHandlers[i].topicName, pTopicFilter) == 0)) {
 			subscriptionExists = true;
+            break;
 		}
 	}
 


### PR DESCRIPTION
Added @warning comment in API to tell users to make sure that the variables topic name and application data passed to the subscribe API needs to be static in memory

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
