### PR TITLE
Fix to issue #35

### DIFF
--- a/include/aws_iot_mqtt_client.h
+++ b/include/aws_iot_mqtt_client.h
@@ -269,7 +269,7 @@ typedef struct _ClientData {
 	 * afterwards */
 	size_t writeBufSize;
 	size_t readBufSize;
-
+    size_t readBufIndex;
 	unsigned char writeBuf[AWS_IOT_MQTT_TX_BUF_LEN];
 	unsigned char readBuf[AWS_IOT_MQTT_RX_BUF_LEN];
 

--- a/include/aws_iot_mqtt_client_common_internal.h
+++ b/include/aws_iot_mqtt_client_common_internal.h
@@ -104,6 +104,7 @@ unsigned char aws_iot_mqtt_internal_read_char(unsigned char **pptr);
 void aws_iot_mqtt_internal_write_char(unsigned char **pptr, unsigned char c);
 void aws_iot_mqtt_internal_write_utf8_string(unsigned char **pptr, const char *string, uint16_t stringLen);
 
+IoT_Error_t aws_iot_mqtt_internal_flushBuffers( AWS_IoT_Client *pClient );
 IoT_Error_t aws_iot_mqtt_internal_send_packet(AWS_IoT_Client *pClient, size_t length, Timer *pTimer);
 IoT_Error_t aws_iot_mqtt_internal_cycle_read(AWS_IoT_Client *pClient, Timer *pTimer, uint8_t *pPacketType);
 IoT_Error_t aws_iot_mqtt_internal_wait_for_read(AWS_IoT_Client *pClient, uint8_t packetType, Timer *pTimer);

--- a/samples/linux/subscribe_publish_sample/aws_iot_config.h
+++ b/samples/linux/subscribe_publish_sample/aws_iot_config.h
@@ -23,10 +23,10 @@
 
 // Get from console
 // =================================================
-#define AWS_IOT_MQTT_HOST              "a3qggb6vsdlf5s.iot.us-west-2.amazonaws.com" ///< Customer specific MQTT HOST. The same will be used for Thing Shadow
+#define AWS_IOT_MQTT_HOST              "" ///< Customer specific MQTT HOST. The same will be used for Thing Shadow
 #define AWS_IOT_MQTT_PORT              443 ///< default port for MQTT/S
-#define AWS_IOT_MQTT_CLIENT_ID         "Hugues_device" ///< MQTT client ID should be unique for every device
-#define AWS_IOT_MY_THING_NAME 		   "Hugues_device" ///< Thing Name of the Shadow this device is associated with
+#define AWS_IOT_MQTT_CLIENT_ID         "c-sdk-client-id" ///< MQTT client ID should be unique for every device
+#define AWS_IOT_MY_THING_NAME 		   "AWS-IoT-C-SDK" ///< Thing Name of the Shadow this device is associated with
 #define AWS_IOT_ROOT_CA_FILENAME       "rootCA.crt" ///< Root CA file name
 #define AWS_IOT_CERTIFICATE_FILENAME   "cert.pem" ///< device signed certificate file name
 #define AWS_IOT_PRIVATE_KEY_FILENAME   "privkey.pem" ///< Device private key filename

--- a/samples/linux/subscribe_publish_sample/aws_iot_config.h
+++ b/samples/linux/subscribe_publish_sample/aws_iot_config.h
@@ -23,10 +23,10 @@
 
 // Get from console
 // =================================================
-#define AWS_IOT_MQTT_HOST              "" ///< Customer specific MQTT HOST. The same will be used for Thing Shadow
+#define AWS_IOT_MQTT_HOST              "a3qggb6vsdlf5s.iot.us-west-2.amazonaws.com" ///< Customer specific MQTT HOST. The same will be used for Thing Shadow
 #define AWS_IOT_MQTT_PORT              443 ///< default port for MQTT/S
-#define AWS_IOT_MQTT_CLIENT_ID         "c-sdk-client-id" ///< MQTT client ID should be unique for every device
-#define AWS_IOT_MY_THING_NAME 		   "AWS-IoT-C-SDK" ///< Thing Name of the Shadow this device is associated with
+#define AWS_IOT_MQTT_CLIENT_ID         "Hugues_device" ///< MQTT client ID should be unique for every device
+#define AWS_IOT_MY_THING_NAME 		   "Hugues_device" ///< Thing Name of the Shadow this device is associated with
 #define AWS_IOT_ROOT_CA_FILENAME       "rootCA.crt" ///< Root CA file name
 #define AWS_IOT_CERTIFICATE_FILENAME   "cert.pem" ///< device signed certificate file name
 #define AWS_IOT_PRIVATE_KEY_FILENAME   "privkey.pem" ///< Device private key filename

--- a/src/aws_iot_mqtt_client_connect.c
+++ b/src/aws_iot_mqtt_client_connect.c
@@ -463,7 +463,7 @@ IoT_Error_t aws_iot_mqtt_connect(AWS_IoT_Client *pClient, IoT_Client_Connect_Par
 	if(NULL == pClient) {
 		FUNC_EXIT_RC(NULL_VALUE_ERROR);
 	}
-
+    aws_iot_mqtt_internal_flushBuffers( pClient );
 	clientState = aws_iot_mqtt_get_client_state(pClient);
 
 	if(false == _aws_iot_mqtt_is_client_state_valid_for_connect(clientState)) {

--- a/src/aws_iot_mqtt_client_yield.c
+++ b/src/aws_iot_mqtt_client_yield.c
@@ -177,6 +177,7 @@ static IoT_Error_t _aws_iot_mqtt_keep_alive(AWS_IoT_Client *pClient) {
  *         If this call results in an error it is likely the MQTT connection has dropped.
  *         iot_is_mqtt_connected can be called to confirm.
  */
+
 static IoT_Error_t _aws_iot_mqtt_internal_yield(AWS_IoT_Client *pClient, uint32_t timeout_ms) {
 	IoT_Error_t yieldRc = SUCCESS;
 
@@ -207,8 +208,7 @@ static IoT_Error_t _aws_iot_mqtt_internal_yield(AWS_IoT_Client *pClient, uint32_
 			yieldRc = _aws_iot_mqtt_keep_alive(pClient);
 		} else {
 			// SSL read and write errors are terminal, connection must be closed and retried
-			if(NETWORK_SSL_READ_ERROR == yieldRc || NETWORK_SSL_READ_TIMEOUT_ERROR == yieldRc
-				|| NETWORK_SSL_WRITE_ERROR == yieldRc || NETWORK_SSL_WRITE_TIMEOUT_ERROR == yieldRc) {
+			if(NETWORK_SSL_READ_ERROR == yieldRc || NETWORK_SSL_WRITE_ERROR == yieldRc || NETWORK_SSL_WRITE_TIMEOUT_ERROR == yieldRc) {
 				yieldRc = _aws_iot_mqtt_handle_disconnect(pClient);
 			}
 		}


### PR DESCRIPTION
See https://github.com/aws/aws-iot-device-sdk-embedded-C/issues/35

Made code more robust to read timeout.
    SSL_READ_TIME_OUT will not create a disconnect anymore.
    Yield should now yield the correct amount of time.
    Data aggregation will ensure data stays in sync

Memory corruption fix + timeout robustness feature
     Fix a potential overflow in the code: _aws_iot_mqtt_internal_read_packet was not checking buffer size properly
    Fix a bug in _aws_iot_mqtt_internal_decode_packet_remaining_len, len was not correctly increase