### PR TITLE
Keep a local copy of topicName on subscription

### DIFF
--- a/src/aws_iot_mqtt_client_subscribe.c
+++ b/src/aws_iot_mqtt_client_subscribe.c
@@ -260,8 +260,10 @@ static IoT_Error_t _aws_iot_mqtt_internal_subscribe(AWS_IoT_Client *pClient, con
 	//	return RX_MESSAGE_INVALID_ERROR;
 	//}
 
+	char *ptr =  calloc(topicNameLen+1, sizeof (char));
+	strncpy(ptr, pTopicName, topicNameLen);
 	pClient->clientData.messageHandlers[indexOfFreeMessageHandler].topicName =
-			pTopicName;
+			ptr;
 	pClient->clientData.messageHandlers[indexOfFreeMessageHandler].topicNameLen =
 			topicNameLen;
 	pClient->clientData.messageHandlers[indexOfFreeMessageHandler].pApplicationHandler =

--- a/src/aws_iot_mqtt_client_unsubscribe.c
+++ b/src/aws_iot_mqtt_client_unsubscribe.c
@@ -187,7 +187,7 @@ static IoT_Error_t _aws_iot_mqtt_internal_unsubscribe(AWS_IoT_Client *pClient, c
 	for(i = 0; i < AWS_IOT_MQTT_NUM_SUBSCRIBE_HANDLERS; ++i) {
 		if(pClient->clientData.messageHandlers[i].topicName != NULL &&
 		   (strcmp(pClient->clientData.messageHandlers[i].topicName, pTopicFilter) == 0)) {
-			pClient->clientData.messageHandlers[i].topicName = NULL;
+			free(pClient->clientData.messageHandlers[i].topicName);
 			/* We don't want to break here, in case the same topic is registered
              * with 2 callbacks. Unlikely scenario */
 		}


### PR DESCRIPTION
On subscription, we should keep a local copy of the topicName, because we need it when receiving a notification to forward it to the correct user handler. If user free memory of the topicName, he will never get notification. 

So use of calloc on subscribe and free on unsubscribe

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
