### PR TITLE
Keep a local copy of topicName on subscription

### DIFF
--- a/include/aws_iot_mqtt_client.h
+++ b/include/aws_iot_mqtt_client.h
@@ -62,6 +62,7 @@ extern "C" {
 #endif
 
 #define MAX_PACKET_ID 65535
+#define TOPIC_NAME_MAX_LEN 256
 
 typedef struct _Client AWS_IoT_Client;
 
@@ -228,7 +229,7 @@ typedef void (*pApplicationHandler_t)(AWS_IoT_Client *pClient, char *pTopicName,
  *
  */
 typedef struct _MessageHandlers {
-	const char *topicName;
+	char topicName[TOPIC_NAME_MAX_LEN];
 	uint16_t topicNameLen;
 	QoS qos;
 	pApplicationHandler_t pApplicationHandler;

--- a/src/aws_iot_mqtt_client.c
+++ b/src/aws_iot_mqtt_client.c
@@ -216,7 +216,8 @@ IoT_Error_t aws_iot_mqtt_init(AWS_IoT_Client *pClient, IoT_Client_Init_Params *p
 	}
 
 	for(i = 0; i < AWS_IOT_MQTT_NUM_SUBSCRIBE_HANDLERS; ++i) {
-		pClient->clientData.messageHandlers[i].topicName = NULL;
+		memset(pClient->clientData.messageHandlers[i].topicName, 0x0, TOPIC_NAME_MAX_LEN);
+		pClient->clientData.messageHandlers[i].topicNameLen = 0;
 		pClient->clientData.messageHandlers[i].pApplicationHandler = NULL;
 		pClient->clientData.messageHandlers[i].pApplicationHandlerData = NULL;
 		pClient->clientData.messageHandlers[i].qos = QOS0;

--- a/src/aws_iot_mqtt_client_common_internal.c
+++ b/src/aws_iot_mqtt_client_common_internal.c
@@ -510,7 +510,7 @@ static IoT_Error_t _aws_iot_mqtt_internal_deliver_message(AWS_IoT_Client *pClien
 
 	/* Find the right message handler - indexed by topic */
 	for(itr = 0; itr < AWS_IOT_MQTT_NUM_SUBSCRIBE_HANDLERS; ++itr) {
-		if(NULL != pClient->clientData.messageHandlers[itr].topicName) {
+		if(pClient->clientData.messageHandlers[itr].topicNameLen != 0) {
 			if(((topicNameLen == pClient->clientData.messageHandlers[itr].topicNameLen)
 				&&
 				(strncmp(pTopicName, (char *) pClient->clientData.messageHandlers[itr].topicName, topicNameLen) == 0))

--- a/src/aws_iot_mqtt_client_subscribe.c
+++ b/src/aws_iot_mqtt_client_subscribe.c
@@ -176,7 +176,7 @@ static uint32_t _aws_iot_mqtt_get_free_message_handler_index(AWS_IoT_Client *pCl
 	FUNC_ENTRY;
 
 	for(itr = 0; itr < AWS_IOT_MQTT_NUM_SUBSCRIBE_HANDLERS; itr++) {
-		if(pClient->clientData.messageHandlers[itr].topicName == NULL) {
+		if(pClient->clientData.messageHandlers[itr].topicNameLen == 0) {
 			break;
 		}
 	}
@@ -260,8 +260,8 @@ static IoT_Error_t _aws_iot_mqtt_internal_subscribe(AWS_IoT_Client *pClient, con
 	//	return RX_MESSAGE_INVALID_ERROR;
 	//}
 
-	pClient->clientData.messageHandlers[indexOfFreeMessageHandler].topicName =
-			pTopicName;
+	memcpy(pClient->clientData.messageHandlers[indexOfFreeMessageHandler].topicName,
+			pTopicName, topicNameLen);
 	pClient->clientData.messageHandlers[indexOfFreeMessageHandler].topicNameLen =
 			topicNameLen;
 	pClient->clientData.messageHandlers[indexOfFreeMessageHandler].pApplicationHandler =
@@ -357,7 +357,7 @@ static IoT_Error_t _aws_iot_mqtt_internal_resubscribe(AWS_IoT_Client *pClient) {
 	existingSubCount = _aws_iot_mqtt_get_free_message_handler_index(pClient);
 
 	for(itr = 0; itr < existingSubCount; itr++) {
-		if(pClient->clientData.messageHandlers[itr].topicName == NULL) {
+		if(pClient->clientData.messageHandlers[itr].topicNameLen == 0) {
 			continue;
 		}
 
@@ -366,7 +366,7 @@ static IoT_Error_t _aws_iot_mqtt_internal_resubscribe(AWS_IoT_Client *pClient) {
 
 		rc = _aws_iot_mqtt_serialize_subscribe(pClient->clientData.writeBuf, pClient->clientData.writeBufSize, 0,
 											   aws_iot_mqtt_get_next_packet_id(pClient), 1,
-											   &(pClient->clientData.messageHandlers[itr].topicName),
+											   (const char **)&(pClient->clientData.messageHandlers[itr].topicName),
 											   &(pClient->clientData.messageHandlers[itr].topicNameLen),
 											   &(pClient->clientData.messageHandlers[itr].qos), &len);
 		if(SUCCESS != rc) {

--- a/src/aws_iot_mqtt_client_unsubscribe.c
+++ b/src/aws_iot_mqtt_client_unsubscribe.c
@@ -146,10 +146,10 @@ static IoT_Error_t _aws_iot_mqtt_internal_unsubscribe(AWS_IoT_Client *pClient, c
 
 	/* Remove from message handler array */
 	for(i = 0; i < AWS_IOT_MQTT_NUM_SUBSCRIBE_HANDLERS; ++i) {
-		if(pClient->clientData.messageHandlers[i].topicName != NULL &&
+		if(pClient->clientData.messageHandlers[i].topicNameLen != 0 &&
 		   (strcmp(pClient->clientData.messageHandlers[i].topicName, pTopicFilter) == 0)) {
 			subscriptionExists = true;
-            break;
+			break;
 		}
 	}
 
@@ -185,9 +185,10 @@ static IoT_Error_t _aws_iot_mqtt_internal_unsubscribe(AWS_IoT_Client *pClient, c
 
 	/* Remove from message handler array */
 	for(i = 0; i < AWS_IOT_MQTT_NUM_SUBSCRIBE_HANDLERS; ++i) {
-		if(pClient->clientData.messageHandlers[i].topicName != NULL &&
+		if(pClient->clientData.messageHandlers[i].topicNameLen != 0 &&
 		   (strcmp(pClient->clientData.messageHandlers[i].topicName, pTopicFilter) == 0)) {
-			pClient->clientData.messageHandlers[i].topicName = NULL;
+			pClient->clientData.messageHandlers[i].topicNameLen = 0;
+			memset(pClient->clientData.messageHandlers[i].topicName, 0x0, TOPIC_NAME_MAX_LEN);
 			/* We don't want to break here, in case the same topic is registered
              * with 2 callbacks. Unlikely scenario */
 		}


### PR DESCRIPTION
following pull request #196 

On subscription, we should keep a local copy of the topicName, because we need it when receiving a notification to forward it to the correct user handler. If user free memory of the topicName, he will never get notification.

This patch does not use dynamic memory allocation. 

The TOPIC_NAME_MAX_LEN is defined to be 256 as described here: https://aws.amazon.com/sns/faqs/#Features_and_Functionality

If this patch is not correct please don't close the case, I would be happy to discuss and modify it. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
