### PR TITLE
samples/linux: remove initialise globals to 0

### DIFF
--- a/samples/linux/shadow_sample/aws_iot_config.h
+++ b/samples/linux/shadow_sample/aws_iot_config.h
@@ -26,7 +26,7 @@
 #define AWS_IOT_MQTT_HOST              "" ///< Customer specific MQTT HOST. The same will be used for Thing Shadow
 #define AWS_IOT_MQTT_PORT              443 ///< default port for MQTT/S
 #define AWS_IOT_MQTT_CLIENT_ID         "c-sdk-client-id" ///< MQTT client ID should be unique for every device
-#define AWS_IOT_MY_THING_NAME 		   "AWS-IoT-C-SDK" ///< Thing Name of the Shadow this device is associated with
+#define AWS_IOT_MY_THING_NAME          "AWS-IoT-C-SDK" ///< Thing Name of the Shadow this device is associated with
 #define AWS_IOT_ROOT_CA_FILENAME       "rootCA.crt" ///< Root CA file name
 #define AWS_IOT_CERTIFICATE_FILENAME   "cert.pem" ///< device signed certificate file name
 #define AWS_IOT_PRIVATE_KEY_FILENAME   "privkey.pem" ///< Device private key filename

--- a/samples/linux/shadow_sample_console_echo/aws_iot_config.h
+++ b/samples/linux/shadow_sample_console_echo/aws_iot_config.h
@@ -26,7 +26,7 @@
 #define AWS_IOT_MQTT_HOST              "" ///< Customer specific MQTT HOST. The same will be used for Thing Shadow
 #define AWS_IOT_MQTT_PORT              443 ///< default port for MQTT/S
 #define AWS_IOT_MQTT_CLIENT_ID         "c-sdk-client-id" ///< MQTT client ID should be unique for every device
-#define AWS_IOT_MY_THING_NAME 		   "AWS-IoT-C-SDK" ///< Thing Name of the Shadow this device is associated with
+#define AWS_IOT_MY_THING_NAME          "AWS-IoT-C-SDK" ///< Thing Name of the Shadow this device is associated with
 #define AWS_IOT_ROOT_CA_FILENAME       "rootCA.crt" ///< Root CA file name
 #define AWS_IOT_CERTIFICATE_FILENAME   "cert.pem" ///< device signed certificate file name
 #define AWS_IOT_PRIVATE_KEY_FILENAME   "privkey.pem" ///< Device private key filename

--- a/samples/linux/shadow_sample_console_echo/shadow_console_echo.c
+++ b/samples/linux/shadow_sample_console_echo/shadow_console_echo.c
@@ -57,7 +57,7 @@ char certDirectory[PATH_MAX + 1] = "../../../certs";
 #define HOST_ADDRESS_SIZE 255
 char HostAddress[HOST_ADDRESS_SIZE] = AWS_IOT_MQTT_HOST;
 uint32_t port = AWS_IOT_MQTT_PORT;
-bool messageArrivedOnDelta = false;
+bool messageArrivedOnDelta;
 
 /*
  * @note The delta message is always sent on the "state" key in the json

--- a/samples/linux/subscribe_publish_library_sample/aws_iot_config.h
+++ b/samples/linux/subscribe_publish_library_sample/aws_iot_config.h
@@ -26,7 +26,7 @@
 #define AWS_IOT_MQTT_HOST              "" ///< Customer specific MQTT HOST. The same will be used for Thing Shadow
 #define AWS_IOT_MQTT_PORT              443 ///< default port for MQTT/S
 #define AWS_IOT_MQTT_CLIENT_ID         "c-sdk-client-id" ///< MQTT client ID should be unique for every device
-#define AWS_IOT_MY_THING_NAME 		   "AWS-IoT-C-SDK" ///< Thing Name of the Shadow this device is associated with
+#define AWS_IOT_MY_THING_NAME          "AWS-IoT-C-SDK" ///< Thing Name of the Shadow this device is associated with
 #define AWS_IOT_ROOT_CA_FILENAME       "rootCA.crt" ///< Root CA file name
 #define AWS_IOT_CERTIFICATE_FILENAME   "cert.pem" ///< device signed certificate file name
 #define AWS_IOT_PRIVATE_KEY_FILENAME   "privkey.pem" ///< Device private key filename

--- a/samples/linux/subscribe_publish_library_sample/subscribe_publish_library_sample.c
+++ b/samples/linux/subscribe_publish_library_sample/subscribe_publish_library_sample.c
@@ -57,7 +57,7 @@ uint32_t port = AWS_IOT_MQTT_PORT;
 /**
  * @brief This parameter will avoid infinite loop of publish and exit the program after certain number of publishes
  */
-uint32_t publishCount = 0;
+uint32_t publishCount;
 
 void iot_subscribe_callback_handler(AWS_IoT_Client *pClient, char *topicName, uint16_t topicNameLen,
 									IoT_Publish_Message_Params *params, void *pData) {

--- a/samples/linux/subscribe_publish_sample/aws_iot_config.h
+++ b/samples/linux/subscribe_publish_sample/aws_iot_config.h
@@ -26,7 +26,7 @@
 #define AWS_IOT_MQTT_HOST              "" ///< Customer specific MQTT HOST. The same will be used for Thing Shadow
 #define AWS_IOT_MQTT_PORT              443 ///< default port for MQTT/S
 #define AWS_IOT_MQTT_CLIENT_ID         "c-sdk-client-id" ///< MQTT client ID should be unique for every device
-#define AWS_IOT_MY_THING_NAME 		   "AWS-IoT-C-SDK" ///< Thing Name of the Shadow this device is associated with
+#define AWS_IOT_MY_THING_NAME          "AWS-IoT-C-SDK" ///< Thing Name of the Shadow this device is associated with
 #define AWS_IOT_ROOT_CA_FILENAME       "rootCA.crt" ///< Root CA file name
 #define AWS_IOT_CERTIFICATE_FILENAME   "cert.pem" ///< device signed certificate file name
 #define AWS_IOT_PRIVATE_KEY_FILENAME   "privkey.pem" ///< Device private key filename

--- a/samples/linux/subscribe_publish_sample/subscribe_publish_sample.c
+++ b/samples/linux/subscribe_publish_sample/subscribe_publish_sample.c
@@ -56,7 +56,7 @@ uint32_t port = AWS_IOT_MQTT_PORT;
 /**
  * @brief This parameter will avoid infinite loop of publish and exit the program after certain number of publishes
  */
-uint32_t publishCount = 0;
+uint32_t publishCount;
 
 void iot_subscribe_callback_handler(AWS_IoT_Client *pClient, char *topicName, uint16_t topicNameLen,
 									IoT_Publish_Message_Params *params, void *pData) {


### PR DESCRIPTION
This PR is also simple fix. 
I think, global variables do not need initialise 0 or false.