### PR TITLE
support 'certificates in sources' option

### DIFF
--- a/certs/.gitignore
+++ b/certs/.gitignore
@@ -1,0 +1,1 @@
+certData.c

--- a/certs/certData.h
+++ b/certs/certData.h
@@ -1,0 +1,13 @@
+#ifndef __CERTDATA_H__
+#define __CERTDATA_H__
+
+extern unsigned const char root_ca_pem[];
+extern const int rootCaLen;
+
+extern unsigned const char client_cert_pem[];
+extern const int clientCertLen;
+
+extern unsigned const char client_private_key_pem[];
+extern const int clientPrivateKeyLen;
+
+#endif /* __CERTDATA_H__ */

--- a/certs/mkcertData.sh
+++ b/certs/mkcertData.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+WD=$(cd `dirname $0` && pwd)
+
+CERTDATA_FILE=certData.c
+
+#1 rootCA
+
+tee ${CERTDATA_FILE} << __EOF__
+
+/* root CA certificate file */
+
+const unsigned char root_ca_pem[] =
+__EOF__
+
+while IFS='' read -r line
+do
+	echo '\t"'"$line"'\\r\\n"' >> ${CERTDATA_FILE}
+done < "$1"
+
+echo ';' >> ${CERTDATA_FILE}
+
+tee -a ${CERTDATA_FILE} << __EOF__
+const int rootCaLen = sizeof(root_ca_pem);
+__EOF__
+
+#2 cert.pem
+
+tee -a ${CERTDATA_FILE} << __EOF__
+
+/* cert.pem certificate file */
+
+const unsigned char client_cert_pem[] =
+__EOF__
+
+while IFS='' read -r line
+do
+	echo '\t"'"$line"'\\r\\n"' >> ${CERTDATA_FILE}
+done < "$2"
+
+echo ';' >> ${CERTDATA_FILE}
+
+tee -a ${CERTDATA_FILE} << __EOF__
+const int clientCertLen = sizeof(client_cert_pem);
+__EOF__
+
+#3 privateKey.pem
+
+tee -a ${CERTDATA_FILE} << __EOF__
+
+/* privateKey.pem certificate file */
+
+const unsigned char client_private_key_pem[] =
+__EOF__
+
+while IFS='' read -r line
+do
+	echo '\t"'"$line"'\\r\\n"' >> ${CERTDATA_FILE}
+done < "$3"
+
+echo ';' >> ${CERTDATA_FILE}
+
+tee -a ${CERTDATA_FILE} << __EOF__
+const int clientPrivateKeyLen = sizeof(client_private_key_pem);
+__EOF__


### PR DESCRIPTION
Some embedded devices must have the certificate files in their source
when they are built. If you disable the 'MBEDTLS_FS_IO' option of
mbedTLS, you can not use the function to import files. This patch
includes a script that inserts the certificate into the source code.
Here's how to use the script:

$ cd ./certs
$ sh mkcertData.sh [root CA file] [certificate file] [private key file]

The certData.c file is generated, and this patch contains mbedtls
function substitution to use it.

Signed-off-by: Junhwan Park <junhwan.park@samsung.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
