### PR TITLE
CBMC proofs of memory safety for MQTT packet parsers

### DIFF
--- a/cbmc/README.md
+++ b/cbmc/README.md
@@ -1,0 +1,20 @@
+# MQTT memory safety proofs
+
+This directory contains CBMC proofs of memory safety of MQTT entry points. [CBMC](http://www.cprover.org/cbmc/) is a bounded model checker for C available from the GitHub [repository](https://github.com/diffblue/cbmc). Each proof is in a separate subdirectory of proofs:
+
+* DeserializeConnack: AwsIotMqttInternal_DeserializeConnack is memory safe assuming:
+  * We abstract the AwsIotLogGeneric logging function
+* DeserializePingresp: AwsIotMqttInternal_DeserializePingresp is memory safe assuming:
+  * We abstract the AwsIotLogGeneric logging function
+* DeserializePuback: AwsIotMqttInternal_DeserializePuback is memory safe assuming:
+  * We abstract the AwsIotLogGeneric logging function
+* DeserializePublish: AwsIotMqttInternal_DeserializePublish is memory safe assuming:
+  * We abstract the AwsIotLogGeneric logging function
+* DeserializeSuback: AwsIotMqttInternal_DeserializeSuback is memory safe assuming:
+  * We abstract the AwsIotLogGeneric logging function
+  * We abstract the AwsIotMqttInternal_RemoveSubscriptionByPacket function
+  * We bound the length of the buffer being parsed
+* DeserializeUnsuback: AwsIotMqttInternal_DeserializeUnsuback is memory safe assuming:
+  * We abstract the AwsIotLogGeneric logging function
+
+

--- a/cbmc/proofs/DeserializeConnack/DeserializeConnack_harness.c
+++ b/cbmc/proofs/DeserializeConnack/DeserializeConnack_harness.c
@@ -1,0 +1,16 @@
+#include IOT_CONFIG_FILE
+#include "private/aws_iot_mqtt_internal.h"
+
+#include <stdlib.h>
+
+void harness()
+{
+  size_t dataLength;
+  uint8_t *pConnackStart = malloc(sizeof(uint8_t) * dataLength);
+  size_t BytesProcessed;
+
+  AwsIotMqttInternal_DeserializeConnack(pConnackStart,
+					dataLength,
+					&BytesProcessed);
+}
+

--- a/cbmc/proofs/DeserializeConnack/Makefile
+++ b/cbmc/proofs/DeserializeConnack/Makefile
@@ -1,0 +1,10 @@
+ENTRY=DeserializeConnack
+
+ABSTRACTIONS = \
+	--remove-function-body AwsIotLogGeneric \
+
+OBJS = \
+	$(ENTRY)_harness.goto \
+	$(MQTT)/lib/source/mqtt/aws_iot_mqtt_serialize.goto \
+
+include ../Makefile.common

--- a/cbmc/proofs/DeserializeConnack/cbmc-batch.yaml
+++ b/cbmc/proofs/DeserializeConnack/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags:        '=--bounds-check;--pointer-check;--unwinding-assertions='
+goto: DeserializeConnack.goto
+expected: SUCCESSFUL

--- a/cbmc/proofs/DeserializePingresp/DeserializePingresp_harness.c
+++ b/cbmc/proofs/DeserializePingresp/DeserializePingresp_harness.c
@@ -1,0 +1,17 @@
+#include IOT_CONFIG_FILE
+#include "private/aws_iot_mqtt_internal.h"
+
+#include <stdlib.h>
+
+void harness()
+{
+  size_t dataLength;
+  uint8_t * pPingrespStart = malloc(sizeof(uint8_t) * dataLength);
+  size_t BytesProcessed;
+
+  AwsIotMqttInternal_DeserializePingresp( pPingrespStart,
+					  dataLength,
+					  &BytesProcessed );
+
+}
+

--- a/cbmc/proofs/DeserializePingresp/Makefile
+++ b/cbmc/proofs/DeserializePingresp/Makefile
@@ -1,0 +1,10 @@
+ENTRY=DeserializePingresp
+
+ABSTRACTIONS = \
+	--remove-function-body AwsIotLogGeneric \
+
+OBJS = \
+	$(ENTRY)_harness.goto \
+	$(MQTT)/lib/source/mqtt/aws_iot_mqtt_serialize.goto \
+
+include ../Makefile.common

--- a/cbmc/proofs/DeserializePingresp/cbmc-batch.yaml
+++ b/cbmc/proofs/DeserializePingresp/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags:        '=--bounds-check;--pointer-check;--unwinding-assertions='
+goto: DeserializePingresp.goto
+expected: SUCCESSFUL

--- a/cbmc/proofs/DeserializePuback/DeserializePuback_harness.c
+++ b/cbmc/proofs/DeserializePuback/DeserializePuback_harness.c
@@ -1,0 +1,19 @@
+#include IOT_CONFIG_FILE
+#include "private/aws_iot_mqtt_internal.h"
+
+#include <stdlib.h>
+
+void harness()
+{
+  size_t dataLength;
+  uint8_t *pPubackStart = malloc(sizeof(uint8_t) * dataLength);
+  uint16_t PacketIdentifier;
+  size_t BytesProcessed;
+
+AwsIotMqttInternal_DeserializePuback( pPubackStart,
+				      dataLength,
+				      &PacketIdentifier,
+				      &BytesProcessed );
+
+}
+

--- a/cbmc/proofs/DeserializePuback/Makefile
+++ b/cbmc/proofs/DeserializePuback/Makefile
@@ -1,0 +1,10 @@
+ENTRY=DeserializePuback
+
+ABSTRACTIONS = \
+	--remove-function-body AwsIotLogGeneric \
+
+OBJS = \
+	$(ENTRY)_harness.goto \
+	$(MQTT)/lib/source/mqtt/aws_iot_mqtt_serialize.goto \
+
+include ../Makefile.common

--- a/cbmc/proofs/DeserializePuback/cbmc-batch.yaml
+++ b/cbmc/proofs/DeserializePuback/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags:        '=--bounds-check;--pointer-check;--unwinding-assertions='
+goto: DeserializePuback.goto
+expected: SUCCESSFUL

--- a/cbmc/proofs/DeserializePublish/DeserializePublish_harness.c
+++ b/cbmc/proofs/DeserializePublish/DeserializePublish_harness.c
@@ -1,0 +1,20 @@
+#include IOT_CONFIG_FILE
+#include "private/aws_iot_mqtt_internal.h"
+
+#include <stdlib.h>
+
+void harness()
+{
+  size_t dataLength;
+  uint8_t *pPublishStart = malloc(sizeof(uint8_t) * dataLength);
+  AwsIotMqttPublishInfo_t Output;
+  uint16_t PacketIdentifier;
+  size_t BytesProcessed;
+
+  AwsIotMqttInternal_DeserializePublish(pPublishStart,
+					dataLength,
+					&Output,
+					&PacketIdentifier,
+					&BytesProcessed);
+}
+

--- a/cbmc/proofs/DeserializePublish/Makefile
+++ b/cbmc/proofs/DeserializePublish/Makefile
@@ -1,0 +1,10 @@
+ENTRY=DeserializePublish
+
+ABSTRACTIONS = \
+	--remove-function-body AwsIotLogGeneric \
+
+OBJS = \
+	$(ENTRY)_harness.goto \
+	$(MQTT)/lib/source/mqtt/aws_iot_mqtt_serialize.goto \
+
+include ../Makefile.common

--- a/cbmc/proofs/DeserializePublish/cbmc-batch.yaml
+++ b/cbmc/proofs/DeserializePublish/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags:        '=--bounds-check;--pointer-check;--unwinding-assertions='
+goto: DeserializePublish.goto
+expected: SUCCESSFUL

--- a/cbmc/proofs/DeserializeSuback/DeserializeSuback_harness.c
+++ b/cbmc/proofs/DeserializeSuback/DeserializeSuback_harness.c
@@ -1,0 +1,23 @@
+#include IOT_CONFIG_FILE
+#include "private/aws_iot_mqtt_internal.h"
+
+#include <stdlib.h>
+
+void harness()
+{
+  AwsIotMqttConnection_t mqttConnection;
+  size_t dataLength;
+  uint8_t *pSubackStart = malloc(sizeof(uint8_t) * dataLength);
+  uint16_t PacketIdentifier;
+  size_t BytesProcessed;
+
+  __CPROVER_assume(dataLength <= BUFFER_SIZE);
+
+  AwsIotMqttInternal_DeserializeSuback( mqttConnection,
+					pSubackStart,
+					dataLength,
+					&PacketIdentifier,
+					&BytesProcessed );
+
+}
+

--- a/cbmc/proofs/DeserializeSuback/Makefile
+++ b/cbmc/proofs/DeserializeSuback/Makefile
@@ -1,0 +1,19 @@
+ENTRY=DeserializeSuback
+
+BUFFER_SIZE = 100
+
+ABSTRACTIONS = \
+	--remove-function-body AwsIotLogGeneric \
+	--remove-function-body AwsIotMqttInternal_RemoveSubscriptionByPacket \
+
+UNWINDING = \
+	--unwindset AwsIotMqttInternal_DeserializeSuback.0:$(BUFFER_SIZE) \
+
+OBJS = \
+	$(ENTRY)_harness.goto \
+	$(MQTT)/lib/source/mqtt/aws_iot_mqtt_subscription.goto \
+	$(MQTT)/lib/source/mqtt/aws_iot_mqtt_serialize.goto \
+
+DEF = -DBUFFER_SIZE=$(BUFFER_SIZE)
+
+include ../Makefile.common

--- a/cbmc/proofs/DeserializeSuback/cbmc-batch.yaml
+++ b/cbmc/proofs/DeserializeSuback/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags:        '=--unwindset;AwsIotMqttInternal_DeserializeSuback.0:200;--bounds-check;--pointer-check;--unwinding-assertions='
+goto: DeserializeSuback.goto
+expected: SUCCESSFUL

--- a/cbmc/proofs/DeserializeUnsuback/DeserializeUnsuback_harness.c
+++ b/cbmc/proofs/DeserializeUnsuback/DeserializeUnsuback_harness.c
@@ -1,0 +1,18 @@
+#include IOT_CONFIG_FILE
+#include "private/aws_iot_mqtt_internal.h"
+
+#include <stdlib.h>
+
+void harness()
+{
+  size_t dataLength;
+  uint8_t *pUnsubackStart =  malloc(sizeof(uint8_t) * dataLength);
+  uint16_t PacketIdentifier;
+  size_t BytesProcessed;
+
+  AwsIotMqttInternal_DeserializeUnsuback( pUnsubackStart,
+					  dataLength,
+					  &PacketIdentifier,
+					  &BytesProcessed );
+}
+

--- a/cbmc/proofs/DeserializeUnsuback/Makefile
+++ b/cbmc/proofs/DeserializeUnsuback/Makefile
@@ -1,0 +1,10 @@
+ENTRY=DeserializeUnsuback
+
+ABSTRACTIONS = \
+	--remove-function-body AwsIotLogGeneric \
+
+OBJS = \
+	$(ENTRY)_harness.goto \
+	$(MQTT)/lib/source/mqtt/aws_iot_mqtt_serialize.goto \
+
+include ../Makefile.common

--- a/cbmc/proofs/DeserializeUnsuback/cbmc-batch.yaml
+++ b/cbmc/proofs/DeserializeUnsuback/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags:        '=--bounds-check;--pointer-check;--unwinding-assertions='
+goto: DeserializeUnsuback.goto
+expected: SUCCESSFUL

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -1,0 +1,189 @@
+SHELL=/bin/bash
+
+default: report
+
+################################################################
+# Define source location and cbmc binaries
+
+# MQTT source directory relative to proof subdirectories.
+MQTT ?= $(abspath ../../..)
+
+GOTO_CC ?= goto-cc
+GOTO_INSTRUMENT ?= goto-instrument
+GOTO_ANALYZER ?= goto-analyzer
+BATCH ?= cbmc-batch
+VIEWER ?= cbmc-viewer
+
+################################################################
+# Build goto binary for cbmc
+# Build goto binaries with options taken from top-level cmake
+
+INC = \
+	-I$(MQTT)/lib/include \
+	-I$(MQTT)/demos \
+
+DEF += \
+	-DIOT_CONFIG_FILE=\"iot_demo_config.h\" \
+	-DIOT_SDK_VERSION=\"4.0.0\" \
+	-Dawsiotmqtt_EXPORTS \
+
+CFLAGS += $(CFLAGS2) $(INC) $(DEF)
+
+%.goto : %.c
+	$(GOTO_CC) -o $@ $(CFLAGS) $<
+
+$(MQTT)/build:
+	(mkdir -p $(MQTT)/build; cd $(MQTT)/build; cmake ..) 2>&1 \
+		| tee $(ENTRY)0.txt \
+		; exit $${PIPESTATUS[0]}
+
+$(ENTRY)1.goto: $(MQTT)/build $(OBJS)
+	$(GOTO_CC) --function harness -o $@ $(OBJS) 2>&1 \
+		| tee $(ENTRY)1.txt \
+		; exit $${PIPESTATUS[0]}
+
+$(ENTRY)2.goto: $(ENTRY)1.goto
+	 $(GOTO_INSTRUMENT) \
+			$(ABSTRACTIONS) \
+			--drop-unused-functions \
+			--slice-global-inits $< $@ 2>&1 \
+		| tee $(ENTRY)2.txt \
+		; exit $${PIPESTATUS[0]}
+
+$(ENTRY).goto: $(ENTRY)2.goto
+	cp $< $@
+
+################################################################
+# Run cbmc and build html report
+
+CBMCFLAGS += \
+	$(UNWINDING) \
+	--bounds-check \
+	--pointer-check \
+	--unwinding-assertions \
+
+goto: $(ENTRY).goto
+
+cbmc.txt: $(ENTRY).goto
+	cbmc $(CBMCFLAGS) --trace $< 2>&1 | tee $@
+
+property.xml: $(ENTRY).goto
+	cbmc $(CBMCFLAGS) --show-properties --xml-ui $< 2>&1 > $@
+
+coverage.xml: $(ENTRY).goto
+	cbmc $(filter-out --unwinding-assertions,$(CBMCFLAGS)) \
+		--cover location --xml-ui $< 2>&1 > $@
+
+cbmc: cbmc.txt
+
+property: property.xml
+
+coverage: coverage.xml
+
+report: cbmc.txt property.xml coverage.xml
+	$(VIEWER) \
+	--goto $(ENTRY).goto \
+	--srcdir $(MQTT) \
+	--blddir $(MQTT) \
+	--htmldir html \
+	--srcexclude "(./verification|./tests|./tools|./lib/third_party)" \
+	--result cbmc.txt \
+	--property property.xml \
+	--block coverage.xml
+
+clean:
+	$(RM) $(OBJS) $(ENTRY).goto
+	$(RM) $(ENTRY)[0-9].goto $(ENTRY)[0-9].txt
+	$(RM) cbmc.txt property.xml coverage.xml TAGS
+	$(RM) *~ \#*
+
+veryclean: clean
+	$(RM) -r html
+
+.PHONY: cbmc property coverage report clean veryclean
+
+################################################################
+# Run cbmc under cbmc-batch
+
+BATCH ?= cbmc-batch
+WS ?= ws
+JOBOS ?= ubuntu16
+
+define encode_options
+       '=$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')='
+endef
+
+PROPMEM ?= 64000
+COVMEM ?= 64000
+CBMCPKG ?= cbmc
+BATCHPKG ?= cbmc-batch
+VIEWERPKG ?= cbmc-viewer
+
+SRC_ROOT ?= $(MQTT)
+SRC_TARFILE ?= s3://cbmc/mqtt.tar.gz
+
+BATCHFLAGS ?= \
+	--srcdir $(MQTT) \
+	--wsdir $(WS) \
+	--jobprefix $(ENTRY) \
+	--no-build \
+	--goto $(ENTRY).goto \
+	--cbmcflags $(call encode_options,$(CBMCFLAGS)) \
+	--property-memory $(PROPMEM) \
+	--coverage-memory $(COVMEM) \
+	--cbmcpkg $(CBMCPKG) \
+	--batchpkg $(BATCHPKG) \
+	--viewerpkg $(VIEWERPKG) \
+	--no-copysrc \
+	--srctarfile $(SRC_TARFILE) \
+	--blddir $(MQTT) \
+	--jobos $(JOBOS) \
+
+define yaml_encode_options
+       "$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')"
+endef
+
+$(ENTRY).yaml: $(ENTRY).goto Makefile
+	echo 'jobos: $(JOBOS)' > $@
+	echo 'cbmcpkg: $(CBMCPKG)' >> $@
+	echo 'batchpkg: $(BATCHPKG)' >> $@
+	echo 'viewerpkg: $(VIEWERPKG)' >> $@
+	echo 'goto: $(ENTRY).goto' >> $@
+	echo 'build: false' >> $@
+	echo 'cbmcflags: $(call yaml_encode_options,$(CBMCFLAGS))' >> $@
+	echo 'property_memory: $(PROPMEM)' >> $@
+	echo 'coverage_memory: $(COVMEM)' >> $@
+	echo 'expected: "SUCCESSFUL"' >> $@
+
+launch: $(ENTRY).goto Makefile
+	mkdir -p $(WS)
+	cp $(ENTRY).goto $(WS)
+	$(BATCH) $(BATCHFLAGS)
+
+launch-clean:
+	for d in $(ENTRY)*; do \
+	  if [ -d $$d ]; then \
+	    for f in $$d.json $$d.yaml Makefile-$$d; do \
+	      if [ -f $$f ]; then mv $$f $$d; fi \
+	    done\
+	  fi \
+	done
+	$(RM) Makefile-$(ENTRY)-[0-9]*-[0-9]*
+	$(RM) $(ENTRY)-[0-9]*-[0-9]*.json $(ENTRY)-[0-9]*-[0-9]*.yaml
+	$(RM) -r $(WS)
+
+launch-veryclean: launch-clean
+	$(RM) -r $(ENTRY)-[0-9]*-[0-9]*
+
+################################################################
+# Build configuration file to run cbmc under cbmc-batch in CI
+
+cbmc-batch.yaml: Makefile ../Makefile.common
+	@echo "Building $@"
+	@$(RM) $@
+	@echo "jobos: $(JOBOS)" >> $@
+	@echo "cbmcflags: $(call encode_options,$(CBMCFLAGS))" >> $@
+	@echo "goto: $(ENTRY).goto" >> $@
+	@echo "expected: SUCCESSFUL" >> $@
+
+################################################################


### PR DESCRIPTION
This pull request includes the CBMC proofs of memory safety for the MQTT packet parsers.  This pull request will enable adding the proofs to the MQTT continuous integration.  The statements of the proofs (the assumptions made in each proof) are in cbmc/README.md.

The proofs have been run against the current tip of v4_beta and pass.