### PR TITLE
Added IOT_SYSTEM_TYPES_FILE to CBMC build

### DIFF
--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -25,6 +25,7 @@ INC = \
 DEF += \
 	-DIOT_CONFIG_FILE=\"iot_demo_config.h\" \
 	-DIOT_SDK_VERSION=\"4.0.0\" \
+	-DIOT_SYSTEM_TYPES_FILE=\"platform/types/iot_platform_types_posix.h\" \
 	-Dawsiotmqtt_EXPORTS \
 
 CFLAGS += $(CFLAGS2) $(INC) $(DEF)


### PR DESCRIPTION
Added a define IOT_SYSTEM_TYPES_FILE just added to CMakeLists.txt to the CBMC build flow.