### PR TITLE
Remove separate persistent session MQTT Connect.

### DIFF
--- a/demos/aws_iot_demo_mqtt.c
+++ b/demos/aws_iot_demo_mqtt.c
@@ -384,6 +384,7 @@ int AwsIotDemo_RunMqttDemo( bool awsIotMqttMode,
     connectInfo.awsIotMqttMode = awsIotMqttMode;
     connectInfo.cleanSession = true;
     connectInfo.keepAliveSeconds = _KEEP_ALIVE_SECONDS;
+    connectInfo.pWillInfo = &willInfo;
 
     /* Set the members of the Last Will and Testament (LWT) message info. The
      * MQTT server will publish the LWT message if this client disconnects
@@ -437,7 +438,6 @@ int AwsIotDemo_RunMqttDemo( bool awsIotMqttMode,
         mqttStatus = AwsIotMqtt_Connect( pMqttConnection,
                                          pNetworkInterface,
                                          &connectInfo,
-                                         &willInfo,
                                          _MQTT_TIMEOUT_MS );
 
         if( mqttStatus != AWS_IOT_MQTT_SUCCESS )

--- a/demos/aws_iot_demo_shadow.c
+++ b/demos/aws_iot_demo_shadow.c
@@ -110,7 +110,6 @@ int AwsIotDemo_RunShadowDemo( const char * const pThingName,
     mqttStatus = AwsIotMqtt_Connect( pMqttConnection,
                                      pNetworkInterface,
                                      &connectInfo,
-                                     NULL,
                                      _TIMEOUT_MS );
 
     if( mqttStatus != AWS_IOT_MQTT_SUCCESS )

--- a/lib/include/private/aws_iot_mqtt_internal.h
+++ b/lib/include/private/aws_iot_mqtt_internal.h
@@ -538,14 +538,12 @@ uint8_t AwsIotMqttInternal_GetPacketType( const uint8_t * const pPacket,
  * @brief Generate a CONNECT packet from the given parameters.
  *
  * @param[in] pConnectInfo User-provided CONNECT information.
- * @param[in] pWillInfo User-provided Last Will and Testament information.
  * @param[out] pConnectPacket Where the CONNECT packet is written.
  * @param[out] pPacketSize Size of the packet written to `pConnectPacket`.
  *
  * @return #AWS_IOT_MQTT_SUCCESS or #AWS_IOT_MQTT_NO_MEMORY.
  */
 AwsIotMqttError_t AwsIotMqttInternal_SerializeConnect( const AwsIotMqttConnectInfo_t * const pConnectInfo,
-                                                       const AwsIotMqttPublishInfo_t * const pWillInfo,
                                                        uint8_t ** const pConnectPacket,
                                                        size_t * const pPacketSize );
 

--- a/lib/source/mqtt/aws_iot_mqtt_validate.c
+++ b/lib/source/mqtt/aws_iot_mqtt_validate.c
@@ -134,6 +134,18 @@ bool AwsIotMqttInternal_ValidateConnect( const AwsIotMqttConnectInfo_t * const p
         }
     }
 
+    /* Check that the number of persistent session subscriptions is valid. */
+    if( pConnectInfo->cleanSession == false )
+    {
+        if( ( pConnectInfo->pPreviousSubscriptions != NULL ) &&
+            ( pConnectInfo->previousSubscriptionCount == 0 ) )
+        {
+            IotLogError( "Previous subscription count cannot be 0." );
+
+            return false;
+        }
+    }
+
     /* In MQTT 3.1.1, servers are not obligated to accept client identifiers longer
      * than 23 characters. */
     if( pConnectInfo->clientIdentifierLength > 23 )

--- a/tests/mqtt/system/aws_iot_tests_mqtt_stress.c
+++ b/tests/mqtt/system/aws_iot_tests_mqtt_stress.c
@@ -489,7 +489,6 @@ TEST_SETUP( MQTT_Stress )
                        AwsIotMqtt_Connect( &_AwsIotTestMqttConnection,
                                            &_AwsIotTestNetworkInterface,
                                            &connectInfo,
-                                           NULL,
                                            AWS_IOT_TEST_MQTT_TIMEOUT_MS ) );
 
     /* Subscribe to the test topic filters. */

--- a/tests/mqtt/system/aws_iot_tests_mqtt_system.c
+++ b/tests/mqtt/system/aws_iot_tests_mqtt_system.c
@@ -179,14 +179,12 @@ static void _freePacket( uint8_t * pPacket )
  * @brief Serializer override for CONNECT.
  */
 static AwsIotMqttError_t _serializeConnect( const AwsIotMqttConnectInfo_t * const pConnectInfo,
-                                            const AwsIotMqttPublishInfo_t * const pWillInfo,
                                             uint8_t ** const pConnectPacket,
                                             size_t * const pPacketSize )
 {
     _connectSerializerOverride = true;
 
     return AwsIotMqttInternal_SerializeConnect( pConnectInfo,
-                                                pWillInfo,
                                                 pConnectPacket,
                                                 pPacketSize );
 }
@@ -358,7 +356,6 @@ static void _subscribePublishWait( int QoS )
         status = AwsIotMqtt_Connect( &_AwsIotTestMqttConnection,
                                      &networkInterface,
                                      &connectInfo,
-                                     NULL,
                                      AWS_IOT_TEST_MQTT_TIMEOUT_MS );
         TEST_ASSERT_EQUAL( AWS_IOT_MQTT_SUCCESS, status );
 
@@ -581,7 +578,6 @@ TEST( MQTT_System, SubscribePublishAsync )
             status = AwsIotMqtt_Connect( &_AwsIotTestMqttConnection,
                                          &_AwsIotTestNetworkInterface,
                                          &connectInfo,
-                                         NULL,
                                          AWS_IOT_TEST_MQTT_TIMEOUT_MS );
             TEST_ASSERT_EQUAL( AWS_IOT_MQTT_SUCCESS, status );
 
@@ -700,7 +696,6 @@ TEST( MQTT_System, LastWillAndTestament )
             status = AwsIotMqtt_Connect( &lwtListener,
                                          &lwtNetIf,
                                          &lwtConnectInfo,
-                                         NULL,
                                          AWS_IOT_TEST_MQTT_TIMEOUT_MS );
             TEST_ASSERT_EQUAL( AWS_IOT_MQTT_SUCCESS, status );
 
@@ -723,6 +718,7 @@ TEST( MQTT_System, LastWillAndTestament )
                 connectInfo.cleanSession = true;
                 connectInfo.pClientIdentifier = _pClientIdentifier;
                 connectInfo.clientIdentifierLength = ( uint16_t ) strlen( _pClientIdentifier );
+                connectInfo.pWillInfo = &willInfo;
 
                 willInfo.pTopicName = AWS_IOT_TEST_MQTT_TOPIC_PREFIX "/LastWillAndTestament";
                 willInfo.topicNameLength = ( uint16_t ) strlen( willInfo.pTopicName );
@@ -732,7 +728,6 @@ TEST( MQTT_System, LastWillAndTestament )
                 status = AwsIotMqtt_Connect( &_AwsIotTestMqttConnection,
                                              &_AwsIotTestNetworkInterface,
                                              &connectInfo,
-                                             &willInfo,
                                              AWS_IOT_TEST_MQTT_TIMEOUT_MS );
                 TEST_ASSERT_EQUAL( AWS_IOT_MQTT_SUCCESS, status );
 
@@ -792,7 +787,6 @@ TEST( MQTT_System, RestorePreviousSession )
         status = AwsIotMqtt_Connect( &_AwsIotTestMqttConnection,
                                      &_AwsIotTestNetworkInterface,
                                      &connectInfo,
-                                     NULL,
                                      AWS_IOT_TEST_MQTT_TIMEOUT_MS );
         TEST_ASSERT_EQUAL( AWS_IOT_MQTT_SUCCESS, status );
 
@@ -818,13 +812,12 @@ TEST( MQTT_System, RestorePreviousSession )
 
         /* Re-establish the MQTT connection with a previous session. */
         connectInfo.cleanSession = false;
-        status = AwsIotMqtt_ConnectRestoreSession( &_AwsIotTestMqttConnection,
-                                                   &_AwsIotTestNetworkInterface,
-                                                   &connectInfo,
-                                                   NULL,
-                                                   &subscription,
-                                                   1,
-                                                   AWS_IOT_TEST_MQTT_TIMEOUT_MS );
+        connectInfo.pPreviousSubscriptions = &subscription;
+        connectInfo.previousSubscriptionCount = 1;
+        status = AwsIotMqtt_Connect( &_AwsIotTestMqttConnection,
+                                     &_AwsIotTestNetworkInterface,
+                                     &connectInfo,
+                                     AWS_IOT_TEST_MQTT_TIMEOUT_MS );
         TEST_ASSERT_EQUAL( AWS_IOT_MQTT_SUCCESS, status );
 
         /* Publish a message to the subscription added in the previous session. */
@@ -865,7 +858,6 @@ TEST( MQTT_System, RestorePreviousSession )
         status = AwsIotMqtt_Connect( &_AwsIotTestMqttConnection,
                                      &_AwsIotTestNetworkInterface,
                                      &connectInfo,
-                                     NULL,
                                      AWS_IOT_TEST_MQTT_TIMEOUT_MS );
         TEST_ASSERT_EQUAL( AWS_IOT_MQTT_SUCCESS, status );
 

--- a/tests/shadow/system/aws_iot_tests_shadow_system.c
+++ b/tests/shadow/system/aws_iot_tests_shadow_system.c
@@ -447,7 +447,6 @@ TEST_SETUP( Shadow_System )
     if( AwsIotMqtt_Connect( &_AwsIotTestMqttConnection,
                             &_AwsIotTestNetworkInterface,
                             &connectInfo,
-                            NULL,
                             AWS_IOT_TEST_SHADOW_TIMEOUT ) != AWS_IOT_MQTT_SUCCESS )
     {
         TEST_FAIL_MESSAGE( "Failed to establish MQTT connection for Shadow tests." );


### PR DESCRIPTION
Expands `AwsIotMqttConnectInfo_t` to include will info and previous subscriptions.  Removes separate Connect restore session function.