### PR TITLE
Added macro with infinite reconnection flag.

### DIFF
--- a/samples/linux/jobs_sample/aws_iot_config.h
+++ b/samples/linux/jobs_sample/aws_iot_config.h
@@ -67,6 +67,7 @@
 // Auto Reconnect specific config
 #define AWS_IOT_MQTT_MIN_RECONNECT_WAIT_INTERVAL 1000 ///< Minimum time before the First reconnect attempt is made as part of the exponential back-off algorithm
 #define AWS_IOT_MQTT_MAX_RECONNECT_WAIT_INTERVAL 128000 ///< Maximum time interval after which exponential back-off will stop attempting to reconnect.
+#define AWS_IOT_MQTT_INFINITE_RECONNECT 0 ///< Infinite reconnect flag. If set to 1 will not stop attempting to reconnect after hitting AWS_IOT_MQTT_MAX_RECONNECT_WAIT_INTERVAL.
 
 #define DISABLE_METRICS false ///< Disable the collection of metrics by setting this to true
 

--- a/samples/linux/shadow_sample/aws_iot_config.h
+++ b/samples/linux/shadow_sample/aws_iot_config.h
@@ -52,6 +52,7 @@
 // Auto Reconnect specific config
 #define AWS_IOT_MQTT_MIN_RECONNECT_WAIT_INTERVAL 1000 ///< Minimum time before the First reconnect attempt is made as part of the exponential back-off algorithm
 #define AWS_IOT_MQTT_MAX_RECONNECT_WAIT_INTERVAL 128000 ///< Maximum time interval after which exponential back-off will stop attempting to reconnect.
+#define AWS_IOT_MQTT_INFINITE_RECONNECT 0 ///< Infinite reconnect flag. If set to 1 will not stop attempting to reconnect after hitting AWS_IOT_MQTT_MAX_RECONNECT_WAIT_INTERVAL.
 
 #define DISABLE_METRICS false ///< Disable the collection of metrics by setting this to true
 

--- a/samples/linux/shadow_sample_console_echo/aws_iot_config.h
+++ b/samples/linux/shadow_sample_console_echo/aws_iot_config.h
@@ -52,6 +52,7 @@
 // Auto Reconnect specific config
 #define AWS_IOT_MQTT_MIN_RECONNECT_WAIT_INTERVAL 1000 ///< Minimum time before the First reconnect attempt is made as part of the exponential back-off algorithm
 #define AWS_IOT_MQTT_MAX_RECONNECT_WAIT_INTERVAL 128000 ///< Maximum time interval after which exponential back-off will stop attempting to reconnect.
+#define AWS_IOT_MQTT_INFINITE_RECONNECT 0 ///< Infinite reconnect flag. If set to 1 will not stop attempting to reconnect after hitting AWS_IOT_MQTT_MAX_RECONNECT_WAIT_INTERVAL.
 
 #define DISABLE_METRICS false ///< Disable the collection of metrics by setting this to true
 

--- a/samples/linux/subscribe_publish_sample/aws_iot_config.h
+++ b/samples/linux/subscribe_publish_sample/aws_iot_config.h
@@ -52,6 +52,7 @@
 // Auto Reconnect specific config
 #define AWS_IOT_MQTT_MIN_RECONNECT_WAIT_INTERVAL 1000 ///< Minimum time before the First reconnect attempt is made as part of the exponential back-off algorithm
 #define AWS_IOT_MQTT_MAX_RECONNECT_WAIT_INTERVAL 128000 ///< Maximum time interval after which exponential back-off will stop attempting to reconnect.
+#define AWS_IOT_MQTT_INFINITE_RECONNECT 0 ///< Infinite reconnect flag. If set to 1 will not stop attempting to reconnect after hitting AWS_IOT_MQTT_MAX_RECONNECT_WAIT_INTERVAL.
 
 #define DISABLE_METRICS false ///< Disable the collection of metrics by setting this to true
 

--- a/src/aws_iot_mqtt_client_yield.c
+++ b/src/aws_iot_mqtt_client_yield.c
@@ -102,7 +102,11 @@ static IoT_Error_t _aws_iot_mqtt_handle_reconnect(AWS_IoT_Client *pClient) {
 	pClient->clientData.currentReconnectWaitInterval *= 2;
 
 	if(AWS_IOT_MQTT_MAX_RECONNECT_WAIT_INTERVAL < pClient->clientData.currentReconnectWaitInterval) {
-		FUNC_EXIT_RC(NETWORK_RECONNECT_TIMED_OUT_ERROR);
+		if(AWS_IOT_MQTT_INFINITE_RECONNECT == 1){
+			pClient->clientData.currentReconnectWaitInterval = AWS_IOT_MQTT_MAX_RECONNECT_WAIT_INTERVAL;
+		} else {
+			FUNC_EXIT_RC(NETWORK_RECONNECT_TIMED_OUT_ERROR);
+		}
 	}
 	countdown_ms(&(pClient->reconnectDelayTimer), pClient->clientData.currentReconnectWaitInterval);
 	FUNC_EXIT_RC(rc);
@@ -194,8 +198,12 @@ static IoT_Error_t _aws_iot_mqtt_internal_yield(AWS_IoT_Client *pClient, uint32_
 		clientState = aws_iot_mqtt_get_client_state(pClient);
 		if(CLIENT_STATE_PENDING_RECONNECT == clientState) {
 			if(AWS_IOT_MQTT_MAX_RECONNECT_WAIT_INTERVAL < pClient->clientData.currentReconnectWaitInterval) {
-				yieldRc = NETWORK_RECONNECT_TIMED_OUT_ERROR;
-				break;
+				if(AWS_IOT_MQTT_INFINITE_RECONNECT == 1){
+					pClient->clientData.currentReconnectWaitInterval = AWS_IOT_MQTT_MAX_RECONNECT_WAIT_INTERVAL;
+				} else {
+					yieldRc = NETWORK_RECONNECT_TIMED_OUT_ERROR;
+					break;
+				}
 			}
 			yieldRc = _aws_iot_mqtt_handle_reconnect(pClient);
 			/* Network reconnect attempted, check if yield timer expired before

--- a/tests/unit/include/aws_iot_config.h
+++ b/tests/unit/include/aws_iot_config.h
@@ -69,5 +69,6 @@
 // Auto Reconnect specific config
 #define AWS_IOT_MQTT_MIN_RECONNECT_WAIT_INTERVAL 1000 ///< Minimum time before the First reconnect attempt is made as part of the exponential back-off algorithm
 #define AWS_IOT_MQTT_MAX_RECONNECT_WAIT_INTERVAL 128000 ///< Maximum time interval after which exponential back-off will stop attempting to reconnect.
+#define AWS_IOT_MQTT_INFINITE_RECONNECT 0 ///< Infinite reconnect flag. If set to 1 will not stop attempting to reconnect after hitting AWS_IOT_MQTT_MAX_RECONNECT_WAIT_INTERVAL.
 
 #endif /* IOT_TESTS_UNIT_CONFIG_H_ */


### PR DESCRIPTION
Decided to add a #define AWS_IOT_MQTT_INFINITE_RECONNECT that can be set to enable infinite retries while reconnecting, using the AWS_IOT_MQTT_MAX_RECONNECT_WAIT_INTERVAL define as a maximum value, after encountering the same issue as #101 and noticing that the issue was closed without the suggested solution present in the comments (https://github.com/aws/aws-iot-device-sdk-embedded-C/issues/101#issuecomment-337764487) being looked into.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
