### PR TITLE
Add "pKeppAliveTime" param on aws_iot_shadow_connect()

### DIFF
--- a/include/aws_iot_shadow_interface.h
+++ b/include/aws_iot_shadow_interface.h
@@ -118,11 +118,19 @@ IoT_Error_t aws_iot_shadow_init(AWS_IoT_Client *pClient, ShadowInitParameters_t 
  *
  * This function does the TLSv1.2 handshake and establishes the MQTT connection
  *
- * @param pClient	MQTT Client used as the protocol layer
- * @param pParams	Shadow Conenction parameters like TLS cert location
+ * @param pClient			MQTT Client used as the protocol layer
+ *
+ * @param pParams			Shadow Conenction parameters like TLS cert location
+ *
+ * @param pKeppAliveTime 	Measured in seconds. Expressed as a 16-bit word (Decimal 65535). Max Interval value is The maximum value is 18 hours 12 minutes and 15 seconds.
+ * 							It is the maximum time interval that is permitted to elapse between
+ * 							the point at which the Client finishes transmitting one Control Packet
+ * 							and the point it starts sending the next.
+ * 							If the AWS server doesn’t receive any packet from a client within [ 1.5 * pKeppAliveTime ] time interval, it close the connection to the client.
+ *
  * @return An IoT Error Type defining successful/failed Connection
  */
-IoT_Error_t aws_iot_shadow_connect(AWS_IoT_Client *pClient, ShadowConnectParameters_t *pParams);
+IoT_Error_t aws_iot_shadow_connect(AWS_IoT_Client *pClient, ShadowConnectParameters_t *pParams, uint16_t pKeppAliveTime );
 
 /**
  * @brief Yield function to let the background tasks of MQTT and Shadow

--- a/samples/linux/shadow_sample/shadow_sample.c
+++ b/samples/linux/shadow_sample/shadow_sample.c
@@ -206,7 +206,7 @@ int main(int argc, char **argv) {
 	scp.mqttClientIdLen = (uint16_t) strlen(AWS_IOT_MQTT_CLIENT_ID);
 
 	IOT_INFO("Shadow Connect");
-	rc = aws_iot_shadow_connect(&mqttClient, &scp);
+	rc = aws_iot_shadow_connect(&mqttClient, &scp, 600);
 	if(SUCCESS != rc) {
 		IOT_ERROR("Shadow Connection Error");
 		return rc;

--- a/samples/linux/shadow_sample_console_echo/shadow_console_echo.c
+++ b/samples/linux/shadow_sample_console_echo/shadow_console_echo.c
@@ -204,7 +204,7 @@ int main(int argc, char** argv) {
 	scp.mqttClientIdLen = (uint16_t) strlen(AWS_IOT_MQTT_CLIENT_ID);
 
 	IOT_INFO("Shadow Connect");
-	rc = aws_iot_shadow_connect(&mqttClient, &scp);
+	rc = aws_iot_shadow_connect(&mqttClient, &scp, 600);
 	if (SUCCESS != rc) {
 		IOT_ERROR("Shadow Connection Error");
 		return rc;

--- a/src/aws_iot_shadow.c
+++ b/src/aws_iot_shadow.c
@@ -103,7 +103,7 @@ IoT_Error_t aws_iot_shadow_init(AWS_IoT_Client *pClient, ShadowInitParameters_t 
 	FUNC_EXIT_RC(SUCCESS);
 }
 
-IoT_Error_t aws_iot_shadow_connect(AWS_IoT_Client *pClient, ShadowConnectParameters_t *pParams) {
+IoT_Error_t aws_iot_shadow_connect(AWS_IoT_Client *pClient, ShadowConnectParameters_t *pParams, uint16_t pKeppAliveTime ) {
 	IoT_Error_t rc = SUCCESS;
 	uint16_t deleteAcceptedTopicLen;
 	IoT_Client_Connect_Params ConnectParams = iotClientConnectParamsDefault;
@@ -117,7 +117,15 @@ IoT_Error_t aws_iot_shadow_connect(AWS_IoT_Client *pClient, ShadowConnectParamet
 	snprintf(myThingName, MAX_SIZE_OF_THING_NAME, "%s", pParams->pMyThingName);
 	snprintf(mqttClientID, MAX_SIZE_OF_UNIQUE_CLIENT_ID_BYTES, "%s", pParams->pMqttClientId);
 
-	ConnectParams.keepAliveIntervalInSec = 600; // NOTE: Temporary fix
+	if ( 0 >= pKeppAliveTime  || 60 >= pKeppAliveTime) {
+		/*	If the user sets "pKeppAliveTime" between 0-60.
+		 *	Then the "ConnectParams.keepAliveIntervalInSec" is set to 60secs (1min).
+		 *	And the actual TimeOut duration will be (60 * 1.5) = 90secs = 1.5Min
+		 */
+		ConnectParams.keepAliveIntervalInSec = 60;
+	} else {
+		ConnectParams.keepAliveIntervalInSec = pKeppAliveTime;
+	}
 	ConnectParams.MQTTVersion = MQTT_3_1_1;
 	ConnectParams.isCleanSession = true;
 	ConnectParams.isWillMsgPresent = false;

--- a/tests/unit/src/aws_iot_tests_unit_shadow_action_helper.c
+++ b/tests/unit/src/aws_iot_tests_unit_shadow_action_helper.c
@@ -82,7 +82,7 @@ TEST_GROUP_C_SETUP(ShadowActionTests) {
 	shadowConnectParams.mqttClientIdLen = (uint16_t) strlen(AWS_IOT_MQTT_CLIENT_ID);
 	ConnectMQTTParamsSetup(&connectParams, AWS_IOT_MQTT_CLIENT_ID, (uint16_t) strlen(AWS_IOT_MQTT_CLIENT_ID));
 	setTLSRxBufferForConnack(&connectParams, 0, 0);
-	ret_val = aws_iot_shadow_connect(&client, &shadowConnectParams);
+	ret_val = aws_iot_shadow_connect(&client, &shadowConnectParams, 600);
 	CHECK_EQUAL_C_INT(SUCCESS, ret_val);
 
 	setTLSRxBufferForPuback();

--- a/tests/unit/src/aws_iot_tests_unit_shadow_delta_helper.c
+++ b/tests/unit/src/aws_iot_tests_unit_shadow_delta_helper.c
@@ -67,7 +67,7 @@ TEST_GROUP_C_SETUP(ShadowDeltaTest) {
 	shadowConnectParams.mqttClientIdLen = (uint16_t) strlen(AWS_IOT_MQTT_CLIENT_ID);
 	ConnectMQTTParamsSetup(&connectParams, AWS_IOT_MQTT_CLIENT_ID, (uint16_t) strlen(AWS_IOT_MQTT_CLIENT_ID));
 	setTLSRxBufferForConnack(&connectParams, 0, 0);
-	ret_val = aws_iot_shadow_connect(&client, &shadowConnectParams);
+	ret_val = aws_iot_shadow_connect(&client, &shadowConnectParams, 600);
 	CHECK_EQUAL_C_INT(SUCCESS, ret_val);
 
 	snprintf(shadowDeltaTopic, MAX_SHADOW_TOPIC_LENGTH_BYTES, SHADOW_DELTA_UPDATE, AWS_IOT_MY_THING_NAME);

--- a/tests/unit/src/aws_iot_tests_unit_shadow_json_builder_helper.c
+++ b/tests/unit/src/aws_iot_tests_unit_shadow_json_builder_helper.c
@@ -53,7 +53,7 @@ TEST_GROUP_C_SETUP(ShadowJsonBuilderTests) {
 	shadowConnectParams.mqttClientIdLen = (uint16_t) strlen(AWS_IOT_MQTT_CLIENT_ID);
 	ConnectMQTTParamsSetup(&connectParams, AWS_IOT_MQTT_CLIENT_ID, (uint16_t) strlen(AWS_IOT_MQTT_CLIENT_ID));
 	setTLSRxBufferForConnack(&connectParams, 0, 0);
-	ret_val = aws_iot_shadow_connect(&iotClient, &shadowConnectParams);
+	ret_val = aws_iot_shadow_connect(&iotClient, &shadowConnectParams, 600);
 	CHECK_EQUAL_C_INT(SUCCESS, ret_val);
 
 	dataFloatHandler.cb = NULL;

--- a/tests/unit/src/aws_iot_tests_unit_shadow_null_fields_helper.c
+++ b/tests/unit/src/aws_iot_tests_unit_shadow_null_fields_helper.c
@@ -83,7 +83,7 @@ TEST_C(ShadowNullFields, NullClientID) {
 
 	shadowConnectParams.pMyThingName = AWS_IOT_MY_THING_NAME;
 	shadowConnectParams.pMqttClientId = NULL;
-	rc = aws_iot_shadow_connect(&client, &shadowConnectParams);
+	rc = aws_iot_shadow_connect(&client, &shadowConnectParams, 600);
 	CHECK_EQUAL_C_INT(NULL_VALUE_ERROR, rc);
 }
 
@@ -109,7 +109,7 @@ TEST_C(ShadowNullFields, NullClientConnect) {
 	shadowConnectParams.pMyThingName = AWS_IOT_MY_THING_NAME;
 	shadowConnectParams.pMqttClientId = AWS_IOT_MQTT_CLIENT_ID;
 	shadowConnectParams.mqttClientIdLen = (uint16_t) strlen(AWS_IOT_MQTT_CLIENT_ID);
-	rc = aws_iot_shadow_connect(NULL, &shadowConnectParams);
+	rc = aws_iot_shadow_connect(NULL, &shadowConnectParams, 600);
 	CHECK_EQUAL_C_INT(NULL_VALUE_ERROR, rc);
 }
 


### PR DESCRIPTION
The user has to set "pKeppAliveTime" to get the AWS connection timeout
according to the user's usage.

*Issue #, N/A:*

*Description of changes:*
The "uint16_t pKeppAliveTime" parameter has been added to the aws_iot_shadow_connect () function.

--> Previous Declaration: IoT_Error_t aws_iot_shadow_connect(AWS_IoT_Client *pClient, ShadowConnectParameters_t *pParams);

--> New Declaration: IoT_Error_t aws_iot_shadow_connect(AWS_IoT_Client *pClient, ShadowConnectParameters_t *pParams, uint16_t pKeppAliveTime);


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
