### PR TITLE
Modify CBMC proofs to update the tinycbor submodule.

### DIFF
--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -35,7 +35,8 @@ CFLAGS += $(CFLAGS2) $(INC) $(DEF)
 	$(GOTO_CC) -o $@ $(CFLAGS) $<
 
 $(MQTT)/build:
-	(mkdir -p $(MQTT)/build; cd $(MQTT)/build; cmake ..) 2>&1 \
+	(cd $(MQTT) && git submodule init && git submodule update && \
+	 mkdir build && cd build && cmake ..) 2>&1 \
 		| tee $(ENTRY)0.txt \
 		; exit $${PIPESTATUS[0]}
 


### PR DESCRIPTION
TinyCBOR was submoduled out as a third-party dependency.  This pull
request modifies the CBMC proof build flow to update the TinyCBOR
submodule before building MQTT for CBMC.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
