### PR TITLE
Clone TinyCBOR for CBMC proofs in continuous integration

### DIFF
--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -34,9 +34,12 @@ CFLAGS += $(CFLAGS2) $(INC) $(DEF)
 %.goto : %.c
 	$(GOTO_CC) -o $@ $(CFLAGS) $<
 
-$(MQTT)/build:
-	(cd $(MQTT) && git submodule init && git submodule update && \
-	 mkdir build && cd build && cmake ..) 2>&1 \
+$(MQTT)/third_party/tinycbor/tinycbor/README:
+	cd $(MQTT)/third_party/tinycbor && \
+	git clone https://github.com/intel/tinycbor.git
+
+$(MQTT)/build: $(MQTT)/third_party/tinycbor/tinycbor/README
+	(cd $(MQTT) && mkdir -p build && cd build && cmake ..) 2>&1 \
 		| tee $(ENTRY)0.txt \
 		; exit $${PIPESTATUS[0]}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The build flow for the CBMC proofs does a "git submodule init" and
"git submodule update" to pull in the TinyCBOR submodule before
building MQTT for CBMC.  In continuous integration, however, we pull
down a straight tar file of the commit and don't actually clone the
repository, and the CBMC build flow fails at "git submodule init" in
continuous integration with the error "not a git repository".  This
pull request just manually clones the TinyCBOR into place if it is
missing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
