### PR TITLE
Fix CBMC proof of DeserializePublish (anonymous unions)

### DIFF
--- a/cbmc/proofs/DeserializePublish/DeserializePublish_harness.c
+++ b/cbmc/proofs/DeserializePublish/DeserializePublish_harness.c
@@ -13,11 +13,11 @@ void harness()
     publishInfo.pPayload = malloc( publishInfo.payloadLength );
 
     _mqttOperation_t operation;
-    operation.publishInfo = publishInfo;
+    operation.u.publish.publishInfo = publishInfo;
 
     _mqttPacket_t publish;
     publish.pRemainingData = malloc( sizeof( uint8_t ) * publish.remainingLength );
-    publish.pIncomingPublish = &operation;
+    publish.u.pIncomingPublish = &operation;
 
 
     _IotMqtt_DeserializePublish( &publish );


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Recent commits removed anonymous unions and structs from MQTT.  This
pull request adds the new names to the CBMC proof harness for
DeserializePublish.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
