### PR TITLE
Check all platform resources freed when testing

### DIFF
--- a/platform/source/posix/iot_clock_posix.c
+++ b/platform/source/posix/iot_clock_posix.c
@@ -286,6 +286,9 @@ void IotClock_TimerDestroy( IotTimer_t * pTimer )
 {
     IotLogDebug( "Destroying timer %p.", pTimer );
 
+    /* Decrement the number of platform resources in use. */
+    UnityMalloc_DecrementMallocCount();
+
     /* Destroy the underlying POSIX timer. */
     if( timer_delete( pTimer->timer ) != 0 )
     {
@@ -294,9 +297,6 @@ void IotClock_TimerDestroy( IotTimer_t * pTimer )
 
         abort();
     }
-
-    /* Decrement the number of platform resources in use. */
-    UnityMalloc_DecrementMallocCount();
 }
 
 /*-----------------------------------------------------------*/

--- a/platform/source/posix/iot_threads_posix.c
+++ b/platform/source/posix/iot_threads_posix.c
@@ -311,6 +311,9 @@ bool IotMutex_Create( IotMutex_t * pNewMutex,
 
 void IotMutex_Destroy( IotMutex_t * pMutex )
 {
+    /* Decrement the number of platform resources in use. */
+    UnityMalloc_DecrementMallocCount();
+
     int mutexError = pthread_mutex_destroy( pMutex );
 
     if( mutexError != 0 )
@@ -322,9 +325,6 @@ void IotMutex_Destroy( IotMutex_t * pMutex )
 
         abort();
     }
-
-    /* Decrement the number of platform resources in use. */
-    UnityMalloc_DecrementMallocCount();
 }
 
 /*-----------------------------------------------------------*/
@@ -438,6 +438,9 @@ uint32_t IotSemaphore_GetCount( IotSemaphore_t * pSemaphore )
 
 void IotSemaphore_Destroy( IotSemaphore_t * pSemaphore )
 {
+    /* Decrement the number of platform resources in use. */
+    UnityMalloc_DecrementMallocCount();
+
     if( sem_destroy( pSemaphore ) != 0 )
     {
         /* This block should not be reached; log an error and abort if it is. */
@@ -447,9 +450,6 @@ void IotSemaphore_Destroy( IotSemaphore_t * pSemaphore )
 
         abort();
     }
-
-    /* Decrement the number of platform resources in use. */
-    UnityMalloc_DecrementMallocCount();
 }
 
 /*-----------------------------------------------------------*/

--- a/third_party/unity/unity/fixture/unity_fixture.c
+++ b/third_party/unity/unity/fixture/unity_fixture.c
@@ -163,6 +163,20 @@ void UnityMalloc_MakeMallocFailAfterCount(int countdown)
     unity_exit_critical_section();
 }
 
+void UnityMalloc_IncrementMallocCount(void)
+{
+    unity_enter_critical_section();
+    malloc_count++;
+    unity_exit_critical_section();
+}
+
+void UnityMalloc_DecrementMallocCount(void)
+{
+    unity_enter_critical_section();
+    malloc_count--;
+    unity_exit_critical_section();
+}
+
 /* These definitions are always included from unity_fixture_malloc_overrides.h */
 /* We undef to use them or avoid conflict with <stdlib.h> per the C standard */
 #undef malloc

--- a/third_party/unity/unity/fixture/unity_fixture_malloc_overrides.h
+++ b/third_party/unity/unity/fixture/unity_fixture_malloc_overrides.h
@@ -39,6 +39,9 @@
 #define realloc unity_realloc_mt
 #define free    unity_free_mt
 
+void UnityMalloc_IncrementMallocCount(void);
+void UnityMalloc_DecrementMallocCount(void);
+
 void unity_provide_critical_section(void(*start)(void), void(*end)(void));
 void unity_enter_critical_section(void);
 void unity_exit_critical_section(void);


### PR DESCRIPTION
Inserts code into the POSIX platform layer (the one used by the CI) to ensure that all calls to create platform resources are paired with a destroy call.  Checks for leaking platform resources (i.e. mutexes, semaphores, timers).
