### PR TITLE
Add empty files for Jobs library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ jobs:
     - env: RUN_TEST=mqtt NETWORK_STACK=mbedtls
     - env: RUN_TEST=mqtt NETWORK_STACK=openssl
     - env: RUN_TEST=shadow
+    - env: RUN_TEST=jobs
     - if: type = push
       compiler: gcc
       env: RUN_TEST=coverage

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,9 @@ add_subdirectory( lib/source/serializer )
 # Defender library.
 add_subdirectory( lib/source/defender )
 
+# Jobs library.
+add_subdirectory( lib/source/jobs )
+
 # TinyCBOR library (third-party).
 add_subdirectory( third_party/tinycbor )
 

--- a/doc/config/jobs
+++ b/doc/config/jobs
@@ -1,0 +1,32 @@
+# Include common configuration options.
+@INCLUDE_PATH = doc/config
+@INCLUDE = common
+
+# Basic project information.
+PROJECT_NAME = "Jobs"
+PROJECT_BRIEF = "AWS IoT Jobs library"
+
+# Library documentation output directory.
+HTML_OUTPUT = jobs
+
+# Generate Doxygen tag file for this library.
+GENERATE_TAGFILE = doc/tag/jobs.tag
+
+# Directories containing library source code.
+INPUT = doc/lib/ \
+        lib/include \
+        lib/include/private \
+        lib/include/types \
+        lib/source/jobs \
+        demos \
+        tests/jobs/unit
+
+# Library file names.
+FILE_PATTERNS = *jobs*.h *jobs*.c *jobs*.txt
+
+# External tag files required by this library.
+TAGFILES = doc/tag/main.tag=../main \
+           doc/tag/mqtt.tag=../mqtt \
+           doc/tag/logging.tag=../logging \
+           doc/tag/static_memory.tag=../static_memory \
+           doc/tag/platform.tag=../platform

--- a/doc/config/layout_main.xml
+++ b/doc/config/layout_main.xml
@@ -9,6 +9,7 @@
     <!-- Links to the library documentation. -->
     <tab type="user" title="MQTT" url="../mqtt/index.html"/>
     <tab type="user" title="Thing Shadows" url="../shadow/index.html"/>
+    <tab type="user" title="Jobs" url="../jobs/index.html"/>
     <tab type="user" title="Device Defender" url="../defender/index.html"/>
     <tab type="usergroup" title="Common" url="[none]">
       <tab type="user" title="Linear Containers" url="../linear_containers/index.html"/>

--- a/doc/lib/jobs.txt
+++ b/doc/lib/jobs.txt
@@ -1,0 +1,5 @@
+/**
+@mainpage
+@anchor jobs
+@brief AWS IoT Device Jobs library.
+*/

--- a/lib/include/aws_iot_jobs.h
+++ b/lib/include/aws_iot_jobs.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file aws_iot_jobs.h
+ * @brief User-facing functions of the Jobs library.
+ */
+
+#ifndef AWS_IOT_JOBS_H_
+#define AWS_IOT_JOBS_H_
+
+/* The config header is always included first. */
+#include "iot_config.h"
+
+/* Jobs types include. */
+#include "types/aws_iot_jobs_types.h"
+
+/*------------------------- Jobs library functions --------------------------*/
+
+#endif

--- a/lib/include/private/aws_iot_jobs_internal.h
+++ b/lib/include/private/aws_iot_jobs_internal.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file aws_iot_jobs_internal.h
+ * @brief Internal header of Jobs library. This header should not be included in
+ * typical application code.
+ */
+
+#ifndef AWS_IOT_JOBS_INTERNAL_H_
+#define AWS_IOT_JOBS_INTERNAL_H_
+
+/* The config header is always included first. */
+#include "iot_config.h"
+
+/* Jobs include. */
+#include "aws_iot_jobs.h"
+
+#endif

--- a/lib/include/types/aws_iot_jobs_types.h
+++ b/lib/include/types/aws_iot_jobs_types.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file aws_iot_jobs_types.h
+ * @brief Types of the Jobs library.
+ */
+
+#ifndef AWS_IOT_JOBS_TYPES_H_
+#define AWS_IOT_JOBS_TYPES_H_
+
+/* The config header is always included first. */
+#include "iot_config.h"
+
+#endif

--- a/lib/source/jobs/CMakeLists.txt
+++ b/lib/source/jobs/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Jobs library source files.
+set( JOBS_SOURCES
+     aws_iot_jobs_api.c )
+
+# Jobs library target.
+add_library( awsiotjobs
+             ${JOBS_SOURCES}
+             ${PROJECT_SOURCE_DIR}/lib/include/aws_iot_jobs.h
+             ${PROJECT_SOURCE_DIR}/lib/include/types/aws_iot_jobs_types.h
+             ${PROJECT_SOURCE_DIR}/lib/include/private/aws_iot_jobs_internal.h )
+
+# Link required libraries.
+target_link_libraries( awsiotjobs PUBLIC iotmqtt )
+
+# Link Unity test framework when building tests.
+if( ${IOT_BUILD_TESTS} )
+    target_link_libraries( awsiotjobs PRIVATE unity )
+endif()
+
+# Organization of Jobs in folders.
+set_property( TARGET awsiotjobs PROPERTY FOLDER "lib" )
+source_group( include FILES ${PROJECT_SOURCE_DIR}/lib/include/aws_iot_jobs.h )
+source_group( include\\types ${PROJECT_SOURCE_DIR}/lib/include/types/aws_iot_jobs_types.h )
+source_group( include\\private ${PROJECT_SOURCE_DIR}/lib/include/private/aws_iot_jobs_internal.h )
+source_group( source FILES ${JOBS_SOURCES} )

--- a/lib/source/jobs/aws_iot_jobs_api.c
+++ b/lib/source/jobs/aws_iot_jobs_api.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file aws_iot_jobs_api.c
+ * @brief Implements the user-facing functions of the Jobs library.
+ */
+
+/* The config header is always included first. */
+#include "iot_config.h"

--- a/scripts/ci_test_jobs.sh
+++ b/scripts/ci_test_jobs.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Travis CI uses this script to test the Jobs library.
+
+# Exit on any nonzero return code.
+set -e
+
+# CMake compiler flags for building Jobs.
+CMAKE_FLAGS="$COMPILER_OPTIONS"
+
+# Build executables.
+cmake .. -DIOT_BUILD_TESTS=1 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="$CMAKE_FLAGS"
+make -j2 aws_iot_tests_jobs
+
+# Run tests.
+./bin/aws_iot_tests_jobs
+
+# Rebuild in static memory mode.
+cmake .. -DIOT_BUILD_TESTS=1 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="$CMAKE_FLAGS -DIOT_STATIC_MEMORY_ONLY=1"
+make -j2 aws_iot_tests_jobs
+
+# Run tests in static memory mode.
+./bin/aws_iot_tests_jobs

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,3 +17,6 @@ add_subdirectory( serializer )
 
 # Shadow tests.
 add_subdirectory( shadow )
+
+# Jobs tests.
+add_subdirectory( jobs )

--- a/tests/jobs/CMakeLists.txt
+++ b/tests/jobs/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Jobs unit test sources.
+set( JOBS_UNIT_TEST_SOURCES
+     unit/aws_iot_tests_jobs_api.c )
+
+# Jobs tests executable.
+add_executable( aws_iot_tests_jobs
+                ${JOBS_UNIT_TEST_SOURCES}
+                aws_iot_tests_jobs.c
+                ${IOT_TEST_APP_FILES} )
+
+# Define the test to run.
+target_compile_definitions( aws_iot_tests_jobs PRIVATE
+                            -DRunTests=RunJobsTests )
+
+# Jobs tests library dependencies.
+target_link_libraries( aws_iot_tests_jobs PRIVATE awsiotjobs unity )
+
+# Organization of Jobs tests in folders.
+set_property( TARGET aws_iot_tests_jobs PROPERTY FOLDER "tests" )
+source_group( unit FILES ${JOBS_UNIT_TEST_SOURCES} )
+source_group( "" FILES ${IOT_TEST_APP_FILES} aws_iot_tests_jobs.c )

--- a/tests/jobs/aws_iot_tests_jobs.c
+++ b/tests/jobs/aws_iot_tests_jobs.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file aws_iot_tests_jobs.c
+ * @brief Test runner for Jobs tests.
+ */
+
+/* Standard includes. */
+#include <stdbool.h>
+
+/* Test framework includes. */
+#include "unity_fixture.h"
+
+/*-----------------------------------------------------------*/
+
+void RunJobsTests( bool disableNetworkTests,
+                   bool disableLongTests )
+{
+    /* Silence warnings about unused parameters. */
+    ( void ) disableNetworkTests;
+    ( void ) disableLongTests;
+
+    RUN_TEST_GROUP( Jobs_Unit_API );
+}
+
+/*-----------------------------------------------------------*/

--- a/tests/jobs/unit/aws_iot_tests_jobs_api.c
+++ b/tests/jobs/unit/aws_iot_tests_jobs_api.c
@@ -53,6 +53,9 @@ TEST_SETUP( Jobs_Unit_API )
 
 /*-----------------------------------------------------------*/
 
+/**
+ * @brief Test tear down for Jobs API tests.
+ */
 TEST_TEAR_DOWN( Jobs_Unit_API )
 {
     IotSdk_Cleanup();

--- a/tests/jobs/unit/aws_iot_tests_jobs_api.c
+++ b/tests/jobs/unit/aws_iot_tests_jobs_api.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file aws_iot_tests_jobs_api.c
+ * @brief Tests for the user-facing API functions (declared in aws_iot_jobs.h).
+ */
+
+/* The config header is always included first. */
+#include "iot_config.h"
+
+/* SDK initialization include. */
+#include "iot_init.h"
+
+/* Test framework includes. */
+#include "unity_fixture.h"
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Test group for Jobs API tests.
+ */
+TEST_GROUP( Jobs_Unit_API );
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Test setup for Jobs API tests.
+ */
+TEST_SETUP( Jobs_Unit_API )
+{
+    /* Initialize SDK. */
+    TEST_ASSERT_EQUAL_INT( true, IotSdk_Init() );
+}
+
+/*-----------------------------------------------------------*/
+
+TEST_TEAR_DOWN( Jobs_Unit_API )
+{
+    IotSdk_Cleanup();
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Test group runner for Jobs API tests.
+ */
+TEST_GROUP_RUNNER( Jobs_Unit_API )
+{
+}
+
+/*-----------------------------------------------------------*/


### PR DESCRIPTION
Adds the minimal files necessary for building Jobs and Jobs docs; and for running on CI.