### PR TITLE
Invoke send directly in blocking MQTT functions

### DIFF
--- a/lib/include/iot_mqtt.h
+++ b/lib/include/iot_mqtt.h
@@ -206,13 +206,13 @@ void IotMqtt_ReceiveCallback( void * pNetworkConnection,
  *
  * // Example network abstraction types.
  * IotNetworkServerInfo_t serverInfo = { ... };
- * IotNetworkCredentialInfo_t credentialInfo = { ... };
+ * IotNetworkCredentials_t credentialInfo = { ... };
  * IotNetworkInterface_t networkInterface = { ... };
  *
  * // Example using a generic network implementation.
  * networkInfo.createNetworkConnection = true;
- * networkInfo.pNetworkServerInfo = &serverInfo;
- * networkInfo.pNetworkCredentialInfo = &credentialInfo;
+ * networkInfo.u.setup.pNetworkServerInfo = &serverInfo;
+ * networkInfo.u.setup.pNetworkCredentialInfo = &credentialInfo;
  * networkInfo.pNetworkInterface = &networkInterface;
  *
  * // Set the members of the connection info (password and username not used).

--- a/lib/include/private/iot_mqtt_internal.h
+++ b/lib/include/private/iot_mqtt_internal.h
@@ -239,6 +239,16 @@
  */
 #define MQTT_REMAINING_LENGTH_INVALID                          ( ( size_t ) 268435456 )
 
+/**
+ * @brief When this flag is passed, MQTT functions will execute jobs on the calling
+ * thread, bypassing the task pool.
+ *
+ * This flag is used along with @ref mqtt_constants_flags, but is intended for internal
+ * use only. Nevertheless, its value must be bitwise exclusive of all conflicting
+ * @ref mqtt_constants_flags.
+ */
+#define MQTT_INTERNAL_FLAG_SERIAL                              ( 0x80000000 )
+
 /*---------------------- MQTT internal data structures ----------------------*/
 
 /**
@@ -303,7 +313,7 @@ typedef struct _mqttOperation
                 struct
                 {
                     uint32_t failure;      /**< @brief Flag tracking keep-alive status. */
-                    uint32_t keepAliveMs;     /**< @brief Keep-alive interval in milliseconds. Its max value (per spec) is 65,535,000. */
+                    uint32_t keepAliveMs;  /**< @brief Keep-alive interval in milliseconds. Its max value (per spec) is 65,535,000. */
                     uint32_t nextPeriodMs; /**< @brief Relative delay for next keep-alive job. */
                 } ping;                    /**< @brief Additional information for keep-alive pings. */
             } periodic;                    /**< @brief Additional information for periodic operations. */

--- a/lib/include/private/iot_mqtt_internal.h
+++ b/lib/include/private/iot_mqtt_internal.h
@@ -247,7 +247,7 @@
  * use only. Nevertheless, its value must be bitwise exclusive of all conflicting
  * @ref mqtt_constants_flags.
  */
-#define MQTT_INTERNAL_FLAG_SERIAL                              ( 0x80000000 )
+#define MQTT_INTERNAL_FLAG_BLOCK_ON_SEND                       ( 0x80000000 )
 
 /*---------------------- MQTT internal data structures ----------------------*/
 

--- a/lib/include/private/iot_mqtt_internal.h
+++ b/lib/include/private/iot_mqtt_internal.h
@@ -209,8 +209,6 @@
  *
  * Used to validate parameters if when connecting to an AWS IoT MQTT server.
  */
-#define AWS_IOT_MQTT_SERVER_MIN_KEEPALIVE                      ( 30 )   /**< @brief Minumum keep-alive interval accepted by AWS IoT. */
-#define AWS_IOT_MQTT_SERVER_MAX_KEEPALIVE                      ( 1200 ) /**< @brief Maximum keep-alive interval accepted by AWS IoT. */
 #define AWS_IOT_MQTT_SERVER_MAX_CLIENTID                       ( 128 )  /**< @brief Maximum length of client identifier accepted by AWS IoT. */
 #define AWS_IOT_MQTT_SERVER_MAX_TOPIC_LENGTH                   ( 256 )  /**< @brief Maximum length of topic names or filters accepted by AWS IoT. */
 #define AWS_IOT_MQTT_SERVER_MAX_TOPIC_FILTERS_PER_SUBSCRIBE    ( 8 )    /**< @brief Maximum number of topic filters in a single SUBSCRIBE packet. */

--- a/lib/source/mqtt/iot_mqtt_api.c
+++ b/lib/source/mqtt/iot_mqtt_api.c
@@ -1139,25 +1139,16 @@ IotMqttError_t IotMqtt_Connect( const IotMqttNetworkInfo_t * pNetworkInfo,
     IotMqtt_Assert( pOperation->u.operation.pMqttPacket != NULL );
     IotMqtt_Assert( pOperation->u.operation.packetSize > 0 );
 
-    /* Add the CONNECT operation to the send queue for network transmission. */
-    status = _IotMqtt_ScheduleOperation( pOperation,
-                                         _IotMqtt_ProcessSend,
-                                         0 );
+    /* Send the CONNECT packet. */
+    _IotMqtt_ProcessSend( IOT_SYSTEM_TASKPOOL, pOperation->job, pOperation );
 
-    if( status != IOT_MQTT_SUCCESS )
-    {
-        IotLogError( "Failed to enqueue CONNECT for sending." );
-    }
-    else
-    {
-        /* Wait for the CONNECT operation to complete, i.e. wait for CONNACK. */
-        status = IotMqtt_Wait( pOperation,
-                               timeoutMs );
+    /* Wait for the CONNECT operation to complete, i.e. wait for CONNACK. */
+    status = IotMqtt_Wait( pOperation,
+                           timeoutMs );
 
-        /* The call to wait cleans up the CONNECT operation, so set the pointer
-         * to NULL. */
-        pOperation = NULL;
-    }
+    /* The call to wait cleans up the CONNECT operation, so set the pointer
+     * to NULL. */
+    pOperation = NULL;
 
     /* When a connection is successfully established, schedule keep-alive job. */
     if( status == IOT_MQTT_SUCCESS )

--- a/lib/source/mqtt/iot_mqtt_api.c
+++ b/lib/source/mqtt/iot_mqtt_api.c
@@ -709,7 +709,7 @@ static IotMqttError_t _subscriptionCommon( IotMqttOperationType_t operation,
     }
 
     /* Send the SUBSCRIBE packet. */
-    if( ( flags & MQTT_INTERNAL_FLAG_SERIAL ) == MQTT_INTERNAL_FLAG_SERIAL )
+    if( ( flags & MQTT_INTERNAL_FLAG_BLOCK_ON_SEND ) == MQTT_INTERNAL_FLAG_BLOCK_ON_SEND )
     {
         _IotMqtt_ProcessSend( IOT_SYSTEM_TASKPOOL, pSubscriptionOperation->job, pSubscriptionOperation );
     }
@@ -1421,7 +1421,7 @@ IotMqttError_t IotMqtt_TimedSubscribe( IotMqttConnection_t mqttConnection,
     status = IotMqtt_Subscribe( mqttConnection,
                                 pSubscriptionList,
                                 subscriptionCount,
-                                IOT_MQTT_FLAG_WAITABLE | MQTT_INTERNAL_FLAG_SERIAL,
+                                IOT_MQTT_FLAG_WAITABLE | MQTT_INTERNAL_FLAG_BLOCK_ON_SEND,
                                 NULL,
                                 &subscribeOperation );
 
@@ -1477,7 +1477,7 @@ IotMqttError_t IotMqtt_TimedUnsubscribe( IotMqttConnection_t mqttConnection,
     status = IotMqtt_Unsubscribe( mqttConnection,
                                   pSubscriptionList,
                                   subscriptionCount,
-                                  IOT_MQTT_FLAG_WAITABLE | MQTT_INTERNAL_FLAG_SERIAL,
+                                  IOT_MQTT_FLAG_WAITABLE | MQTT_INTERNAL_FLAG_BLOCK_ON_SEND,
                                   NULL,
                                   &unsubscribeOperation );
 
@@ -1685,7 +1685,7 @@ IotMqttError_t IotMqtt_Publish( IotMqttConnection_t mqttConnection,
     }
 
     /* Send the PUBLISH packet. */
-    if( ( flags & MQTT_INTERNAL_FLAG_SERIAL ) == MQTT_INTERNAL_FLAG_SERIAL )
+    if( ( flags & MQTT_INTERNAL_FLAG_BLOCK_ON_SEND ) == MQTT_INTERNAL_FLAG_BLOCK_ON_SEND )
     {
         _IotMqtt_ProcessSend( IOT_SYSTEM_TASKPOOL, pOperation->job, pOperation );
     }
@@ -1770,7 +1770,7 @@ IotMqttError_t IotMqtt_TimedPublish( IotMqttConnection_t mqttConnection,
                        * pPublishOperation = NULL;
 
     /* Clear the flags, setting only the "serial" flag. */
-    flags = MQTT_INTERNAL_FLAG_SERIAL;
+    flags = MQTT_INTERNAL_FLAG_BLOCK_ON_SEND;
 
     /* Set the waitable flag and reference for QoS 1 PUBLISH. */
     if( pPublishInfo->qos == IOT_MQTT_QOS_1 )

--- a/lib/source/mqtt/iot_mqtt_api.c
+++ b/lib/source/mqtt/iot_mqtt_api.c
@@ -1143,8 +1143,7 @@ IotMqttError_t IotMqtt_Connect( const IotMqttNetworkInfo_t * pNetworkInfo,
     _IotMqtt_ProcessSend( IOT_SYSTEM_TASKPOOL, pOperation->job, pOperation );
 
     /* Wait for the CONNECT operation to complete, i.e. wait for CONNACK. */
-    status = IotMqtt_Wait( pOperation,
-                           timeoutMs );
+    status = IotMqtt_Wait( pOperation, timeoutMs );
 
     /* The call to wait cleans up the CONNECT operation, so set the pointer
      * to NULL. */

--- a/lib/source/mqtt/iot_mqtt_api.c
+++ b/lib/source/mqtt/iot_mqtt_api.c
@@ -378,32 +378,6 @@ static _mqttConnection_t * _createMqttConnection( bool awsIotMqttMode,
     IotListDouble_Create( &( pMqttConnection->pendingProcessing ) );
     IotListDouble_Create( &( pMqttConnection->pendingResponse ) );
 
-    /* AWS IoT service limits set minimum and maximum values for keep-alive interval.
-     * Adjust the user-provided keep-alive interval based on these requirements. */
-    if( awsIotMqttMode == true )
-    {
-        if( keepAliveSeconds < AWS_IOT_MQTT_SERVER_MIN_KEEPALIVE )
-        {
-            keepAliveSeconds = AWS_IOT_MQTT_SERVER_MIN_KEEPALIVE;
-        }
-        else if( keepAliveSeconds > AWS_IOT_MQTT_SERVER_MAX_KEEPALIVE )
-        {
-            keepAliveSeconds = AWS_IOT_MQTT_SERVER_MAX_KEEPALIVE;
-        }
-        else if( keepAliveSeconds == 0 )
-        {
-            keepAliveSeconds = AWS_IOT_MQTT_SERVER_MAX_KEEPALIVE;
-        }
-        else
-        {
-            EMPTY_ELSE_MARKER;
-        }
-    }
-    else
-    {
-        EMPTY_ELSE_MARKER;
-    }
-
     /* Check if keep-alive is active for this connection. */
     if( keepAliveSeconds != 0 )
     {

--- a/lib/source/mqtt/iot_mqtt_operation.c
+++ b/lib/source/mqtt/iot_mqtt_operation.c
@@ -506,11 +506,6 @@ bool _IotMqtt_DecrementOperationReferences( _mqttOperation_t * pOperation,
                                                 pOperation->job,
                                                 NULL );
 
-        /* If the operation's job was not canceled, it must be already executing.
-         * Any other return value is invalid. */
-        IotMqtt_Assert( ( taskPoolStatus == IOT_TASKPOOL_SUCCESS ) ||
-                        ( taskPoolStatus == IOT_TASKPOOL_CANCEL_FAILED ) );
-
         if( taskPoolStatus == IOT_TASKPOOL_SUCCESS )
         {
             IotLogDebug( "(MQTT connection %p, %s operation %p) Job canceled.",

--- a/lib/source/mqtt/iot_mqtt_validate.c
+++ b/lib/source/mqtt/iot_mqtt_validate.c
@@ -139,32 +139,6 @@ bool _IotMqtt_ValidateConnect( const IotMqttConnectInfo_t * pConnectInfo )
         {
             EMPTY_ELSE_MARKER;
         }
-
-        /* Check for compliance with AWS IoT keep-alive limits. */
-        if( pConnectInfo->keepAliveSeconds == 0 )
-        {
-            IotLogWarn( "AWS IoT does not support disabling keep-alive. Default keep-alive "
-                        "of %d seconds will be used.",
-                        AWS_IOT_MQTT_SERVER_MAX_KEEPALIVE );
-        }
-        else if( pConnectInfo->keepAliveSeconds < AWS_IOT_MQTT_SERVER_MIN_KEEPALIVE )
-        {
-            IotLogWarn( "AWS IoT does not support keep-alive intervals less than %d seconds. "
-                        "An interval of %d seconds will be used.",
-                        AWS_IOT_MQTT_SERVER_MIN_KEEPALIVE,
-                        AWS_IOT_MQTT_SERVER_MIN_KEEPALIVE );
-        }
-        else if( pConnectInfo->keepAliveSeconds > AWS_IOT_MQTT_SERVER_MAX_KEEPALIVE )
-        {
-            IotLogWarn( "AWS IoT does not support keep-alive intervals greater than %d seconds. "
-                        "An interval of %d seconds will be used.",
-                        AWS_IOT_MQTT_SERVER_MAX_KEEPALIVE,
-                        AWS_IOT_MQTT_SERVER_MAX_KEEPALIVE );
-        }
-        else
-        {
-            EMPTY_ELSE_MARKER;
-        }
     }
     else
     {

--- a/tests/mqtt/CMakeLists.txt
+++ b/tests/mqtt/CMakeLists.txt
@@ -14,7 +14,12 @@ add_executable( iot_tests_mqtt
                 ${MQTT_SYSTEM_TEST_SOURCES}
                 ${MQTT_UNIT_TEST_SOURCES}
                 iot_tests_mqtt.c
-                ${IOT_TEST_APP_FILES} )
+                ${IOT_TEST_APP_FILES}
+                ${MQTT_MOCK_SOURCES} )
+
+# Include directory for MQTT mock.
+target_include_directories( iot_tests_mqtt PRIVATE
+                            ${PROJECT_SOURCE_DIR}/tests/mqtt/mock )
 
 # Define the test to run.
 target_compile_definitions( iot_tests_mqtt PRIVATE
@@ -27,4 +32,5 @@ target_link_libraries( iot_tests_mqtt PRIVATE iotmqtt unity )
 set_property( TARGET iot_tests_mqtt PROPERTY FOLDER "tests" )
 source_group( system FILES ${MQTT_SYSTEM_TEST_SOURCES} )
 source_group( unit FILES ${MQTT_UNIT_TEST_SOURCES} )
+source_group( mock FILES ${MQTT_MOCK_SOURCES} )
 source_group( "" FILES ${IOT_TEST_APP_FILES} iot_tests_mqtt.c )

--- a/tests/mqtt/mock/iot_tests_mqtt_mock.c
+++ b/tests/mqtt/mock/iot_tests_mqtt_mock.c
@@ -261,9 +261,9 @@ static size_t _sendSuccess( void * pSendContext,
         IotTest_Assert( _lastPacketIdentifier != 0 );
 
         /* Set the receive thread to run after a "network round-trip". */
-        IotTest_Assert( IotClock_TimerArm( &_receiveTimer,
-                                           NETWORK_ROUND_TRIP_TIME_MS,
-                                           0 ) == true );
+        ( void ) IotClock_TimerArm( &_receiveTimer,
+                                    NETWORK_ROUND_TRIP_TIME_MS,
+                                    0 );
     }
 
     IotMutex_Unlock( &_lastPacketMutex );

--- a/tests/mqtt/unit/iot_tests_mqtt_api.c
+++ b/tests/mqtt/unit/iot_tests_mqtt_api.c
@@ -46,6 +46,9 @@
 /* MQTT test access include. */
 #include "iot_test_access_mqtt.h"
 
+/* MQTT mock include. */
+#include "iot_tests_mqtt_mock.h"
+
 /* Atomics include. */
 #include "iot_atomic.h"
 
@@ -567,6 +570,7 @@ TEST_GROUP_RUNNER( MQTT_Unit_API )
     RUN_TEST_CASE( MQTT_Unit_API, SubscribeUnsubscribeParameters );
     RUN_TEST_CASE( MQTT_Unit_API, SubscribeMallocFail );
     RUN_TEST_CASE( MQTT_Unit_API, UnsubscribeMallocFail );
+    RUN_TEST_CASE( MQTT_Unit_API, SingleThreaded );
     RUN_TEST_CASE( MQTT_Unit_API, KeepAlivePeriodic );
     RUN_TEST_CASE( MQTT_Unit_API, KeepAliveJobCleanup );
 }
@@ -1350,6 +1354,46 @@ TEST( MQTT_Unit_API, UnsubscribeMallocFail )
     }
 
     IotMqtt_Disconnect( _pMqttConnection, IOT_MQTT_FLAG_CLEANUP_ONLY );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Test that MQTT can work in a single thread without the task pool.
+ */
+TEST( MQTT_Unit_API, SingleThreaded )
+{
+    IotMqttError_t status = IOT_MQTT_STATUS_PENDING;
+    IotMqttConnection_t mqttConnection = IOT_MQTT_CONNECTION_INITIALIZER;
+    IotMqttSubscription_t subscription = IOT_MQTT_SUBSCRIPTION_INITIALIZER;
+    IotTaskPoolInfo_t taskPoolInfo = IOT_TASKPOOL_INFO_INITIALIZER_SMALL;
+
+    /* Shut down the system task pool to test if MQTT works without it. */
+    IotTaskPool_Destroy( IOT_SYSTEM_TASKPOOL );
+
+    /* Set the members of the subscription. */
+    subscription.pTopicFilter = TEST_TOPIC_NAME;
+    subscription.topicFilterLength = TEST_TOPIC_NAME_LENGTH;
+    subscription.callback.function = SUBSCRIPTION_CALLBACK;
+
+    if( TEST_PROTECT() )
+    {
+        /* Set up a mocked MQTT connection. */
+        TEST_ASSERT_EQUAL_INT( true, IotTest_MqttMockInit( &mqttConnection ) );
+
+        /* Add a subscription. */
+        status = IotMqtt_TimedSubscribe( mqttConnection, &subscription, 1, 0, TIMEOUT_MS );
+        TEST_ASSERT_EQUAL_INT( IOT_MQTT_SUCCESS, status );
+
+        /* Remove the subscription. */
+        status = IotMqtt_TimedUnsubscribe( mqttConnection, &subscription, 1, 0, TIMEOUT_MS );
+        TEST_ASSERT_EQUAL_INT( IOT_MQTT_SUCCESS, status );
+
+        IotTest_MqttMockCleanup();
+    }
+
+    /* Re-initialize the system task pool for test tear down. */
+    TEST_ASSERT_EQUAL( IOT_TASKPOOL_SUCCESS, IotTaskPool_CreateSystemTaskPool( &taskPoolInfo ) );
 }
 
 /*-----------------------------------------------------------*/

--- a/tests/mqtt/unit/iot_tests_mqtt_api.c
+++ b/tests/mqtt/unit/iot_tests_mqtt_api.c
@@ -1384,32 +1384,40 @@ TEST( MQTT_Unit_API, SingleThreaded )
     publishInfo.payloadLength = 4;
     publishInfo.qos = IOT_MQTT_QOS_1;
 
-    /* Set up a mocked MQTT connection. */
-    TEST_ASSERT_EQUAL_INT( true, IotTest_MqttMockInit( &mqttConnection ) );
+    if( TEST_PROTECT() )
+    {
+        /* Set up a mocked MQTT connection. */
+        TEST_ASSERT_EQUAL_INT( true, IotTest_MqttMockInit( &mqttConnection ) );
 
-    /* Add a subscription. */
-    status = IotMqtt_TimedSubscribe( mqttConnection, &subscription, 1, 0, DUP_CHECK_TIMEOUT );
-    TEST_ASSERT_EQUAL_INT( IOT_MQTT_SUCCESS, status );
+        /* Add a subscription. */
+        status = IotMqtt_TimedSubscribe( mqttConnection, &subscription, 1, 0, DUP_CHECK_TIMEOUT );
+        TEST_ASSERT_EQUAL_INT( IOT_MQTT_SUCCESS, status );
 
-    /* Transmit a message with no retry. */
-    status = IotMqtt_TimedPublish( mqttConnection, &publishInfo, 0, DUP_CHECK_TIMEOUT );
-    TEST_ASSERT_EQUAL_INT( IOT_MQTT_SUCCESS, status );
+        /* Transmit a message with no retry. */
+        status = IotMqtt_TimedPublish( mqttConnection, &publishInfo, 0, DUP_CHECK_TIMEOUT );
+        TEST_ASSERT_EQUAL_INT( IOT_MQTT_SUCCESS, status );
 
-    /* Remove the subscription. */
-    status = IotMqtt_TimedUnsubscribe( mqttConnection, &subscription, 1, 0, DUP_CHECK_TIMEOUT );
-    TEST_ASSERT_EQUAL_INT( IOT_MQTT_SUCCESS, status );
+        /* Remove the subscription. */
+        status = IotMqtt_TimedUnsubscribe( mqttConnection, &subscription, 1, 0, DUP_CHECK_TIMEOUT );
+        TEST_ASSERT_EQUAL_INT( IOT_MQTT_SUCCESS, status );
 
-    /* Re-initialize the system task pool. The task pool must be available to
-     * send messages with a retry. */
-    TEST_ASSERT_EQUAL( IOT_TASKPOOL_SUCCESS, IotTaskPool_CreateSystemTaskPool( &taskPoolInfo ) );
+        /* Re-initialize the system task pool. The task pool must be available to
+         * send messages with a retry. */
+        TEST_ASSERT_EQUAL( IOT_TASKPOOL_SUCCESS, IotTaskPool_CreateSystemTaskPool( &taskPoolInfo ) );
 
-    /* Transmit a message with a retry. */
-    publishInfo.retryLimit = DUP_CHECK_RETRY_LIMIT;
-    publishInfo.retryMs = DUP_CHECK_RETRY_MS;
-    status = IotMqtt_TimedPublish( mqttConnection, &publishInfo, 0, DUP_CHECK_TIMEOUT );
-    TEST_ASSERT_EQUAL_INT( IOT_MQTT_SUCCESS, status );
+        /* Transmit a message with a retry. */
+        publishInfo.retryLimit = DUP_CHECK_RETRY_LIMIT;
+        publishInfo.retryMs = DUP_CHECK_RETRY_MS;
+        status = IotMqtt_TimedPublish( mqttConnection, &publishInfo, 0, DUP_CHECK_TIMEOUT );
+        TEST_ASSERT_EQUAL_INT( IOT_MQTT_SUCCESS, status );
 
-    IotTest_MqttMockCleanup();
+        IotTest_MqttMockCleanup();
+    }
+    else
+    {
+        /* Re-initialize the system task pool for test tear down. */
+        TEST_ASSERT_EQUAL( IOT_TASKPOOL_SUCCESS, IotTaskPool_CreateSystemTaskPool( &taskPoolInfo ) );
+    }
 }
 
 /*-----------------------------------------------------------*/

--- a/tests/mqtt/unit/iot_tests_mqtt_validate.c
+++ b/tests/mqtt/unit/iot_tests_mqtt_validate.c
@@ -143,21 +143,6 @@ TEST( MQTT_Unit_Validate, ValidateConnectInfo )
         validateStatus = _IotMqtt_ValidateConnect( &connectInfo );
         TEST_ASSERT_EQUAL_INT( false, validateStatus );
         connectInfo.clientIdentifierLength = 24;
-
-        /* Keep-alive disabled. */
-        connectInfo.keepAliveSeconds = 0;
-        validateStatus = _IotMqtt_ValidateConnect( &connectInfo );
-        TEST_ASSERT_EQUAL_INT( true, validateStatus );
-
-        /* Keep-alive too small. */
-        connectInfo.keepAliveSeconds = AWS_IOT_MQTT_SERVER_MIN_KEEPALIVE - 1;
-        validateStatus = _IotMqtt_ValidateConnect( &connectInfo );
-        TEST_ASSERT_EQUAL_INT( true, validateStatus );
-
-        /* Keep-alive too large. */
-        connectInfo.keepAliveSeconds = AWS_IOT_MQTT_SERVER_MAX_KEEPALIVE + 1;
-        validateStatus = _IotMqtt_ValidateConnect( &connectInfo );
-        TEST_ASSERT_EQUAL_INT( true, validateStatus );
     #endif /* if AWS_IOT_MQTT_SERVER == true */
 }
 


### PR DESCRIPTION
Changes MQTT blocking CONNECT, SUBSCRIBE, UNSUBSCRIBE and DISCONNECT to not use a background thread.

For MQTT PUBLISH, a blocking QoS 1 publish with retries still uses the background thread to send any required retransmissions.
