### PR TITLE
iot_demo_mqtt.c : check identifier for v4_beta

### DIFF
--- a/demos/source/iot_demo_mqtt.c
+++ b/demos/source/iot_demo_mqtt.c
@@ -427,7 +427,7 @@ static int _establishMqttConnection( bool awsIotMqttMode,
 
     /* Use the parameter client identifier if provided. Otherwise, generate a
      * unique client identifier. */
-    if( pIdentifier != NULL )
+    if( ( pIdentifier != NULL ) && ( pIdentifier[ 0 ] != '\0' ) )
     {
         connectInfo.pClientIdentifier = pIdentifier;
         connectInfo.clientIdentifierLength = ( uint16_t ) strlen( pIdentifier );


### PR DESCRIPTION
*Issue #, if available:*

See demos\source\iot_demo_mqtt.c in v4_beta:

By default, `clientcredentialIOT_THING_NAME` is defined as an empty string. When `_establishMqttConnection()` is called with a zero-length identifier, an error will be thrown later on.

*Description of changes:*

This PR is essentially the same as [PR 1056](https://github.com/aws/amazon-freertos/pull/1056).

@dcgaws requested me to create an identical PR for the branch v4_beta.

Hein.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
