### PR TITLE
Don't treat resubscribe failures as reconnect failures

### DIFF
--- a/include/aws_iot_mqtt_client.h
+++ b/include/aws_iot_mqtt_client.h
@@ -230,6 +230,7 @@ typedef void (*pApplicationHandler_t)(AWS_IoT_Client *pClient, char *pTopicName,
 typedef struct _MessageHandlers {
 	const char *topicName;
 	uint16_t topicNameLen;
+	char resubscribed;
 	QoS qos;
 	pApplicationHandler_t pApplicationHandler;
 	void *pApplicationHandlerData;

--- a/src/aws_iot_mqtt_client_connect.c
+++ b/src/aws_iot_mqtt_client_connect.c
@@ -204,8 +204,8 @@ static IoT_Error_t _aws_iot_mqtt_serialize_connect(unsigned char *pTxBuf, size_t
 	if (pConnectParams->isWillMsgPresent)
 	{
 		flags.all |= 1 << 2;
-		flags.all |= pConnectParams->will.qos << 3;
-		flags.all |= pConnectParams->will.isRetained << 5;
+		flags.all |= (uint8_t) (pConnectParams->will.qos << 3);
+		flags.all |= (uint8_t) (pConnectParams->will.isRetained << 5);
 	}
 
 	if(pConnectParams->pPassword) {
@@ -594,6 +594,7 @@ IoT_Error_t aws_iot_mqtt_disconnect(AWS_IoT_Client *pClient) {
  */
 IoT_Error_t aws_iot_mqtt_attempt_reconnect(AWS_IoT_Client *pClient) {
 	IoT_Error_t rc;
+	ClientState currentState = aws_iot_mqtt_get_client_state(pClient);
 
 	FUNC_ENTRY;
 
@@ -601,22 +602,26 @@ IoT_Error_t aws_iot_mqtt_attempt_reconnect(AWS_IoT_Client *pClient) {
 		FUNC_EXIT_RC(NULL_VALUE_ERROR);
 	}
 
-	if(aws_iot_mqtt_is_client_connected(pClient)) {
-		FUNC_EXIT_RC(NETWORK_ALREADY_CONNECTED_ERROR);
+	if(!aws_iot_mqtt_is_client_connected(pClient)) {
+		/* Ignoring return code. failures expected if network is disconnected */
+		aws_iot_mqtt_connect(pClient, NULL);
+
+		/* If still disconnected handle disconnect */
+		if(CLIENT_STATE_CONNECTED_IDLE != aws_iot_mqtt_get_client_state(pClient)) {
+			aws_iot_mqtt_set_client_state(pClient, CLIENT_STATE_DISCONNECTED_ERROR, CLIENT_STATE_PENDING_RECONNECT);
+			FUNC_EXIT_RC(NETWORK_ATTEMPTING_RECONNECT);
+		}
 	}
-
-	/* Ignoring return code. failures expected if network is disconnected */
-	rc = aws_iot_mqtt_connect(pClient, NULL);
-
-	/* If still disconnected handle disconnect */
-	if(CLIENT_STATE_CONNECTED_IDLE != aws_iot_mqtt_get_client_state(pClient)) {
-		aws_iot_mqtt_set_client_state(pClient, CLIENT_STATE_DISCONNECTED_ERROR, CLIENT_STATE_PENDING_RECONNECT);
-		FUNC_EXIT_RC(NETWORK_ATTEMPTING_RECONNECT);
+	else {
+		/* Don't need to do anything if not resubscribing */
+		if(currentState != CLIENT_STATE_CONNECTED_RESUBSCRIBE_IN_PROGRESS) {
+			FUNC_EXIT_RC(NETWORK_ALREADY_CONNECTED_ERROR);
+		}
 	}
 
 	rc = aws_iot_mqtt_resubscribe(pClient);
 	if(SUCCESS != rc) {
-		FUNC_EXIT_RC(rc);
+		FUNC_EXIT_RC(NETWORK_ATTEMPTING_RECONNECT);
 	}
 
 	FUNC_EXIT_RC(NETWORK_RECONNECTED);

--- a/src/aws_iot_mqtt_client_connect.c
+++ b/src/aws_iot_mqtt_client_connect.c
@@ -602,6 +602,7 @@ IoT_Error_t aws_iot_mqtt_attempt_reconnect(AWS_IoT_Client *pClient) {
 		FUNC_EXIT_RC(NULL_VALUE_ERROR);
 	}
 
+	/* Only attempt a connect if not already connected. */
 	if(!aws_iot_mqtt_is_client_connected(pClient)) {
 		/* Ignoring return code. failures expected if network is disconnected */
 		aws_iot_mqtt_connect(pClient, NULL);
@@ -613,8 +614,9 @@ IoT_Error_t aws_iot_mqtt_attempt_reconnect(AWS_IoT_Client *pClient) {
 		}
 	}
 	else {
-		/* Don't need to do anything if not resubscribing */
-		if(currentState != CLIENT_STATE_CONNECTED_RESUBSCRIBE_IN_PROGRESS) {
+		/* If already connected and no subscribe operation pending, then return
+		already connected error. */
+		if(CLIENT_STATE_CONNECTED_RESUBSCRIBE_IN_PROGRESS != aws_iot_mqtt_get_client_state(pClient)) {
 			FUNC_EXIT_RC(NETWORK_ALREADY_CONNECTED_ERROR);
 		}
 	}

--- a/src/aws_iot_mqtt_client_subscribe.c
+++ b/src/aws_iot_mqtt_client_subscribe.c
@@ -430,8 +430,7 @@ IoT_Error_t aws_iot_mqtt_resubscribe(AWS_IoT_Client *pClient) {
 	}
 
 	if(CLIENT_STATE_CONNECTED_RESUBSCRIBE_IN_PROGRESS != currentState) {
-		rc = aws_iot_mqtt_set_client_state(pClient, CLIENT_STATE_CONNECTED_IDLE,
-											CLIENT_STATE_CONNECTED_RESUBSCRIBE_IN_PROGRESS);
+		rc = aws_iot_mqtt_set_client_state(pClient, CLIENT_STATE_CONNECTED_IDLE, CLIENT_STATE_CONNECTED_RESUBSCRIBE_IN_PROGRESS);
 
 		if(SUCCESS != rc) {
 			FUNC_EXIT_RC(MQTT_CLIENT_NOT_IDLE_ERROR);
@@ -441,8 +440,7 @@ IoT_Error_t aws_iot_mqtt_resubscribe(AWS_IoT_Client *pClient) {
 	resubRc = _aws_iot_mqtt_internal_resubscribe(pClient);
 
 	if(SUCCESS == resubRc) {
-		resubRc = aws_iot_mqtt_set_client_state(pClient, CLIENT_STATE_CONNECTED_RESUBSCRIBE_IN_PROGRESS,
-												CLIENT_STATE_CONNECTED_IDLE);
+		resubRc = aws_iot_mqtt_set_client_state(pClient, CLIENT_STATE_CONNECTED_RESUBSCRIBE_IN_PROGRESS, CLIENT_STATE_CONNECTED_IDLE);
 	}
 
 	FUNC_EXIT_RC(resubRc);

--- a/src/aws_iot_mqtt_client_yield.c
+++ b/src/aws_iot_mqtt_client_yield.c
@@ -180,6 +180,7 @@ static IoT_Error_t _aws_iot_mqtt_keep_alive(AWS_IoT_Client *pClient) {
 
 static IoT_Error_t _aws_iot_mqtt_internal_yield(AWS_IoT_Client *pClient, uint32_t timeout_ms) {
 	IoT_Error_t yieldRc = SUCCESS;
+	int itr = 0;
 
 	uint8_t packet_type;
 	ClientState clientState;
@@ -192,7 +193,8 @@ static IoT_Error_t _aws_iot_mqtt_internal_yield(AWS_IoT_Client *pClient, uint32_
 	// evaluate timeout at the end of the loop to make sure the actual yield runs at least once
 	do {
 		clientState = aws_iot_mqtt_get_client_state(pClient);
-		if(CLIENT_STATE_PENDING_RECONNECT == clientState) {
+		if((CLIENT_STATE_PENDING_RECONNECT == clientState) ||
+			(CLIENT_STATE_CONNECTED_RESUBSCRIBE_IN_PROGRESS == clientState)) {
 			if(AWS_IOT_MQTT_MAX_RECONNECT_WAIT_INTERVAL < pClient->clientData.currentReconnectWaitInterval) {
 				yieldRc = NETWORK_RECONNECT_TIMED_OUT_ERROR;
 				break;
@@ -224,6 +226,11 @@ static IoT_Error_t _aws_iot_mqtt_internal_yield(AWS_IoT_Client *pClient, uint32_
 
 				pClient->clientData.currentReconnectWaitInterval = AWS_IOT_MQTT_MIN_RECONNECT_WAIT_INTERVAL;
 				countdown_ms(&(pClient->reconnectDelayTimer), pClient->clientData.currentReconnectWaitInterval);
+
+				for(itr = 0; itr < AWS_IOT_MQTT_NUM_SUBSCRIBE_HANDLERS; itr++) {
+					pClient->clientData.messageHandlers[itr].resubscribed = 0;
+				}
+
 				/* Depending on timer values, it is possible that yield timer has expired
 				 * Set to rc to attempting reconnect to inform client that autoreconnect
 				 * attempt has started */
@@ -272,9 +279,10 @@ IoT_Error_t aws_iot_mqtt_yield(AWS_IoT_Client *pClient, uint32_t timeout_ms) {
 		FUNC_EXIT_RC(NETWORK_MANUALLY_DISCONNECTED);
 	}
 
-	/* If we are in the pending reconnect state, skip other checks.
+	/* If we are in the pending reconnect or pending resubscribe state, skip other checks.
 	 * Pending reconnect state is only set when auto-reconnect is enabled */
-	if(CLIENT_STATE_PENDING_RECONNECT != clientState) {
+	if((CLIENT_STATE_PENDING_RECONNECT != clientState) &&
+		(CLIENT_STATE_CONNECTED_RESUBSCRIBE_IN_PROGRESS != clientState)) {
 		/* Check if network is disconnected and auto-reconnect is not enabled */
 		if(!aws_iot_mqtt_is_client_connected(pClient)) {
 			FUNC_EXIT_RC(NETWORK_DISCONNECTED_ERROR);
@@ -308,4 +316,3 @@ IoT_Error_t aws_iot_mqtt_yield(AWS_IoT_Client *pClient, uint32_t timeout_ms) {
 #ifdef __cplusplus
 }
 #endif
-

--- a/tests/unit/include/aws_iot_tests_unit_helper_functions.h
+++ b/tests/unit/include/aws_iot_tests_unit_helper_functions.h
@@ -68,6 +68,10 @@ void setTLSRxBufferForUnsuback(void);
 
 void setTLSRxBufferForPingresp(void);
 
+void setTLSRxBufferForError(IoT_Error_t error);
+
+void setTLSTxBufferForError(IoT_Error_t error);
+
 void setTLSRxBufferForConnackAndSuback(IoT_Client_Connect_Params *conParams, unsigned char sessionPresent,
 											  char *topicName, size_t topicNameLen, QoS qos);
 

--- a/tests/unit/src/aws_iot_tests_unit_connect.cpp
+++ b/tests/unit/src/aws_iot_tests_unit_connect.cpp
@@ -83,4 +83,4 @@ TEST_GROUP_C_WRAPPER(ConnectTests, cleanSessionInitSubscribers)
 /* B:28 - Connect attempt, power cycle with clean session false */
 TEST_GROUP_C_WRAPPER(ConnectTests, PowerCycleWithCleanSessionFalse)
 /* B:29 - Reconnect attempt succeeds, but resubscribes fail */
-TEST_GROUP_C_WRAPPER(ConnectTests, ConnectAndResubscribe)
+TEST_GROUP_C_WRAPPER(ConnectTests, ReconnectAndResubscribe)

--- a/tests/unit/src/aws_iot_tests_unit_connect.cpp
+++ b/tests/unit/src/aws_iot_tests_unit_connect.cpp
@@ -82,3 +82,5 @@ TEST_GROUP_C_WRAPPER(ConnectTests, ConnectDisconnectConnect)
 TEST_GROUP_C_WRAPPER(ConnectTests, cleanSessionInitSubscribers)
 /* B:28 - Connect attempt, power cycle with clean session false */
 TEST_GROUP_C_WRAPPER(ConnectTests, PowerCycleWithCleanSessionFalse)
+/* B:29 - Reconnect attempt succeeds, but resubscribes fail */
+TEST_GROUP_C_WRAPPER(ConnectTests, ConnectAndResubscribe)

--- a/tests/unit/src/aws_iot_tests_unit_connect_helper.c
+++ b/tests/unit/src/aws_iot_tests_unit_connect_helper.c
@@ -781,7 +781,7 @@ TEST_C(ConnectTests, ConnectAndResubscribe) {
 	// 7. Add 2 more SUBACKs to complete the resubscribe
 	setTLSRxBufferForDoubleSuback("sdk/topic1", 10, QOS0, publish);
 	rc = aws_iot_mqtt_yield(&iotClient, 2 * AWS_IOT_MQTT_MIN_RECONNECT_WAIT_INTERVAL + 100);
-	CHECK_EQUAL_C_INT(NETWORK_RECONNECTED, rc);
+	CHECK_EQUAL_C_INT(SUCCESS, rc);
 	CHECK_EQUAL_C_INT(CLIENT_STATE_CONNECTED_IDLE, aws_iot_mqtt_get_client_state(&iotClient));
 	CHECK_EQUAL_C_INT(1, iotClient.clientData.messageHandlers[0].resubscribed);
 	CHECK_EQUAL_C_INT(1, iotClient.clientData.messageHandlers[1].resubscribed);

--- a/tests/unit/src/aws_iot_tests_unit_helper_functions.c
+++ b/tests/unit/src/aws_iot_tests_unit_helper_functions.c
@@ -247,6 +247,14 @@ void setTLSRxBufferForPingresp(void) {
 	RxIndex = 0;
 }
 
+void setTLSRxBufferForError(IoT_Error_t error) {
+	RxBuffer.mockedError = error;
+}
+
+void setTLSTxBufferForError(IoT_Error_t error) {
+	TxBuffer.mockedError = error;
+}
+
 void ResetTLSBuffer(void) {
 	size_t i;
 	RxBuffer.len = 0;

--- a/tests/unit/src/aws_iot_tests_unit_subscribe.cpp
+++ b/tests/unit/src/aws_iot_tests_unit_subscribe.cpp
@@ -65,9 +65,9 @@ TEST_GROUP_C_WRAPPER(SubscribeTests, subscribeMalformedResponse)
 /* C:16 - Subscribe, multiple topics, messages on each topic */
 TEST_GROUP_C_WRAPPER(SubscribeTests, SubscribeToMultipleTopicsSuccess)
 /* C:17 - Subscribe, max topics, messages on each topic */
-TEST_GROUP_C_WRAPPER(SubscribeTests, SubcribeToMaxAllowedTopicsSuccess)
+TEST_GROUP_C_WRAPPER(SubscribeTests, SubscribeToMaxAllowedTopicsSuccess)
 /* C:18 - Subscribe, max topics, another subscribe */
-TEST_GROUP_C_WRAPPER(SubscribeTests, SubcribeToMaxPlusOneAllowedTopicsFailure)
+TEST_GROUP_C_WRAPPER(SubscribeTests, SubscribeToMaxPlusOneAllowedTopicsFailure)
 
 /* C:19 - Subscribe, '#' not last character in topic name, Failure */
 TEST_GROUP_C_WRAPPER(SubscribeTests, subscribeTopicWithHashkeyAllSubTopicSuccess)

--- a/tests/unit/src/aws_iot_tests_unit_subscribe_helper.c
+++ b/tests/unit/src/aws_iot_tests_unit_subscribe_helper.c
@@ -69,7 +69,7 @@ static void iot_subscribe_callback_handler1(AWS_IoT_Client *pClient, char *topic
 	char *tmp = params->payload;
 	unsigned int i;
 
-	printf("callback topic %s\n", topicName);
+	printf("callback topic %.*s\n", topicNameLen, topicName);
 	for(i = 0; i < (params->payloadLen); i++) {
 		CallbackMsgString1[i] = tmp[i];
 	}
@@ -363,7 +363,7 @@ TEST_C(SubscribeTests, SubscribeToMultipleTopicsSuccess) {
 	IOT_DEBUG("-->Success - C:16 - Subscribe, multiple topics, messages on each topic \n");
 }
 /* C:17 - Subscribe, max topics, messages on each topic */
-TEST_C(SubscribeTests, SubcribeToMaxAllowedTopicsSuccess) {
+TEST_C(SubscribeTests, SubscribeToMaxAllowedTopicsSuccess) {
 	IoT_Error_t rc = SUCCESS;
 	char expectedCallbackString[] = "topics sdk/Test1";
 	char expectedCallbackString2[] = "topics sdk/Test2";
@@ -422,7 +422,7 @@ TEST_C(SubscribeTests, SubcribeToMaxAllowedTopicsSuccess) {
 	IOT_DEBUG("-->Success - C:17 - Subscribe, max topics, messages on each topic \n");
 }
 /* C:18 - Subscribe, max topics, another subscribe */
-TEST_C(SubscribeTests, SubcribeToMaxPlusOneAllowedTopicsFailure) {
+TEST_C(SubscribeTests, SubscribeToMaxPlusOneAllowedTopicsFailure) {
 	IoT_Error_t rc = SUCCESS;
 
 	IOT_DEBUG("-->Running Subscribe Tests - C:18 - Subscribe, max topics, another subscribe \n");

--- a/tests/unit/tls_mock/aws_iot_tests_unit_mock_tls.c
+++ b/tests/unit/tls_mock/aws_iot_tests_unit_mock_tls.c
@@ -111,8 +111,18 @@ IoT_Error_t iot_tls_write(Network *pNetwork, unsigned char *pMsg, size_t len, Ti
 	uint8_t firstPacketByte;
 	size_t mqttPacketLength;
 	size_t variableHeaderStart;
+	IoT_Error_t status = SUCCESS;
 	IOT_UNUSED(pNetwork);
 	IOT_UNUSED(timer);
+
+	if(TxBuffer.mockedError != SUCCESS ) {
+		status = TxBuffer.mockedError;
+
+		/* Clear the error before returning. */
+		TxBuffer.mockedError = SUCCESS;
+
+		return status;
+	}
 
 	for(i = 0; (i < len) && left_ms(timer) > 0; i++) {
 		TxBuffer.pBuffer[i] = pMsg[i];
@@ -151,7 +161,7 @@ IoT_Error_t iot_tls_write(Network *pNetwork, unsigned char *pMsg, size_t len, Ti
 		LastPublishMessagePayload[lastPublishMessagePayloadLen] = 0;
 	}
 
-	return SUCCESS;
+	return status;
 }
 
 static unsigned char isTimerExpired(struct timeval target_time) {
@@ -171,8 +181,19 @@ static unsigned char isTimerExpired(struct timeval target_time) {
 }
 
 IoT_Error_t iot_tls_read(Network *pNetwork, unsigned char *pMsg, size_t len, Timer *pTimer, size_t *read_len) {
+	IoT_Error_t status = SUCCESS;
+
 	IOT_UNUSED(pNetwork);
 	IOT_UNUSED(pTimer);
+
+	if(RxBuffer.mockedError != SUCCESS) {
+		status = RxBuffer.mockedError;
+
+		/* Clear the error before returning. */
+		RxBuffer.mockedError = SUCCESS;
+
+		return status;
+	}
 
 	if(RxIndex > TLSMaxBufferSize - 1) {
 		RxIndex = TLSMaxBufferSize - 1;
@@ -188,7 +209,7 @@ IoT_Error_t iot_tls_read(Network *pNetwork, unsigned char *pMsg, size_t len, Tim
 		*read_len = len;
 	}
 
-	return SUCCESS;
+	return status;
 }
 
 IoT_Error_t iot_tls_disconnect(Network *pNetwork) {

--- a/tests/unit/tls_mock/aws_iot_tests_unit_mock_tls_params.c
+++ b/tests/unit/tls_mock/aws_iot_tests_unit_mock_tls_params.c
@@ -35,8 +35,8 @@ size_t lastPublishMessageTopicLen;
 char LastPublishMessagePayload[TLSMaxBufferSize];
 size_t lastPublishMessagePayloadLen;
 
-TlsBuffer RxBuffer = {.pBuffer = RxBuf,.len = 512, .NoMsgFlag=1, .expiry_time = {0, 0}, .BufMaxSize = TLSMaxBufferSize};
-TlsBuffer TxBuffer = {.pBuffer = TxBuf,.len = 512, .NoMsgFlag=1, .expiry_time = {0, 0}, .BufMaxSize = TLSMaxBufferSize};
+TlsBuffer RxBuffer = {.pBuffer = RxBuf,.len = 512, .NoMsgFlag=1, .expiry_time = {0, 0}, .BufMaxSize = TLSMaxBufferSize, .mockedError = SUCCESS};
+TlsBuffer TxBuffer = {.pBuffer = TxBuf,.len = 512, .NoMsgFlag=1, .expiry_time = {0, 0}, .BufMaxSize = TLSMaxBufferSize, .mockedError = SUCCESS};
 
 size_t RxIndex = 0;
 

--- a/tests/unit/tls_mock/aws_iot_tests_unit_mock_tls_params.h
+++ b/tests/unit/tls_mock/aws_iot_tests_unit_mock_tls_params.h
@@ -36,6 +36,7 @@ typedef struct {
 	bool NoMsgFlag;
 	struct timeval expiry_time;
 	size_t BufMaxSize;
+	IoT_Error_t mockedError;
 } TlsBuffer;
 
 


### PR DESCRIPTION
Fixes a bug where failures during the resubscribe step of auto-reconnect would be treated as a failure of the entire auto-reconnect sequence.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
