### PR TITLE
Release dispatch blocks in macOS port

### DIFF
--- a/platform/ports/macos/source/iot_clock_macos.c
+++ b/platform/ports/macos/source/iot_clock_macos.c
@@ -194,6 +194,11 @@ void IotClock_TimerDestroy( IotTimer_t * pTimer )
     if( pTimer->dispatchBlock != NULL )
     {
         dispatch_block_cancel( pTimer->dispatchBlock );
+
+        /* Block_release only needs to be called if ARC is not being used. */
+        #if( OS_OBJECT_HAVE_OBJC_SUPPORT == 0 )
+            Block_release( pTimer->dispatchBlock );
+        #endif
     }
 }
 

--- a/platform/ports/macos/types/iot_platform_types_macos.h
+++ b/platform/ports/macos/types/iot_platform_types_macos.h
@@ -37,6 +37,9 @@
 /* Grand Central Dispatch include. */
 #include <dispatch/dispatch.h>
 
+/* Dispatch blocks API include. */
+#include <Block.h>
+
 /**
  * @brief The native mutex type on macOS systems.
  *


### PR DESCRIPTION
Release timer dispatch blocks in macOS port when not using Objective-C.

*Issue #, if available:*

*Description of changes:*
dispatch_block_t objects need to be released using Block_release() when not using ARC and Objective-C. The function is part of libclosure and defined in <Block.h>.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
