### PR TITLE
Adjust KeepAlive test timeout for macOS

### DIFF
--- a/tests/mqtt/unit/iot_tests_mqtt_api.c
+++ b/tests/mqtt/unit/iot_tests_mqtt_api.c
@@ -1537,7 +1537,7 @@ TEST( MQTT_Unit_API, KeepAlivePeriodic )
 
     /* An estimate for the amount of time this test requires. */
     const uint32_t sleepTimeMs = ( KEEP_ALIVE_COUNT * SHORT_KEEP_ALIVE_MS ) +
-                                 ( IOT_MQTT_RESPONSE_WAIT_MS * KEEP_ALIVE_COUNT ) + 1500;
+                                 ( IOT_MQTT_RESPONSE_WAIT_MS * KEEP_ALIVE_COUNT ) + 2500;
 
     /* Print a newline so this test may log its status. */
     UNITY_PRINT_EOL();


### PR DESCRIPTION
Adjust the wait time for the MQTT KeepAlivePeriodic unit test when on macOS.

*Issue #, if available:*

*Description of changes:*
The time for the KeepAlivePeriodic unit test can sometimes take about 10% longer on macOS. This adds an extra second to the sleep time to avoid any timeouts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
