### PR TITLE
Add Windows build to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,14 @@ jobs:
         directories:
           - $HOME/Library/Caches/Homebrew
           - /usr/local/Homebrew
+    - os: windows
+      env: RUN_TEST=mqtt NETWORK_STACK=mbedtls
+      compiler: msvc
 
 # Install dependencies.
 install:
   # Run the OS-specific CI setup script.
-  - bash ./scripts/setup/ci_setup_$TRAVIS_OS_NAME.sh
+  - source ./scripts/setup/ci_setup_$TRAVIS_OS_NAME.sh
 
 # Run the test script based on matrix environment variable.
 script:

--- a/scripts/ci_test_mqtt.sh
+++ b/scripts/ci_test_mqtt.sh
@@ -11,6 +11,9 @@ CMAKE_FLAGS="-DIOT_DEMO_MQTT_TOPIC_PREFIX=\"\\\"$IOT_IDENTIFIER\\\"\" "
 if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
     CMAKE_FLAGS+="$AWS_IOT_CREDENTIAL_DEFINES $COMPILER_OPTIONS"
     DEMO_OPTIONS="-i $IOT_IDENTIFIER"
+elif [ "$TRAVIS_OS_NAME" = "windows" ]; then
+    CMAKE_FLAGS+=$COMPILER_OPTIONS
+    DEMO_OPTIONS="-n -i $IOT_IDENTIFIER"
 else
     CMAKE_FLAGS+="-DIOT_TEST_MQTT_MOSQUITTO=1 -DIOT_TEST_SERVER=\\\"localhost\\\" $COMPILER_OPTIONS"
     DEMO_OPTIONS="-n -i $IOT_IDENTIFIER -u -h localhost -p 1883"
@@ -18,7 +21,13 @@ fi
 
 # Build executables.
 cmake .. -DIOT_BUILD_TESTS=1 -DCMAKE_BUILD_TYPE=Debug -DIOT_NETWORK_USE_OPENSSL=$IOT_NETWORK_USE_OPENSSL -DCMAKE_C_FLAGS="$CMAKE_FLAGS"
-make -j2 iot_tests_mqtt iot_demo_mqtt
+if [ "$TRAVIS_OS_NAME" != "windows" ]; then
+    make -j2 iot_tests_mqtt iot_demo_mqtt
+else
+    MSBuild.exe tests/mqtt/iot_tests_mqtt.vcxproj -m -clp:summary -verbosity:minimal
+    MSBuild.exe demos/app/iot_demo_mqtt.vcxproj -m -clp:summary -verbosity:minimal
+    mv ./bin/Debug/* ./bin/
+fi
 
 # Run tests and demos.
 ./bin/iot_tests_mqtt
@@ -26,7 +35,12 @@ make -j2 iot_tests_mqtt iot_demo_mqtt
 
 # Rebuild in static memory mode.
 cmake .. -DIOT_BUILD_TESTS=1 -DCMAKE_BUILD_TYPE=Debug -DIOT_NETWORK_USE_OPENSSL=$IOT_NETWORK_USE_OPENSSL -DCMAKE_C_FLAGS="$CMAKE_FLAGS -DIOT_STATIC_MEMORY_ONLY=1"
-make -j2 iot_tests_mqtt
+if [ "$TRAVIS_OS_NAME" != "windows" ]; then
+    make -j2 iot_tests_mqtt
+else
+    MSBuild.exe tests/mqtt/iot_tests_mqtt.vcxproj -m -clp:summary -verbosity:minimal
+    mv ./bin/Debug/* ./bin/
+fi
 
 # Run tests in static memory mode.
 ./bin/iot_tests_mqtt

--- a/scripts/setup/ci_setup_windows.sh
+++ b/scripts/setup/ci_setup_windows.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Travis CI uses this script to set up the test environment on Windows.
+
+# Location of MSBuild.exe in the test environment
+MSBUILD_PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin"
+export PATH=$PATH:$MSBUILD_PATH
+
+# Use default compiler options for windows.
+export COMPILER_OPTIONS=""


### PR DESCRIPTION
Runs MQTT tests for Windows on Travis. 
* Mosquitto tests are disabled for pull requests as the mosquitto installer is not friendly to the Travis build environment.
* Fixed an issue where no compiler options were being set.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
