### PR TITLE
Update MQTT System tests for connection retries

### DIFF
--- a/doc/lib/mqtt.txt
+++ b/doc/lib/mqtt.txt
@@ -158,7 +158,11 @@ This value will be passed as `timeoutMs` to all calls to @ref mqtt_function_wait
 @section IOT_TEST_MQTT_CONNECT_RETRY_COUNT
 @brief The number of connection attempts for the MQTT system tests.
 
-@configpossible Any integer greater than or equal to 1. <br>
+The MQTT system tests require a network connection to an MQTT server. If the network is unreliable, this setting may be used to enable retries when connecting to the MQTT server.
+
+This value represents a limit on the number of retries. When set to 1, the tests will perform one connection attempt. When set to a value greater than 1, the tests will attempt to reconnect with an exponential back-off strategy, up to the limit specified by this setting.
+
+@configpossible Any integer of at least 1. <br>
 @configdefault `1`
 */
 

--- a/doc/lib/mqtt.txt
+++ b/doc/lib/mqtt.txt
@@ -154,6 +154,12 @@ This value will be passed as `timeoutMs` to all calls to @ref mqtt_function_wait
 @configpossible Any non-negative integer. <br>
 @configrecommended This setting should be at least `1000`. <br>
 @configdefault `5000`
+
+@section IOT_TEST_MQTT_CONNECT_RETRY_COUNT
+@brief The number of connection attempts for the MQTT system tests.
+
+@configpossible Any integer greater than or equal to 1. <br>
+@configdefault `1`
 */
 
 /**

--- a/libraries/standard/mqtt/test/system/iot_tests_mqtt_system.c
+++ b/libraries/standard/mqtt/test/system/iot_tests_mqtt_system.c
@@ -243,7 +243,7 @@ static IotMqttError_t _mqttConnect( const IotMqttNetworkInfo_t * pNetworkInfo,
      * Wait until 1100 ms have elapsed since the last connection. */
     uint32_t periodMs = 1100;
 
-    for( ; retryCount <= IOT_TEST_MQTT_CONNECT_RETRY_COUNT; retryCount++ )
+    for( ; retryCount < IOT_TEST_MQTT_CONNECT_RETRY_COUNT; retryCount++ )
     {
         status = IotMqtt_Connect( pNetworkInfo, pConnectInfo, timeoutMs, pMqttConnection );
 

--- a/libraries/standard/mqtt/test/system/iot_tests_mqtt_system.c
+++ b/libraries/standard/mqtt/test/system/iot_tests_mqtt_system.c
@@ -243,13 +243,12 @@ static IotMqttError_t _mqttConnect( const IotMqttNetworkInfo_t * pNetworkInfo,
         status = IotMqtt_Connect( pNetworkInfo, pConnectInfo, timeoutMs, pMqttConnection );
 
         #if ( IOT_TEST_MQTT_CONNECT_RETRY_COUNT > 1 )
-            /* AWS IoT Service limits only allow 1 connection per MQTT client ID per second.
-             * Wait until 1100 ms have elapsed since the last connection. */
-            uint32_t periodMs = 1100;
             if( ( status == IOT_MQTT_NETWORK_ERROR ) || ( status == IOT_MQTT_TIMEOUT ) )
             {
-                IotClock_SleepMs( periodMs );
-                periodMs *= 2;
+                /* AWS IoT Service limits only allow 1 connection per MQTT client ID per second.
+                 * Initially wait until 1100 ms have elapsed since the last connection, then 
+                 * increase exponentially. */
+                IotClock_SleepMs( 1100 << retryCount );
             }
             else
             {

--- a/libraries/standard/mqtt/test/system/iot_tests_mqtt_system.c
+++ b/libraries/standard/mqtt/test/system/iot_tests_mqtt_system.c
@@ -236,18 +236,16 @@ static IotMqttError_t _mqttConnect( const IotMqttNetworkInfo_t * pNetworkInfo,
                                     IotMqttConnection_t * const pMqttConnection )
 {
     IotMqttError_t status = IOT_MQTT_STATUS_PENDING;
-
     int32_t retryCount = 0;
-
-    /* AWS IoT Service limits only allow 1 connection per MQTT client ID per second.
-     * Wait until 1100 ms have elapsed since the last connection. */
-    uint32_t periodMs = 1100;
 
     for( ; retryCount < IOT_TEST_MQTT_CONNECT_RETRY_COUNT; retryCount++ )
     {
         status = IotMqtt_Connect( pNetworkInfo, pConnectInfo, timeoutMs, pMqttConnection );
 
         #if ( IOT_TEST_MQTT_CONNECT_RETRY_COUNT > 1 )
+            /* AWS IoT Service limits only allow 1 connection per MQTT client ID per second.
+             * Wait until 1100 ms have elapsed since the last connection. */
+            uint32_t periodMs = 1100;
             if( ( status == IOT_MQTT_NETWORK_ERROR ) || ( status == IOT_MQTT_TIMEOUT ) )
             {
                 IotClock_SleepMs( periodMs );

--- a/libraries/standard/mqtt/test/system/iot_tests_mqtt_system.c
+++ b/libraries/standard/mqtt/test/system/iot_tests_mqtt_system.c
@@ -59,7 +59,14 @@
 #ifndef IOT_TEST_MQTT_TIMEOUT_MS
     #define IOT_TEST_MQTT_TIMEOUT_MS    ( 5000 )
 #endif
+#ifndef IOT_TEST_MQTT_CONNECT_RETRY_COUNT
+    #define IOT_TEST_MQTT_CONNECT_RETRY_COUNT    ( 1 )
+#endif
 /** @endcond */
+
+#if IOT_TEST_MQTT_CONNECT_RETRY_COUNT < 1
+    #error "IOT_TEST_MQTT_CONNECT_RETRY_COUNT must be at least 1."
+#endif
 
 /**
  * @brief Determine which MQTT server mode to test (AWS IoT or Mosquitto).
@@ -217,6 +224,44 @@ static bool _pubackSerializerOverride = false;      /**< @brief Tracks if #_puba
 static bool _subscribeSerializerOverride = false;   /**< @brief Tracks if #_subscribeSerializerOverride was called. */
 static bool _unsubscribeSerializerOverride = false; /**< @brief Tracks if #_unsubscribeSerializerOverride was called. */
 static bool _disconnectSerializerOverride = false;  /**< @brief Tracks if #_disconnectSerializerOverride was called. */
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Establish an MQTT connection. Retry if enabled.
+ */
+static IotMqttError_t _mqttConnect( const IotMqttNetworkInfo_t * pNetworkInfo,
+                                    const IotMqttConnectInfo_t * pConnectInfo,
+                                    uint32_t timeoutMs,
+                                    IotMqttConnection_t * const pMqttConnection )
+{
+    IotMqttError_t status = IOT_MQTT_STATUS_PENDING;
+
+    int32_t retryCount = 0;
+
+    /* AWS IoT Service limits only allow 1 connection per MQTT client ID per second.
+     * Wait until 1100 ms have elapsed since the last connection. */
+    uint32_t periodMs = 1100;
+
+    for( ; retryCount <= IOT_TEST_MQTT_CONNECT_RETRY_COUNT; retryCount++ )
+    {
+        status = IotMqtt_Connect( pNetworkInfo, pConnectInfo, timeoutMs, pMqttConnection );
+
+        #if ( IOT_TEST_MQTT_CONNECT_RETRY_COUNT > 1 )
+            if( ( status == IOT_MQTT_NETWORK_ERROR ) || ( status == IOT_MQTT_TIMEOUT ) )
+            {
+                IotClock_SleepMs( periodMs );
+                periodMs *= 2;
+            }
+            else
+            {
+                break;
+            }
+        #endif
+    }
+
+    return status;
+}
 
 /*-----------------------------------------------------------*/
 
@@ -508,10 +553,10 @@ static void _subscribePublishWait( IotMqttQos_t qos )
         connectInfo.clientIdentifierLength = ( uint16_t ) strlen( _pClientIdentifier );
 
         /* Establish the MQTT connection. */
-        status = IotMqtt_Connect( &networkInfo,
-                                  &connectInfo,
-                                  IOT_TEST_MQTT_TIMEOUT_MS,
-                                  &_mqttConnection );
+        status = _mqttConnect( &networkInfo,
+                               &connectInfo,
+                               IOT_TEST_MQTT_TIMEOUT_MS,
+                               &_mqttConnection );
         TEST_ASSERT_EQUAL( IOT_MQTT_SUCCESS, status );
 
         if( TEST_PROTECT() )
@@ -764,10 +809,10 @@ TEST( MQTT_System, SubscribePublishAsync )
         if( TEST_PROTECT() )
         {
             /* Establish the MQTT connection. */
-            status = IotMqtt_Connect( &_networkInfo,
-                                      &connectInfo,
-                                      IOT_TEST_MQTT_TIMEOUT_MS,
-                                      &_mqttConnection );
+            status = _mqttConnect( &_networkInfo,
+                                   &connectInfo,
+                                   IOT_TEST_MQTT_TIMEOUT_MS,
+                                   &_mqttConnection );
             TEST_ASSERT_EQUAL( IOT_MQTT_SUCCESS, status );
 
             if( TEST_PROTECT() )
@@ -886,10 +931,10 @@ TEST( MQTT_System, LastWillAndTestament )
 
     if( TEST_PROTECT() )
     {
-        status = IotMqtt_Connect( &lwtNetworkInfo,
-                                  &lwtConnectInfo,
-                                  IOT_TEST_MQTT_TIMEOUT_MS,
-                                  &lwtListener );
+        status = _mqttConnect( &lwtNetworkInfo,
+                               &lwtConnectInfo,
+                               IOT_TEST_MQTT_TIMEOUT_MS,
+                               &lwtListener );
         TEST_ASSERT_EQUAL( IOT_MQTT_SUCCESS, status );
 
         if( TEST_PROTECT() )
@@ -919,10 +964,10 @@ TEST( MQTT_System, LastWillAndTestament )
             willInfo.pPayload = _pSamplePayload;
             willInfo.payloadLength = _samplePayloadLength;
 
-            status = IotMqtt_Connect( &_networkInfo,
-                                      &connectInfo,
-                                      IOT_TEST_MQTT_TIMEOUT_MS,
-                                      &_mqttConnection );
+            status = _mqttConnect( &_networkInfo,
+                                   &connectInfo,
+                                   IOT_TEST_MQTT_TIMEOUT_MS,
+                                   &_mqttConnection );
             TEST_ASSERT_EQUAL( IOT_MQTT_SUCCESS, status );
 
             /* Abruptly close the MQTT connection. This should cause the LWT
@@ -970,10 +1015,10 @@ TEST( MQTT_System, RestorePreviousSession )
     if( TEST_PROTECT() )
     {
         /* Establish a persistent MQTT connection. */
-        status = IotMqtt_Connect( &_networkInfo,
-                                  &connectInfo,
-                                  IOT_TEST_MQTT_TIMEOUT_MS,
-                                  &_mqttConnection );
+        status = _mqttConnect( &_networkInfo,
+                               &connectInfo,
+                               IOT_TEST_MQTT_TIMEOUT_MS,
+                               &_mqttConnection );
         TEST_ASSERT_EQUAL( IOT_MQTT_SUCCESS, status );
 
         /* Add a subscription. */
@@ -998,10 +1043,10 @@ TEST( MQTT_System, RestorePreviousSession )
         connectInfo.cleanSession = false;
         connectInfo.pPreviousSubscriptions = &subscription;
         connectInfo.previousSubscriptionCount = 1;
-        status = IotMqtt_Connect( &_networkInfo,
-                                  &connectInfo,
-                                  IOT_TEST_MQTT_TIMEOUT_MS,
-                                  &_mqttConnection );
+        status = _mqttConnect( &_networkInfo,
+                               &connectInfo,
+                               IOT_TEST_MQTT_TIMEOUT_MS,
+                               &_mqttConnection );
         TEST_ASSERT_EQUAL( IOT_MQTT_SUCCESS, status );
 
         /* Publish a message to the subscription added in the previous session. */
@@ -1044,10 +1089,10 @@ TEST( MQTT_System, RestorePreviousSession )
          * session to clean up persistent sessions on the MQTT server created by this
          * test. */
         connectInfo.cleanSession = true;
-        status = IotMqtt_Connect( &_networkInfo,
-                                  &connectInfo,
-                                  IOT_TEST_MQTT_TIMEOUT_MS,
-                                  &_mqttConnection );
+        status = _mqttConnect( &_networkInfo,
+                               &connectInfo,
+                               IOT_TEST_MQTT_TIMEOUT_MS,
+                               &_mqttConnection );
 
         if( status == IOT_MQTT_SUCCESS )
         {
@@ -1087,10 +1132,10 @@ TEST( MQTT_System, WaitAfterDisconnect )
     publishInfo.retryMs = 5000;
 
     /* Establish the MQTT connection. */
-    status = IotMqtt_Connect( &_networkInfo,
-                              &connectInfo,
-                              IOT_TEST_MQTT_TIMEOUT_MS,
-                              &_mqttConnection );
+    status = _mqttConnect( &_networkInfo,
+                           &connectInfo,
+                           IOT_TEST_MQTT_TIMEOUT_MS,
+                           &_mqttConnection );
     TEST_ASSERT_EQUAL( IOT_MQTT_SUCCESS, status );
 
     if( TEST_PROTECT() )
@@ -1158,10 +1203,10 @@ TEST( MQTT_System, SubscribeCompleteReentrancy )
             if( TEST_PROTECT() )
             {
                 /* Establish the MQTT connection. */
-                status = IotMqtt_Connect( &_networkInfo,
-                                          &connectInfo,
-                                          IOT_TEST_MQTT_TIMEOUT_MS,
-                                          &_mqttConnection );
+                status = _mqttConnect( &_networkInfo,
+                                       &connectInfo,
+                                       IOT_TEST_MQTT_TIMEOUT_MS,
+                                       &_mqttConnection );
                 TEST_ASSERT_EQUAL( IOT_MQTT_SUCCESS, status );
 
                 /* Subscribe with a completion callback. */
@@ -1234,10 +1279,10 @@ TEST( MQTT_System, IncomingPublishReentrancy )
             if( TEST_PROTECT() )
             {
                 /* Establish the MQTT connection. */
-                status = IotMqtt_Connect( &_networkInfo,
-                                          &connectInfo,
-                                          IOT_TEST_MQTT_TIMEOUT_MS,
-                                          &_mqttConnection );
+                status = _mqttConnect( &_networkInfo,
+                                       &connectInfo,
+                                       IOT_TEST_MQTT_TIMEOUT_MS,
+                                       &_mqttConnection );
                 TEST_ASSERT_EQUAL( IOT_MQTT_SUCCESS, status );
 
                 /* Subscribe with to the test topics. */


### PR DESCRIPTION
*Issue #, if available:*N/A

*Description of changes:*
- In Amazon FreeRTOS the number of retries is set to 3.
- In the CSDK the number of retries is the default of 1,
  since there are no failures in these tests' connections.

This commit synchronizes changes in Amazon FreeRTOS (https://github.com/aws/amazon-freertos/commit/d518cf5e823bd05ea46e526c59c6060a47644ba4) to the CSDK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
