### PR TITLE
Make tinycbor stepOut() implementation more resilient

### DIFF
--- a/libraries/standard/serializer/src/cbor/iot_serializer_tinycbor_decoder.c
+++ b/libraries/standard/serializer/src/cbor/iot_serializer_tinycbor_decoder.c
@@ -496,8 +496,19 @@ static IotSerializerError_t _stepOut( IotSerializerDecoderIterator_t iterator,
     _cborValueWrapper_t * pOuterCborValueWrapper = _castDecoderObjectToCborValue( pDecoderObject );
     _cborValueWrapper_t * pInnerCborValueWrapper = _castDecoderIteratorToCborValue( iterator );
 
+
+    CborValue outerCborValueCopy;
+
+    /* Clone the underlying CborValue object of the parent container, so that the original CborValue object's state/data
+     * is unaffected with this function's operation. This allows the container's decoder object re-usable for accessor
+     * and iteration operations.
+     *
+     * Note: By performing a cbor_value_leave_container() operation on the cloned copy, only the state/data of the copy
+     * is changed.*/
+    memcpy( &outerCborValueCopy, &pOuterCborValueWrapper->cborValue, sizeof( CborValue ) );
+
     cborError = cbor_value_leave_container(
-        &pOuterCborValueWrapper->cborValue,
+        &outerCborValueCopy,
         &pInnerCborValueWrapper->cborValue );
 
     if( cborError == CborNoError )


### PR DESCRIPTION
*Issue #, if available:*
[TS-9769](https://sim.amazon.com/issues/TS-9796)
*Description of changes:*
Context: `IotSerializerDecoderInterface_t::stepOut()` implementation for `tinycbor` library wrapper  mutates the state/contents the iterated decoder object, which makes the object not re-usable.
Fix: Clone the underlying `CborValue` represented by the decoder object before calling the `cbor_value_leave_container` tinycbor API

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
