### PR TITLE
Allow override for STACK_SIZE and PRIORITY defines

### DIFF
--- a/libraries/platform/types/iot_platform_types.h
+++ b/libraries/platform/types/iot_platform_types.h
@@ -39,12 +39,16 @@
 /**
  * @brief A value representing the system default for new thread priority.
  */
+#ifndef IOT_THREAD_DEFAULT_PRIORITY
 #define IOT_THREAD_DEFAULT_PRIORITY      0
+#endif
 
 /**
  * @brief A value representhing the system default for new thread stack size.
  */
+#ifndef IOT_THREAD_DEFAULT_STACK_SIZE
 #define IOT_THREAD_DEFAULT_STACK_SIZE    0
+#endif
 
 /**
  * @ingroup platform_datatypes_handles


### PR DESCRIPTION
*Description of changes:*
When working on a port for ESP32/FreeRTOS, I ran into the issue of iot_platform_types.h re-defining IOT_THREAD_DEFAULT_PRIORITY and IOT_THREAD_DEFAULT_STACK_SIZE.  This trivial  change fixes that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
