### PR TITLE
Fix some spelling, grammar, and whitespace 

### DIFF
--- a/libraries/platform/types/iot_platform_types.h
+++ b/libraries/platform/types/iot_platform_types.h
@@ -40,14 +40,14 @@
  * @brief A value representing the system default for new thread priority.
  */
 #ifndef IOT_THREAD_DEFAULT_PRIORITY
-#define IOT_THREAD_DEFAULT_PRIORITY      0
+    #define IOT_THREAD_DEFAULT_PRIORITY      0
 #endif
 
 /**
  * @brief A value representhing the system default for new thread stack size.
  */
 #ifndef IOT_THREAD_DEFAULT_STACK_SIZE
-#define IOT_THREAD_DEFAULT_STACK_SIZE    0
+    #define IOT_THREAD_DEFAULT_STACK_SIZE    0
 #endif
 
 /**

--- a/libraries/standard/common/include/iot_taskpool.h
+++ b/libraries/standard/common/include/iot_taskpool.h
@@ -83,8 +83,8 @@
  *
  * This function should be called once by the application to initialize the one single instance of the system task pool.
  * An application should initialize the system task pool early in the boot sequence, before initializing any other library
- * that uses the system task pool. such as MQTT, Shadow, Defernder, etc.. An application should also initialize the system
- * task pool before posting any jobs. Early initialization it typically easy to accomplish by creating the system task pool
+ * that uses the system task pool. such as MQTT, Shadow, Defernder, etc. An application should also initialize the system
+ * task pool before posting any jobs. Early initialization is typically easy to accomplish by creating the system task pool
  * before the scheduler is started.
  *
  * This function does not allocate memory to hold the task pool data structures and state, but it

--- a/libraries/standard/common/include/iot_taskpool.h
+++ b/libraries/standard/common/include/iot_taskpool.h
@@ -83,7 +83,7 @@
  *
  * This function should be called once by the application to initialize the one single instance of the system task pool.
  * An application should initialize the system task pool early in the boot sequence, before initializing any other library
- * that uses the system task pool. such as MQTT, Shadow, Defernder, etc. An application should also initialize the system
+ * that uses the system task pool, such as MQTT, Shadow, Defender, etc. An application should also initialize the system
  * task pool before posting any jobs. Early initialization is typically easy to accomplish by creating the system task pool
  * before the scheduler is started.
  *

--- a/libraries/standard/common/include/types/iot_taskpool_types.h
+++ b/libraries/standard/common/include/types/iot_taskpool_types.h
@@ -322,13 +322,13 @@ typedef struct IotTaskPoolInfo
  */
 /* @[define_taskpool_initializers] */
 /** @brief Initializer for a small #IotTaskPoolInfo_t. */
-#define IOT_TASKPOOL_INFO_INITIALIZER_SMALL     { .minThreads = 1, .maxThreads = 1, .stackSize = IOT_THREAD_DEFAULT_STACK_SIZE, .priority = IOT_THREAD_DEFAULT_PRIORITY } 
+#define IOT_TASKPOOL_INFO_INITIALIZER_SMALL     { .minThreads = 1, .maxThreads = 1, .stackSize = IOT_THREAD_DEFAULT_STACK_SIZE, .priority = IOT_THREAD_DEFAULT_PRIORITY }
 /** @brief Initializer for a medium #IotTaskPoolInfo_t. */
-#define IOT_TASKPOOL_INFO_INITIALIZER_MEDIUM    { .minThreads = 1, .maxThreads = 2, .stackSize = IOT_THREAD_DEFAULT_STACK_SIZE, .priority = IOT_THREAD_DEFAULT_PRIORITY } 
+#define IOT_TASKPOOL_INFO_INITIALIZER_MEDIUM    { .minThreads = 1, .maxThreads = 2, .stackSize = IOT_THREAD_DEFAULT_STACK_SIZE, .priority = IOT_THREAD_DEFAULT_PRIORITY }
 /** @brief Initializer for a large #IotTaskPoolInfo_t. */
-#define IOT_TASKPOOL_INFO_INITIALIZER_LARGE     { .minThreads = 2, .maxThreads = 3, .stackSize = IOT_THREAD_DEFAULT_STACK_SIZE, .priority = IOT_THREAD_DEFAULT_PRIORITY } 
+#define IOT_TASKPOOL_INFO_INITIALIZER_LARGE     { .minThreads = 2, .maxThreads = 3, .stackSize = IOT_THREAD_DEFAULT_STACK_SIZE, .priority = IOT_THREAD_DEFAULT_PRIORITY }
 /** @brief Initializer for a very large #IotTaskPoolInfo_t. */
-#define IOT_TASKPOOL_INFO_INITIALIZER_XLARGE    { .minThreads = 2, .maxThreads = 4, .stackSize = IOT_THREAD_DEFAULT_STACK_SIZE, .priority = IOT_THREAD_DEFAULT_PRIORITY } 
+#define IOT_TASKPOOL_INFO_INITIALIZER_XLARGE    { .minThreads = 2, .maxThreads = 4, .stackSize = IOT_THREAD_DEFAULT_STACK_SIZE, .priority = IOT_THREAD_DEFAULT_PRIORITY }
 /** @brief Initializer for a typical #IotTaskPoolInfo_t. */
 #define IOT_TASKPOOL_INFO_INITIALIZER           IOT_TASKPOOL_INFO_INITIALIZER_MEDIUM
 /** @brief Initializer for a #IotTaskPool_t. */

--- a/libraries/standard/common/src/iot_logging.c
+++ b/libraries/standard/common/src/iot_logging.c
@@ -214,7 +214,7 @@ void IotLog_Generic( int libraryLogSetting,
     /* Estimate the amount of buffer needed for this log message. */
     if( ( pLogConfig == NULL ) || ( pLogConfig->hideLibraryName == false ) )
     {
-        /* Add size of library name if requested. Add 2 to accomodate "[]". */
+        /* Add size of library name if requested. Add 2 to accommodate "[]". */
         bufferSize += strlen( pLibraryName ) + 2;
     }
 

--- a/libraries/standard/common/src/iot_taskpool.c
+++ b/libraries/standard/common/src/iot_taskpool.c
@@ -1587,7 +1587,7 @@ static IotTaskPoolError_t _tryCancelInternal( _taskPool_t * const pTaskPool,
             break;
 
         default:
-            /* Log message for debug purposes purposes. */
+            /* Log message for debug purposes. */
             IotLogError( "Attempt to cancel a job with an undefined state." );
             break;
     }

--- a/libraries/standard/common/src/iot_taskpool.c
+++ b/libraries/standard/common/src/iot_taskpool.c
@@ -1582,12 +1582,12 @@ static IotTaskPoolError_t _tryCancelInternal( _taskPool_t * const pTaskPool,
             break;
 
         case IOT_TASKPOOL_STATUS_COMPLETED:
-            /* Log mesggesong purposes. */
+            /* Log message for debug purposes. */
             IotLogWarn( "Attempt to cancel a job that is already executing, or canceled." );
             break;
 
         default:
-            /* Log mesggesong purposes. */
+            /* Log message for debug purposes purposes. */
             IotLogError( "Attempt to cancel a job with an undefined state." );
             break;
     }


### PR DESCRIPTION
Fix some spelling, grammar, and whitespace in logging and taskpool comments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
