### PR TITLE
feature: Lightweight serializer API for MQTT.

### DIFF
--- a/libraries/standard/mqtt/CMakeLists.txt
+++ b/libraries/standard/mqtt/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library( iotmqtt
              ${CONFIG_HEADER_PATH}/iot_config.h
              ${MQTT_SOURCES}
              include/iot_mqtt.h
+             include/iot_mqtt_serialize.h
              include/types/iot_mqtt_types.h
              src/private/iot_mqtt_internal.h )
 

--- a/libraries/standard/mqtt/include/iot_mqtt_serialize.h
+++ b/libraries/standard/mqtt/include/iot_mqtt_serialize.h
@@ -1,0 +1,700 @@
+/*
+ * IoT MQTT V2.1.0
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file iot_mqtt_serialize.h
+ * @brief User-facing functions for serializing MQTT 3.1.1 packets. This header should
+ * be included for building a single threaded light-weight MQTT client bypassing
+ * stateful CSDK MQTT library.
+ */
+
+#ifndef _IOT_MQTT_SERIALIZE_H_
+#define _IOT_MQTT_SERIALIZE_H_
+
+/* The config header is always included first. */
+#include "iot_config.h"
+
+/* MQTT types include. */
+#include "types/iot_mqtt_types.h"
+
+/*------------------------- MQTT library functions --------------------------*/
+
+/**
+ * @functionspage{mqtt,MQTT library}
+ * - @functionname{mqtt_function_getconnectpacketsize}
+ * - @functionname{mqtt_function_serializeconnect}
+ * - @functionname{mqtt_function_getsubscriptionpacketsize}
+ * - @functionname{mqtt_function_serializesubscribe}
+ * - @functionname{mqtt_function_serializeunsubscribe}
+ * - @functionname{mqtt_function_getpublishpacketsize}
+ * - @functionname{mqtt_function_serializepublish}
+ * - @functionname{mqtt_function_serializedisconnect}
+ * - @functionname{mqtt_function_serializepingreq}
+ * - @functionname{mqtt_function_getincomingmqttpackettypeandlength}
+ * - @functionname{mqtt_function_deserializeresponse}
+ * - @functionname{mqtt_function_deserializepublish}
+ */
+
+/**
+ * @functionpage{IotMqtt_GetConnectPacketSize,mqtt,getconnectpacketsize}
+ * @functionpage{IotMqtt_SerializeConnect,mqtt,serializeconnect}
+ * @functionpage{IotMqtt_GetSubscriptionPacketSize,mqtt,getsubscriptionpacketsize}
+ * @functionpage{IotMqtt_SerializeSubscribe,mqtt,serializesubscribe}
+ * @functionpage{IotMqtt_SerializeUnsubscribe,mqtt,serializeunsubscribe}
+ * @functionpage{IotMqtt_GetPublishPacketSize,mqtt,getpublishpacketsize}
+ * @functionpage{IotMqtt_SerializePublish,mqtt,serializepublish}
+ * @functionpage{IotMqtt_SerializeDisconnect,mqtt,serializedisconnect}
+ * @functionpage{IotMqtt_SerializePingreq,mqtt,serializepingreq}
+ * @functionpage{IotMqtt_GetIncomingMQTTPacketTypeAndLength,mqtt,getincomingmqttpackettypeandlength}
+ * @functionpage{IotMqtt_DeserializeResponse,mqtt,deserializeresponse}
+ * @functionpage{IotMqtt_DeserializePublish,mqtt,deserializepublish}
+ */
+
+/**
+ * @brief Calculate the size and "Remaining length" of a CONNECT packet generated
+ * from the given parameters.
+ *
+ * @param[in] pConnectInfo User-provided CONNECT information struct.
+ * @param[out] pRemainingLength Output for calculated "Remaining length" field.
+ * @param[out] pPacketSize Output for calculated total packet size.
+ *
+ * @return IOT_MQTT_SUCCESS if the packet is within the length allowed by MQTT 3.1.1 spec;
+ * IOT_MQTT_BAD_PARAMETER otherwise. If this function returns `IOT_MQTT_BAD_PARAMETER`,
+ * the output parameters should be ignored.
+ *
+ * @note This call is part of serializer API used for implementing light-weight MQTT client.
+ * 
+ * <b>Example</b>
+ * @code{c}
+ * // Example code below shows how IotMqtt_GetConnectPacketSize() should be used to calculate
+ * // the size of connect request. 
+ *
+ * IotMqttConnectInfo_t xConnectInfo;
+ * size_t xRemainingLength = 0;
+ * size_t xPacketSize = 0;
+ * IotMqttError_t xResult;
+ * 
+ * // start with everything set to zero
+ * memset( ( void * ) &xConnectInfo, 0x00, sizeof( xConnectInfo ) );
+ *	
+ * // Initialize connection info, details are out of scope for this example.
+ * _initializeConnectInfo( &xConnectInfo );
+ * // Get size requirement for the connect packet 
+ * xResult = IotMqtt_GetConnectPacketSize( &xConnectInfo, &xRemainingLength, &xPacketSize );
+ * IotMqtt_Assert( xResult == IOT_MQTT_SUCCESS );
+ *
+ *  // Application should allocate buffer with size == xPacketSize or use static buffer
+ *  // with size >= xPacketSize to serialize connect request.
+ * @endcode
+ */
+/* @[declare_mqtt_getconnectpacketsize] */
+IotMqttError_t IotMqtt_GetConnectPacketSize( const IotMqttConnectInfo_t * pConnectInfo,
+                                             size_t * pRemainingLength,
+                                             size_t * pPacketSize );
+/* @[declare_mqtt_getconnectpacketsize] */
+
+/**
+ * @brief Generate a CONNECT packet from the given parameters.
+ *
+ * @param[in] pConnectInfo User-provided CONNECT information.
+ * @param[in] remainingLength remaining length of the packet to be serialized.
+ * @param[in, out] pBuffer User provided buffer where the CONNECT packet is written.
+ * @param[in] bufferSize Size of the buffer pointed to by pBuffer.
+ *
+ * @return #IOT_MQTT_SUCCESS or #IOT_MQTT_NO_MEMORY.
+ *
+ * @note pBuffer must be allocated by caller. Use @ref mqtt_function_getconnectpacketsize
+ * to determine the required size.
+ * @note This call is part of serializer API used for implementing light-weight MQTT client.
+ * 
+ * <b>Example</b>
+ * @code{c}
+ * // Example code below shows how IotMqtt_SerializeConnect() should be used to serialize
+ * // MQTT connect packet and send it to MQTT broker.
+ * // Example uses static memory but dynamically allocated memory can be used as well.
+ * // Get size requirement for the connect packet.
+ * 
+ * #define mqttexampleSHARED_BUFFER_SIZE 100
+ * static ucSharedBuffer[mqttexampleSHARED_BUFFER_SIZE];
+ * void sendConnectPacket( int xMQTTSocket )
+ * {
+ *    IotMqttConnectInfo_t xConnectInfo;
+ *    size_t xRemainingLength = 0;
+ *    size_t xPacketSize = 0;
+ *    IotMqttError_t xResult;
+ *    size_t xSentBytes = 0;
+ *    // Get size requirement for MQTT connect packet.
+ *    xResult = IotMqtt_GetConnectPacketSize( &xConnectInfo, &xRemainingLength, &xPacketSize );
+ *    IotMqtt_Assert( xResult == IOT_MQTT_SUCCESS );
+ *    // Make sure the packet size is less than static buffer size
+ *    IotMqtt_Assert( xPacketSize < mqttexampleSHARED_BUFFER_SIZE );
+ *    // Serialize MQTT connect packet into provided buffer
+ *    xResult = IotMqtt_SerializeConnect( &xConnectInfo, xRemainingLength, ucSharedBuffer, xPacketSize );
+ *    IotMqtt_Assert( xResult == IOT_MQTT_SUCCESS ); 
+ *    // xMQTTSocket here is posix socket created and connected to MQTT broker outside of this function.
+ *    xSentBytes = send( xMQTTSocket, ( void * ) ucSharedBuffer, xPacketSize, 0 );
+ *    IotMqtt_Assert( xSentBytes == xPacketSize );
+ * }
+ * @endcode
+ */
+/* @[declare_mqtt_serializeconnect] */
+IotMqttError_t IotMqtt_SerializeConnect( const IotMqttConnectInfo_t * pConnectInfo,
+                                         size_t remainingLength,
+                                         uint8_t * pBuffer,
+                                         size_t bufferSize );
+/* @[declare_mqtt_serializeconnect] */
+
+/**
+ * @brief Calculate the size and "Remaining length" of a SUBSCRIBE or UNSUBSCRIBE
+ * packet generated from the given parameters.
+ *
+ * @param[in] type Either IOT_MQTT_SUBSCRIBE or IOT_MQTT_UNSUBSCRIBE.
+ * @param[in] pSubscriptionList User-provided array of subscriptions.
+ * @param[in] subscriptionCount Size of `pSubscriptionList`.
+ * @param[out] pRemainingLength Output for calculated "Remaining length" field.
+ * @param[out] pPacketSize Output for calculated total packet size.
+ *
+ * @return IOT_MQTT_SUCCESS if the packet is within the length allowed by MQTT 3.1.1 spec;
+ * IOT_MQTT_BAD_PARAMETER otherwise. If this function returns IOT_MQTT_BAD_PARAMETER,
+ * the output parameters should be ignored.
+ *
+ * @note This call is part of serializer API used for implementing light-weight MQTT client.
+ * 
+ * <b>Example</b>
+ * @code{c}
+ * // Example code below shows how IotMqtt_GetSubscriptionPacketSize() should be used to calculate
+ * // the size of subscribe or unsubscribe request. 
+ *
+ * IotMqttError_t xResult;
+ * IotMqttSubscription_t xMQTTSubscription[ 1 ];
+ * size_t xRemainingLength = 0;
+ * size_t xPacketSize = 0;
+ * 
+ * // Initialize Subscribe parameters. Details are out of scope for this example.
+ * // It will involve setting QOS, topic filter  and topic filter length. 
+ *  _initializeSubscribe( xMQTTSubscription );
+ *
+ * xResult = IotMqtt_GetSubscriptionPacketSize( IOT_MQTT_SUBSCRIBE,
+ *												 xMQTTSubscription,
+ *												 sizeof( xMQTTSubscription ) / sizeof( IotMqttSubscription_t ),
+ *												 &xRemainingLength, &xPacketSize );
+ * IotMqtt_Assert( xResult == IOT_MQTT_SUCCESS );
+ *
+ * // Application should allocate buffer with size == xPacketSize or use static buffer
+ * // with size >= xPacketSize to serialize connect request.
+ * @endcode
+ */
+/* @[declare_mqtt_getsubscriptionpacketsize] */
+IotMqttError_t IotMqtt_GetSubscriptionPacketSize( IotMqttOperationType_t type,
+                                                  const IotMqttSubscription_t * pSubscriptionList,
+                                                  size_t subscriptionCount,
+                                                  size_t * pRemainingLength,
+                                                  size_t * pPacketSize );
+/* @[declare_mqtt_getsubscriptionpacketsize] */
+
+/**
+ * @brief Generate a SUBSCRIBE packet from the given parameters.
+ *
+ * @param[in] pSubscriptionList User-provided array of subscriptions.
+ * @param[in] subscriptionCount Size of `pSubscriptionList`.
+ * @param[in] remainingLength remaining length of the packet to be serialized.
+ * @param[out] pPacketIdentifier The packet identifier generated for this SUBSCRIBE.
+ * @param[in, out] pBuffer User provide buffer where the SUBSCRIBE packet is written.
+ * @param[in] bufferSize Size of the buffer pointed to by pBuffer.
+ *
+ * @return #IOT_MQTT_SUCCESS or #IOT_MQTT_NO_MEMORY.
+ *
+ * @note pBuffer must be allocated by caller.
+ * @note This call is part of serializer API used for implementing light-weight MQTT client.
+ * <b>Example</b>
+ * @code{c}
+ * // Example code below shows how IotMqtt_SerializeSubscribe() should be used to serialize
+ * // MQTT Subscribe packet and send it to MQTT broker.
+ * // Example uses static memory, but dynamically allocated memory can be used as well.
+ * // Get size requirement for the MQTT subscribe packet.
+ * 
+ * #define mqttexampleSHARED_BUFFER_SIZE 100
+ * static ucSharedBuffer[mqttexampleSHARED_BUFFER_SIZE];
+ * void sendSubscribePacket( int xMQTTSocket )
+ * {
+ *    IotMqttSubscription_t xMQTTSubscription[ 1 ];
+ *    size_t xRemainingLength = 0;
+ *    size_t xPacketSize = 0;
+ *    IotMqttError_t xResult;
+ *    size_t xSentBytes = 0;
+ *  
+ *    // Initialize Subscribe parameters. Details are out of scope for this example.
+ *    // It will involve setting QOS, topic filter  and topic filter length. 
+ *    _initializeSubscribe( xMQTTSubscription );
+ *    // Get size requirement for MQTT Subscribe packet.
+ *    xResult = IotMqtt_GetSubscriptionPacketSize( IOT_MQTT_SUBSCRIBE,
+ *												 xMQTTSubscription,
+ *												 sizeof( xMQTTSubscription ) / sizeof( IotMqttSubscription_t ),
+ *												 &xRemainingLength, &xPacketSize );
+ *    IotMqtt_Assert( xResult == IOT_MQTT_SUCCESS );
+ *    // Make sure the packet size is less than static buffer size.
+ *    IotMqtt_Assert( xPacketSize < mqttexampleSHARED_BUFFER_SIZE );
+ * 
+ *    // Serialize subscribe into statically allocated ucSharedBuffer.
+ *	   xResult = IotMqtt_SerializeSubscribe( xMQTTSubscription, 
+ *										  sizeof( xMQTTSubscription ) / sizeof( IotMqttSubscription_t ),
+ *										  xRemainingLength,
+ *										  &usPacketIdentifier,
+ *										  ucSharedBuffer,
+ *										  xPacketSize );
+ *    IotMqtt_Assert( xResult == IOT_MQTT_SUCCESS ); 
+ *    // xMQTTSocket here is posix socket created and connected to MQTT broker outside of this function.
+ *    xSentBytes = send( xMQTTSocket, ( void * ) ucSharedBuffer, xPacketSize, 0 );
+ *    IotMqtt_Assert( xSentBytes == xPacketSize );
+ * }
+ * @endcode
+ */
+/* @[declare_mqtt_serializesubscribe] */
+IotMqttError_t IotMqtt_SerializeSubscribe( const IotMqttSubscription_t * pSubscriptionList,
+                                           size_t subscriptionCount,
+                                           size_t remainingLength,
+                                           uint16_t * pPacketIdentifier,
+                                           uint8_t * pBuffer,
+                                           size_t bufferSize );
+/* @[declare_mqtt_serializesubscribe] */
+
+/**
+ * @brief Generate a UNSUBSCRIBE packet from the given parameters.
+ *
+ * @param[in] pSubscriptionList User-provided array of subscriptions to remove.
+ * @param[in] subscriptionCount Size of `pSubscriptionList`.
+ * @param[in] remainingLength remaining length of the packet to be serialized.
+ * @param[out] pPacketIdentifier The packet identifier generated for this UNSUBSCRIBE.
+ * @param[in, out] pBuffer User provide buffer where the UNSUBSCRIBE packet is written.
+ * @param[in] bufferSize Size of the buffer pointed to by pBuffer.
+ *
+ * @return #IOT_MQTT_SUCCESS or #IOT_MQTT_NO_MEMORY.
+ *
+ * @note pBuffer must be allocated by caller.
+ * @note This call is part of serializer API used for implementing light-weight MQTT client.
+ * 
+ * <b>Example</b>
+ * @code{c}
+ * // Example code below shows how IotMqtt_SerializeUnsubscribe() should be used to serialize
+ * // MQTT unsubscribe packet and send it to MQTT broker.
+ * // Example uses static memory, but dynamically allocated memory can be used as well.
+ * // Get size requirement for the Unsubscribe packet.
+ * 
+ * #define mqttexampleSHARED_BUFFER_SIZE 100
+ * static ucSharedBuffer[mqttexampleSHARED_BUFFER_SIZE];
+ * void sendUnsubscribePacket( int xMQTTSocket )
+ * {
+ *    // Following example shows one topic example.
+ *    IotMqttSubscription_t xMQTTSubscription[ 1 ];
+ *    size_t xRemainingLength = 0;
+ *    size_t xPacketSize = 0;
+ *    IotMqttError_t xResult;
+ *    size_t xSentBytes = 0;
+ *    // Get size requirement for MQTT unsubscribe packet.
+ *    xResult = IotMqtt_GetSubscriptionPacketSize( IOT_MQTT_UNSUBSCRIBE,
+ *												 xMQTTSubscription,
+ *												 sizeof( xMQTTSubscription ) / sizeof( IotMqttSubscription_t ),
+ *												 &xRemainingLength, &xPacketSize );
+ *    IotMqtt_Assert( xResult == IOT_MQTT_SUCCESS );
+ *    // Make sure the packet size is less than static buffer size.
+ *    IotMqtt_Assert( xPacketSize < mqttexampleSHARED_BUFFER_SIZE );
+ *    // Serialize subscribe into staticallu allocated ucSharedBuffer.
+ *	   xResult = IotMqtt_SerializeUnsubscribe( xMQTTSubscription, 
+ *										  sizeof( xMQTTSubscription ) / sizeof( IotMqttSubscription_t ),
+ *										  xRemainingLength,
+ *										  &usPacketIdentifier,
+ *										  ucSharedBuffer,
+ *										  xPacketSize );
+ *    IotMqtt_Assert( xResult == IOT_MQTT_SUCCESS ); 
+ *    // xMQTTSocket here is posix socket created and connected to MQTT broker outside of this function.
+ *    xSentBytes = send( xMQTTSocket, ( void * ) ucSharedBuffer, xPacketSize, 0 );
+ *    IotMqtt_Assert( xSentBytes == xPacketSize );
+ * }
+ * @endcode
+ */
+/* @[declare_mqtt_serializeunsubscribe] */
+IotMqttError_t IotMqtt_SerializeUnsubscribe( const IotMqttSubscription_t * pSubscriptionList,
+                                             size_t subscriptionCount,
+                                             size_t remainingLength,
+                                             uint16_t * pPacketIdentifier,
+                                             uint8_t * pBuffer,
+                                             size_t bufferSize );
+/* @[declare_mqtt_serializeunsubscribe] */
+
+/**
+ * @brief Calculate the size and "Remaining length" of a PUBLISH packet generated
+ * from the given parameters.
+ *
+ * @param[in] pPublishInfo User-provided PUBLISH information struct.
+ * @param[out] pRemainingLength Output for calculated "Remaining length" field.
+ * @param[out] pPacketSize Output for calculated total packet size.
+ *
+ * @return IOT_MQTT_SUCCESS if the packet is within the length allowed by MQTT 3.1.1 spec;
+ * IOT_MQTT_BAD_PARAMETER otherwise. If this function returns IOT_MQTT_BAD_PARAMETER,
+ * the output parameters should be ignored.
+ *
+ * @note This call is part of serializer API used for implementing light-weight MQTT client.
+ * 
+ * <b>Example</b>
+ * @code{c}
+ * // Example code below shows how IotMqtt_GetPublishPacketSize() should be used to calculate
+ * // the size of MQTT publish request. 
+ *
+ * IotMqttError_t xResult;
+ * IotMqttPublishInfo_t xMQTTPublishInfo;
+ * size_t xRemainingLength = 0;
+ * size_t xPacketSize = 0;
+ * 
+ * // Initialize Publish parameters. Details are out of scope for this example.
+ * // It will involve setting QOS, topic filter, topic filter length, payload
+ * // payload length
+ *  _initializePublish( &xMQTTPublishInfo );
+ *
+ * // Find out length of Publish packet size.
+ * xResult = IotMqtt_GetPublishPacketSize( &xMQTTPublishInfo, &xRemainingLength, &xPacketSize );
+ * IotMqtt_Assert( xResult == IOT_MQTT_SUCCESS );
+ *
+ * // Application should allocate buffer with size == xPacketSize or use static buffer
+ * // with size >= xPacketSize to serialize connect request.
+ * @endcode
+ */
+/* @[declare_mqtt_getpublishpacketsize] */
+IotMqttError_t IotMqtt_GetPublishPacketSize( IotMqttPublishInfo_t * pPublishInfo,
+                                             size_t * pRemainingLength,
+                                             size_t * pPacketSize );
+/* @[declare_mqtt_getpublishpacketsize] */
+
+/**
+ * @brief Generate a PUBLISH packet from the given parameters.
+ *
+ * @param[in] pPublishInfo User-provided PUBLISH information.
+ * @param[in] remainingLength remaining length of the packet to be serialized.
+ * @param[out] pPacketIdentifier The packet identifier generated for this PUBLISH.
+ * @param[out] pPacketIdentifierHigh Where the high byte of the packet identifier
+ * is written.
+ * @param[in, out] pBuffer User provide buffer where the PUBLISH packet is written.
+ * @param[in] bufferSize Size of the buffer pointed to by pBuffer.
+ *
+ * @return #IOT_MQTT_SUCCESS or #IOT_MQTT_BAD_PARAMETER.
+ *
+ * @note pBuffer must be allocated by caller.
+ * @note This call is part of serializer API used for implementing light-weight MQTT client.
+ *
+ * <b>Example</b>
+ * @code{c}
+ * // Example code below shows how IotMqtt_SerializePublish() should be used to serialize
+ * // MQTT Publish packet and send it to broker.
+ * // Example uses static memory, but dynamically allocated memory can be used as well.
+ * 
+ * #define mqttexampleSHARED_BUFFER_SIZE 100
+ * static ucSharedBuffer[mqttexampleSHARED_BUFFER_SIZE];
+ * void sendUnsubscribePacket( int xMQTTSocket )
+ * {
+ *    IotMqttError_t xResult;
+ *    IotMqttPublishInfo_t xMQTTPublishInfo;
+ *    size_t xRemainingLength = 0;
+ *    size_t xPacketSize = 0;
+ *    size_t xSentBytes = 0;
+ *    uint16_t usPacketIdentifier;
+ *    uint8_t * pusPacketIdentifierHigh;
+ *
+ *    // Initialize Publish parameters. Details are out of scope for this example.
+ *    // It will involve setting QOS, topic filter, topic filter length, payload
+ *    // payload length.
+ *    _initializePublish( &xMQTTPublishInfo );
+ *
+ *    // Find out length of Publish packet size.
+ *    xResult = IotMqtt_GetPublishPacketSize( &xMQTTPublishInfo, &xRemainingLength, &xPacketSize );
+ *    IotMqtt_Assert( xResult == IOT_MQTT_SUCCESS );
+ * 
+ *    xResult = IotMqtt_SerializePublish( &xMQTTPublishInfo,
+ *										xRemainingLength,
+ *										&usPacketIdentifier,
+ *										&pusPacketIdentifierHigh,
+ *										ucSharedBuffer,
+ *										xPacketSize );
+ *    IotMqtt_Assert( xResult == IOT_MQTT_SUCCESS ); 
+ * 
+ *    // xMQTTSocket here is posix socket created and connected to MQTT broker outside of this function.
+ *    xSentBytes = send( xMQTTSocket, ( void * ) ucSharedBuffer, xPacketSize, 0 );
+ *    IotMqtt_Assert( xSentBytes == xPacketSize );
+ * }
+ * @endcode
+ */
+/* @[declare_mqtt_serializepublish] */
+IotMqttError_t IotMqtt_SerializePublish( IotMqttPublishInfo_t * pPublishInfo,
+                                         size_t remainingLength,
+                                         uint16_t * pPacketIdentifier,
+                                         uint8_t ** pPacketIdentifierHigh,
+                                         uint8_t * pBuffer,
+                                         size_t bufferSize );
+/* @[declare_mqtt_serializepublish] */
+
+/**
+ * @brief Generate a DISCONNECT packet
+ *
+ * @param[in, out] pBuffer User provide buffer where the DISCONNECT packet is written.
+ * @param[in] bufferSize Size of the buffer pointed to by pBuffer.
+ *
+ * @return  returns #IOT_MQTT_SUCCESS or #IOT_MQTT_BAD_PARAMETER
+ *
+ * @note This call is part of serializer API used for implementing light-weight MQTT client.
+ * 
+ * <b>Example</b>
+ * @code{c}
+ * // Example below shows how IotMqtt_SerializeDisconnect() should be used.
+ * 
+ * #define mqttexampleSHARED_BUFFER_SIZE 100
+ * static ucSharedBuffer[mqttexampleSHARED_BUFFER_SIZE];
+ * void sendDisconnectRequest( int xMQTTSocket )
+ * {
+ *     size_t xSentBytes = 0;
+ * 
+ *    // Disconnect is fixed length packet, therefore there is no need to calculate the size,
+ *    // just makes sure static buffer can accomodate disconnect request.
+ *    IotMqtt_Assert( MQTT_PACKET_DISCONNECT_SIZE <= mqttexampleSHARED_BUFFER_SIZE );
+ *
+ *    // Serialize Disconnect packet into static buffer (dynamicaly allocated buffer can be used as well)
+ *    xResult = IotMqtt_SerializeDisconnect( ucSharedBuffer, MQTT_PACKET_DISCONNECT_SIZE );
+ *    IotMqtt_Assert( xResult == IOT_MQTT_SUCCESS );
+ *
+ *    // xMQTTSocket here is posix socket created and connected to MQTT broker outside of this function.
+ *    xSentByte = send( xMQTTSocket, ( void * ) ucSharedBuffer, MQTT_PACKET_DISCONNECT_SIZE, 0 );
+ *    IotMqtt_Assert( xSentByte == MQTT_PACKET_DISCONNECT_SIZE );
+ * }
+ *	
+ * @endcode
+ */
+/* @[declare_mqtt_serializedisconnect] */
+IotMqttError_t IotMqtt_SerializeDisconnect( uint8_t * pBuffer,
+                                            size_t bufferSize );
+/* @[declare_mqtt_serializedisconnect] */
+
+/**
+ * @brief Generate a PINGREQ packet.
+ *
+ * @param[in, out] pBuffer User provide buffer where the PINGREQ packet is written.
+ * @param[in] bufferSize Size of the buffer pointed to by pBuffer.
+ *
+ * @return #IOT_MQTT_SUCCESS or #IOT_MQTT_BAD_PARAMETER.
+ * 
+ * @note This call is part of serializer API used for implementing light-weight MQTT client.
+ * 
+ * <b>Example</b>
+ * @code{c}
+ * // Example below shows how IotMqtt_SerializePingReq() should be used.
+ * 
+ * #define mqttexampleSHARED_BUFFER_SIZE 100
+ * static ucSharedBuffer[mqttexampleSHARED_BUFFER_SIZE];
+ * void sendPingRequest( int xMQTTSocket )
+ * {
+ *    size_t xSentBytes = 0;
+ * 
+ *    // PingReq is fixed length packet, therefore there is no need to calculate the size,
+ *    // just makes sure static buffer can accomodate Ping request.
+ *    IotMqtt_Assert( MQTT_PACKET_PINGREQ_SIZE <= mqttexampleSHARED_BUFFER_SIZE );
+ *
+ *    xResult = IotMqtt_SerializePingreq( ucSharedBuffer, MQTT_PACKET_PINGREQ_SIZE );
+ *    IotMqtt_Assert( xResult == IOT_MQTT_SUCCESS );
+ *    
+ *    // xMQTTSocket here is posix socket created and connected to MQTT broker outside of this function.
+ *    xSentByte = send( xMQTTSocket, ( void * ) ucSharedBuffer, MQTT_PACKET_DISCONNECT_SIZE, 0 );
+ *    IotMqtt_Assert( xSentByte ==  MQTT_PACKET_PINGREQ_SIZE); 
+ * }
+ * @endcode
+ */
+/* @[declare_mqtt_serializepingreq] */
+IotMqttError_t IotMqtt_SerializePingreq( uint8_t * pBuffer,
+                                         size_t bufferSize );
+/* @[declare_mqtt_serializepingreq] */
+
+/**
+ * @brief Extract MQTT packet type and length from incoming packet
+ *
+ * @param[in, out] pIncomingPacket Pointer to IotMqttPacketInfo_t structure
+ * where type, remaining length and packet identifier are stored.
+ * @param[in] getNextByte Pointer to platform specific function  which is used
+ * to extract type and length from incoming received stream (see example ).
+ * @param[in] pNetworkConnection Pointer to platform specific network connection
+ * which is used by getNextByte to receive network data
+ *
+ * @return #IOT_MQTT_SUCCESS on successful extraction of type and length,
+ * #IOT_MQTT_BAD_RESPONSE on failure.
+ *
+ * @note This call is part of serializer API used for implementing light-weight MQTT client.
+ *
+ * <b>Example</b>
+ * @code{c}
+ * // Example code below shows how to implement getNetxByte function with posix sockets.
+ * // Note: IotMqttGetNextByte_t typedef IotMqttError_t (* IotMqttGetNextByte_t)( void * pNetworkContext,
+ * //                                              uint8_t * pNextByte );
+ * // Note: It is assumed that socket is aleady created and connected,
+ *
+ * IotMqttError_t getNextByte( void * pContext,
+ *                           uint8_t * pNextByte )
+ * {
+ *      int socket = ( int ) ( *pvContext );
+ *      int receivedBytes;
+ *      IotMqttError_t result;
+ *
+ *      receivedBytes = recv( socket, ( void * ) pNextByte, sizeof( uint8_t ), 0 );
+ *
+ *      if( receivedBytes == sizeof( uint8_t ) )
+ *      {
+ *          result = IOT_MQTT_SUCCESS;
+ *      }
+ *      else
+ *      {
+ *          result = IOT_MQTT_TIMEOUT;
+ *      }
+ *
+ *       return result;
+ * }
+ * 
+ * // Example below shows how IotMqtt_GetIncomingMQTTPacketTypeAndLength() is used to extract type
+ * // and length from incoming ping response.
+ * // xMQTTSocket here is posix socket created and connected to MQTT broker outside of this function.
+ * void getTypeAndLengthFromIncomingMQTTPingResponse( int xMQTTSocket )
+ * {
+ *    IotMqttPacketInfo_t xIncomingPacket;
+ *    IotMqttError_t xResult = IotMqtt_GetIncomingMQTTPacketTypeAndLength( &xIncomingPacket, getNextByte, ( void * ) xMQTTSocket );
+ *	  IotMqtt_Assert( xResult == IOT_MQTT_SUCCESS );
+ *    IotMqtt_Assert( xIncomingPacket.type == MQTT_PACKET_TYPE_PINGRESP );
+ * }
+ * @endcode
+ *
+ */
+/* @[declare_mqtt_getincomingmqttpackettypeandlength] */
+IotMqttError_t IotMqtt_GetIncomingMQTTPacketTypeAndLength( IotMqttPacketInfo_t * pIncomingPacket,
+                                                           IotMqttGetNextByte_t getNextByte,
+                                                           void * pNetworkConnection );
+/* @[declare_mqtt_getincomingmqttpackettypeandlength] */
+
+/**
+ * @brief Deserialize incoming publish packet.
+ *
+ * @param[in, out] pMqttPacket The caller of this API sets type, remainingLength and pRemainingData.
+ * On success, packetIdentifier and pubInfo will be set by the function.
+ *
+ * @return One of the following:
+ * - #IOT_MQTT_SUCCESS
+ * - #IOT_MQTT_BAD_RESPONSE
+ * - #IOT_MQTT_SERVER_REFUSED
+ *
+ * @note This call is part of serializer API used for implementing light-weight MQTT client.
+ * 
+ * <b>Example</b>
+ * @code{c}
+ * // Example below shows how IotMqtt_DeserializePublish() used to extract contents of incoming 
+ * // Publish.  xMQTTSocket here is posix socket created and connected to MQTT broker outside of this function.
+ * void processIncomingPublish( int xMQTTSocket )
+ * {
+ *    IotMqttError_t xResult;
+ *    IotMqttPacketInfo_t xIncomingPacket;
+ *
+ *	  xResult = IotMqtt_GetIncomingMQTTPacketTypeAndLength( &xIncomingPacket, getNextByte, ( void * ) xMQTTSocket );
+ *	  IotMqtt_Assert( xResult == IOT_MQTT_SUCCESS );
+ *	  IotMqtt_Assert( ( xIncomingPacket.type & 0xf0 ) == MQTT_PACKET_TYPE_PUBLISH );
+ *	  IotMqtt_Assert( xIncomingPacket.remainingLength <= mqttexampleSHARED_BUFFER_SIZE );
+ *
+ *	  // Receive the remaining bytes.
+ *	  if( recv( xMQTTSocket, ( void * ) ucSharedBuffer, xIncomingPacket.remainingLength, 0 ) ==  xIncomingPacket.remainingLength )
+ *	  {
+ *		xIncomingPacket.pRemainingData = ucSharedBuffer;
+ *
+ *		if( IotMqtt_DeserializePublish( &xIncomingPacket ) != IOT_MQTT_SUCCESS )
+ *		{
+ *			xResult = IOT_MQTT_BAD_RESPONSE;
+ *		}
+ *		else
+ *		{
+ *			// Process incoming Publish.
+ *			IotLogInfo( "Incoming QOS : %d\n", xIncomingPacket.pubInfo.qos );
+ *			IotLogInfo( "Incoming Publish Topic Name: %.*s\n", xIncomingPacket.pubInfo.topicNameLength, xIncomingPacket.pubInfo.pTopicName );
+ *			IotLogInfo( "Incoming Publish Message : %.*s\n", xIncomingPacket.pubInfo.payloadLength, xIncomingPacket.pubInfo.pPayload  );
+ *		}
+ *	  }
+ *	  else
+ *	  {
+ *		xResult = IOT_MQTT_NETWORK_ERROR;
+ *	  }
+ *
+ *	IotMqtt_Assert( xResult == IOT_MQTT_SUCCESS );
+ * }
+ * @endcode
+ */
+/* @[declare_mqtt_deserializepublish] */
+IotMqttError_t IotMqtt_DeserializePublish( IotMqttPacketInfo_t * pMqttPacket );
+/* @[declare_mqtt_deserializepublish] */
+
+/**
+ * @brief Deserialize incoming ack packets.
+ *
+ * @param[in, out] pMqttPacket The caller of this API sets type, remainingLength and pRemainingData.
+ * On success, packetIdentifier will be set.
+ *
+ * @return One of the following:
+ * - #IOT_MQTT_SUCCESS
+ * - #IOT_MQTT_BAD_RESPONSE
+ * - #IOT_MQTT_SERVER_REFUSED
+ *
+ * @note This call is part of serializer API used for implementing light-weight MQTT client.
+ * 
+ * <b>Example</b>
+ * @code{c}
+ * // Example below shows how  IotMqtt_DeserializeResponse() is used to process unsubscribe ack.
+ * // xMQTTSocket here is posix socket created and connected to MQTT broker outside of this function.
+ * void processUnsubscribeAck( int xMQTTSocket )
+ * {
+ *      IotMqttError_t xResult;
+ *      IotMqttPacketInfo_t xIncomingPacket;
+ * 
+ * 		xResult = IotMqtt_GetIncomingMQTTPacketTypeAndLength( &xIncomingPacket, getNextByte, ( void * ) xMQTTSocket );
+ *		IotMqtt_Assert( xResult == IOT_MQTT_SUCCESS );
+ *		IotMqtt_Assert( xIncomingPacket.type == MQTT_PACKET_TYPE_UNSUBACK );
+ *		IotMqtt_Assert( xIncomingPacket.remainingLength <= sizeof( ucSharedBuffer ) );
+ *
+ *		// Receive the remaining bytes.
+ *		if( recv( xMQTTSocket, ( void * ) ucSharedBuffer, xIncomingPacket.remainingLength, 0 ) == xIncomingPacket.remainingLength )
+ *		{
+ *			xIncomingPacket.pRemainingData = ucSharedBuffer;
+ *
+ *			if( IotMqtt_DeserializeResponse( &xIncomingPacket ) != IOT_MQTT_SUCCESS )
+ *			{
+ *				xResult = IOT_MQTT_BAD_RESPONSE;
+ *			}
+ *		}
+ *		else
+ *		{
+ *			xResult = IOT_MQTT_NETWORK_ERROR;
+ *		}
+ *      IotMqtt_Assert( xResult == IOT_MQTT_SUCCESS );
+ * }
+ * @endcode
+ */
+/* @[declare_mqtt_deserializeresponse] */
+IotMqttError_t IotMqtt_DeserializeResponse( IotMqttPacketInfo_t * pMqttPacket );
+/* @[declare_mqtt_deserializeresponse] */
+
+
+
+#endif /* ifndef IOT_MQTT_SERIALIZE_H_ */

--- a/libraries/standard/mqtt/include/iot_mqtt_serialize.h
+++ b/libraries/standard/mqtt/include/iot_mqtt_serialize.h
@@ -425,6 +425,8 @@ IotMqttError_t IotMqtt_GetPublishPacketSize( IotMqttPublishInfo_t * pPublishInfo
  *    // Find out length of Publish packet size.
  *    xResult = IotMqtt_GetPublishPacketSize( &xMQTTPublishInfo, &xRemainingLength, &xPacketSize );
  *    IotMqtt_Assert( xResult == IOT_MQTT_SUCCESS );
+ *    // Make sure the packet size is less than static buffer size
+ *	  configASSERT( xPacketSize < mqttexampleSHARED_BUFFER_SIZE );
  * 
  *    xResult = IotMqtt_SerializePublish( &xMQTTPublishInfo,
  *										xRemainingLength,

--- a/libraries/standard/mqtt/include/types/iot_mqtt_types.h
+++ b/libraries/standard/mqtt/include/types/iot_mqtt_types.h
@@ -675,6 +675,29 @@ typedef struct IotMqttConnectInfo
 } IotMqttConnectInfo_t;
 
 /**
+ * @ingroup mqtt_datatypes_paramstructs
+ * @brief MQTT packet details.
+ *
+ * @paramfor @ref mqtt_function_deserializeresponse @ref mqtt_function_deserializepublish
+ *
+ * Passed as an argument to public low level mqtt deserialize functions.
+ *
+ * @initializer{IotMqttPacketInfo_t,IOT_MQTT_PACKET_INFO_INITIALIZER}
+ *
+ * @note This structure should be only used while accessing low level MQTT deserialization API.
+ * The low level serialization/ deserialization API should be only used for implementing
+ * light weight single threaded mqtt client.
+ */
+typedef struct IotMqttPacketInfo
+{
+    uint8_t * pRemainingData;     /**< @brief (Input) The remaining data in MQTT packet. */
+    size_t remainingLength;       /**< @brief (Input) Length of the remaining data in the MQTT packet. */
+    uint16_t packetIdentifier;    /**< @brief (Output) MQTT packet identifier. */
+    uint8_t type;                 /**< @brief (Input) A value identifying the packet type. */
+    IotMqttPublishInfo_t pubInfo; /**< @brief (Output) Publish info in case of deserializing PUBLISH. */
+} IotMqttPacketInfo_t;
+
+/**
  * @cond DOXYGEN_IGNORE
  * Doxygen should ignore this section.
  *
@@ -791,6 +814,14 @@ typedef IotMqttError_t ( * IotMqttSerializePuback_t )( uint16_t packetIdentifier
 typedef void ( * IotMqttPublishSetDup_t )( uint8_t * pPublishPacket,
                                            uint8_t * pPacketIdentifierHigh,
                                            uint16_t * pNewPacketIdentifier );
+
+/**
+ * @brief Function pointer to read the next available byte on a network connection.
+ * @param[in] pNetworkContext reference to network connection like socket.
+ * @param[out] pNextByte Pointer to the byte read from the network.
+ */
+typedef IotMqttError_t (* IotMqttGetNextByte_t)( void * pNetworkContext,
+                                                 uint8_t * pNextByte );
 
 #if IOT_MQTT_ENABLE_SERIALIZER_OVERRIDES == 1
 
@@ -1098,6 +1129,8 @@ typedef struct IotMqttNetworkInfo
 #define IOT_MQTT_CONNECTION_INITIALIZER       NULL
 /** @brief Initializer for #IotMqttOperation_t. */
 #define IOT_MQTT_OPERATION_INITIALIZER        NULL
+/** @brief Initializer for #IotMqttPacketInfo_t. */
+#define IOT_MQTT_PACKET_INFO_INITIALIZER      { .pRemainingData = NULL, remainingLength = 0, packetIdentifier = 0, .type = 0 }
 /* @[define_mqtt_initializers] */
 
 /**

--- a/libraries/standard/mqtt/src/iot_mqtt_network.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_network.c
@@ -873,6 +873,10 @@ IotMqttError_t IotMqtt_GetIncomingMQTTPacketTypeAndLength( IotMqttPacketInfo_t *
             }
         }
     }
+    else
+    {
+        status = IOT_MQTT_NETWORK_ERROR;
+    }
 
     return status;
 }

--- a/libraries/standard/mqtt/src/iot_mqtt_network.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_network.c
@@ -152,7 +152,7 @@ static void _flushPacket( void * pNetworkConnection,
                                    _getMqttFreePacketFunc,
                                    _IotMqtt_FreePacket,
                                    freePacket )
-#else  /* if IOT_MQTT_ENABLE_SERIALIZER_OVERRIDES == 1 */
+#else /* if IOT_MQTT_ENABLE_SERIALIZER_OVERRIDES == 1 */
     #define _getPacketTypeFunc( pSerializer )          _IotMqtt_GetPacketType
     #define _getRemainingLengthFunc( pSerializer )     _IotMqtt_GetRemainingLength
     #define _getConnackDeserializer( pSerializer )     _IotMqtt_DeserializeConnack
@@ -840,6 +840,41 @@ void IotMqtt_ReceiveCallback( IotNetworkConnection_t pNetworkConnection,
     {
         EMPTY_ELSE_MARKER;
     }
+}
+
+/*-----------------------------------------------------------*/
+
+IotMqttError_t IotMqtt_GetIncomingMQTTPacketTypeAndLength( IotMqttPacketInfo_t * pIncomingPacket,
+                                                           IotMqttGetNextByte_t getNextByte,
+                                                           void * pNetworkConnection )
+{
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
+
+    /* Read the packet type, which is the first byte available. */
+    if( getNextByte( pNetworkConnection, &( pIncomingPacket->type ) ) == IOT_MQTT_SUCCESS )
+    {
+        /* Check that the incoming packet type is valid. */
+        if( _incomingPacketValid( pIncomingPacket->type ) == false )
+        {
+            IotLogError( "(MQTT connection) Unknown packet type %02x received.",
+                         pIncomingPacket->type );
+
+            status = IOT_MQTT_BAD_RESPONSE;
+        }
+        else
+        {
+            /* Read the remaining length. */
+            pIncomingPacket->remainingLength = _IotMqtt_GetRemainingLength_Generic( pNetworkConnection,
+                                                                                    getNextByte );
+
+            if( pIncomingPacket->remainingLength == MQTT_REMAINING_LENGTH_INVALID )
+            {
+                status = IOT_MQTT_BAD_RESPONSE;
+            }
+        }
+    }
+
+    return status;
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/standard/mqtt/src/iot_mqtt_serialize.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_serialize.c
@@ -267,6 +267,75 @@ static bool _subscriptionPacketSize( IotMqttOperationType_t type,
                                      size_t * pRemainingLength,
                                      size_t * pPacketSize );
 
+/**
+ * @brief Generate a CONNECT packet from the given parameters.
+ *
+ * @param[in] pConnectInfo User-provided CONNECT information.
+ * @param[in] remainingLength User provided remaining length.
+ * @param[in, out] pBuffer User provided buffer where the CONNECT packet is written.
+ * @param[in] connectPacketSize Size of the buffer pointed to by `pBuffer`.
+ *
+ */
+void _serializeConnect( const IotMqttConnectInfo_t * pConnectInfo,
+                        size_t remainingLength,
+                        uint8_t * pBuffer,
+                        size_t connectPacketSize );
+
+/**
+ * @brief Generate a PUBLISH packet from the given parameters.
+ *
+ * @param[in] pPublishInfo User-provided PUBLISH information.
+ * @param[in] remainingLength User provided remaining length.
+ * @param[out] pPacketIdentifier The packet identifier generated for this PUBLISH.
+ * @param[out] pPacketIdentifierHigh Where the high byte of the packet identifier
+ * is written.
+ * @param[in, out] pBuffer User provided buffer where the PUBLISH packet is written.
+ * @param[in] publishPacketSize Size of buffer pointed to by `pBuffer`.
+ *
+ */
+void _serializePublish( const IotMqttPublishInfo_t * pPublishInfo,
+                        size_t remainingLength,
+                        uint16_t * pPacketIdentifier,
+                        uint8_t ** pPacketIdentifierHigh,
+                        uint8_t * pBuffer,
+                        size_t publishPacketSize );
+
+/**
+ * @brief Generate a SUBSCRIBE packet from the given parameters.
+ *
+ * @param[in] pSubscriptionList User-provided array of subscriptions.
+ * @param[in] subscriptionCount Size of `pSubscriptionList`.
+ * @param[in] remainingLength User provided remaining length.
+ * @param[out] pPacketIdentifier The packet identifier generated for this SUBSCRIBE.
+ * @param[in, out] pBuffer User provided buffer where the SUBSCRIBE packet is written.
+ * @param[in] subscribePacketSize Size of the buffer pointed to by  `pBuffer`.
+ *
+ */
+void _serializeSubscribe( const IotMqttSubscription_t * pSubscriptionList,
+                          size_t subscriptionCount,
+                          size_t remainingLength,
+                          uint16_t * pPacketIdentifier,
+                          uint8_t * pBuffer,
+                          size_t subscribePacketSize );
+
+/**
+ * @brief Generate an UNSUBSCRIBE packet from the given parameters.
+ *
+ * @param[in] pSubscriptionList User-provided array of subscriptions to remove.
+ * @param[in] subscriptionCount Size of `pSubscriptionList`.
+ * @param[in] remainingLength User provided remaining length.
+ * @param[out] pPacketIdentifier The packet identifier generated for this UNSUBSCRIBE.
+ * @param[in, out] pBuffer User provided buffer where the UNSUBSCRIBE packet is written.
+ * @param[in] unsubscribePacketSize size of the buffer pointed to by  `pBuffer`.
+ *
+ */
+void _serializeUnsubscribe( const IotMqttSubscription_t * pSubscriptionList,
+                            size_t subscriptionCount,
+                            size_t remainingLength,
+                            uint16_t * pPacketIdentifier,
+                            uint8_t * pBuffer,
+                            size_t unsubscribePacketSize );
+
 /*-----------------------------------------------------------*/
 
 #if LIBRARY_LOG_LEVEL > IOT_LOG_NONE
@@ -400,14 +469,7 @@ static bool _connectPacketSize( const IotMqttConnectInfo_t * pConnectInfo,
     connectPacketSize += 10U;
 
     /* Add the length of the client identifier if provided. */
-    if( pConnectInfo->clientIdentifierLength > 0 )
-    {
-        connectPacketSize += pConnectInfo->clientIdentifierLength + sizeof( uint16_t );
-    }
-    else
-    {
-        EMPTY_ELSE_MARKER;
-    }
+    connectPacketSize += pConnectInfo->clientIdentifierLength + sizeof( uint16_t );
 
     /* Add the lengths of the will message and topic name if provided. */
     if( pConnectInfo->pWillInfo != NULL )
@@ -594,124 +656,13 @@ static bool _subscriptionPacketSize( IotMqttOperationType_t type,
 
 /*-----------------------------------------------------------*/
 
-uint8_t _IotMqtt_GetPacketType( void * pNetworkConnection,
-                                const IotNetworkInterface_t * pNetworkInterface )
+void _serializeConnect( const IotMqttConnectInfo_t * pConnectInfo,
+                        size_t remainingLength,
+                        uint8_t * pBuffer,
+                        size_t connectPacketSize )
 {
-    uint8_t packetType = 0xff;
-
-    /* The MQTT packet type is in the first byte of the packet. */
-    ( void ) _IotMqtt_GetNextByte( pNetworkConnection,
-                                   pNetworkInterface,
-                                   &packetType );
-
-    return packetType;
-}
-
-/*-----------------------------------------------------------*/
-
-size_t _IotMqtt_GetRemainingLength( void * pNetworkConnection,
-                                    const IotNetworkInterface_t * pNetworkInterface )
-{
-    uint8_t encodedByte = 0;
-    size_t remainingLength = 0, multiplier = 1, bytesDecoded = 0, expectedSize = 0;
-
-    /* This algorithm is copied from the MQTT v3.1.1 spec. */
-    do
-    {
-        if( multiplier > 2097152 ) /* 128 ^ 3 */
-        {
-            remainingLength = MQTT_REMAINING_LENGTH_INVALID;
-            break;
-        }
-        else
-        {
-            if( _IotMqtt_GetNextByte( pNetworkConnection,
-                                      pNetworkInterface,
-                                      &encodedByte ) == true )
-            {
-                remainingLength += ( encodedByte & 0x7F ) * multiplier;
-                multiplier *= 128;
-                bytesDecoded++;
-            }
-            else
-            {
-                remainingLength = MQTT_REMAINING_LENGTH_INVALID;
-                break;
-            }
-        }
-    } while( ( encodedByte & 0x80 ) != 0 );
-
-    /* Check that the decoded remaining length conforms to the MQTT specification. */
-    if( remainingLength != MQTT_REMAINING_LENGTH_INVALID )
-    {
-        expectedSize = _remainingLengthEncodedSize( remainingLength );
-
-        if( bytesDecoded != expectedSize )
-        {
-            remainingLength = MQTT_REMAINING_LENGTH_INVALID;
-        }
-        else
-        {
-            /* Valid remaining length should be at most 4 bytes. */
-            IotMqtt_Assert( bytesDecoded <= 4 );
-        }
-    }
-    else
-    {
-        EMPTY_ELSE_MARKER;
-    }
-
-    return remainingLength;
-}
-
-/*-----------------------------------------------------------*/
-
-IotMqttError_t _IotMqtt_SerializeConnect( const IotMqttConnectInfo_t * pConnectInfo,
-                                          uint8_t ** pConnectPacket,
-                                          size_t * pPacketSize )
-{
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
     uint8_t connectFlags = 0;
-    size_t remainingLength = 0, connectPacketSize = 0;
-    uint8_t * pBuffer = NULL;
-
-    /* Calculate the "Remaining length" field and total packet size. If it exceeds
-     * what is allowed in the MQTT standard, return an error. */
-    if( _connectPacketSize( pConnectInfo, &remainingLength, &connectPacketSize ) == false )
-    {
-        IotLogError( "Connect packet length exceeds %lu, which is the maximum"
-                     " size allowed by MQTT 3.1.1.",
-                     MQTT_PACKET_CONNECT_MAX_SIZE );
-
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
-    }
-    else
-    {
-        EMPTY_ELSE_MARKER;
-    }
-
-    /* Total size of the connect packet should be larger than the "Remaining length"
-     * field. */
-    IotMqtt_Assert( connectPacketSize > remainingLength );
-
-    /* Allocate memory to hold the CONNECT packet. */
-    pBuffer = IotMqtt_MallocMessage( connectPacketSize );
-
-    /* Check that sufficient memory was allocated. */
-    if( pBuffer == NULL )
-    {
-        IotLogError( "Failed to allocate memory for CONNECT packet." );
-
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_NO_MEMORY );
-    }
-    else
-    {
-        EMPTY_ELSE_MARKER;
-    }
-
-    /* Set the output parameters. The remainder of this function always succeeds. */
-    *pConnectPacket = pBuffer;
-    *pPacketSize = connectPacketSize;
+    uint8_t * pConnectPacket = pBuffer;
 
     /* The first byte in the CONNECT packet is the control packet type. */
     *pBuffer = MQTT_PACKET_TYPE_CONNECT;
@@ -875,10 +826,381 @@ IotMqttError_t _IotMqtt_SerializeConnect( const IotMqttConnectInfo_t * pConnectI
 
     /* Ensure that the difference between the end and beginning of the buffer
      * is equal to connectPacketSize, i.e. pBuffer did not overflow. */
-    IotMqtt_Assert( ( size_t ) ( pBuffer - *pConnectPacket ) == connectPacketSize );
+    IotMqtt_Assert( ( size_t ) ( pBuffer - pConnectPacket ) == connectPacketSize );
 
     /* Print out the serialized CONNECT packet for debugging purposes. */
-    IotLog_PrintBuffer( "MQTT CONNECT packet:", *pConnectPacket, connectPacketSize );
+    IotLog_PrintBuffer( "MQTT CONNECT packet:", pConnectPacket, connectPacketSize );
+}
+
+/*-----------------------------------------------------------*/
+
+void _serializePublish( const IotMqttPublishInfo_t * pPublishInfo,
+                        size_t remainingLength,
+                        uint16_t * pPacketIdentifier,
+                        uint8_t ** pPacketIdentifierHigh,
+                        uint8_t * pBuffer,
+                        size_t publishPacketSize )
+{
+    uint8_t publishFlags = 0;
+    uint16_t packetIdentifier = 0;
+    uint8_t * pPublishPacket = pBuffer;
+
+    /* The first byte of a PUBLISH packet contains the packet type and flags. */
+    publishFlags = MQTT_PACKET_TYPE_PUBLISH;
+
+    if( pPublishInfo->qos == IOT_MQTT_QOS_1 )
+    {
+        UINT8_SET_BIT( publishFlags, MQTT_PUBLISH_FLAG_QOS1 );
+    }
+    else if( pPublishInfo->qos == IOT_MQTT_QOS_2 )
+    {
+        UINT8_SET_BIT( publishFlags, MQTT_PUBLISH_FLAG_QOS2 );
+    }
+    else
+    {
+        EMPTY_ELSE_MARKER;
+    }
+
+    if( pPublishInfo->retain == true )
+    {
+        UINT8_SET_BIT( publishFlags, MQTT_PUBLISH_FLAG_RETAIN );
+    }
+    else
+    {
+        EMPTY_ELSE_MARKER;
+    }
+
+    *pBuffer = publishFlags;
+    pBuffer++;
+
+    /* The "Remaining length" is encoded from the second byte. */
+    pBuffer = _encodeRemainingLength( pBuffer, remainingLength );
+
+    /* The topic name is placed after the "Remaining length". */
+    pBuffer = _encodeString( pBuffer,
+                             pPublishInfo->pTopicName,
+                             pPublishInfo->topicNameLength );
+
+    /* A packet identifier is required for QoS 1 and 2 messages. */
+    if( pPublishInfo->qos > IOT_MQTT_QOS_0 )
+    {
+        /* Get the next packet identifier. It should always be nonzero. */
+        packetIdentifier = _nextPacketIdentifier();
+        IotMqtt_Assert( packetIdentifier != 0 );
+
+        /* Set the packet identifier output parameters. */
+        *pPacketIdentifier = packetIdentifier;
+
+        if( pPacketIdentifierHigh != NULL )
+        {
+            *pPacketIdentifierHigh = pBuffer;
+        }
+        else
+        {
+            EMPTY_ELSE_MARKER;
+        }
+
+        /* Place the packet identifier into the PUBLISH packet. */
+        *pBuffer = UINT16_HIGH_BYTE( packetIdentifier );
+        *( pBuffer + 1 ) = UINT16_LOW_BYTE( packetIdentifier );
+        pBuffer += 2;
+    }
+    else
+    {
+        EMPTY_ELSE_MARKER;
+    }
+
+    /* The payload is placed after the packet identifier. */
+    if( pPublishInfo->payloadLength > 0 )
+    {
+        ( void ) memcpy( pBuffer, pPublishInfo->pPayload, pPublishInfo->payloadLength );
+        pBuffer += pPublishInfo->payloadLength;
+    }
+    else
+    {
+        EMPTY_ELSE_MARKER;
+    }
+
+    /* Ensure that the difference between the end and beginning of the buffer
+     * is equal to publishPacketSize, i.e. pBuffer did not overflow. */
+    IotMqtt_Assert( ( size_t ) ( pBuffer - pPublishPacket ) == publishPacketSize );
+
+    /* Print out the serialized PUBLISH packet for debugging purposes. */
+    IotLog_PrintBuffer( "MQTT PUBLISH packet:", pPublishPacket, publishPacketSize );
+}
+
+/*-----------------------------------------------------------*/
+
+void _serializeSubscribe( const IotMqttSubscription_t * pSubscriptionList,
+                          size_t subscriptionCount,
+                          size_t remainingLength,
+                          uint16_t * pPacketIdentifier,
+                          uint8_t * pBuffer,
+                          size_t subscribePacketSize )
+{
+    uint16_t packetIdentifier = 0;
+    size_t i = 0;
+    uint8_t * pSubscribePacket = pBuffer;
+
+    /* The first byte in SUBSCRIBE is the packet type. */
+    *pBuffer = MQTT_PACKET_TYPE_SUBSCRIBE;
+    pBuffer++;
+
+    /* Encode the "Remaining length" starting from the second byte. */
+    pBuffer = _encodeRemainingLength( pBuffer, remainingLength );
+
+    /* Get the next packet identifier. It should always be nonzero. */
+    packetIdentifier = _nextPacketIdentifier();
+    *pPacketIdentifier = packetIdentifier;
+    IotMqtt_Assert( packetIdentifier != 0 );
+
+    /* Place the packet identifier into the SUBSCRIBE packet. */
+    *pBuffer = UINT16_HIGH_BYTE( packetIdentifier );
+    *( pBuffer + 1 ) = UINT16_LOW_BYTE( packetIdentifier );
+    pBuffer += 2;
+
+    /* Serialize each subscription topic filter and QoS. */
+    for( i = 0; i < subscriptionCount; i++ )
+    {
+        pBuffer = _encodeString( pBuffer,
+                                 pSubscriptionList[ i ].pTopicFilter,
+                                 pSubscriptionList[ i ].topicFilterLength );
+
+        /* Place the QoS in the SUBSCRIBE packet. */
+        *pBuffer = ( uint8_t ) ( pSubscriptionList[ i ].qos );
+        pBuffer++;
+    }
+
+    /* Ensure that the difference between the end and beginning of the buffer
+     * is equal to subscribePacketSize, i.e. pBuffer did not overflow. */
+    IotMqtt_Assert( ( size_t ) ( pBuffer - pSubscribePacket ) == subscribePacketSize );
+
+    /* Print out the serialized SUBSCRIBE packet for debugging purposes. */
+    IotLog_PrintBuffer( "MQTT SUBSCRIBE packet:", pSubscribePacket, subscribePacketSize );
+}
+
+/*-----------------------------------------------------------*/
+
+void _serializeUnsubscribe( const IotMqttSubscription_t * pSubscriptionList,
+                            size_t subscriptionCount,
+                            size_t remainingLength,
+                            uint16_t * pPacketIdentifier,
+                            uint8_t * pBuffer,
+                            size_t unsubscribePacketSize )
+{
+    uint16_t packetIdentifier = 0;
+    size_t i = 0;
+    uint8_t * pUnsubscribePacket = pBuffer;
+
+    /* The first byte in UNSUBSCRIBE is the packet type. */
+    *pBuffer = MQTT_PACKET_TYPE_UNSUBSCRIBE;
+    pBuffer++;
+
+    /* Encode the "Remaining length" starting from the second byte. */
+    pBuffer = _encodeRemainingLength( pBuffer, remainingLength );
+
+    /* Get the next packet identifier. It should always be nonzero. */
+    packetIdentifier = _nextPacketIdentifier();
+    *pPacketIdentifier = packetIdentifier;
+    IotMqtt_Assert( packetIdentifier != 0 );
+
+    /* Place the packet identifier into the UNSUBSCRIBE packet. */
+    *pBuffer = UINT16_HIGH_BYTE( packetIdentifier );
+    *( pBuffer + 1 ) = UINT16_LOW_BYTE( packetIdentifier );
+    pBuffer += 2;
+
+    /* Serialize each subscription topic filter. */
+    for( i = 0; i < subscriptionCount; i++ )
+    {
+        pBuffer = _encodeString( pBuffer,
+                                 pSubscriptionList[ i ].pTopicFilter,
+                                 pSubscriptionList[ i ].topicFilterLength );
+    }
+
+    /* Ensure that the difference between the end and beginning of the buffer
+     * is equal to unsubscribePacketSize, i.e. pBuffer did not overflow. */
+    IotMqtt_Assert( ( size_t ) ( pBuffer - pUnsubscribePacket ) == unsubscribePacketSize );
+
+    /* Print out the serialized UNSUBSCRIBE packet for debugging purposes. */
+    IotLog_PrintBuffer( "MQTT UNSUBSCRIBE packet:", pUnsubscribePacket, unsubscribePacketSize );
+}
+
+/*-----------------------------------------------------------*/
+
+uint8_t _IotMqtt_GetPacketType( void * pNetworkConnection,
+                                const IotNetworkInterface_t * pNetworkInterface )
+{
+    uint8_t packetType = 0xff;
+
+    /* The MQTT packet type is in the first byte of the packet. */
+    ( void ) _IotMqtt_GetNextByte( pNetworkConnection,
+                                   pNetworkInterface,
+                                   &packetType );
+
+    return packetType;
+}
+
+/*-----------------------------------------------------------*/
+
+size_t _IotMqtt_GetRemainingLength( void * pNetworkConnection,
+                                    const IotNetworkInterface_t * pNetworkInterface )
+{
+    uint8_t encodedByte = 0;
+    size_t remainingLength = 0, multiplier = 1, bytesDecoded = 0, expectedSize = 0;
+
+    /* This algorithm is copied from the MQTT v3.1.1 spec. */
+    do
+    {
+        if( multiplier > 2097152 ) /* 128 ^ 3 */
+        {
+            remainingLength = MQTT_REMAINING_LENGTH_INVALID;
+            break;
+        }
+        else
+        {
+            if( _IotMqtt_GetNextByte( pNetworkConnection,
+                                      pNetworkInterface,
+                                      &encodedByte ) == true )
+            {
+                remainingLength += ( encodedByte & 0x7F ) * multiplier;
+                multiplier *= 128;
+                bytesDecoded++;
+            }
+            else
+            {
+                remainingLength = MQTT_REMAINING_LENGTH_INVALID;
+                break;
+            }
+        }
+    } while( ( encodedByte & 0x80 ) != 0 );
+
+    /* Check that the decoded remaining length conforms to the MQTT specification. */
+    if( remainingLength != MQTT_REMAINING_LENGTH_INVALID )
+    {
+        expectedSize = _remainingLengthEncodedSize( remainingLength );
+
+        if( bytesDecoded != expectedSize )
+        {
+            remainingLength = MQTT_REMAINING_LENGTH_INVALID;
+        }
+        else
+        {
+            /* Valid remaining length should be at most 4 bytes. */
+            IotMqtt_Assert( bytesDecoded <= 4 );
+        }
+    }
+    else
+    {
+        EMPTY_ELSE_MARKER;
+    }
+
+    return remainingLength;
+}
+
+/*-----------------------------------------------------------*/
+
+size_t _IotMqtt_GetRemainingLength_Generic( void * pNetworkConnecton,
+                                            IotMqttGetNextByte_t getNextByte )
+{
+    uint8_t encodedByte = 0;
+    size_t remainingLength = 0, multiplier = 1, bytesDecoded = 0, expectedSize = 0;
+
+    /* This algorithm is copied from the MQTT v3.1.1 spec. */
+    do
+    {
+        if( multiplier > 2097152 ) /* 128 ^ 3 */
+        {
+            remainingLength = MQTT_REMAINING_LENGTH_INVALID;
+            break;
+        }
+        else
+        {
+            if( getNextByte( pNetworkConnecton, &encodedByte ) == IOT_MQTT_SUCCESS )
+            {
+                remainingLength += ( encodedByte & 0x7F ) * multiplier;
+                multiplier *= 128;
+                bytesDecoded++;
+            }
+            else
+            {
+                remainingLength = MQTT_REMAINING_LENGTH_INVALID;
+                break;
+            }
+        }
+    } while( ( encodedByte & 0x80 ) != 0 );
+
+    /* Check that the decoded remaining length conforms to the MQTT specification. */
+    if( remainingLength != MQTT_REMAINING_LENGTH_INVALID )
+    {
+        expectedSize = _remainingLengthEncodedSize( remainingLength );
+
+        if( bytesDecoded != expectedSize )
+        {
+            remainingLength = MQTT_REMAINING_LENGTH_INVALID;
+        }
+        else
+        {
+            /* Valid remaining length should be at most 4 bytes. */
+            IotMqtt_Assert( bytesDecoded <= 4 );
+        }
+    }
+    else
+    {
+        EMPTY_ELSE_MARKER;
+    }
+
+    return remainingLength;
+}
+
+/*-----------------------------------------------------------*/
+
+IotMqttError_t _IotMqtt_SerializeConnect( const IotMqttConnectInfo_t * pConnectInfo,
+                                          uint8_t ** pConnectPacket,
+                                          size_t * pPacketSize )
+{
+    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    size_t remainingLength = 0, connectPacketSize = 0;
+    uint8_t * pBuffer = NULL;
+
+    /* Calculate the "Remaining length" field and total packet size. If it exceeds
+     * what is allowed in the MQTT standard, return an error. */
+    if( _connectPacketSize( pConnectInfo, &remainingLength, &connectPacketSize ) == false )
+    {
+        IotLogError( "Connect packet length exceeds %lu, which is the maximum"
+                     " size allowed by MQTT 3.1.1.",
+                     MQTT_PACKET_CONNECT_MAX_SIZE );
+
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+    else
+    {
+        EMPTY_ELSE_MARKER;
+    }
+
+    /* Total size of the connect packet should be larger than the "Remaining length"
+     * field. */
+    IotMqtt_Assert( connectPacketSize > remainingLength );
+
+    /* Allocate memory to hold the CONNECT packet. */
+    pBuffer = IotMqtt_MallocMessage( connectPacketSize );
+
+    /* Check that sufficient memory was allocated. */
+    if( pBuffer == NULL )
+    {
+        IotLogError( "Failed to allocate memory for CONNECT packet." );
+
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_NO_MEMORY );
+    }
+    else
+    {
+        EMPTY_ELSE_MARKER;
+    }
+
+    /* Set the output parameters. The remainder of this function always succeeds. */
+    *pConnectPacket = pBuffer;
+    *pPacketSize = connectPacketSize;
+
+    _serializeConnect( pConnectInfo, remainingLength, pBuffer, connectPacketSize );
 
     IOT_FUNCTION_EXIT_NO_CLEANUP();
 }
@@ -1023,8 +1345,6 @@ IotMqttError_t _IotMqtt_SerializePublish( const IotMqttPublishInfo_t * pPublishI
                                           uint8_t ** pPacketIdentifierHigh )
 {
     IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
-    uint8_t publishFlags = 0;
-    uint16_t packetIdentifier = 0;
     size_t remainingLength = 0, publishPacketSize = 0;
     uint8_t * pBuffer = NULL;
 
@@ -1066,88 +1386,13 @@ IotMqttError_t _IotMqtt_SerializePublish( const IotMqttPublishInfo_t * pPublishI
     *pPublishPacket = pBuffer;
     *pPacketSize = publishPacketSize;
 
-    /* The first byte of a PUBLISH packet contains the packet type and flags. */
-    publishFlags = MQTT_PACKET_TYPE_PUBLISH;
-
-    if( pPublishInfo->qos == IOT_MQTT_QOS_1 )
-    {
-        UINT8_SET_BIT( publishFlags, MQTT_PUBLISH_FLAG_QOS1 );
-    }
-    else if( pPublishInfo->qos == IOT_MQTT_QOS_2 )
-    {
-        UINT8_SET_BIT( publishFlags, MQTT_PUBLISH_FLAG_QOS2 );
-    }
-    else
-    {
-        EMPTY_ELSE_MARKER;
-    }
-
-    if( pPublishInfo->retain == true )
-    {
-        UINT8_SET_BIT( publishFlags, MQTT_PUBLISH_FLAG_RETAIN );
-    }
-    else
-    {
-        EMPTY_ELSE_MARKER;
-    }
-
-    *pBuffer = publishFlags;
-    pBuffer++;
-
-    /* The "Remaining length" is encoded from the second byte. */
-    pBuffer = _encodeRemainingLength( pBuffer, remainingLength );
-
-    /* The topic name is placed after the "Remaining length". */
-    pBuffer = _encodeString( pBuffer,
-                             pPublishInfo->pTopicName,
-                             pPublishInfo->topicNameLength );
-
-    /* A packet identifier is required for QoS 1 and 2 messages. */
-    if( pPublishInfo->qos > IOT_MQTT_QOS_0 )
-    {
-        /* Get the next packet identifier. It should always be nonzero. */
-        packetIdentifier = _nextPacketIdentifier();
-        IotMqtt_Assert( packetIdentifier != 0 );
-
-        /* Set the packet identifier output parameters. */
-        *pPacketIdentifier = packetIdentifier;
-
-        if( pPacketIdentifierHigh != NULL )
-        {
-            *pPacketIdentifierHigh = pBuffer;
-        }
-        else
-        {
-            EMPTY_ELSE_MARKER;
-        }
-
-        /* Place the packet identifier into the PUBLISH packet. */
-        *pBuffer = UINT16_HIGH_BYTE( packetIdentifier );
-        *( pBuffer + 1 ) = UINT16_LOW_BYTE( packetIdentifier );
-        pBuffer += 2;
-    }
-    else
-    {
-        EMPTY_ELSE_MARKER;
-    }
-
-    /* The payload is placed after the packet identifier. */
-    if( pPublishInfo->payloadLength > 0 )
-    {
-        ( void ) memcpy( pBuffer, pPublishInfo->pPayload, pPublishInfo->payloadLength );
-        pBuffer += pPublishInfo->payloadLength;
-    }
-    else
-    {
-        EMPTY_ELSE_MARKER;
-    }
-
-    /* Ensure that the difference between the end and beginning of the buffer
-     * is equal to publishPacketSize, i.e. pBuffer did not overflow. */
-    IotMqtt_Assert( ( size_t ) ( pBuffer - *pPublishPacket ) == publishPacketSize );
-
-    /* Print out the serialized PUBLISH packet for debugging purposes. */
-    IotLog_PrintBuffer( "MQTT PUBLISH packet:", *pPublishPacket, publishPacketSize );
+    /* Serialize publish into buffer pointed to by pBuffer */
+    _serializePublish( pPublishInfo,
+                       remainingLength,
+                       pPacketIdentifier,
+                       pPacketIdentifierHigh,
+                       pBuffer,
+                       publishPacketSize );
 
     IOT_FUNCTION_EXIT_NO_CLEANUP();
 }
@@ -1490,8 +1735,7 @@ IotMqttError_t _IotMqtt_SerializeSubscribe( const IotMqttSubscription_t * pSubsc
                                             uint16_t * pPacketIdentifier )
 {
     IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
-    size_t i = 0, subscribePacketSize = 0, remainingLength = 0;
-    uint16_t packetIdentifier = 0;
+    size_t subscribePacketSize = 0, remainingLength = 0;
     uint8_t * pBuffer = NULL;
 
     /* Calculate the "Remaining length" field and total packet size. If it exceeds
@@ -1536,41 +1780,14 @@ IotMqttError_t _IotMqtt_SerializeSubscribe( const IotMqttSubscription_t * pSubsc
     *pSubscribePacket = pBuffer;
     *pPacketSize = subscribePacketSize;
 
-    /* The first byte in SUBSCRIBE is the packet type. */
-    *pBuffer = MQTT_PACKET_TYPE_SUBSCRIBE;
-    pBuffer++;
+    /* Serialize subscribe into buffer pointed to by pBuffer */
+    _serializeSubscribe( pSubscriptionList,
+                         subscriptionCount,
+                         remainingLength,
+                         pPacketIdentifier,
+                         pBuffer,
+                         subscribePacketSize );
 
-    /* Encode the "Remaining length" starting from the second byte. */
-    pBuffer = _encodeRemainingLength( pBuffer, remainingLength );
-
-    /* Get the next packet identifier. It should always be nonzero. */
-    packetIdentifier = _nextPacketIdentifier();
-    *pPacketIdentifier = packetIdentifier;
-    IotMqtt_Assert( packetIdentifier != 0 );
-
-    /* Place the packet identifier into the SUBSCRIBE packet. */
-    *pBuffer = UINT16_HIGH_BYTE( packetIdentifier );
-    *( pBuffer + 1 ) = UINT16_LOW_BYTE( packetIdentifier );
-    pBuffer += 2;
-
-    /* Serialize each subscription topic filter and QoS. */
-    for( i = 0; i < subscriptionCount; i++ )
-    {
-        pBuffer = _encodeString( pBuffer,
-                                 pSubscriptionList[ i ].pTopicFilter,
-                                 pSubscriptionList[ i ].topicFilterLength );
-
-        /* Place the QoS in the SUBSCRIBE packet. */
-        *pBuffer = ( uint8_t ) ( pSubscriptionList[ i ].qos );
-        pBuffer++;
-    }
-
-    /* Ensure that the difference between the end and beginning of the buffer
-     * is equal to subscribePacketSize, i.e. pBuffer did not overflow. */
-    IotMqtt_Assert( ( size_t ) ( pBuffer - *pSubscribePacket ) == subscribePacketSize );
-
-    /* Print out the serialized SUBSCRIBE packet for debugging purposes. */
-    IotLog_PrintBuffer( "MQTT SUBSCRIBE packet:", *pSubscribePacket, subscribePacketSize );
 
     IOT_FUNCTION_EXIT_NO_CLEANUP();
 }
@@ -1687,8 +1904,7 @@ IotMqttError_t _IotMqtt_SerializeUnsubscribe( const IotMqttSubscription_t * pSub
                                               uint16_t * pPacketIdentifier )
 {
     IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
-    size_t i = 0, unsubscribePacketSize = 0, remainingLength = 0;
-    uint16_t packetIdentifier = 0;
+    size_t unsubscribePacketSize = 0, remainingLength = 0;
     uint8_t * pBuffer = NULL;
 
     /* Calculate the "Remaining length" field and total packet size. If it exceeds
@@ -1733,37 +1949,13 @@ IotMqttError_t _IotMqtt_SerializeUnsubscribe( const IotMqttSubscription_t * pSub
     *pUnsubscribePacket = pBuffer;
     *pPacketSize = unsubscribePacketSize;
 
-    /* The first byte in UNSUBSCRIBE is the packet type. */
-    *pBuffer = MQTT_PACKET_TYPE_UNSUBSCRIBE;
-    pBuffer++;
-
-    /* Encode the "Remaining length" starting from the second byte. */
-    pBuffer = _encodeRemainingLength( pBuffer, remainingLength );
-
-    /* Get the next packet identifier. It should always be nonzero. */
-    packetIdentifier = _nextPacketIdentifier();
-    *pPacketIdentifier = packetIdentifier;
-    IotMqtt_Assert( packetIdentifier != 0 );
-
-    /* Place the packet identifier into the UNSUBSCRIBE packet. */
-    *pBuffer = UINT16_HIGH_BYTE( packetIdentifier );
-    *( pBuffer + 1 ) = UINT16_LOW_BYTE( packetIdentifier );
-    pBuffer += 2;
-
-    /* Serialize each subscription topic filter. */
-    for( i = 0; i < subscriptionCount; i++ )
-    {
-        pBuffer = _encodeString( pBuffer,
-                                 pSubscriptionList[ i ].pTopicFilter,
-                                 pSubscriptionList[ i ].topicFilterLength );
-    }
-
-    /* Ensure that the difference between the end and beginning of the buffer
-     * is equal to unsubscribePacketSize, i.e. pBuffer did not overflow. */
-    IotMqtt_Assert( ( size_t ) ( pBuffer - *pUnsubscribePacket ) == unsubscribePacketSize );
-
-    /* Print out the serialized UNSUBSCRIBE packet for debugging purposes. */
-    IotLog_PrintBuffer( "MQTT UNSUBSCRIBE packet:", *pUnsubscribePacket, unsubscribePacketSize );
+    /* Serialize unsubscribe into buffer pointed to by pBuffer */
+    _serializeUnsubscribe( pSubscriptionList,
+                           subscriptionCount,
+                           remainingLength,
+                           pPacketIdentifier,
+                           pBuffer,
+                           unsubscribePacketSize );
 
     IOT_FUNCTION_EXIT_NO_CLEANUP();
 }
@@ -1931,6 +2123,471 @@ void _IotMqtt_FreePacket( uint8_t * pPacket )
     {
         EMPTY_ELSE_MARKER;
     }
+}
+
+/*-----------------------------------------------------------*/
+
+/* Public interface functions for serialization */
+
+/*-----------------------------------------------------------*/
+
+IotMqttError_t IotMqtt_GetConnectPacketSize( const IotMqttConnectInfo_t * pConnectInfo,
+                                             size_t * pRemainingLength,
+                                             size_t * pPacketSize )
+{
+    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+
+    if( ( pConnectInfo == NULL ) || ( pRemainingLength == NULL ) || ( pPacketSize == NULL ) )
+    {
+        IotLogError( "IotMqtt_GetConnectPacketSize() called with required parameter(s) set to NULL." );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    if( ( pConnectInfo->clientIdentifierLength == 0 ) || ( pConnectInfo->pClientIdentifier == NULL ) )
+    {
+        IotLogError( "IotMqtt_GetConnectPacketSize() client identifier must be set." );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    /* Calculate the "Remaining length" field and total packet size. If it exceeds
+     * what is allowed in the MQTT standard, return an error. */
+    if( _connectPacketSize( pConnectInfo, pRemainingLength, pPacketSize ) == false )
+    {
+        IotLogError( "Connect packet length exceeds %lu, which is the maximum"
+                     " size allowed by MQTT 3.1.1.",
+                     MQTT_PACKET_CONNECT_MAX_SIZE );
+
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+    else
+    {
+        EMPTY_ELSE_MARKER;
+    }
+
+    /* Total size of the subscribe packet should be larger than the "Remaining length"
+     * field. */
+    if( ( *pPacketSize ) < ( *pRemainingLength ) )
+    {
+        IotLogError( "Connection packet remaining length (%lu) exceeds packet size (%lu)",
+                     ( *pRemainingLength ), ( *pPacketSize ) );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    IOT_FUNCTION_EXIT_NO_CLEANUP();
+}
+
+/*-----------------------------------------------------------*/
+
+IotMqttError_t IotMqtt_SerializeConnect( const IotMqttConnectInfo_t * pConnectInfo,
+                                         size_t remainingLength,
+                                         uint8_t * pBuffer,
+                                         size_t bufferSize )
+{
+    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+
+    if( ( pBuffer == NULL ) || ( pConnectInfo == NULL ) )
+    {
+        IotLogError( "IotMqtt_SerializeConnect() called with required parameter(s) set to NULL." );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    if( ( pConnectInfo->clientIdentifierLength == 0 ) || ( pConnectInfo->pClientIdentifier == NULL ) )
+    {
+        IotLogError( "IotMqtt_SerializeConnect() client identifier must be set." );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    if( remainingLength > bufferSize )
+    {
+        IotLogError( " Serialize Connect packet remaining length (%lu) exceeds buffer size (%lu)",
+                     remainingLength, bufferSize );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    _serializeConnect( pConnectInfo,
+                       remainingLength,
+                       pBuffer,
+                       bufferSize );
+
+    IOT_FUNCTION_EXIT_NO_CLEANUP();
+}
+
+/*-----------------------------------------------------------*/
+
+IotMqttError_t IotMqtt_GetSubscriptionPacketSize( IotMqttOperationType_t type,
+                                                  const IotMqttSubscription_t * pSubscriptionList,
+                                                  size_t subscriptionCount,
+                                                  size_t * pRemainingLength,
+                                                  size_t * pPacketSize )
+{
+    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+
+    if( ( pSubscriptionList == NULL ) || ( pRemainingLength == NULL ) || ( pPacketSize == NULL ) )
+    {
+        IotLogError( "IotMqtt_GetSubscriptionPacketSize() called with required parameter(s) set to NULL." );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    if( ( type != IOT_MQTT_SUBSCRIBE ) && ( type != IOT_MQTT_UNSUBSCRIBE ) )
+    {
+        IotLogError( "IotMqtt_GetSubscriptionPacketSize() called with unknown type." );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    if( subscriptionCount == 0 )
+    {
+        IotLogError( "IotMqtt_GetSubscriptionPacketSize() called with zero subscription count." );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    if( _subscriptionPacketSize( type,
+                                 pSubscriptionList,
+                                 subscriptionCount,
+                                 pRemainingLength,
+                                 pPacketSize ) == false )
+    {
+        IotLogError( "Unsubscribe packet remaining length exceeds %lu, which is the "
+                     "maximum size allowed by MQTT 3.1.1.",
+                     MQTT_MAX_REMAINING_LENGTH );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+    else
+    {
+        EMPTY_ELSE_MARKER;
+    }
+
+    /* Total size of the subscribe packet should be larger than the "Remaining length"
+     * field. */
+    if( ( *pPacketSize ) < ( *pRemainingLength ) )
+    {
+        IotLogError( "Subscription packet remaining length (%lu) exceeds packet size (%lu)",
+                     ( *pRemainingLength ), ( *pPacketSize ) );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    IOT_FUNCTION_EXIT_NO_CLEANUP();
+}
+
+/*-----------------------------------------------------------*/
+
+IotMqttError_t IotMqtt_SerializeSubscribe( const IotMqttSubscription_t * pSubscriptionList,
+                                           size_t subscriptionCount,
+                                           size_t remainingLength,
+                                           uint16_t * pPacketIdentifier,
+                                           uint8_t * pBuffer,
+                                           size_t bufferSize )
+{
+    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+
+    if( ( pBuffer == NULL ) || ( pSubscriptionList == NULL ) || ( pPacketIdentifier == NULL ) )
+    {
+        IotLogError( "IotMqtt_SerializeSubscribe() called with required parameter(s) set to NULL." );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    if( subscriptionCount == 0 )
+    {
+        IotLogError( "IotMqtt_SerializeSubscribe() called with zero subscription count." );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    if( remainingLength > bufferSize )
+    {
+        IotLogError( " Subscribe packet remaining length (%lu) exceeds buffer size (%lu).",
+                     remainingLength, bufferSize );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    _serializeSubscribe( pSubscriptionList,
+                         subscriptionCount,
+                         remainingLength,
+                         pPacketIdentifier,
+                         pBuffer,
+                         bufferSize );
+
+    IOT_FUNCTION_EXIT_NO_CLEANUP();
+}
+
+/*-----------------------------------------------------------*/
+
+IotMqttError_t IotMqtt_GetPublishPacketSize( IotMqttPublishInfo_t * pPublishInfo,
+                                             size_t * pRemainingLength,
+                                             size_t * pPacketSize )
+{
+    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+
+    if( ( pPublishInfo == NULL ) || ( pRemainingLength == NULL ) || ( pPacketSize == NULL ) )
+    {
+        IotLogError( "IotMqtt_GetPublishPacketSize() called reuired parameter(s) set to NULL." );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    /* Calculate the "Remaining length" field and total packet size. If it exceeds
+     * what is allowed in the MQTT standard, return an error. */
+    if( _publishPacketSize( pPublishInfo, pRemainingLength, pPacketSize ) == false )
+    {
+        IotLogError( "Publish packet remaining length exceeds %lu, which is the "
+                     "maximum size allowed by MQTT 3.1.1.",
+                     MQTT_MAX_REMAINING_LENGTH );
+
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+    else
+    {
+        EMPTY_ELSE_MARKER;
+    }
+
+    /* Total size of the publish packet should be larger than the "Remaining length"
+     * field. */
+    if( ( *pPacketSize ) < ( *pRemainingLength ) )
+    {
+        IotLogError( "Publish packet remaining length (%lu) exceeds packet size (%lu).",
+                     ( *pRemainingLength ), ( *pPacketSize ) );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    IOT_FUNCTION_EXIT_NO_CLEANUP();
+}
+
+/*-----------------------------------------------------------*/
+
+IotMqttError_t IotMqtt_SerializePublish( IotMqttPublishInfo_t * pPublishInfo,
+                                         size_t remainingLength,
+                                         uint16_t * pPacketIdentifier,
+                                         uint8_t ** pPakcetIndentifierHigh,
+                                         uint8_t * pBuffer,
+                                         size_t bufferSize )
+
+{
+    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+
+    if( ( pBuffer == NULL ) || ( pPublishInfo == NULL ) || ( pPacketIdentifier == NULL ) )
+    {
+        IotLogError( "IotMqtt_SerializePublish() called reuired parameter(s) set to NULL." );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+    
+    if( remainingLength > bufferSize )
+    {
+        IotLogError( "Publish packet remaining length (%lu) exceeds buffer size (%lu).",
+                     remainingLength, bufferSize );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    _serializePublish( pPublishInfo,
+                       remainingLength,
+                       pPacketIdentifier,
+                       pPakcetIndentifierHigh,
+                       pBuffer,
+                       bufferSize );
+    IOT_FUNCTION_EXIT_NO_CLEANUP();
+}
+
+/*-----------------------------------------------------------*/
+
+IotMqttError_t IotMqtt_SerializeUnsubscribe( const IotMqttSubscription_t * pSubscriptionList,
+                                             size_t subscriptionCount,
+                                             size_t remainingLength,
+                                             uint16_t * pPacketIdentifier,
+                                             uint8_t * pBuffer,
+                                             size_t bufferSize )
+{
+    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+
+    if( ( pBuffer == NULL ) || ( pPacketIdentifier == NULL ) || ( pSubscriptionList == NULL ) )
+    {
+        IotLogError( "IotMqtt_SerializeUnsubscribe() called with required parameter(s) set to NULL." );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    if( subscriptionCount == 0 )
+    {
+        IotLogError( "IotMqtt_SerializeUnsubscribe() called with zero subscription count." );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    if( remainingLength > bufferSize )
+    {
+        IotLogError( "Unsubscribe packet remaining length (%lu) exceeds buffer size (%lu).",
+                     remainingLength, bufferSize );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    _serializeUnsubscribe( pSubscriptionList,
+                           subscriptionCount,
+                           remainingLength,
+                           pPacketIdentifier,
+                           pBuffer,
+                           bufferSize );
+    IOT_FUNCTION_EXIT_NO_CLEANUP();
+}
+
+/*-----------------------------------------------------------*/
+
+IotMqttError_t IotMqtt_SerializeDisconnect( uint8_t * pBuffer,
+                                            size_t bufferSize )
+{
+    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    uint8_t * pDisconnectPacket = NULL;
+    size_t remainingLength = 0;
+
+    if( pBuffer == NULL )
+    {
+        IotLogError( "IotMqtt_SerializeDisconnect() called with NULL buffer pointer." );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    if( bufferSize < MQTT_PACKET_DISCONNECT_SIZE )
+    {
+        IotLogError( "Disconnect packet length (%lu) exceeds buffer size (%lu).",
+                     MQTT_PACKET_DISCONNECT_SIZE, bufferSize );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    /* Call internal function with local varaibles, as disconnect  uses
+     * static memory, there is no need to pass the buffer
+     * Note: _IotMqtt_SerializeDisconnect always succeeds */
+    _IotMqtt_SerializeDisconnect( &pDisconnectPacket, &remainingLength );
+
+    memcpy( pBuffer, pDisconnectPacket, MQTT_PACKET_DISCONNECT_SIZE );
+    IOT_FUNCTION_EXIT_NO_CLEANUP();
+}
+
+/*-----------------------------------------------------------*/
+
+IotMqttError_t IotMqtt_SerializePingreq( uint8_t * pBuffer,
+                                         size_t bufferSize )
+{
+    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    uint8_t * pPingreqPacket = NULL;
+    size_t packetSize = 0;
+
+    if( pBuffer == NULL )
+    {
+        IotLogError( "IotMqtt_SerializePingreq() called with NULL buffer pointer." );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    if( bufferSize < MQTT_PACKET_PINGREQ_SIZE )
+    {
+        IotLogError( "Pingreq length (%lu) exceeds buffer size (%lu).",
+                     MQTT_PACKET_DISCONNECT_SIZE, bufferSize );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    /* Call internal function with local varaibles, as ping request uses
+     * static memory, there is no need to pass the buffer
+     * Note: _IotMqtt_SerializePingReq always succeeds */
+    _IotMqtt_SerializePingreq( &pPingreqPacket, &packetSize );
+    memcpy( pBuffer, pPingreqPacket, MQTT_PACKET_PINGREQ_SIZE );
+    IOT_FUNCTION_EXIT_NO_CLEANUP();
+}
+
+/*-----------------------------------------------------------*/
+
+IotMqttError_t IotMqtt_DeserializePublish( IotMqttPacketInfo_t * pMqttPacket )
+{
+    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    /* Internal MQTT packet structure */
+    _mqttPacket_t mqttPacket;
+    /* Internal MQTT operation structure needed for deserializing publish */
+    _mqttOperation_t mqttOperation;
+
+    if( pMqttPacket == NULL )
+    {
+        IotLogError( "IotMqtt_DeserializePublish()called with NULL pMqttPacket pointer." );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    if( ( pMqttPacket->type & 0xf0 ) != MQTT_PACKET_TYPE_PUBLISH )
+    {
+        IotLogError( "IotMqtt_DeserializePublish() called with incorrect packet type:(%lu).", pMqttPacket->type );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    /* Set intenal mqtt packet parameters. */
+    memset( ( void * ) &mqttPacket, 0x00, sizeof( _mqttPacket_t ) );
+    mqttPacket.pRemainingData = pMqttPacket->pRemainingData;
+    mqttPacket.remainingLength = pMqttPacket->remainingLength;
+    mqttPacket.type = pMqttPacket->type;
+
+    /* Set Publish specific parameters */
+    memset( ( void * ) &mqttOperation, 0x00, sizeof( _mqttOperation_t ) );
+    mqttOperation.incomingPublish = true;
+    mqttPacket.u.pIncomingPublish = &mqttOperation;
+    status = _IotMqtt_DeserializePublish( &mqttPacket );
+
+    if( status == IOT_MQTT_SUCCESS )
+    {
+        pMqttPacket->pubInfo = mqttOperation.u.publish.publishInfo;
+        pMqttPacket->packetIdentifier = mqttPacket.packetIdentifier;
+    }
+
+    IOT_FUNCTION_EXIT_NO_CLEANUP();
+}
+
+/*-----------------------------------------------------------*/
+
+IotMqttError_t IotMqtt_DeserializeResponse( IotMqttPacketInfo_t * pMqttPacket )
+{
+    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    /* Internal MQTT packet structure */
+    _mqttPacket_t mqttPacket;
+
+    if( pMqttPacket == NULL )
+    {
+        IotLogError( "IotMqtt_DeserializeResponse() called with NULL pMqttPacket pointer." );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    /* Set intenal mqtt packet parameters. This API does not care about
+     * pMqttConnection it is not set */
+    memset( ( void * ) &mqttPacket, 0x00, sizeof( _mqttPacket_t ) );
+
+    mqttPacket.pRemainingData = pMqttPacket->pRemainingData;
+    mqttPacket.remainingLength = pMqttPacket->remainingLength;
+    mqttPacket.type = pMqttPacket->type;
+
+    /* Call internal deserialize */
+    switch( pMqttPacket->type & 0xf0 )
+    {
+        case MQTT_PACKET_TYPE_CONNACK:
+            status = _IotMqtt_DeserializeConnack( &mqttPacket );
+            break;
+
+        case MQTT_PACKET_TYPE_PUBACK:
+            status = _IotMqtt_DeserializePuback( &mqttPacket );
+            break;
+
+        case MQTT_PACKET_TYPE_SUBACK:
+            status = _IotMqtt_DeserializeSuback( &mqttPacket );
+            break;
+
+        case MQTT_PACKET_TYPE_UNSUBACK:
+            status = _IotMqtt_DeserializeUnsuback( &mqttPacket );
+            break;
+
+        case MQTT_PACKET_TYPE_PINGRESP:
+            status = _IotMqtt_DeserializePingresp( &mqttPacket );
+            break;
+
+        /* Any other packet type is invalid. */
+        default:
+            IotLogError( "IotMqtt_DeserializeResponse() called with unknown packet type:(%lu).", pMqttPacket->type );
+            IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    if( status != IOT_MQTT_SUCCESS )
+    {
+        IOT_SET_AND_GOTO_CLEANUP( status );
+    }
+    else
+    {
+        /* set packetIdentfier only if success is returned */
+        pMqttPacket->packetIdentifier = mqttPacket.packetIdentifier;
+    }
+
+    IOT_FUNCTION_EXIT_NO_CLEANUP();
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/standard/mqtt/src/iot_mqtt_serialize.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_serialize.c
@@ -2318,7 +2318,13 @@ IotMqttError_t IotMqtt_GetPublishPacketSize( IotMqttPublishInfo_t * pPublishInfo
 
     if( ( pPublishInfo == NULL ) || ( pRemainingLength == NULL ) || ( pPacketSize == NULL ) )
     {
-        IotLogError( "IotMqtt_GetPublishPacketSize() called reuired parameter(s) set to NULL." );
+        IotLogError( "IotMqtt_GetPublishPacketSize() called with required parameter(s) set to NULL." );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
+    if( ( pPublishInfo->pTopicName == NULL ) || ( pPublishInfo->topicNameLength == 0 ) )
+    {
+        IotLogError( "IotMqtt_GetPublishPacketSize() called with no topic." );
         IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
     }
 
@@ -2354,7 +2360,7 @@ IotMqttError_t IotMqtt_GetPublishPacketSize( IotMqttPublishInfo_t * pPublishInfo
 IotMqttError_t IotMqtt_SerializePublish( IotMqttPublishInfo_t * pPublishInfo,
                                          size_t remainingLength,
                                          uint16_t * pPacketIdentifier,
-                                         uint8_t ** pPakcetIndentifierHigh,
+                                         uint8_t ** pPacketIdentifierHigh,
                                          uint8_t * pBuffer,
                                          size_t bufferSize )
 
@@ -2363,10 +2369,16 @@ IotMqttError_t IotMqtt_SerializePublish( IotMqttPublishInfo_t * pPublishInfo,
 
     if( ( pBuffer == NULL ) || ( pPublishInfo == NULL ) || ( pPacketIdentifier == NULL ) )
     {
-        IotLogError( "IotMqtt_SerializePublish() called reuired parameter(s) set to NULL." );
+        IotLogError( "IotMqtt_SerializePublish() called with required parameter(s) set to NULL." );
         IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
     }
-    
+
+    if( ( pPublishInfo->pTopicName == NULL ) || ( pPublishInfo->topicNameLength == 0 ) )
+    {
+        IotLogError( "IotMqtt_SerializePublish() called with no topic." );
+        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+    }
+
     if( remainingLength > bufferSize )
     {
         IotLogError( "Publish packet remaining length (%lu) exceeds buffer size (%lu).",
@@ -2377,7 +2389,7 @@ IotMqttError_t IotMqtt_SerializePublish( IotMqttPublishInfo_t * pPublishInfo,
     _serializePublish( pPublishInfo,
                        remainingLength,
                        pPacketIdentifier,
-                       pPakcetIndentifierHigh,
+                       pPacketIdentifierHigh,
                        pBuffer,
                        bufferSize );
     IOT_FUNCTION_EXIT_NO_CLEANUP();
@@ -2444,7 +2456,7 @@ IotMqttError_t IotMqtt_SerializeDisconnect( uint8_t * pBuffer,
         IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
     }
 
-    /* Call internal function with local varaibles, as disconnect  uses
+    /* Call internal function with local variables, as disconnect  uses
      * static memory, there is no need to pass the buffer
      * Note: _IotMqtt_SerializeDisconnect always succeeds */
     _IotMqtt_SerializeDisconnect( &pDisconnectPacket, &remainingLength );
@@ -2475,7 +2487,7 @@ IotMqttError_t IotMqtt_SerializePingreq( uint8_t * pBuffer,
         IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
     }
 
-    /* Call internal function with local varaibles, as ping request uses
+    /* Call internal function with local variables, as ping request uses
      * static memory, there is no need to pass the buffer
      * Note: _IotMqtt_SerializePingReq always succeeds */
     _IotMqtt_SerializePingreq( &pPingreqPacket, &packetSize );
@@ -2505,7 +2517,7 @@ IotMqttError_t IotMqtt_DeserializePublish( IotMqttPacketInfo_t * pMqttPacket )
         IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
     }
 
-    /* Set intenal mqtt packet parameters. */
+    /* Set internal mqtt packet parameters. */
     memset( ( void * ) &mqttPacket, 0x00, sizeof( _mqttPacket_t ) );
     mqttPacket.pRemainingData = pMqttPacket->pRemainingData;
     mqttPacket.remainingLength = pMqttPacket->remainingLength;
@@ -2534,14 +2546,13 @@ IotMqttError_t IotMqtt_DeserializeResponse( IotMqttPacketInfo_t * pMqttPacket )
     /* Internal MQTT packet structure */
     _mqttPacket_t mqttPacket;
 
-    if( pMqttPacket == NULL )
+    if( ( pMqttPacket == NULL ) || ( pMqttPacket->pRemainingData == NULL ) )
     {
-        IotLogError( "IotMqtt_DeserializeResponse() called with NULL pMqttPacket pointer." );
+        IotLogError( "IotMqtt_DeserializeResponse() called with NULL pMqttPacket pointer or NULL pRemainingLength." );
         IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
     }
 
-    /* Set intenal mqtt packet parameters. This API does not care about
-     * pMqttConnection it is not set */
+    /* Set internal mqtt packet parameters. */
     memset( ( void * ) &mqttPacket, 0x00, sizeof( _mqttPacket_t ) );
 
     mqttPacket.pRemainingData = pMqttPacket->pRemainingData;

--- a/libraries/standard/mqtt/src/private/iot_mqtt_internal.h
+++ b/libraries/standard/mqtt/src/private/iot_mqtt_internal.h
@@ -321,7 +321,7 @@ typedef struct _mqttOperation
     /* Pointers to neighboring queue elements. */
     IotLink_t link;                           /**< @brief List link member. */
 
-    bool incomingPublish;                     /**< @brief Set to true if this operation an incoming PUBLISH. */
+    bool incomingPublish;                     /**< @brief Set to true if this operation is an incoming PUBLISH. */
     struct _mqttConnection * pMqttConnection; /**< @brief MQTT connection associated with this operation. */
 
     IotTaskPoolJobStorage_t jobStorage;       /**< @brief Task pool job storage associated with this operation. */
@@ -552,6 +552,24 @@ uint8_t _IotMqtt_GetPacketType( void * pNetworkConnection,
  */
 size_t _IotMqtt_GetRemainingLength( void * pNetworkConnection,
                                     const IotNetworkInterface_t * pNetworkInterface );
+
+/**
+ * @brief Get the remaining length from a stream of bytes off the network.
+ *
+ * @param[in] pNetworkConnection Reference to the network connection.
+ * @param[in] getNextByte Function pointer used to interact with the
+ * network to get next byte.
+ *
+ * @return The remaining length; #MQTT_REMAINING_LENGTH_INVALID on error.
+ *
+ * @note This function is similar to _IotMqtt_GetRemainingLength() but it uses
+ * user provided getNextByte function to parse the stream instead of using
+ * _IotMqtt_GetNextByte(). pNetworkConnection is impelementation dependent and
+ * user provided function makes use of it.
+ *
+ */
+size_t _IotMqtt_GetRemainingLength_Generic( void * pNetworkConnection,
+                                            IotMqttGetNextByte_t getNextByte );
 
 /**
  * @brief Generate a CONNECT packet from the given parameters.


### PR DESCRIPTION
**Note:TODO Unit tests**
Please look for changes that may  break existing API. 
Note: Changes are tested with demo code in FreeRTOS.org

MQTT serializer API changes to support lightweight single threaded app.

CSDK MQTT Library provides stateful MQTT API that makes use of taskpool
and network abstraction. The library makes use dynamic memory
allocations and makes use of multiple threads or tasks.
Embedded applications running on microcontroller may want to
use single threaded model to run MQTT.
The API changes enable application developers to use MQTT serializer
and deserializer APIs without use of taskpool and network abstraction.
The API does no allocate any dynamic memory, therefore application can
make use of statically allocated memory. Application can implement its
own state machine and make use of any network interface like sockets
to handle MQTT messages.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
