### PR TITLE
Fix buffer overflows in json parser

### DIFF
--- a/libraries/standard/serializer/src/iot_json_utils.c
+++ b/libraries/standard/serializer/src/iot_json_utils.c
@@ -75,6 +75,12 @@ bool IotJsonUtils_FindJsonValue( const char * pJsonDocument,
             /* Skip the characters in the JSON key and closing double quote. */
             i += jsonKeyLength + 1;
 
+	    /* If the end of the document is reached, this isn't a match. */
+	    if( i >= jsonDocumentLength )
+	    {
+		return false;
+	    }
+
             /* Skip all whitespace characters between the closing " and the : */
             while( pJsonDocument[ i ] == ' ' ||
                    pJsonDocument[ i ] == '\n' ||
@@ -101,6 +107,12 @@ bool IotJsonUtils_FindJsonValue( const char * pJsonDocument,
                 /* Skip the : */
                 i++;
             }
+
+	    /* If the end of the document is reached, this isn't a match. */
+	    if( i >= jsonDocumentLength )
+	    {
+		return false;
+	    }
 
             /* Skip all whitespace characters between : and the first character in the value. */
             while( pJsonDocument[ i ] == ' ' ||
@@ -133,6 +145,12 @@ bool IotJsonUtils_FindJsonValue( const char * pJsonDocument,
 
                     /* Skip the opening double quote. */
                     i++;
+
+		    /* If the end of the document is reached, this isn't a match. */
+		    if( i >= jsonDocumentLength )
+		    {
+			return false;
+		    }
 
                     /* Add the length of all characters in the JSON string. */
                     while( pJsonDocument[ i ] != '\"' )
@@ -211,6 +229,12 @@ bool IotJsonUtils_FindJsonValue( const char * pJsonDocument,
 
                 /* Skip the opening character. */
                 i++;
+
+                /* If the end of the document is reached, this isn't a match. */
+                if( i >= jsonDocumentLength )
+                {
+                    return false;
+                }
 
                 /* Add the length of all characters in the JSON object or array. This
                  * includes the length of nested objects. */

--- a/libraries/standard/serializer/src/iot_json_utils.c
+++ b/libraries/standard/serializer/src/iot_json_utils.c
@@ -83,8 +83,8 @@ bool IotJsonUtils_FindJsonValue( const char * pJsonDocument,
             /* Key found; this is a potential match. */
 
             /* Skip the characters in the JSON key and closing double quote. */
-	    /* While loop guarantees that i < jsonDocumentLength - 2 */
-            i += jsonKeyLength + 1;
+	    /* While loop guarantees that i < jsonDocumentLength - 1 */
+            i += jsonKeyLength + 2;
 
             /* Skip all whitespace characters between the closing " and the : */
             while( IS_WHITESPACE( pJsonDocument, i ) )


### PR DESCRIPTION
Fixed buffer overflows in json parser:
* Return false immediately after incrementing index i past jsonDocumentLength to avoid buffer overflow in pJsonDocument[i].  Copied existing check to several other locations in the code.
* Return false immediately when key has length 0 to avoid buffer overflow in comparison pJsonDocument[i+1] == pJsonKey[0].

Fixed error in json key lookup:  Check for lead quotation mark when comparing key with json key to avoid key "b" matching json key "ab".

Simplified some code with IS_QUOTE and IS_WHITESPACE defines.

CBMC currently demonstrates memory safety on json documents and keys of length at most 10. 
