### PR TITLE
Use previous subscriptions list for unsolicited messages

### DIFF
--- a/libraries/standard/mqtt/include/iot_mqtt.h
+++ b/libraries/standard/mqtt/include/iot_mqtt.h
@@ -148,6 +148,12 @@ void IotMqtt_ReceiveCallback( IotNetworkConnection_t pNetworkConnection,
  * Any restored subscriptions <b>MUST</b> have been present in the persistent session;
  * <b>this function does not send an MQTT SUBSCRIBE packet!</b>
  *
+ * [pConnectInfo->pPreviousSubscriptions](@ref IotMqttConnectInfo_t.pPreviousSubscriptions)
+ * and [pConnectInfo->previousSubscriptionCount](@ref IotMqttConnectInfo_t.previousSubscriptionCount) can
+ * also be used to pass a list of subscriptions to be stored locally without a SUBSCRIBE packet being
+ * sent to broker. These subscriptions are useful to invoke application level callbacks for messages received
+ * on unsolicited topics from broker.
+ *
  * This MQTT library is network agnostic, meaning it has no knowledge of the
  * underlying network protocol carrying the MQTT packets. It interacts with the
  * network through a network abstraction layer, allowing it to be used with many
@@ -197,12 +203,18 @@ void IotMqtt_ReceiveCallback( IotNetworkConnection_t pNetworkConnection,
  *
  * <b>Example</b>
  * @code{c}
-*
+ *
+ * // Callback function to receive messages from broker on an unsolicited topic.
+ * void unsolicitedMessageCallback( void * pArgument, IotMqttCallbackParam_t * pPublish );
+ *
  * // Parameters to MQTT connect.
  * IotMqttConnection_t mqttConnection = IOT_MQTT_CONNECTION_INITIALIZER;
  * IotMqttNetworkInfo_t networkInfo = IOT_MQTT_NETWORK_INFO_INITIALIZER;
  * IotMqttConnectInfo_t connectInfo = IOT_MQTT_CONNECT_INFO_INITIALIZER;
  * IotMqttPublishInfo_t willInfo = IOT_MQTT_PUBLISH_INFO_INITIALIZER;
+ *
+ * // A local subscription to receive messages from broker on an unsolicited topic.
+ * IotMqttSubscription_t subscription = IOT_MQTT_SUBSCRIPTION_INITIALIZER;
  *
  * // Example network abstraction types.
  * IotNetworkServerInfo_t serverInfo = { ... };
@@ -230,6 +242,15 @@ void IotMqtt_ReceiveCallback( IotNetworkConnection_t pNetworkConnection,
  *
  * // Set the pointer to the will info.
  * connectInfo.pWillInfo = &willInfo;
+ *
+ * // [Optional] Set a local subscription to receive broker messages on an unsolicited topic.
+ * subscription.qos = IOT_MQTT_QOS_0;
+ * subscription.pTopicFilter = "some/unsolicited/topic";
+ * subscription.topicLength = strlen(subscription.pTopicFilter)
+ * subscription.callback.function = unsolicitedMessageCallback;
+ * connectInfo.pPreviousSubscriptions = &subscription;
+ * connectInfo.previousSubscriptionCount = 1;
+ *
  *
  * // Call CONNECT with a 5 second block time. Should return
  * // IOT_MQTT_SUCCESS when successful.

--- a/libraries/standard/mqtt/include/iot_mqtt.h
+++ b/libraries/standard/mqtt/include/iot_mqtt.h
@@ -246,7 +246,7 @@ void IotMqtt_ReceiveCallback( IotNetworkConnection_t pNetworkConnection,
  * // [Optional] Set a local subscription to receive broker messages on an unsolicited topic.
  * subscription.qos = IOT_MQTT_QOS_0;
  * subscription.pTopicFilter = "some/unsolicited/topic";
- * subscription.topicLength = strlen(subscription.pTopicFilter)
+ * subscription.topicLength = ( uint16_t ) strlen( subscription.pTopicFilter );
  * subscription.callback.function = unsolicitedMessageCallback;
  * connectInfo.pPreviousSubscriptions = &subscription;
  * connectInfo.previousSubscriptionCount = 1;

--- a/libraries/standard/mqtt/include/types/iot_mqtt_types.h
+++ b/libraries/standard/mqtt/include/types/iot_mqtt_types.h
@@ -627,6 +627,11 @@ typedef struct IotMqttConnectInfo
      * Pointer to the start of an array of subscriptions present a previous session,
      * if any. These subscriptions will be immediately restored upon reconnecting.
      *
+     * [Optional] The field can also be used to pass a list of subscriptions to be
+     * stored locally without a SUBSCRIBE packet being sent to broker. These subscriptions
+     * are useful to invoke application level callbacks for messages received on unsolicited
+     * topics from broker.
+     *
      * This member is ignored if it is `NULL`. If this member is not `NULL`,
      * #IotMqttConnectInfo_t.previousSubscriptionCount must be nonzero.
      */

--- a/libraries/standard/mqtt/include/types/iot_mqtt_types.h
+++ b/libraries/standard/mqtt/include/types/iot_mqtt_types.h
@@ -627,9 +627,8 @@ typedef struct IotMqttConnectInfo
      * Pointer to the start of an array of subscriptions present a previous session,
      * if any. These subscriptions will be immediately restored upon reconnecting.
      *
-     * This member is ignored if it is `NULL` or #IotMqttConnectInfo_t.cleanSession
-     * is `true`. If this member is not `NULL`, #IotMqttConnectInfo_t.previousSubscriptionCount
-     * must be nonzero.
+     * This member is ignored if it is `NULL`. If this member is not `NULL`,
+     * #IotMqttConnectInfo_t.previousSubscriptionCount must be nonzero.
      */
     const IotMqttSubscription_t * pPreviousSubscriptions;
 
@@ -640,9 +639,8 @@ typedef struct IotMqttConnectInfo
      * #IotMqttConnectInfo_t.pPreviousSubscriptions.
      *
      * This value is ignored if #IotMqttConnectInfo_t.pPreviousSubscriptions
-     * is `NULL` or #IotMqttConnectInfo_t.cleanSession is `true`. If
-     * #IotMqttConnectInfo_t.pPreviousSubscriptions is not `NULL`, this value
-     * must be nonzero.
+     * is `NULL`. If #IotMqttConnectInfo_t.pPreviousSubscriptions is not `NULL`,
+     * this value must be nonzero.
      */
     size_t previousSubscriptionCount;
 

--- a/libraries/standard/mqtt/src/iot_mqtt_validate.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_validate.c
@@ -105,21 +105,14 @@ bool _IotMqtt_ValidateConnect( const IotMqttConnectInfo_t * pConnectInfo )
     }
 
     /* Check that the number of persistent session subscriptions is valid. */
-    if( pConnectInfo->cleanSession == false )
+    if( pConnectInfo->pPreviousSubscriptions != NULL )
     {
-        if( pConnectInfo->pPreviousSubscriptions != NULL )
+        if( _IotMqtt_ValidateSubscriptionList( IOT_MQTT_SUBSCRIBE,
+                                                pConnectInfo->awsIotMqttMode,
+                                                pConnectInfo->pPreviousSubscriptions,
+                                                pConnectInfo->previousSubscriptionCount ) == false )
         {
-            if( _IotMqtt_ValidateSubscriptionList( IOT_MQTT_SUBSCRIBE,
-                                                   pConnectInfo->awsIotMqttMode,
-                                                   pConnectInfo->pPreviousSubscriptions,
-                                                   pConnectInfo->previousSubscriptionCount ) == false )
-            {
-                IOT_SET_AND_GOTO_CLEANUP( false );
-            }
-            else
-            {
-                EMPTY_ELSE_MARKER;
-            }
+            IOT_SET_AND_GOTO_CLEANUP( false );
         }
         else
         {


### PR DESCRIPTION

*Description of changes:*
Modify documentation of previous subscriptions list so that it can be used as a generic parameter for devices to receive unsolicited messages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
