### PR TITLE
Update porting template for network types

### DIFF
--- a/ports/template/include/iot_platform_types_template.h
+++ b/ports/template/include/iot_platform_types_template.h
@@ -42,4 +42,19 @@ typedef void * _IotSystemSemaphore_t;
  */
 typedef void * _IotSystemTimer_t;
 
+/**
+ * @brief The format for remote server host and port on this system.
+ */
+typedef void * _IotNetworkServerInfo_t;
+
+/**
+ * @brief The format for network credentials on this system.
+ */
+typedef void * _IotNetworkCredentials_t;
+
+/**
+ * @brief The handle of a network connection on this system.
+ */
+typedef void * _IotNetworkConnection_t;
+
 #endif /* ifndef IOT_PLATFORM_TYPES_TEMPLATE_H_ */

--- a/ports/template/template.cmake
+++ b/ports/template/template.cmake
@@ -4,15 +4,10 @@
 # Warn that the template port only builds. It will not create usable libraries.
 message( WARNING "This is a template port that contains only stubs. Libraries built with this port will not work!")
 
-# Add the template network header.
-set( PLATFORM_COMMON_HEADERS ${PLATFORM_COMMON_HEADERS}
-     ${PORTS_DIRECTORY}/common/include/iot_network_template.h )
-
-# Template platform sources.
+# Template platform sources. A network implementation (not listed below) is also needed.
 set( PLATFORM_SOURCES
      ${PORTS_DIRECTORY}/${IOT_PLATFORM_NAME}/src/iot_clock_${IOT_PLATFORM_NAME}.c
-     ${PORTS_DIRECTORY}/${IOT_PLATFORM_NAME}/src/iot_threads_${IOT_PLATFORM_NAME}.c
-     ${PORTS_DIRECTORY}/${IOT_PLATFORM_NAME}/src/iot_network_${IOT_PLATFORM_NAME}.c )
+     ${PORTS_DIRECTORY}/${IOT_PLATFORM_NAME}/src/iot_threads_${IOT_PLATFORM_NAME}.c )
 
 # Set the types header for this port.
 set( PORT_TYPES_HEADER ${PORTS_DIRECTORY}/${IOT_PLATFORM_NAME}/include/iot_platform_types_${IOT_PLATFORM_NAME}.h )

--- a/ports/template/template.cmake
+++ b/ports/template/template.cmake
@@ -4,21 +4,15 @@
 # Warn that the template port only builds. It will not create usable libraries.
 message( WARNING "This is a template port that contains only stubs. Libraries built with this port will not work!")
 
-# Add the mbed TLS header in the template. The mbed TLS network port is supposed
-# to be platform-independent, so it is built in the template.
+# Add the template network header.
 set( PLATFORM_COMMON_HEADERS ${PLATFORM_COMMON_HEADERS}
-     ${PORTS_DIRECTORY}/common/include/iot_network_mbedtls.h )
+     ${PORTS_DIRECTORY}/common/include/iot_network_template.h )
 
-# Template platform sources. Except for the network sources, these files contain
-# only stubs.
+# Template platform sources.
 set( PLATFORM_SOURCES
-     # Stubs
      ${PORTS_DIRECTORY}/${IOT_PLATFORM_NAME}/src/iot_clock_${IOT_PLATFORM_NAME}.c
-     ${PORTS_DIRECTORY}/${IOT_PLATFORM_NAME}/src/iot_threads_${IOT_PLATFORM_NAME}.c )
+     ${PORTS_DIRECTORY}/${IOT_PLATFORM_NAME}/src/iot_threads_${IOT_PLATFORM_NAME}.c
+     ${PORTS_DIRECTORY}/${IOT_PLATFORM_NAME}/src/iot_network_${IOT_PLATFORM_NAME}.c )
 
 # Set the types header for this port.
 set( PORT_TYPES_HEADER ${PORTS_DIRECTORY}/${IOT_PLATFORM_NAME}/include/iot_platform_types_${IOT_PLATFORM_NAME}.h )
-
-# Set the dependencies required by this port.
-# As this template uses the mbed TLS network implementation, mbed TLS is linked.
-set( PLATFORM_DEPENDENCIES mbedtls )

--- a/ports/template/template.cmake
+++ b/ports/template/template.cmake
@@ -14,11 +14,7 @@ set( PLATFORM_COMMON_HEADERS ${PLATFORM_COMMON_HEADERS}
 set( PLATFORM_SOURCES
      # Stubs
      ${PORTS_DIRECTORY}/${IOT_PLATFORM_NAME}/src/iot_clock_${IOT_PLATFORM_NAME}.c
-     ${PORTS_DIRECTORY}/${IOT_PLATFORM_NAME}/src/iot_threads_${IOT_PLATFORM_NAME}.c
-
-     # Network sources
-     ${PORTS_DIRECTORY}/common/src/iot_network_mbedtls.c
-     ${PORTS_DIRECTORY}/common/src/iot_network_metrics.c )
+     ${PORTS_DIRECTORY}/${IOT_PLATFORM_NAME}/src/iot_threads_${IOT_PLATFORM_NAME}.c )
 
 # Set the types header for this port.
 set( PORT_TYPES_HEADER ${PORTS_DIRECTORY}/${IOT_PLATFORM_NAME}/include/iot_platform_types_${IOT_PLATFORM_NAME}.h )


### PR DESCRIPTION
Adds dummy defines so that the porting template builds with the defined network types.
