### PR TITLE
Refactor/coverage ci job

### DIFF
--- a/scripts/ci_test_common.sh
+++ b/scripts/ci_test_common.sh
@@ -15,7 +15,7 @@ make -j2 iot_tests_common
 # Run common tests.
 ./output/bin/iot_tests_common
 
-# We do not build in static memory mode if the script has been invoked in a coverage job.
+# Don't reconfigure CMake if script is invoked for coverage build.
 if [ "$RUN_TEST" != "coverage" ]; then 
     # Rebuild in static memory mode.
     cmake .. -DIOT_BUILD_TESTS=1 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="$CMAKE_FLAGS -DIOT_STATIC_MEMORY_ONLY=1"

--- a/scripts/ci_test_common.sh
+++ b/scripts/ci_test_common.sh
@@ -15,9 +15,11 @@ make -j2 iot_tests_common
 # Run common tests.
 ./output/bin/iot_tests_common
 
-# Rebuild in static memory mode.
-cmake .. -DIOT_BUILD_TESTS=1 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="$CMAKE_FLAGS -DIOT_STATIC_MEMORY_ONLY=1"
-make -j2 iot_tests_common
+if [ "$RUN_TEST" != "coverage" ]; then 
+    # Rebuild in static memory mode.
+    cmake .. -DIOT_BUILD_TESTS=1 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="$CMAKE_FLAGS -DIOT_STATIC_MEMORY_ONLY=1"
+    make -j2 iot_tests_common
 
-# Run common tests in static memory mode.
-./output/bin/iot_tests_common
+    # Run common tests in static memory mode.
+    ./output/bin/iot_tests_common
+fi

--- a/scripts/ci_test_common.sh
+++ b/scripts/ci_test_common.sh
@@ -15,6 +15,7 @@ make -j2 iot_tests_common
 # Run common tests.
 ./output/bin/iot_tests_common
 
+# We do not build in static memory mode if the script has been invoked in a coverage job.
 if [ "$RUN_TEST" != "coverage" ]; then 
     # Rebuild in static memory mode.
     cmake .. -DIOT_BUILD_TESTS=1 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="$CMAKE_FLAGS -DIOT_STATIC_MEMORY_ONLY=1"

--- a/scripts/ci_test_coverage.sh
+++ b/scripts/ci_test_coverage.sh
@@ -45,7 +45,7 @@ generate_coverage jobs.info
 # Combine the coverage files of all libraries into a single master coverage file.
 lcov --add-tracefile common.info \
      --add-tracefile mqtt.info \
-     --add-tracefile shadow.info \ 
+     --add-tracefile shadow.info \
      --add-tracefile jobs.info \
      --output-file coverage.info  
 

--- a/scripts/ci_test_coverage.sh
+++ b/scripts/ci_test_coverage.sh
@@ -47,7 +47,7 @@ lcov --add-tracefile common.info \
      --add-tracefile mqtt.info \
      --add-tracefile shadow.info \
      --add-tracefile jobs.info \
-     --output-file coverage.info  
+     --output-file coverage.info
 
 # Submit the code coverage results. Must be submitted from SDK root directory so
 # Coveralls displays the correct paths.

--- a/scripts/ci_test_jobs.sh
+++ b/scripts/ci_test_jobs.sh
@@ -57,13 +57,15 @@ if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then trap "delete_jobs" EXIT; fi
 run_tests
 if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then delete_jobs; fi
 
-# Rebuild in static memory mode.
-cmake .. -DIOT_BUILD_TESTS=1 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="$CMAKE_FLAGS -DIOT_STATIC_MEMORY_ONLY=1"
-make -j2 aws_iot_tests_jobs
+if [ "$RUN_TEST" != "coverage" ]; then
+    # Rebuild in static memory mode.
+    cmake .. -DIOT_BUILD_TESTS=1 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="$CMAKE_FLAGS -DIOT_STATIC_MEMORY_ONLY=1"
+    make -j2 aws_iot_tests_jobs
 
-# Run tests in static memory mode.
-if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then create_jobs; fi
-run_tests
-if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then delete_jobs; fi
-
+    # Run tests in static memory mode.
+    if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then create_jobs; fi
+    run_tests
+    if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then delete_jobs; fi
+fi
+    
 if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then trap - EXIT; fi

--- a/scripts/ci_test_jobs.sh
+++ b/scripts/ci_test_jobs.sh
@@ -57,6 +57,7 @@ if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then trap "delete_jobs" EXIT; fi
 run_tests
 if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then delete_jobs; fi
 
+# We do not build in static memory mode if the script has been invoked in a coverage job.
 if [ "$RUN_TEST" != "coverage" ]; then
     # Rebuild in static memory mode.
     cmake .. -DIOT_BUILD_TESTS=1 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="$CMAKE_FLAGS -DIOT_STATIC_MEMORY_ONLY=1"

--- a/scripts/ci_test_jobs.sh
+++ b/scripts/ci_test_jobs.sh
@@ -57,7 +57,7 @@ if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then trap "delete_jobs" EXIT; fi
 run_tests
 if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then delete_jobs; fi
 
-# We do not build in static memory mode if the script has been invoked in a coverage job.
+# Don't reconfigure CMake if script is invoked for coverage build.
 if [ "$RUN_TEST" != "coverage" ]; then
     # Rebuild in static memory mode.
     cmake .. -DIOT_BUILD_TESTS=1 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="$CMAKE_FLAGS -DIOT_STATIC_MEMORY_ONLY=1"

--- a/scripts/ci_test_mqtt.sh
+++ b/scripts/ci_test_mqtt.sh
@@ -35,9 +35,11 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
     ./output/bin/iot_demo_mqtt $DEMO_OPTIONS
 fi
 
-# Rebuild and run tests in static memory mode.
-cmake .. -DIOT_BUILD_TESTS=1 -DCMAKE_BUILD_TYPE=Debug -DIOT_NETWORK_USE_OPENSSL=$IOT_NETWORK_USE_OPENSSL -DCMAKE_C_FLAGS="$CMAKE_FLAGS -DIOT_STATIC_MEMORY_ONLY=1"
+if [ "$RUN_TEST" != "coverage" ]; then
+    # Rebuild and run tests in static memory mode.
+    cmake .. -DIOT_BUILD_TESTS=1 -DCMAKE_BUILD_TYPE=Debug -DIOT_NETWORK_USE_OPENSSL=$IOT_NETWORK_USE_OPENSSL -DCMAKE_C_FLAGS="$CMAKE_FLAGS -DIOT_STATIC_MEMORY_ONLY=1"
 
-make -j2 iot_tests_mqtt iot_demo_mqtt
+    make -j2 iot_tests_mqtt iot_demo_mqtt
 
-./output/bin/iot_tests_mqtt $TEST_OPTIONS
+    ./output/bin/iot_tests_mqtt $TEST_OPTIONS
+fi

--- a/scripts/ci_test_mqtt.sh
+++ b/scripts/ci_test_mqtt.sh
@@ -31,11 +31,11 @@ make -j2 iot_tests_mqtt iot_demo_mqtt
 
 ./output/bin/iot_tests_mqtt $TEST_OPTIONS
 
-if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-    ./output/bin/iot_demo_mqtt $DEMO_OPTIONS
-fi
-
 if [ "$RUN_TEST" != "coverage" ]; then
+    if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+        ./output/bin/iot_demo_mqtt $DEMO_OPTIONS
+    fi
+
     # Rebuild and run tests in static memory mode.
     cmake .. -DIOT_BUILD_TESTS=1 -DCMAKE_BUILD_TYPE=Debug -DIOT_NETWORK_USE_OPENSSL=$IOT_NETWORK_USE_OPENSSL -DCMAKE_C_FLAGS="$CMAKE_FLAGS -DIOT_STATIC_MEMORY_ONLY=1"
 

--- a/scripts/ci_test_mqtt.sh
+++ b/scripts/ci_test_mqtt.sh
@@ -33,7 +33,7 @@ make -j2 iot_tests_mqtt iot_demo_mqtt
 
 ./output/bin/iot_tests_mqtt $TEST_OPTIONS
 
-# We do not build in static memory mode if the script has been invoked in a coverage job.
+# Don't reconfigure CMake if script is invoked for coverage build.
 if [ "$RUN_TEST" != "coverage" ]; then
     if [ "$TRAVIS_OS_NAME" = "linux" ]; then
         ./output/bin/iot_demo_mqtt $DEMO_OPTIONS

--- a/scripts/ci_test_mqtt.sh
+++ b/scripts/ci_test_mqtt.sh
@@ -5,7 +5,7 @@
 # Exit on any nonzero return code.
 set -e
 
-CMAKE_FLAGS="-DIOT_DEMO_MQTT_TOPIC_PREFIX=\"\\\"$IOT_IDENTIFIER\\\"\" $COMPILER_OPTIONS"
+CMAKE_NON_CREDENTIAL_FLAGS="-DIOT_DEMO_MQTT_TOPIC_PREFIX=\"\\\"$IOT_IDENTIFIER\\\"\" $COMPILER_OPTIONS"
 TEST_OPTIONS=""
 
 DEMO_OPTIONS="-i $IOT_IDENTIFIER"
@@ -16,13 +16,15 @@ DEMO_OPTIONS="-i $IOT_IDENTIFIER"
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
     if [ "$TRAVIS_OS_NAME" = "linux" ]; then
         # Set the flags and options for a local Mosquitto broker on Linux.
-        CMAKE_FLAGS+=" -DIOT_TEST_MQTT_MOSQUITTO=1 -DIOT_TEST_SERVER=\\\"localhost\\\""
+        CMAKE_CREDENTIAL_FLAGS+=" -DIOT_TEST_MQTT_MOSQUITTO=1 -DIOT_TEST_SERVER=\\\"localhost\\\""
         DEMO_OPTIONS+=" -n -u -h localhost -p 1883"
     fi
 else
     # Set credentials for AWS IoT.
-    CMAKE_FLAGS+=" $AWS_IOT_CREDENTIAL_DEFINES"
+    CMAKE_CREDENTIAL_FLAGS="$AWS_IOT_CREDENTIAL_DEFINES"
 fi
+
+CMAKE_FLAGS="$CMAKE_NON_CREDENTIAL_FLAGS $CMAKE_CREDENTIAL_FLAGS"
 
 # Build and run executables.
 cmake .. -DIOT_BUILD_TESTS=1 -DCMAKE_BUILD_TYPE=Debug -DIOT_NETWORK_USE_OPENSSL=$IOT_NETWORK_USE_OPENSSL -DCMAKE_C_FLAGS="$CMAKE_FLAGS"

--- a/scripts/ci_test_mqtt.sh
+++ b/scripts/ci_test_mqtt.sh
@@ -33,6 +33,7 @@ make -j2 iot_tests_mqtt iot_demo_mqtt
 
 ./output/bin/iot_tests_mqtt $TEST_OPTIONS
 
+# We do not build in static memory mode if the script has been invoked in a coverage job.
 if [ "$RUN_TEST" != "coverage" ]; then
     if [ "$TRAVIS_OS_NAME" = "linux" ]; then
         ./output/bin/iot_demo_mqtt $DEMO_OPTIONS

--- a/scripts/ci_test_shadow.sh
+++ b/scripts/ci_test_shadow.sh
@@ -30,9 +30,11 @@ make -j2 aws_iot_tests_shadow aws_iot_demo_shadow
 # Run tests and demos.
 run_tests_and_demos
 
-# Rebuild in static memory mode.
-cmake .. -DIOT_BUILD_TESTS=1 -DCMAKE_BUILD_TYPE=Debug -DIOT_NETWORK_USE_OPENSSL=$IOT_NETWORK_USE_OPENSSL -DCMAKE_C_FLAGS="$CMAKE_FLAGS -DIOT_STATIC_MEMORY_ONLY=1"
-make -j2 aws_iot_tests_shadow aws_iot_demo_shadow
+if [ "$RUN_TEST" != "coverage" ]; then
+    # Rebuild in static memory mode.
+    cmake .. -DIOT_BUILD_TESTS=1 -DCMAKE_BUILD_TYPE=Debug -DIOT_NETWORK_USE_OPENSSL=$IOT_NETWORK_USE_OPENSSL -DCMAKE_C_FLAGS="$CMAKE_FLAGS -DIOT_STATIC_MEMORY_ONLY=1"
+    make -j2 aws_iot_tests_shadow aws_iot_demo_shadow
 
-# Run tests and demos in static memory mode.
-run_tests_and_demos
+    # Run tests and demos in static memory mode.
+    run_tests_and_demos
+fi

--- a/scripts/ci_test_shadow.sh
+++ b/scripts/ci_test_shadow.sh
@@ -14,7 +14,8 @@ run_tests_and_demos() {
         ./output/bin/aws_iot_tests_shadow
         sleep 1.1
 
-        if [ "$RUN_TEST" != "coverage" ]; then
+        # We do not build in static memory mode if the script has been invoked in a coverage job.
+if [ "$RUN_TEST" != "coverage" ]; then
             ./output/bin/aws_iot_demo_shadow
         fi
     else
@@ -33,6 +34,7 @@ make -j2 aws_iot_tests_shadow aws_iot_demo_shadow
 # Run tests and demos.
 run_tests_and_demos
 
+# We do not build in static memory mode if the script has been invoked in a coverage job.
 if [ "$RUN_TEST" != "coverage" ]; then
     # Rebuild in static memory mode.
     cmake .. -DIOT_BUILD_TESTS=1 -DCMAKE_BUILD_TYPE=Debug -DIOT_NETWORK_USE_OPENSSL=$IOT_NETWORK_USE_OPENSSL -DCMAKE_C_FLAGS="$CMAKE_FLAGS -DIOT_STATIC_MEMORY_ONLY=1"

--- a/scripts/ci_test_shadow.sh
+++ b/scripts/ci_test_shadow.sh
@@ -13,7 +13,10 @@ run_tests_and_demos() {
     if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
         ./output/bin/aws_iot_tests_shadow
         sleep 1.1
-        ./output/bin/aws_iot_demo_shadow
+
+        if [ "$RUN_TEST" != "coverage" ]; then
+            ./output/bin/aws_iot_demo_shadow
+        fi
     else
         # Run only Shadow unit tests.
         ./output/bin/aws_iot_tests_shadow -n

--- a/scripts/ci_test_shadow.sh
+++ b/scripts/ci_test_shadow.sh
@@ -14,8 +14,8 @@ run_tests_and_demos() {
         ./output/bin/aws_iot_tests_shadow
         sleep 1.1
 
-        # We do not build in static memory mode if the script has been invoked in a coverage job.
-if [ "$RUN_TEST" != "coverage" ]; then
+        # Don't reconfigure CMake if script is invoked for coverage build.
+        if [ "$RUN_TEST" != "coverage" ]; then
             ./output/bin/aws_iot_demo_shadow
         fi
     else
@@ -34,7 +34,7 @@ make -j2 aws_iot_tests_shadow aws_iot_demo_shadow
 # Run tests and demos.
 run_tests_and_demos
 
-# We do not build in static memory mode if the script has been invoked in a coverage job.
+# Don't reconfigure CMake if script is invoked for coverage build.
 if [ "$RUN_TEST" != "coverage" ]; then
     # Rebuild in static memory mode.
     cmake .. -DIOT_BUILD_TESTS=1 -DCMAKE_BUILD_TYPE=Debug -DIOT_NETWORK_USE_OPENSSL=$IOT_NETWORK_USE_OPENSSL -DCMAKE_C_FLAGS="$CMAKE_FLAGS -DIOT_STATIC_MEMORY_ONLY=1"


### PR DESCRIPTION
*Description of changes:*
Refactor `ci_test_coverage.sh` script to remove logic duplication of invoking library tests. Instead, use the existing library specific scripts to run their tests. 
(Temporary Update) Update library specific CI scripts to avoid building with static memory when running coverage job. A better solution for avoiding static memory build will be promulgated in a separate PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
