### PR TITLE
Update aws_iot_mqtt_client_connect.c

### DIFF
--- a/src/aws_iot_mqtt_client_connect.c
+++ b/src/aws_iot_mqtt_client_connect.c
@@ -527,7 +527,7 @@ static IoT_Error_t _aws_iot_mqtt_internal_disconnect(AWS_IoT_Client *pClient) {
 	/* Clean network stack */
 	pClient->networkStack.disconnect(&(pClient->networkStack));
 	rc = pClient->networkStack.destroy(&(pClient->networkStack));
-	if(0 != rc) {
+	if(SUCCESS != rc) {
 		/* TLS Destroy failed, return error */
 		FUNC_EXIT_RC(FAILURE);
 	}


### PR DESCRIPTION
Fix enum instead of hardcoded values

*Issue #, if available:* Hard coded value is used of using Enum

*Description of changes:* Changed the default hard coded number into the enum value


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
