### PR TITLE
Remove macros hiding the control flow in MQTT

### DIFF
--- a/libraries/standard/mqtt/src/iot_mqtt_network.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_network.c
@@ -31,9 +31,6 @@
 /* Standard includes. */
 #include <string.h>
 
-/* Error handling include. */
-#include "iot_error.h"
-
 /* MQTT internal include. */
 #include "private/iot_mqtt_internal.h"
 
@@ -199,7 +196,7 @@ static IotMqttError_t _getIncomingPacket( void * pNetworkConnection,
                                           const _mqttConnection_t * pMqttConnection,
                                           _mqttPacket_t * pIncomingPacket )
 {
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
     size_t dataBytesRead = 0;
 
     /* No buffer for remaining data should be allocated. */
@@ -217,7 +214,8 @@ static IotMqttError_t _getIncomingPacket( void * pNetworkConnection,
                      pMqttConnection,
                      pIncomingPacket->type );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+        status = IOT_MQTT_BAD_RESPONSE;
+        goto cleanup;
     }
     else
     {
@@ -230,7 +228,8 @@ static IotMqttError_t _getIncomingPacket( void * pNetworkConnection,
 
     if( pIncomingPacket->remainingLength == MQTT_REMAINING_LENGTH_INVALID )
     {
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+        status = IOT_MQTT_BAD_RESPONSE;
+        goto cleanup;
     }
     else
     {
@@ -252,7 +251,8 @@ static IotMqttError_t _getIncomingPacket( void * pNetworkConnection,
 
             _flushPacket( pNetworkConnection, pMqttConnection, pIncomingPacket->remainingLength );
 
-            IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_NO_MEMORY );
+            status = IOT_MQTT_NO_MEMORY;
+            goto cleanup;
         }
         else
         {
@@ -265,7 +265,8 @@ static IotMqttError_t _getIncomingPacket( void * pNetworkConnection,
 
         if( dataBytesRead != pIncomingPacket->remainingLength )
         {
-            IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+            status = IOT_MQTT_BAD_RESPONSE;
+            goto cleanup;
         }
         else
         {
@@ -278,7 +279,7 @@ static IotMqttError_t _getIncomingPacket( void * pNetworkConnection,
     }
 
     /* Clean up on error. */
-    IOT_FUNCTION_CLEANUP_BEGIN();
+cleanup:
 
     if( status != IOT_MQTT_SUCCESS )
     {
@@ -296,7 +297,7 @@ static IotMqttError_t _getIncomingPacket( void * pNetworkConnection,
         EMPTY_ELSE_MARKER;
     }
 
-    IOT_FUNCTION_CLEANUP_END();
+    return status;
 }
 
 /*-----------------------------------------------------------*/
@@ -576,7 +577,7 @@ static void _sendPuback( _mqttConnection_t * pMqttConnection,
 
     if( status != IOT_MQTT_SUCCESS )
     {
-        IOT_GOTO_CLEANUP();
+        goto cleanup;
     }
 
     /* Set the operation type. */
@@ -589,7 +590,7 @@ static void _sendPuback( _mqttConnection_t * pMqttConnection,
 
     if( status != IOT_MQTT_SUCCESS )
     {
-        IOT_GOTO_CLEANUP();
+        goto cleanup;
     }
 
     /* Add the PUBACK operation to the send queue for network transmission. */
@@ -602,7 +603,7 @@ static void _sendPuback( _mqttConnection_t * pMqttConnection,
         IotLogError( "(MQTT connection %p) Failed to enqueue PUBACK for sending.",
                      pMqttConnection );
 
-        IOT_GOTO_CLEANUP();
+        goto cleanup;
     }
     else
     {
@@ -610,7 +611,7 @@ static void _sendPuback( _mqttConnection_t * pMqttConnection,
     }
 
     /* Clean up on error. */
-    IOT_FUNCTION_CLEANUP_BEGIN();
+cleanup:
 
     if( status != IOT_MQTT_SUCCESS )
     {

--- a/libraries/standard/mqtt/src/iot_mqtt_operation.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_operation.c
@@ -31,9 +31,6 @@
 /* Standard includes. */
 #include <string.h>
 
-/* Error handling include. */
-#include "iot_error.h"
-
 /* MQTT internal include. */
 #include "private/iot_mqtt_internal.h"
 
@@ -59,7 +56,7 @@
                                    _getMqttFreePacketFunc,
                                    _IotMqtt_FreePacket,
                                    freePacket )
-#else  /* if IOT_MQTT_ENABLE_SERIALIZER_OVERRIDES == 1 */
+#else /* if IOT_MQTT_ENABLE_SERIALIZER_OVERRIDES == 1 */
     #define _getMqttFreePacketFunc( pSerializer )       _IotMqtt_FreePacket
     #define _getMqttPublishSetDupFunc( pSerializer )    _IotMqtt_PublishSetDup
 #endif /* if IOT_MQTT_ENABLE_SERIALIZER_OVERRIDES == 1 */
@@ -349,7 +346,7 @@ IotMqttError_t _IotMqtt_CreateOperation( _mqttConnection_t * pMqttConnection,
                                          const IotMqttCallbackInfo_t * pCallbackInfo,
                                          _mqttOperation_t ** pNewOperation )
 {
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
     bool decrementOnError = false;
     _mqttOperation_t * pOperation = NULL;
     bool waitable = ( ( flags & IOT_MQTT_FLAG_WAITABLE ) == IOT_MQTT_FLAG_WAITABLE );
@@ -361,7 +358,8 @@ IotMqttError_t _IotMqtt_CreateOperation( _mqttConnection_t * pMqttConnection,
         {
             IotLogError( "Callback should not be set for a waitable operation." );
 
-            IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+            status = IOT_MQTT_BAD_PARAMETER;
+            goto cleanup;
         }
         else
         {
@@ -384,7 +382,8 @@ IotMqttError_t _IotMqtt_CreateOperation( _mqttConnection_t * pMqttConnection,
                      " for a closed connection",
                      pMqttConnection );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_NETWORK_ERROR );
+        status = IOT_MQTT_NETWORK_ERROR;
+        goto cleanup;
     }
     else
     {
@@ -401,7 +400,8 @@ IotMqttError_t _IotMqtt_CreateOperation( _mqttConnection_t * pMqttConnection,
                      "operation record.",
                      pMqttConnection );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_NO_MEMORY );
+        status = IOT_MQTT_NO_MEMORY;
+        goto cleanup;
     }
     else
     {
@@ -426,7 +426,8 @@ IotMqttError_t _IotMqtt_CreateOperation( _mqttConnection_t * pMqttConnection,
                          "waitable operation.",
                          pMqttConnection );
 
-            IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_NO_MEMORY );
+            status = IOT_MQTT_NO_MEMORY;
+            goto cleanup;
         }
         else
         {
@@ -459,7 +460,7 @@ IotMqttError_t _IotMqtt_CreateOperation( _mqttConnection_t * pMqttConnection,
     *pNewOperation = pOperation;
 
     /* Clean up operation and decrement reference count if this function failed. */
-    IOT_FUNCTION_CLEANUP_BEGIN();
+cleanup:
 
     if( status != IOT_MQTT_SUCCESS )
     {
@@ -486,7 +487,7 @@ IotMqttError_t _IotMqtt_CreateOperation( _mqttConnection_t * pMqttConnection,
         EMPTY_ELSE_MARKER;
     }
 
-    IOT_FUNCTION_CLEANUP_END();
+    return status;
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/standard/mqtt/src/iot_mqtt_serialize.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_serialize.c
@@ -32,9 +32,6 @@
 #include <string.h>
 #include <limits.h>
 
-/* Error handling include. */
-#include "iot_error.h"
-
 /* MQTT internal includes. */
 #include "private/iot_mqtt_internal.h"
 
@@ -278,9 +275,9 @@ static bool _subscriptionPacketSize( IotMqttOperationType_t type,
  *
  */
 static void _serializeConnect( const IotMqttConnectInfo_t * pConnectInfo,
-                        size_t remainingLength,
-                        uint8_t * pBuffer,
-                        size_t connectPacketSize );
+                               size_t remainingLength,
+                               uint8_t * pBuffer,
+                               size_t connectPacketSize );
 
 /**
  * @brief Generate a PUBLISH packet from the given parameters.
@@ -295,11 +292,11 @@ static void _serializeConnect( const IotMqttConnectInfo_t * pConnectInfo,
  *
  */
 static void _serializePublish( const IotMqttPublishInfo_t * pPublishInfo,
-                        size_t remainingLength,
-                        uint16_t * pPacketIdentifier,
-                        uint8_t ** pPacketIdentifierHigh,
-                        uint8_t * pBuffer,
-                        size_t publishPacketSize );
+                               size_t remainingLength,
+                               uint16_t * pPacketIdentifier,
+                               uint8_t ** pPacketIdentifierHigh,
+                               uint8_t * pBuffer,
+                               size_t publishPacketSize );
 
 /**
  * @brief Generate a SUBSCRIBE packet from the given parameters.
@@ -313,11 +310,11 @@ static void _serializePublish( const IotMqttPublishInfo_t * pPublishInfo,
  *
  */
 static void _serializeSubscribe( const IotMqttSubscription_t * pSubscriptionList,
-                          size_t subscriptionCount,
-                          size_t remainingLength,
-                          uint16_t * pPacketIdentifier,
-                          uint8_t * pBuffer,
-                          size_t subscribePacketSize );
+                                 size_t subscriptionCount,
+                                 size_t remainingLength,
+                                 uint16_t * pPacketIdentifier,
+                                 uint8_t * pBuffer,
+                                 size_t subscribePacketSize );
 
 /**
  * @brief Generate an UNSUBSCRIBE packet from the given parameters.
@@ -331,11 +328,11 @@ static void _serializeSubscribe( const IotMqttSubscription_t * pSubscriptionList
  *
  */
 static void _serializeUnsubscribe( const IotMqttSubscription_t * pSubscriptionList,
-                            size_t subscriptionCount,
-                            size_t remainingLength,
-                            uint16_t * pPacketIdentifier,
-                            uint8_t * pBuffer,
-                            size_t unsubscribePacketSize );
+                                   size_t subscriptionCount,
+                                   size_t remainingLength,
+                                   uint16_t * pPacketIdentifier,
+                                   uint8_t * pBuffer,
+                                   size_t unsubscribePacketSize );
 
 /*-----------------------------------------------------------*/
 
@@ -659,9 +656,9 @@ static bool _subscriptionPacketSize( IotMqttOperationType_t type,
 /*-----------------------------------------------------------*/
 
 static void _serializeConnect( const IotMqttConnectInfo_t * pConnectInfo,
-                        size_t remainingLength,
-                        uint8_t * pBuffer,
-                        size_t connectPacketSize )
+                               size_t remainingLength,
+                               uint8_t * pBuffer,
+                               size_t connectPacketSize )
 {
     uint8_t connectFlags = 0;
     uint8_t * pConnectPacket = pBuffer;
@@ -882,11 +879,11 @@ static void _serializeConnect( const IotMqttConnectInfo_t * pConnectInfo,
 /*-----------------------------------------------------------*/
 
 static void _serializePublish( const IotMqttPublishInfo_t * pPublishInfo,
-                        size_t remainingLength,
-                        uint16_t * pPacketIdentifier,
-                        uint8_t ** pPacketIdentifierHigh,
-                        uint8_t * pBuffer,
-                        size_t publishPacketSize )
+                               size_t remainingLength,
+                               uint16_t * pPacketIdentifier,
+                               uint8_t ** pPacketIdentifierHigh,
+                               uint8_t * pBuffer,
+                               size_t publishPacketSize )
 {
     uint8_t publishFlags = 0;
     uint16_t packetIdentifier = 0;
@@ -983,11 +980,11 @@ static void _serializePublish( const IotMqttPublishInfo_t * pPublishInfo,
 /*-----------------------------------------------------------*/
 
 static void _serializeSubscribe( const IotMqttSubscription_t * pSubscriptionList,
-                          size_t subscriptionCount,
-                          size_t remainingLength,
-                          uint16_t * pPacketIdentifier,
-                          uint8_t * pBuffer,
-                          size_t subscribePacketSize )
+                                 size_t subscriptionCount,
+                                 size_t remainingLength,
+                                 uint16_t * pPacketIdentifier,
+                                 uint8_t * pBuffer,
+                                 size_t subscribePacketSize )
 {
     uint16_t packetIdentifier = 0;
     size_t i = 0;
@@ -1037,16 +1034,16 @@ static void _serializeSubscribe( const IotMqttSubscription_t * pSubscriptionList
 /*-----------------------------------------------------------*/
 
 static void _serializeUnsubscribe( const IotMqttSubscription_t * pSubscriptionList,
-                            size_t subscriptionCount,
-                            size_t remainingLength,
-                            uint16_t * pPacketIdentifier,
-                            uint8_t * pBuffer,
-                            size_t unsubscribePacketSize )
+                                   size_t subscriptionCount,
+                                   size_t remainingLength,
+                                   uint16_t * pPacketIdentifier,
+                                   uint8_t * pBuffer,
+                                   size_t unsubscribePacketSize )
 {
     uint16_t packetIdentifier = 0;
     size_t i = 0;
     uint8_t * pUnsubscribePacket = pBuffer;
-    
+
     /* Avoid unused variable warning when logging and asserts are disabled. */
     ( void ) pUnsubscribePacket;
     ( void ) unsubscribePacketSize;
@@ -1217,7 +1214,7 @@ IotMqttError_t _IotMqtt_SerializeConnect( const IotMqttConnectInfo_t * pConnectI
                                           uint8_t ** pConnectPacket,
                                           size_t * pPacketSize )
 {
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
     size_t remainingLength = 0, connectPacketSize = 0;
     uint8_t * pBuffer = NULL;
 
@@ -1229,7 +1226,8 @@ IotMqttError_t _IotMqtt_SerializeConnect( const IotMqttConnectInfo_t * pConnectI
                      " size allowed by MQTT 3.1.1.",
                      MQTT_PACKET_CONNECT_MAX_SIZE );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
     else
     {
@@ -1248,7 +1246,8 @@ IotMqttError_t _IotMqtt_SerializeConnect( const IotMqttConnectInfo_t * pConnectI
     {
         IotLogError( "Failed to allocate memory for CONNECT packet." );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_NO_MEMORY );
+        status = IOT_MQTT_NO_MEMORY;
+        goto cleanup;
     }
     else
     {
@@ -1261,14 +1260,15 @@ IotMqttError_t _IotMqtt_SerializeConnect( const IotMqttConnectInfo_t * pConnectI
 
     _serializeConnect( pConnectInfo, remainingLength, pBuffer, connectPacketSize );
 
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/
 
 IotMqttError_t _IotMqtt_DeserializeConnack( _mqttPacket_t * pConnack )
 {
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
     const uint8_t * pRemainingData = pConnack->pRemainingData;
 
     /* If logging is enabled, declare the CONNACK response code strings. The
@@ -1293,7 +1293,8 @@ IotMqttError_t _IotMqtt_DeserializeConnack( _mqttPacket_t * pConnack )
                 "Bad control packet type 0x%02x.",
                 pConnack->type );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+        status = IOT_MQTT_BAD_RESPONSE;
+        goto cleanup;
     }
     else
     {
@@ -1309,7 +1310,8 @@ IotMqttError_t _IotMqtt_DeserializeConnack( _mqttPacket_t * pConnack )
                 "CONNACK does not have remaining length of %d.",
                 MQTT_PACKET_CONNACK_REMAINING_LENGTH );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+        status = IOT_MQTT_BAD_RESPONSE;
+        goto cleanup;
     }
     else
     {
@@ -1324,7 +1326,8 @@ IotMqttError_t _IotMqtt_DeserializeConnack( _mqttPacket_t * pConnack )
                 &_logHideAll,
                 "Reserved bits in CONNACK incorrect." );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+        status = IOT_MQTT_BAD_RESPONSE;
+        goto cleanup;
     }
     else
     {
@@ -1344,7 +1347,8 @@ IotMqttError_t _IotMqtt_DeserializeConnack( _mqttPacket_t * pConnack )
          * "Session Present" bit is set. */
         if( pRemainingData[ 1 ] != 0 )
         {
-            IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+            status = IOT_MQTT_BAD_RESPONSE;
+            goto cleanup;
         }
         else
         {
@@ -1366,7 +1370,8 @@ IotMqttError_t _IotMqtt_DeserializeConnack( _mqttPacket_t * pConnack )
                 "CONNACK response %hhu is not valid.",
                 pRemainingData[ 1 ] );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+        status = IOT_MQTT_BAD_RESPONSE;
+        goto cleanup;
     }
     else
     {
@@ -1385,14 +1390,16 @@ IotMqttError_t _IotMqtt_DeserializeConnack( _mqttPacket_t * pConnack )
     /* A nonzero CONNACK response code means the connection was refused. */
     if( pRemainingData[ 1 ] > 0 )
     {
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_SERVER_REFUSED );
+        status = IOT_MQTT_SERVER_REFUSED;
+        goto cleanup;
     }
     else
     {
         EMPTY_ELSE_MARKER;
     }
 
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/
@@ -1403,7 +1410,7 @@ IotMqttError_t _IotMqtt_SerializePublish( const IotMqttPublishInfo_t * pPublishI
                                           uint16_t * pPacketIdentifier,
                                           uint8_t ** pPacketIdentifierHigh )
 {
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
     size_t remainingLength = 0, publishPacketSize = 0;
     uint8_t * pBuffer = NULL;
 
@@ -1415,7 +1422,8 @@ IotMqttError_t _IotMqtt_SerializePublish( const IotMqttPublishInfo_t * pPublishI
                      "maximum size allowed by MQTT 3.1.1.",
                      MQTT_MAX_REMAINING_LENGTH );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
     else
     {
@@ -1434,7 +1442,8 @@ IotMqttError_t _IotMqtt_SerializePublish( const IotMqttPublishInfo_t * pPublishI
     {
         IotLogError( "Failed to allocate memory for PUBLISH packet." );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_NO_MEMORY );
+        status = IOT_MQTT_NO_MEMORY;
+        goto cleanup;
     }
     else
     {
@@ -1453,7 +1462,8 @@ IotMqttError_t _IotMqtt_SerializePublish( const IotMqttPublishInfo_t * pPublishI
                        pBuffer,
                        publishPacketSize );
 
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/
@@ -1495,7 +1505,7 @@ void _IotMqtt_PublishSetDup( uint8_t * pPublishPacket,
 
 IotMqttError_t _IotMqtt_DeserializePublish( _mqttPacket_t * pPublish )
 {
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
     IotMqttPublishInfo_t * pOutput = &( pPublish->u.pIncomingPublish->u.publish.publishInfo );
     uint8_t publishFlags = 0;
     const uint8_t * pVariableHeader = pPublish->pRemainingData, * pPacketIdentifierHigh = NULL;
@@ -1520,7 +1530,8 @@ IotMqttError_t _IotMqtt_DeserializePublish( _mqttPacket_t * pPublish )
                     &_logHideAll,
                     "Bad QoS: 3." );
 
-            IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+            status = IOT_MQTT_BAD_RESPONSE;
+            goto cleanup;
         }
         else
         {
@@ -1569,7 +1580,8 @@ IotMqttError_t _IotMqtt_DeserializePublish( _mqttPacket_t * pPublish )
                     &_logHideAll,
                     "QoS 0 PUBLISH cannot have a remaining length less than 3." );
 
-            IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+            status = IOT_MQTT_BAD_RESPONSE;
+            goto cleanup;
         }
         else
         {
@@ -1587,7 +1599,8 @@ IotMqttError_t _IotMqtt_DeserializePublish( _mqttPacket_t * pPublish )
                     &_logHideAll,
                     "QoS 1 or 2 PUBLISH cannot have a remaining length less than 5." );
 
-            IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+            status = IOT_MQTT_BAD_RESPONSE;
+            goto cleanup;
         }
         else
         {
@@ -1610,7 +1623,8 @@ IotMqttError_t _IotMqtt_DeserializePublish( _mqttPacket_t * pPublish )
                     &_logHideAll,
                     "Remaining length cannot be less than variable header length." );
 
-            IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+            status = IOT_MQTT_BAD_RESPONSE;
+            goto cleanup;
         }
         else
         {
@@ -1627,7 +1641,8 @@ IotMqttError_t _IotMqtt_DeserializePublish( _mqttPacket_t * pPublish )
                     &_logHideAll,
                     "Remaining length cannot be less than variable header length." );
 
-            IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+            status = IOT_MQTT_BAD_RESPONSE;
+            goto cleanup;
         }
         else
         {
@@ -1660,7 +1675,8 @@ IotMqttError_t _IotMqtt_DeserializePublish( _mqttPacket_t * pPublish )
         /* Packet identifier cannot be 0. */
         if( pPublish->packetIdentifier == 0 )
         {
-            IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+            status = IOT_MQTT_BAD_RESPONSE;
+            goto cleanup;
         }
         else
         {
@@ -1689,7 +1705,8 @@ IotMqttError_t _IotMqtt_DeserializePublish( _mqttPacket_t * pPublish )
             &_logHideAll,
             "Payload length %hu.", pOutput->payloadLength );
 
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/
@@ -1732,7 +1749,7 @@ IotMqttError_t _IotMqtt_SerializePuback( uint16_t packetIdentifier,
 
 IotMqttError_t _IotMqtt_DeserializePuback( _mqttPacket_t * pPuback )
 {
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
 
     /* Check the "Remaining length" of the received PUBACK. */
     if( pPuback->remainingLength != MQTT_PACKET_PUBACK_REMAINING_LENGTH )
@@ -1742,7 +1759,8 @@ IotMqttError_t _IotMqtt_DeserializePuback( _mqttPacket_t * pPuback )
                 "PUBACK does not have remaining length of %d.",
                 MQTT_PACKET_PUBACK_REMAINING_LENGTH );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+        status = IOT_MQTT_BAD_RESPONSE;
+        goto cleanup;
     }
     else
     {
@@ -1759,7 +1777,8 @@ IotMqttError_t _IotMqtt_DeserializePuback( _mqttPacket_t * pPuback )
     /* Packet identifier cannot be 0. */
     if( pPuback->packetIdentifier == 0 )
     {
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+        status = IOT_MQTT_BAD_RESPONSE;
+        goto cleanup;
     }
     else
     {
@@ -1775,14 +1794,16 @@ IotMqttError_t _IotMqtt_DeserializePuback( _mqttPacket_t * pPuback )
                 "Bad control packet type 0x%02x.",
                 pPuback->type );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+        status = IOT_MQTT_BAD_RESPONSE;
+        goto cleanup;
     }
     else
     {
         EMPTY_ELSE_MARKER;
     }
 
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/
@@ -1793,7 +1814,7 @@ IotMqttError_t _IotMqtt_SerializeSubscribe( const IotMqttSubscription_t * pSubsc
                                             size_t * pPacketSize,
                                             uint16_t * pPacketIdentifier )
 {
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
     size_t subscribePacketSize = 0, remainingLength = 0;
     uint8_t * pBuffer = NULL;
 
@@ -1809,7 +1830,8 @@ IotMqttError_t _IotMqtt_SerializeSubscribe( const IotMqttSubscription_t * pSubsc
                      "maximum size allowed by MQTT 3.1.1.",
                      MQTT_MAX_REMAINING_LENGTH );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
     else
     {
@@ -1828,7 +1850,8 @@ IotMqttError_t _IotMqtt_SerializeSubscribe( const IotMqttSubscription_t * pSubsc
     {
         IotLogError( "Failed to allocate memory for SUBSCRIBE packet." );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_NO_MEMORY );
+        status = IOT_MQTT_NO_MEMORY;
+        goto cleanup;
     }
     else
     {
@@ -1848,14 +1871,15 @@ IotMqttError_t _IotMqtt_SerializeSubscribe( const IotMqttSubscription_t * pSubsc
                          subscribePacketSize );
 
 
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/
 
 IotMqttError_t _IotMqtt_DeserializeSuback( _mqttPacket_t * pSuback )
 {
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
     size_t i = 0, remainingLength = pSuback->remainingLength;
     uint8_t subscriptionStatus = 0;
     const uint8_t * pVariableHeader = pSuback->pRemainingData;
@@ -1868,7 +1892,8 @@ IotMqttError_t _IotMqtt_DeserializeSuback( _mqttPacket_t * pSuback )
                 &_logHideAll,
                 "SUBACK cannot have a remaining length less than 3." );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+        status = IOT_MQTT_BAD_RESPONSE;
+        goto cleanup;
     }
     else
     {
@@ -1891,7 +1916,8 @@ IotMqttError_t _IotMqtt_DeserializeSuback( _mqttPacket_t * pSuback )
                 "Bad control packet type 0x%02x.",
                 pSuback->type );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+        status = IOT_MQTT_BAD_RESPONSE;
+        goto cleanup;
     }
     else
     {
@@ -1951,7 +1977,8 @@ IotMqttError_t _IotMqtt_DeserializeSuback( _mqttPacket_t * pSuback )
         }
     }
 
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/
@@ -1962,7 +1989,7 @@ IotMqttError_t _IotMqtt_SerializeUnsubscribe( const IotMqttSubscription_t * pSub
                                               size_t * pPacketSize,
                                               uint16_t * pPacketIdentifier )
 {
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
     size_t unsubscribePacketSize = 0, remainingLength = 0;
     uint8_t * pBuffer = NULL;
 
@@ -1978,7 +2005,8 @@ IotMqttError_t _IotMqtt_SerializeUnsubscribe( const IotMqttSubscription_t * pSub
                      "maximum size allowed by MQTT 3.1.1.",
                      MQTT_MAX_REMAINING_LENGTH );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
     else
     {
@@ -1997,7 +2025,8 @@ IotMqttError_t _IotMqtt_SerializeUnsubscribe( const IotMqttSubscription_t * pSub
     {
         IotLogError( "Failed to allocate memory for UNSUBSCRIBE packet." );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_NO_MEMORY );
+        status = IOT_MQTT_NO_MEMORY;
+        goto cleanup;
     }
     else
     {
@@ -2016,14 +2045,15 @@ IotMqttError_t _IotMqtt_SerializeUnsubscribe( const IotMqttSubscription_t * pSub
                            pBuffer,
                            unsubscribePacketSize );
 
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/
 
 IotMqttError_t _IotMqtt_DeserializeUnsuback( _mqttPacket_t * pUnsuback )
 {
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
 
     /* Check the "Remaining length" (second byte) of the received UNSUBACK. */
     if( pUnsuback->remainingLength != MQTT_PACKET_UNSUBACK_REMAINING_LENGTH )
@@ -2033,7 +2063,8 @@ IotMqttError_t _IotMqtt_DeserializeUnsuback( _mqttPacket_t * pUnsuback )
                 "UNSUBACK does not have remaining length of %d.",
                 MQTT_PACKET_UNSUBACK_REMAINING_LENGTH );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+        status = IOT_MQTT_BAD_RESPONSE;
+        goto cleanup;
     }
     else
     {
@@ -2046,7 +2077,8 @@ IotMqttError_t _IotMqtt_DeserializeUnsuback( _mqttPacket_t * pUnsuback )
     /* Packet identifier cannot be 0. */
     if( pUnsuback->packetIdentifier == 0 )
     {
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+        status = IOT_MQTT_BAD_RESPONSE;
+        goto cleanup;
     }
     else
     {
@@ -2066,14 +2098,16 @@ IotMqttError_t _IotMqtt_DeserializeUnsuback( _mqttPacket_t * pUnsuback )
                 "Bad control packet type 0x%02x.",
                 pUnsuback->type );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+        status = IOT_MQTT_BAD_RESPONSE;
+        goto cleanup;
     }
     else
     {
         EMPTY_ELSE_MARKER;
     }
 
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/
@@ -2102,7 +2136,7 @@ IotMqttError_t _IotMqtt_SerializePingreq( uint8_t ** pPingreqPacket,
 
 IotMqttError_t _IotMqtt_DeserializePingresp( _mqttPacket_t * pPingresp )
 {
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
 
     /* Check that the control packet type is 0xd0. */
     if( pPingresp->type != MQTT_PACKET_TYPE_PINGRESP )
@@ -2112,7 +2146,8 @@ IotMqttError_t _IotMqtt_DeserializePingresp( _mqttPacket_t * pPingresp )
                 "Bad control packet type 0x%02x.",
                 pPingresp->type );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+        status = IOT_MQTT_BAD_RESPONSE;
+        goto cleanup;
     }
     else
     {
@@ -2127,14 +2162,16 @@ IotMqttError_t _IotMqtt_DeserializePingresp( _mqttPacket_t * pPingresp )
                 "PINGRESP does not have remaining length of %d.",
                 MQTT_PACKET_PINGRESP_REMAINING_LENGTH );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_RESPONSE );
+        status = IOT_MQTT_BAD_RESPONSE;
+        goto cleanup;
     }
     else
     {
         EMPTY_ELSE_MARKER;
     }
 
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/
@@ -2194,18 +2231,20 @@ IotMqttError_t IotMqtt_GetConnectPacketSize( const IotMqttConnectInfo_t * pConne
                                              size_t * pRemainingLength,
                                              size_t * pPacketSize )
 {
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
 
     if( ( pConnectInfo == NULL ) || ( pRemainingLength == NULL ) || ( pPacketSize == NULL ) )
     {
         IotLogError( "IotMqtt_GetConnectPacketSize() called with required parameter(s) set to NULL." );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     if( ( pConnectInfo->clientIdentifierLength == 0 ) || ( pConnectInfo->pClientIdentifier == NULL ) )
     {
         IotLogError( "IotMqtt_GetConnectPacketSize() client identifier must be set." );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     /* Calculate the "Remaining length" field and total packet size. If it exceeds
@@ -2216,7 +2255,8 @@ IotMqttError_t IotMqtt_GetConnectPacketSize( const IotMqttConnectInfo_t * pConne
                      " size allowed by MQTT 3.1.1.",
                      MQTT_PACKET_CONNECT_MAX_SIZE );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
     else
     {
@@ -2229,10 +2269,12 @@ IotMqttError_t IotMqtt_GetConnectPacketSize( const IotMqttConnectInfo_t * pConne
     {
         IotLogError( "Connection packet remaining length (%lu) exceeds packet size (%lu)",
                      ( *pRemainingLength ), ( *pPacketSize ) );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/
@@ -2242,25 +2284,28 @@ IotMqttError_t IotMqtt_SerializeConnect( const IotMqttConnectInfo_t * pConnectIn
                                          uint8_t * pBuffer,
                                          size_t bufferSize )
 {
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
 
     if( ( pBuffer == NULL ) || ( pConnectInfo == NULL ) )
     {
         IotLogError( "IotMqtt_SerializeConnect() called with required parameter(s) set to NULL." );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     if( ( pConnectInfo->clientIdentifierLength == 0 ) || ( pConnectInfo->pClientIdentifier == NULL ) )
     {
         IotLogError( "IotMqtt_SerializeConnect() client identifier must be set." );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     if( remainingLength > bufferSize )
     {
         IotLogError( " Serialize Connect packet remaining length (%lu) exceeds buffer size (%lu)",
                      remainingLength, bufferSize );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     _serializeConnect( pConnectInfo,
@@ -2268,7 +2313,8 @@ IotMqttError_t IotMqtt_SerializeConnect( const IotMqttConnectInfo_t * pConnectIn
                        pBuffer,
                        bufferSize );
 
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/
@@ -2279,24 +2325,27 @@ IotMqttError_t IotMqtt_GetSubscriptionPacketSize( IotMqttOperationType_t type,
                                                   size_t * pRemainingLength,
                                                   size_t * pPacketSize )
 {
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
 
     if( ( pSubscriptionList == NULL ) || ( pRemainingLength == NULL ) || ( pPacketSize == NULL ) )
     {
         IotLogError( "IotMqtt_GetSubscriptionPacketSize() called with required parameter(s) set to NULL." );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     if( ( type != IOT_MQTT_SUBSCRIBE ) && ( type != IOT_MQTT_UNSUBSCRIBE ) )
     {
         IotLogError( "IotMqtt_GetSubscriptionPacketSize() called with unknown type." );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     if( subscriptionCount == 0 )
     {
         IotLogError( "IotMqtt_GetSubscriptionPacketSize() called with zero subscription count." );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     if( _subscriptionPacketSize( type,
@@ -2308,7 +2357,8 @@ IotMqttError_t IotMqtt_GetSubscriptionPacketSize( IotMqttOperationType_t type,
         IotLogError( "Unsubscribe packet remaining length exceeds %lu, which is the "
                      "maximum size allowed by MQTT 3.1.1.",
                      MQTT_MAX_REMAINING_LENGTH );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
     else
     {
@@ -2321,10 +2371,12 @@ IotMqttError_t IotMqtt_GetSubscriptionPacketSize( IotMqttOperationType_t type,
     {
         IotLogError( "Subscription packet remaining length (%lu) exceeds packet size (%lu)",
                      ( *pRemainingLength ), ( *pPacketSize ) );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/
@@ -2336,25 +2388,28 @@ IotMqttError_t IotMqtt_SerializeSubscribe( const IotMqttSubscription_t * pSubscr
                                            uint8_t * pBuffer,
                                            size_t bufferSize )
 {
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
 
     if( ( pBuffer == NULL ) || ( pSubscriptionList == NULL ) || ( pPacketIdentifier == NULL ) )
     {
         IotLogError( "IotMqtt_SerializeSubscribe() called with required parameter(s) set to NULL." );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     if( subscriptionCount == 0 )
     {
         IotLogError( "IotMqtt_SerializeSubscribe() called with zero subscription count." );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     if( remainingLength > bufferSize )
     {
         IotLogError( " Subscribe packet remaining length (%lu) exceeds buffer size (%lu).",
                      remainingLength, bufferSize );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     _serializeSubscribe( pSubscriptionList,
@@ -2364,7 +2419,8 @@ IotMqttError_t IotMqtt_SerializeSubscribe( const IotMqttSubscription_t * pSubscr
                          pBuffer,
                          bufferSize );
 
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/
@@ -2373,18 +2429,20 @@ IotMqttError_t IotMqtt_GetPublishPacketSize( IotMqttPublishInfo_t * pPublishInfo
                                              size_t * pRemainingLength,
                                              size_t * pPacketSize )
 {
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
 
     if( ( pPublishInfo == NULL ) || ( pRemainingLength == NULL ) || ( pPacketSize == NULL ) )
     {
         IotLogError( "IotMqtt_GetPublishPacketSize() called with required parameter(s) set to NULL." );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     if( ( pPublishInfo->pTopicName == NULL ) || ( pPublishInfo->topicNameLength == 0 ) )
     {
         IotLogError( "IotMqtt_GetPublishPacketSize() called with no topic." );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     /* Calculate the "Remaining length" field and total packet size. If it exceeds
@@ -2395,7 +2453,8 @@ IotMqttError_t IotMqtt_GetPublishPacketSize( IotMqttPublishInfo_t * pPublishInfo
                      "maximum size allowed by MQTT 3.1.1.",
                      MQTT_MAX_REMAINING_LENGTH );
 
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
     else
     {
@@ -2408,10 +2467,12 @@ IotMqttError_t IotMqtt_GetPublishPacketSize( IotMqttPublishInfo_t * pPublishInfo
     {
         IotLogError( "Publish packet remaining length (%lu) exceeds packet size (%lu).",
                      ( *pRemainingLength ), ( *pPacketSize ) );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/
@@ -2424,25 +2485,28 @@ IotMqttError_t IotMqtt_SerializePublish( IotMqttPublishInfo_t * pPublishInfo,
                                          size_t bufferSize )
 
 {
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
 
     if( ( pBuffer == NULL ) || ( pPublishInfo == NULL ) || ( pPacketIdentifier == NULL ) )
     {
         IotLogError( "IotMqtt_SerializePublish() called with required parameter(s) set to NULL." );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     if( ( pPublishInfo->pTopicName == NULL ) || ( pPublishInfo->topicNameLength == 0 ) )
     {
         IotLogError( "IotMqtt_SerializePublish() called with no topic." );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     if( remainingLength > bufferSize )
     {
         IotLogError( "Publish packet remaining length (%lu) exceeds buffer size (%lu).",
                      remainingLength, bufferSize );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     _serializePublish( pPublishInfo,
@@ -2451,7 +2515,8 @@ IotMqttError_t IotMqtt_SerializePublish( IotMqttPublishInfo_t * pPublishInfo,
                        pPacketIdentifierHigh,
                        pBuffer,
                        bufferSize );
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/
@@ -2463,25 +2528,28 @@ IotMqttError_t IotMqtt_SerializeUnsubscribe( const IotMqttSubscription_t * pSubs
                                              uint8_t * pBuffer,
                                              size_t bufferSize )
 {
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
 
     if( ( pBuffer == NULL ) || ( pPacketIdentifier == NULL ) || ( pSubscriptionList == NULL ) )
     {
         IotLogError( "IotMqtt_SerializeUnsubscribe() called with required parameter(s) set to NULL." );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     if( subscriptionCount == 0 )
     {
         IotLogError( "IotMqtt_SerializeUnsubscribe() called with zero subscription count." );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     if( remainingLength > bufferSize )
     {
         IotLogError( "Unsubscribe packet remaining length (%lu) exceeds buffer size (%lu).",
                      remainingLength, bufferSize );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     _serializeUnsubscribe( pSubscriptionList,
@@ -2490,7 +2558,8 @@ IotMqttError_t IotMqtt_SerializeUnsubscribe( const IotMqttSubscription_t * pSubs
                            pPacketIdentifier,
                            pBuffer,
                            bufferSize );
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/
@@ -2498,21 +2567,23 @@ IotMqttError_t IotMqtt_SerializeUnsubscribe( const IotMqttSubscription_t * pSubs
 IotMqttError_t IotMqtt_SerializeDisconnect( uint8_t * pBuffer,
                                             size_t bufferSize )
 {
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
     uint8_t * pDisconnectPacket = NULL;
     size_t remainingLength = 0;
 
     if( pBuffer == NULL )
     {
         IotLogError( "IotMqtt_SerializeDisconnect() called with NULL buffer pointer." );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     if( bufferSize < MQTT_PACKET_DISCONNECT_SIZE )
     {
         IotLogError( "Disconnect packet length (%lu) exceeds buffer size (%lu).",
                      MQTT_PACKET_DISCONNECT_SIZE, bufferSize );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     /* Call internal function with local variables, as disconnect  uses
@@ -2521,7 +2592,8 @@ IotMqttError_t IotMqtt_SerializeDisconnect( uint8_t * pBuffer,
     _IotMqtt_SerializeDisconnect( &pDisconnectPacket, &remainingLength );
 
     memcpy( pBuffer, pDisconnectPacket, MQTT_PACKET_DISCONNECT_SIZE );
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/
@@ -2529,21 +2601,23 @@ IotMqttError_t IotMqtt_SerializeDisconnect( uint8_t * pBuffer,
 IotMqttError_t IotMqtt_SerializePingreq( uint8_t * pBuffer,
                                          size_t bufferSize )
 {
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
     uint8_t * pPingreqPacket = NULL;
     size_t packetSize = 0;
 
     if( pBuffer == NULL )
     {
         IotLogError( "IotMqtt_SerializePingreq() called with NULL buffer pointer." );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     if( bufferSize < MQTT_PACKET_PINGREQ_SIZE )
     {
         IotLogError( "Pingreq length (%lu) exceeds buffer size (%lu).",
                      MQTT_PACKET_DISCONNECT_SIZE, bufferSize );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     /* Call internal function with local variables, as ping request uses
@@ -2551,14 +2625,15 @@ IotMqttError_t IotMqtt_SerializePingreq( uint8_t * pBuffer,
      * Note: _IotMqtt_SerializePingReq always succeeds */
     _IotMqtt_SerializePingreq( &pPingreqPacket, &packetSize );
     memcpy( pBuffer, pPingreqPacket, MQTT_PACKET_PINGREQ_SIZE );
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/
 
 IotMqttError_t IotMqtt_DeserializePublish( IotMqttPacketInfo_t * pMqttPacket )
 {
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
     /* Internal MQTT packet structure */
     _mqttPacket_t mqttPacket;
     /* Internal MQTT operation structure needed for deserializing publish */
@@ -2567,13 +2642,15 @@ IotMqttError_t IotMqtt_DeserializePublish( IotMqttPacketInfo_t * pMqttPacket )
     if( pMqttPacket == NULL )
     {
         IotLogError( "IotMqtt_DeserializePublish()called with NULL pMqttPacket pointer." );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     if( ( pMqttPacket->type & 0xf0 ) != MQTT_PACKET_TYPE_PUBLISH )
     {
         IotLogError( "IotMqtt_DeserializePublish() called with incorrect packet type:(%lu).", pMqttPacket->type );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     /* Set internal mqtt packet parameters. */
@@ -2594,21 +2671,23 @@ IotMqttError_t IotMqtt_DeserializePublish( IotMqttPacketInfo_t * pMqttPacket )
         pMqttPacket->packetIdentifier = mqttPacket.packetIdentifier;
     }
 
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/
 
 IotMqttError_t IotMqtt_DeserializeResponse( IotMqttPacketInfo_t * pMqttPacket )
 {
-    IOT_FUNCTION_ENTRY( IotMqttError_t, IOT_MQTT_SUCCESS );
+    IotMqttError_t status = IOT_MQTT_SUCCESS;
     /* Internal MQTT packet structure */
     _mqttPacket_t mqttPacket;
 
     if( ( pMqttPacket == NULL ) || ( pMqttPacket->pRemainingData == NULL ) )
     {
         IotLogError( "IotMqtt_DeserializeResponse() called with NULL pMqttPacket pointer or NULL pRemainingLength." );
-        IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+        status = IOT_MQTT_BAD_PARAMETER;
+        goto cleanup;
     }
 
     /* Set internal mqtt packet parameters. */
@@ -2644,12 +2723,13 @@ IotMqttError_t IotMqtt_DeserializeResponse( IotMqttPacketInfo_t * pMqttPacket )
         /* Any other packet type is invalid. */
         default:
             IotLogError( "IotMqtt_DeserializeResponse() called with unknown packet type:(%lu).", pMqttPacket->type );
-            IOT_SET_AND_GOTO_CLEANUP( IOT_MQTT_BAD_PARAMETER );
+            status = IOT_MQTT_BAD_PARAMETER;
+            goto cleanup;
     }
 
     if( status != IOT_MQTT_SUCCESS )
     {
-        IOT_SET_AND_GOTO_CLEANUP( status );
+        goto cleanup;
     }
     else
     {
@@ -2657,7 +2737,8 @@ IotMqttError_t IotMqtt_DeserializeResponse( IotMqttPacketInfo_t * pMqttPacket )
         pMqttPacket->packetIdentifier = mqttPacket.packetIdentifier;
     }
 
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/standard/mqtt/src/iot_mqtt_subscription.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_subscription.c
@@ -32,9 +32,6 @@
 #include <stdbool.h>
 #include <string.h>
 
-/* Error handling include. */
-#include "iot_error.h"
-
 /* MQTT internal include. */
 #include "private/iot_mqtt_internal.h"
 
@@ -94,7 +91,7 @@ static bool _packetMatch( const IotLink_t * pSubscriptionLink,
 static bool _topicMatch( const IotLink_t * pSubscriptionLink,
                          void * pMatch )
 {
-    IOT_FUNCTION_ENTRY( bool, false );
+    bool status = false;
     uint16_t nameIndex = 0, filterIndex = 0;
 
     /* Because this function is called from a container function, the given link
@@ -117,7 +114,7 @@ static bool _topicMatch( const IotLink_t * pSubscriptionLink,
     {
         status = ( strncmp( pTopicName, pTopicFilter, topicNameLength ) == 0 );
 
-        IOT_GOTO_CLEANUP();
+        goto cleanup;
     }
     else
     {
@@ -128,7 +125,8 @@ static bool _topicMatch( const IotLink_t * pSubscriptionLink,
      * false. */
     if( pParam->exactMatchOnly == true )
     {
-        IOT_SET_AND_GOTO_CLEANUP( false );
+        status = false;
+        goto cleanup;
     }
     else
     {
@@ -152,7 +150,8 @@ static bool _topicMatch( const IotLink_t * pSubscriptionLink,
                     {
                         if( pTopicFilter[ filterIndex + 2 ] == '#' )
                         {
-                            IOT_SET_AND_GOTO_CLEANUP( true );
+                            status = true;
+                            goto cleanup;
                         }
                         else
                         {
@@ -181,7 +180,8 @@ static bool _topicMatch( const IotLink_t * pSubscriptionLink,
                 {
                     if( pTopicFilter[ filterIndex + 1 ] == '+' )
                     {
-                        IOT_SET_AND_GOTO_CLEANUP( true );
+                        status = true;
+                        goto cleanup;
                     }
                     else
                     {
@@ -218,13 +218,15 @@ static bool _topicMatch( const IotLink_t * pSubscriptionLink,
             {
                 /* Subsequent characters don't need to be checked if the for the
                  * multi-level wildcard. */
-                IOT_SET_AND_GOTO_CLEANUP( true );
+                status = true;
+                goto cleanup;
             }
             else
             {
                 /* Any character mismatch other than '+' or '#' means the topic
                  * name does not match the topic filter. */
-                IOT_SET_AND_GOTO_CLEANUP( false );
+                status = false;
+                goto cleanup;
             }
         }
 
@@ -236,14 +238,16 @@ static bool _topicMatch( const IotLink_t * pSubscriptionLink,
     /* If the end of both strings has been reached, they match. */
     if( ( nameIndex == topicNameLength ) && ( filterIndex == topicFilterLength ) )
     {
-        IOT_SET_AND_GOTO_CLEANUP( true );
+        status = true;
+        goto cleanup;
     }
     else
     {
         EMPTY_ELSE_MARKER;
     }
 
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/standard/mqtt/src/iot_mqtt_validate.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_validate.c
@@ -28,9 +28,6 @@
 /* The config header is always included first. */
 #include "iot_config.h"
 
-/* Error handling include. */
-#include "iot_error.h"
-
 /* MQTT internal include. */
 #include "private/iot_mqtt_internal.h"
 
@@ -54,7 +51,7 @@ static bool _validatePublish( bool awsIotMqttMode,
 
 bool _IotMqtt_ValidateConnect( const IotMqttConnectInfo_t * pConnectInfo )
 {
-    IOT_FUNCTION_ENTRY( bool, true );
+    bool status = true;
     uint16_t maxClientIdLength = MQTT_SERVER_MAX_CLIENTID_LENGTH;
     bool enforceMaxClientIdLength = false;
 
@@ -63,7 +60,8 @@ bool _IotMqtt_ValidateConnect( const IotMqttConnectInfo_t * pConnectInfo )
     {
         IotLogError( "MQTT connection information cannot be NULL." );
 
-        IOT_SET_AND_GOTO_CLEANUP( false );
+        status = false;
+        goto cleanup;
     }
     else
     {
@@ -75,7 +73,8 @@ bool _IotMqtt_ValidateConnect( const IotMqttConnectInfo_t * pConnectInfo )
     {
         IotLogError( "Client identifier must be set." );
 
-        IOT_SET_AND_GOTO_CLEANUP( false );
+        status = false;
+        goto cleanup;
     }
     else
     {
@@ -92,7 +91,8 @@ bool _IotMqtt_ValidateConnect( const IotMqttConnectInfo_t * pConnectInfo )
         {
             IotLogError( "A zero-length client identifier cannot be used with a clean session." );
 
-            IOT_SET_AND_GOTO_CLEANUP( false );
+            status = false;
+            goto cleanup;
         }
         else
         {
@@ -108,11 +108,12 @@ bool _IotMqtt_ValidateConnect( const IotMqttConnectInfo_t * pConnectInfo )
     if( pConnectInfo->pPreviousSubscriptions != NULL )
     {
         if( _IotMqtt_ValidateSubscriptionList( IOT_MQTT_SUBSCRIBE,
-                                                pConnectInfo->awsIotMqttMode,
-                                                pConnectInfo->pPreviousSubscriptions,
-                                                pConnectInfo->previousSubscriptionCount ) == false )
+                                               pConnectInfo->awsIotMqttMode,
+                                               pConnectInfo->pPreviousSubscriptions,
+                                               pConnectInfo->previousSubscriptionCount ) == false )
         {
-            IOT_SET_AND_GOTO_CLEANUP( false );
+            status = false;
+            goto cleanup;
         }
         else
         {
@@ -130,7 +131,8 @@ bool _IotMqtt_ValidateConnect( const IotMqttConnectInfo_t * pConnectInfo )
         if( _IotMqtt_ValidateLwtPublish( pConnectInfo->awsIotMqttMode,
                                          pConnectInfo->pWillInfo ) == false )
         {
-            IOT_SET_AND_GOTO_CLEANUP( false );
+            status = false;
+            goto cleanup;
         }
         else
         {
@@ -166,7 +168,8 @@ bool _IotMqtt_ValidateConnect( const IotMqttConnectInfo_t * pConnectInfo )
                          pConnectInfo->clientIdentifierLength,
                          maxClientIdLength );
 
-            IOT_SET_AND_GOTO_CLEANUP( false );
+            status = false;
+            goto cleanup;
         }
     }
     else
@@ -174,7 +177,8 @@ bool _IotMqtt_ValidateConnect( const IotMqttConnectInfo_t * pConnectInfo )
         EMPTY_ELSE_MARKER;
     }
 
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/
@@ -184,7 +188,7 @@ static bool _validatePublish( bool awsIotMqttMode,
                               const char * pPublishTypeDescription,
                               const IotMqttPublishInfo_t * pPublishInfo )
 {
-    IOT_FUNCTION_ENTRY( bool, true );
+    bool status = true;
 
     /* This parameter is not used when logging is disabled. */
     ( void ) pPublishTypeDescription;
@@ -194,7 +198,8 @@ static bool _validatePublish( bool awsIotMqttMode,
     {
         IotLogError( "Publish information cannot be NULL." );
 
-        IOT_SET_AND_GOTO_CLEANUP( false );
+        status = false;
+        goto cleanup;
     }
     else
     {
@@ -215,7 +220,8 @@ static bool _validatePublish( bool awsIotMqttMode,
     {
         IotLogError( "Publish topic name length cannot be 0." );
 
-        IOT_SET_AND_GOTO_CLEANUP( false );
+        status = false;
+        goto cleanup;
     }
     else
     {
@@ -231,7 +237,8 @@ static bool _validatePublish( bool awsIotMqttMode,
                          pPublishInfo->payloadLength,
                          maximumPayloadLength );
 
-            IOT_SET_AND_GOTO_CLEANUP( false );
+            status = false;
+            goto cleanup;
         }
         else
         {
@@ -239,7 +246,8 @@ static bool _validatePublish( bool awsIotMqttMode,
             {
                 IotLogError( "Nonzero payload length cannot have a NULL payload." );
 
-                IOT_SET_AND_GOTO_CLEANUP( false );
+                status = false;
+                goto cleanup;
             }
             else
             {
@@ -259,7 +267,8 @@ static bool _validatePublish( bool awsIotMqttMode,
         {
             IotLogError( "Publish QoS must be either 0 or 1." );
 
-            IOT_SET_AND_GOTO_CLEANUP( false );
+            status = false;
+            goto cleanup;
         }
         else
         {
@@ -278,7 +287,8 @@ static bool _validatePublish( bool awsIotMqttMode,
         {
             IotLogError( "Publish retry time must be positive." );
 
-            IOT_SET_AND_GOTO_CLEANUP( false );
+            status = false;
+            goto cleanup;
         }
         else
         {
@@ -298,7 +308,8 @@ static bool _validatePublish( bool awsIotMqttMode,
         {
             IotLogError( "AWS IoT does not support retained publish messages." );
 
-            IOT_SET_AND_GOTO_CLEANUP( false );
+            status = false;
+            goto cleanup;
         }
         else
         {
@@ -311,7 +322,8 @@ static bool _validatePublish( bool awsIotMqttMode,
             IotLogError( "AWS IoT does not support topic names longer than %d bytes.",
                          AWS_IOT_MQTT_SERVER_MAX_TOPIC_LENGTH );
 
-            IOT_SET_AND_GOTO_CLEANUP( false );
+            status = false;
+            goto cleanup;
         }
         else
         {
@@ -323,7 +335,8 @@ static bool _validatePublish( bool awsIotMqttMode,
         EMPTY_ELSE_MARKER;
     }
 
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/
@@ -363,14 +376,15 @@ bool _IotMqtt_ValidateLwtPublish( bool awsIotMqttMode,
 
 bool _IotMqtt_ValidateOperation( IotMqttOperation_t operation )
 {
-    IOT_FUNCTION_ENTRY( bool, true );
+    bool status = true;
 
     /* Check for NULL. */
     if( operation == NULL )
     {
         IotLogError( "Operation reference cannot be NULL." );
 
-        IOT_SET_AND_GOTO_CLEANUP( false );
+        status = false;
+        goto cleanup;
     }
     else
     {
@@ -382,14 +396,16 @@ bool _IotMqtt_ValidateOperation( IotMqttOperation_t operation )
     {
         IotLogError( "Operation is not waitable." );
 
-        IOT_SET_AND_GOTO_CLEANUP( false );
+        status = false;
+        goto cleanup;
     }
     else
     {
         EMPTY_ELSE_MARKER;
     }
 
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/
@@ -399,7 +415,7 @@ bool _IotMqtt_ValidateSubscriptionList( IotMqttOperationType_t operation,
                                         const IotMqttSubscription_t * pListStart,
                                         size_t listSize )
 {
-    IOT_FUNCTION_ENTRY( bool, true );
+    bool status = true;
     size_t i = 0;
     uint16_t j = 0;
     const IotMqttSubscription_t * pListElement = NULL;
@@ -413,7 +429,8 @@ bool _IotMqtt_ValidateSubscriptionList( IotMqttOperationType_t operation,
     {
         IotLogError( "Subscription list pointer cannot be NULL." );
 
-        IOT_SET_AND_GOTO_CLEANUP( false );
+        status = false;
+        goto cleanup;
     }
     else
     {
@@ -424,7 +441,8 @@ bool _IotMqtt_ValidateSubscriptionList( IotMqttOperationType_t operation,
     {
         IotLogError( "Empty subscription list." );
 
-        IOT_SET_AND_GOTO_CLEANUP( false );
+        status = false;
+        goto cleanup;
     }
     else
     {
@@ -440,7 +458,8 @@ bool _IotMqtt_ValidateSubscriptionList( IotMqttOperationType_t operation,
                          "subscription request.",
                          AWS_IOT_MQTT_SERVER_MAX_TOPIC_FILTERS_PER_SUBSCRIBE );
 
-            IOT_SET_AND_GOTO_CLEANUP( false );
+            status = false;
+            goto cleanup;
         }
         else
         {
@@ -465,7 +484,8 @@ bool _IotMqtt_ValidateSubscriptionList( IotMqttOperationType_t operation,
                 {
                     IotLogError( "Subscription QoS must be either 0 or 1." );
 
-                    IOT_SET_AND_GOTO_CLEANUP( false );
+                    status = false;
+                    goto cleanup;
                 }
                 else
                 {
@@ -481,7 +501,8 @@ bool _IotMqtt_ValidateSubscriptionList( IotMqttOperationType_t operation,
             {
                 IotLogError( "Callback function must be set." );
 
-                IOT_SET_AND_GOTO_CLEANUP( false );
+                status = false;
+                goto cleanup;
             }
             else
             {
@@ -498,7 +519,8 @@ bool _IotMqtt_ValidateSubscriptionList( IotMqttOperationType_t operation,
         {
             IotLogError( "Subscription topic filter cannot be NULL." );
 
-            IOT_SET_AND_GOTO_CLEANUP( false );
+            status = false;
+            goto cleanup;
         }
         else
         {
@@ -509,7 +531,8 @@ bool _IotMqtt_ValidateSubscriptionList( IotMqttOperationType_t operation,
         {
             IotLogError( "Subscription topic filter length cannot be 0." );
 
-            IOT_SET_AND_GOTO_CLEANUP( false );
+            status = false;
+            goto cleanup;
         }
         else
         {
@@ -525,7 +548,8 @@ bool _IotMqtt_ValidateSubscriptionList( IotMqttOperationType_t operation,
                 IotLogError( "AWS IoT does not support topic filters longer than %d bytes.",
                              AWS_IOT_MQTT_SERVER_MAX_TOPIC_LENGTH );
 
-                IOT_SET_AND_GOTO_CLEANUP( false );
+                status = false;
+                goto cleanup;
             }
             else
             {
@@ -554,7 +578,8 @@ bool _IotMqtt_ValidateSubscriptionList( IotMqttOperationType_t operation,
                                          pListElement->topicFilterLength,
                                          pListElement->pTopicFilter );
 
-                            IOT_SET_AND_GOTO_CLEANUP( false );
+                            status = false;
+                            goto cleanup;
                         }
                         else
                         {
@@ -575,7 +600,8 @@ bool _IotMqtt_ValidateSubscriptionList( IotMqttOperationType_t operation,
                                          pListElement->topicFilterLength,
                                          pListElement->pTopicFilter );
 
-                            IOT_SET_AND_GOTO_CLEANUP( false );
+                            status = false;
+                            goto cleanup;
                         }
                         else
                         {
@@ -599,7 +625,8 @@ bool _IotMqtt_ValidateSubscriptionList( IotMqttOperationType_t operation,
                                      pListElement->topicFilterLength,
                                      pListElement->pTopicFilter );
 
-                        IOT_SET_AND_GOTO_CLEANUP( false );
+                        status = false;
+                        goto cleanup;
                     }
                     else
                     {
@@ -615,7 +642,8 @@ bool _IotMqtt_ValidateSubscriptionList( IotMqttOperationType_t operation,
                                          pListElement->topicFilterLength,
                                          pListElement->pTopicFilter );
 
-                            IOT_SET_AND_GOTO_CLEANUP( false );
+                            status = false;
+                            goto cleanup;
                         }
                         else
                         {
@@ -635,7 +663,8 @@ bool _IotMqtt_ValidateSubscriptionList( IotMqttOperationType_t operation,
         }
     }
 
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+cleanup:
+    return status;
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/standard/mqtt/test/mock/iot_tests_mqtt_mock.c
+++ b/libraries/standard/mqtt/test/mock/iot_tests_mqtt_mock.c
@@ -44,9 +44,6 @@
 #include "platform/iot_clock.h"
 #include "platform/iot_threads.h"
 
-/* Error handling include. */
-#include "iot_error.h"
-
 /*-----------------------------------------------------------*/
 
 /**
@@ -317,7 +314,7 @@ static size_t _receive( IotNetworkConnection_t pNetworkConnection,
 
 bool IotTest_MqttMockInit( IotMqttConnection_t * pMqttConnection )
 {
-    IOT_FUNCTION_ENTRY( bool, true );
+    bool status = true;
     IotMqttNetworkInfo_t networkInfo = IOT_MQTT_NETWORK_INFO_INITIALIZER;
 
     /* Flags to track clean up */
@@ -334,7 +331,8 @@ bool IotTest_MqttMockInit( IotMqttConnection_t * pMqttConnection )
 
     if( packetMutexCreated == false )
     {
-        IOT_SET_AND_GOTO_CLEANUP( false );
+        status = false;
+        goto cleanup;
     }
 
     /* Create the receive thread timer. */
@@ -344,7 +342,8 @@ bool IotTest_MqttMockInit( IotMqttConnection_t * pMqttConnection )
 
     if( timerCreated == false )
     {
-        IOT_SET_AND_GOTO_CLEANUP( false );
+        status = false;
+        goto cleanup;
     }
 
     /* Initialize the MQTT connection object. */
@@ -354,10 +353,11 @@ bool IotTest_MqttMockInit( IotMqttConnection_t * pMqttConnection )
 
     if( _pMqttConnection == NULL )
     {
-        IOT_SET_AND_GOTO_CLEANUP( false );
+        status = false;
+        goto cleanup;
     }
 
-    IOT_FUNCTION_CLEANUP_BEGIN();
+cleanup:
 
     /* Clean up on error. */
     if( status == false )
@@ -378,7 +378,7 @@ bool IotTest_MqttMockInit( IotMqttConnection_t * pMqttConnection )
         *pMqttConnection = _pMqttConnection;
     }
 
-    IOT_FUNCTION_CLEANUP_END();
+    return status;
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Remove macros hiding the control flow in MQTT

Macros that hide control flow by defining variables, labels, or by hiding goto statements shall be removed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
