### PR TITLE
Automate generation of cbmc-batch.yaml during continuous integration.

### DIFF
--- a/cbmc/proofs/DeserializeSuback/cbmc-batch.yaml
+++ b/cbmc/proofs/DeserializeSuback/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags:        '=--unwindset;_IotMqtt_DeserializeSuback.0:100;--bounds-check;--pointer-check;--unwinding-assertions='
+cbmcflags:        '=--unwindset;_decodeSubackStatus.0:100;--bounds-check;--pointer-check;--unwinding-assertions='
 goto: DeserializeSuback.goto
 expected: SUCCESSFUL

--- a/cbmc/proofs/make_cbmc_batch_files.py
+++ b/cbmc/proofs/make_cbmc_batch_files.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+#
+# Generation of the cbmc-batch.yaml files for the CBMC proofs.
+#
+# Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import platform
+import subprocess
+
+
+def remove_cbmc_yaml_files():
+    for dyr, _, files in os.walk("."):
+        cbmc_batch_files = [os.path.join(os.path.abspath(dyr), file)
+                            for file in files if file == "cbmc-batch.yaml"]
+        for file in cbmc_batch_files:
+            os.remove(file)
+
+
+def create_cbmc_yaml_files():
+    # The YAML files are only used by CI and are not needed on Windows.
+    if platform.system() == "Windows":
+        return
+    for dyr, _, files in os.walk("."):
+        harness = [file for file in files if file.endswith("_harness.c")]
+        if harness and "Makefile" in files:
+            subprocess.run(["make", "cbmc-batch.yaml"],
+                           stdout=subprocess.PIPE,
+                           stderr=subprocess.PIPE,
+                           cwd=os.path.abspath(dyr),
+                           check=True)
+
+if __name__ == '__main__':
+    remove_cbmc_yaml_files()
+    create_cbmc_yaml_files()

--- a/cbmc/proofs/prepare.py
+++ b/cbmc/proofs/prepare.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+#
+# Python script for preparing the code base for the CBMC proofs.
+#
+# Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import logging
+import os
+import sys
+import textwrap
+from subprocess import CalledProcessError
+
+from make_cbmc_batch_files import create_cbmc_yaml_files
+
+def build():
+    try:
+        create_cbmc_yaml_files()
+    except CalledProcessError as e:
+        logging.error(textwrap.dedent("""\
+            An error occured during cbmc-batch generation.
+            The error message is: {}
+            """.format(str(e))))
+        exit(1)
+
+################################################################
+
+if __name__ == '__main__':
+    logging.basicConfig(format="{script}: %(levelname)s %(message)s".format(
+        script=os.path.basename(__file__)))
+    build()


### PR DESCRIPTION
This patch resolves an issue where the DeserializeSuback proof for MQTT  was failing to terminate during continuous integration.  The proof was succeeding on the developer's local machine and failing in continuous integration.

Proofs are developed locally using a Makefile, but checking the proofs in CI is driven by a file cbmc-batch.yaml sitting next to the Makefile in the proof directory.  When the Makefile is changed, the yaml file needs to be updated.  The Makefile has a target to regenerate the yaml file.

This patch automates the regeneration of the yaml files during CI before launching the proof checking.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
