### PR TITLE
Refactor MQTT operations for complexity

### DIFF
--- a/libraries/standard/mqtt/src/iot_mqtt_operation.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_operation.c
@@ -116,7 +116,7 @@ static bool _scheduleNextRetry( _mqttOperation_t * pOperation );
  *
  * @return `true` if the operation was successful; `false` otherwise.
  */
-static bool _sendKeepAlivePingReq( _mqttConnection_t * pMqttConnection );
+static bool _sendPingReq( _mqttConnection_t * pMqttConnection );
 
 /**
  * @brief Schedule a callback for a completed MQTT operation.
@@ -332,7 +332,7 @@ static bool _scheduleNextRetry( _mqttOperation_t * pOperation )
 
 /*-----------------------------------------------------------*/
 
-static bool _sendKeepAlivePingReq( _mqttConnection_t * pMqttConnection )
+static bool _sendPingReq( _mqttConnection_t * pMqttConnection )
 {
     bool status = true;
     uint32_t swapStatus = 0;
@@ -363,12 +363,10 @@ static bool _sendKeepAlivePingReq( _mqttConnection_t * pMqttConnection )
                                                 0 );
         IotMqtt_Assert( swapStatus == 1 );
 
-        /* Schedule a check for PINGRESP. */
+        /* Set the period for scheduling a PINGRESP check. */
         pPingreqOperation->u.operation.periodic.ping.nextPeriodMs = IOT_MQTT_RESPONSE_WAIT_MS;
 
-        IotLogDebug( "(MQTT connection %p) PINGREQ sent. Scheduling check for PINGRESP in %d ms.",
-                     pMqttConnection,
-                     IOT_MQTT_RESPONSE_WAIT_MS );
+        IotLogDebug( "(MQTT connection %p) PINGREQ sent.", pMqttConnection );
     }
 
     return status;
@@ -779,7 +777,7 @@ void _IotMqtt_ProcessKeepAlive( IotTaskPool_t pTaskPool,
     {
         IotLogDebug( "(MQTT connection %p) Sending PINGREQ.", pMqttConnection );
 
-        status = _sendKeepAlivePingReq( pMqttConnection );
+        status = _sendPingReq( pMqttConnection );
     }
     else
     {

--- a/libraries/standard/mqtt/src/iot_mqtt_operation.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_operation.c
@@ -134,7 +134,7 @@ static IotMqttError_t _scheduleCallback( _mqttOperation_t * pOperation );
  * @param[in] pOperation The pending MQTT send operation.
  * @param[out] pDestroyOperation Whether the operation should be destroyed afterwards.
  *
- * @return `true if the operation is awaiting a response from the network;
+ * @return `true` if the operation is awaiting a response from the network;
  * `false` if not.
  */
 static bool _completePendingSend( _mqttOperation_t * pOperation,

--- a/libraries/standard/mqtt/src/iot_mqtt_subscription.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_subscription.c
@@ -421,25 +421,23 @@ IotMqttError_t _IotMqtt_AddSubscriptions( _mqttConnection_t * pMqttConnection,
                 status = IOT_MQTT_NO_MEMORY;
                 break;
             }
-            else
-            {
-                /* Clear the new subscription. */
-                ( void ) memset( pNewSubscription,
-                                 0x00,
-                                 sizeof( _mqttSubscription_t ) + pSubscriptionList[ i ].topicFilterLength );
 
-                /* Set the members of the new subscription and add it to the list. */
-                pNewSubscription->packetInfo.identifier = subscribePacketIdentifier;
-                pNewSubscription->packetInfo.order = i;
-                pNewSubscription->callback = pSubscriptionList[ i ].callback;
-                pNewSubscription->topicFilterLength = pSubscriptionList[ i ].topicFilterLength;
-                ( void ) memcpy( pNewSubscription->pTopicFilter,
-                                 pSubscriptionList[ i ].pTopicFilter,
-                                 ( size_t ) ( pSubscriptionList[ i ].topicFilterLength ) );
+            /* Clear the new subscription. */
+            ( void ) memset( pNewSubscription,
+                             0x00,
+                             sizeof( _mqttSubscription_t ) + pSubscriptionList[ i ].topicFilterLength );
 
-                IotListDouble_InsertHead( &( pMqttConnection->subscriptionList ),
-                                          &( pNewSubscription->link ) );
-            }
+            /* Set the members of the new subscription and add it to the list. */
+            pNewSubscription->packetInfo.identifier = subscribePacketIdentifier;
+            pNewSubscription->packetInfo.order = i;
+            pNewSubscription->callback = pSubscriptionList[ i ].callback;
+            pNewSubscription->topicFilterLength = pSubscriptionList[ i ].topicFilterLength;
+            ( void ) memcpy( pNewSubscription->pTopicFilter,
+                             pSubscriptionList[ i ].pTopicFilter,
+                             ( size_t ) ( pSubscriptionList[ i ].topicFilterLength ) );
+
+            IotListDouble_InsertHead( &( pMqttConnection->subscriptionList ),
+                                      &( pNewSubscription->link ) );
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Refactors _IotMqtt_ProcessSend, _IotMqtt_Notify, and _IotMqtt_AddSubscriptions to reduce GNU complexity below 8.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
