### PR TITLE
Reduce complexity in MQTT serialize and API

### DIFF
--- a/libraries/standard/mqtt/src/iot_mqtt_api.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_api.c
@@ -222,7 +222,7 @@ static IotMqttError_t _checkPublishSetup( IotMqttConnection_t mqttConnection,
                                           const IotMqttPublishInfo_t * pPublishInfo,
                                           uint32_t flags,
                                           const IotMqttCallbackInfo_t * pCallbackInfo,
-                                          IotMqttOperation_t * const pPublishOperation);
+                                          IotMqttOperation_t * const pPublishOperation );
 
 /**
  * @brief Utility function used by @ref mqtt_function_wait.
@@ -855,7 +855,7 @@ cleanup:
 static void _setOperationIfNotNull( IotMqttOperation_t * const pOperationReference,
                                     _mqttOperation_t * pNewOperation )
 {
-    if( pOperationReference != NULL)
+    if( pOperationReference != NULL )
     {
         *pOperationReference = pNewOperation;
     }
@@ -867,7 +867,7 @@ static IotMqttError_t _checkPublishSetup( IotMqttConnection_t mqttConnection,
                                           const IotMqttPublishInfo_t * pPublishInfo,
                                           uint32_t flags,
                                           const IotMqttCallbackInfo_t * pCallbackInfo,
-                                          IotMqttOperation_t * const pPublishOperation)
+                                          IotMqttOperation_t * const pPublishOperation )
 {
     IotMqttError_t status = IOT_MQTT_SUCCESS;
 
@@ -1678,7 +1678,7 @@ IotMqttError_t IotMqtt_PublishAsync( IotMqttConnection_t mqttConnection,
                          mqttConnection );
 
             /* Clear the previously set (and now invalid) reference. */
-            if( pPublishInfo-> qos != IOT_MQTT_QOS_0 )
+            if( pPublishInfo->qos != IOT_MQTT_QOS_0 )
             {
                 _setOperationIfNotNull( pPublishOperation, IOT_MQTT_OPERATION_INITIALIZER );
             }

--- a/libraries/standard/mqtt/src/iot_mqtt_serialize.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_serialize.c
@@ -106,9 +106,10 @@
  */
 #define MQTT_MAX_REMAINING_LENGTH                   ( 268435455UL )
 
-/*
- * The minimum remaining length for a QoS PUBLISH, including two bytes for
- * topic name length and one byte for topic name.
+/**
+ * @brief The minimum remaining length for a QoS PUBLISH.
+ *
+ * Includes two bytes for topic name length and one byte for topic name.
  */
 #define MQTT_MIN_PUBLISH_REMAINING_LENGTH_QOS0      ( 3 )
 

--- a/libraries/standard/mqtt/src/private/iot_mqtt_internal.h
+++ b/libraries/standard/mqtt/src/private/iot_mqtt_internal.h
@@ -464,16 +464,22 @@ typedef struct _mqttPacket
 bool _IotMqtt_ValidateConnect( const IotMqttConnectInfo_t * pConnectInfo );
 
 /**
- * @brief Check that an #IotMqttPublishInfo_t is valid.
+ * @brief Check that parameters for an MQTT PUBLISH are valid.
  *
  * @param[in] awsIotMqttMode Specifies if this PUBLISH packet is being sent to
  * an AWS IoT MQTT server.
  * @param[in] pPublishInfo The #IotMqttPublishInfo_t to validate.
+ * @param[in] flags Behavior modification flags to validate. See @ref mqtt_constants_flags.
+ * @param[in] pCallbackInfo #IotMqttCallbackInfo_t to validate.
+ * @param[in] pPublishOperation Handle to a PUBLISH operation.
  *
- * @return `true` if `pPublishInfo` is valid; `false` otherwise.
+ * @return `true` if all parameters are valid; `false` otherwise.
  */
 bool _IotMqtt_ValidatePublish( bool awsIotMqttMode,
-                               const IotMqttPublishInfo_t * pPublishInfo );
+                               const IotMqttPublishInfo_t * pPublishInfo,
+                               uint32_t flags,
+                               const IotMqttCallbackInfo_t * pCallbackInfo,
+                               IotMqttOperation_t * const pPublishOperation );
 
 /**
  * @brief Check that an #IotMqttPublishInfo_t is valid for an LWT publish

--- a/libraries/standard/mqtt/test/unit/iot_tests_mqtt_receive.c
+++ b/libraries/standard/mqtt/test/unit/iot_tests_mqtt_receive.c
@@ -418,7 +418,10 @@ static void _publishCallback( void * pCallbackContext,
 
     /* Check that the parameters to this function are valid. */
     if( ( _IotMqtt_ValidatePublish( AWS_IOT_MQTT_SERVER,
-                                    &( pPublish->u.message.info ) ) == true ) &&
+                                    &( pPublish->u.message.info ),
+                                    0,
+                                    NULL,
+                                    NULL ) == true ) &&
         ( pPublish->u.message.info.topicNameLength == TEST_TOPIC_LENGTH ) &&
         ( strncmp( TEST_TOPIC_NAME, pPublish->u.message.info.pTopicName, TEST_TOPIC_LENGTH ) == 0 ) )
     {

--- a/libraries/standard/mqtt/test/unit/iot_tests_mqtt_subscription.c
+++ b/libraries/standard/mqtt/test/unit/iot_tests_mqtt_subscription.c
@@ -236,7 +236,10 @@ static void _publishCallback( void * pArgument,
     /* Ensure that publish info is valid. */
     TEST_ASSERT_EQUAL_INT( true,
                            _IotMqtt_ValidatePublish( AWS_IOT_MQTT_SERVER,
-                                                     &( pPublish->u.message.info ) ) );
+                                                     &( pPublish->u.message.info ),
+                                                     0,
+                                                     NULL,
+                                                     NULL ) );
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Refactors `_IotMqtt_DeserializePublish`, `IotMqtt_PublishAsync`, and `IotMqtt_Wait` to reduce GNU complexity below 8.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
