### PR TITLE
Update/reduce complexity of provisioning api functions

### DIFF
--- a/libraries/aws/provisioning/src/aws_iot_provisioning_api.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_api.c
@@ -148,7 +148,7 @@ static AwsIotProvisioningError_t _timedWaitForServerResponse( uint32_t timeoutMs
 /**
  * @brief Checks whether the data that is provided to send along with the provisioning device request is valid.
  * @param pRequestData The data for the RegisterThing service API request whose validity will be checked.
- * @return Returns #true if data is valid; #false otherwise.
+ * @return Returns `true` if data is valid; `false` otherwise.
  */
 static bool _isDataForRegisterThingRequestValid( const AwsIotProvisioningRegisterThingRequestInfo_t * pRequestData );
 

--- a/libraries/aws/provisioning/src/aws_iot_provisioning_api.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_api.c
@@ -403,7 +403,7 @@ AwsIotProvisioningError_t AwsIotProvisioning_Init( uint32_t mqttTimeoutMs )
 
 AwsIotProvisioningError_t _timedWaitForServerResponse( uint32_t timeoutMs )
 {
-    IOT_FUNCTION_ENTRY( AwsIotProvisioningError_t, AWS_IOT_PROVISIONING_SUCCESS );
+    AwsIotProvisioningError_t status = AWS_IOT_PROVISIONING_SUCCESS;
 
     /* Wait for response from the server. */
     if( IotSemaphore_TimedWait( &_activeOperation.responseReceivedSem,
@@ -427,7 +427,7 @@ AwsIotProvisioningError_t _timedWaitForServerResponse( uint32_t timeoutMs )
 
     IotMutex_Unlock( &_activeOperation.lock );
 
-    IOT_FUNCTION_EXIT_NO_CLEANUP();
+    return status;
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/aws/provisioning/src/aws_iot_provisioning_serializer.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_serializer.c
@@ -67,22 +67,46 @@ static bool _checkSuccess( IotSerializerError_t error );
  */
 static bool _checkSuccessOrBufferToSmall( IotSerializerError_t error );
 
+/**
+ * @brief Performs serialization operations on the passed buffer for creating the MQTT request payload for the CreateKeysAndCertification operation.
+ * @param[in] pOutermostEncoder The outermost encoder object to use for serialization.
+ * @param[out] pSerializationBuffer The buffer to store the serialized payload data.
+ * @param[in] bufferSize The size of the serialization buffer.
+ * @return Returns #AWS_IOT_PROVISIONING_SUCCESS if payload serialization is successful; otherwise #AWS_IOT_PROVISIONING_INTERNAL_FAILURE.
+ */
+static AwsIotProvisioningError_t _serializeCreateKeysAndCertificateRequestPayload( IotSerializerEncoderObject_t * pOutermostEncoder,
+                                                                                   uint8_t * pSerializationBuffer,
+                                                                                   size_t bufferSize );
+
+/**
+ * @brief Performs serializes operations on the passed buffer for creating the MQTT request payload for the RegisterThing operation.
+ * @param[in] pOutermostEncoder The outermost encoder object to use for serialization.
+ * @param[out] pSerializationBuffer The buffer to store the serialized payload data.
+ * @param[in] bufferSize The size of the serialization buffer.
+ * @return Returns #AWS_IOT_PROVISIONING_SUCCESS if payload serialization is successful; otherwise #AWS_IOT_PROVISIONING_INTERNAL_FAILURE.
+ */
+static AwsIotProvisioningError_t _serializeRegisterThingRequestPayload( const AwsIotProvisioningRegisterThingRequestInfo_t * pRequestData,
+                                                                        IotSerializerEncoderObject_t * pOutermostEncoder,
+                                                                        uint8_t * pSerializationBuffer,
+                                                                        size_t bufferSize );
+
 static bool _checkSuccess( IotSerializerError_t error )
 {
     return( error == IOT_SERIALIZER_SUCCESS );
 }
 
+/*------------------------------------------------------------------*/
+
 static bool _checkSuccessOrBufferToSmall( IotSerializerError_t error )
 {
-    return( error == IOT_SERIALIZER_SUCCESS || error ==
-            IOT_SERIALIZER_BUFFER_TOO_SMALL );
+    return( error == IOT_SERIALIZER_SUCCESS || error == IOT_SERIALIZER_BUFFER_TOO_SMALL );
 }
 
 /*------------------------------------------------------------------*/
 
-AwsIotProvisioningError_t _AwsIotProvisioning_SerializeCreateKeysAndCertificateRequestPayload( IotSerializerEncoderObject_t * pOutermostEncoder,
-                                                                                               uint8_t * pSerializationBuffer,
-                                                                                               size_t bufferSize )
+static AwsIotProvisioningError_t _serializeCreateKeysAndCertificateRequestPayload( IotSerializerEncoderObject_t * pOutermostEncoder,
+                                                                                   uint8_t * pSerializationBuffer,
+                                                                                   size_t bufferSize )
 {
     AwsIotProvisioning_Assert( pOutermostEncoder != NULL );
     IotSerializerEncoderObject_t emptyPayloadEncoder = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_MAP;
@@ -129,13 +153,12 @@ AwsIotProvisioningError_t _AwsIotProvisioning_SerializeCreateKeysAndCertificateR
     IOT_FUNCTION_EXIT_NO_CLEANUP();
 }
 
-
 /*------------------------------------------------------------------*/
 
-AwsIotProvisioningError_t _serializeRegisterThingRequestPayload( const AwsIotProvisioningRegisterThingRequestInfo_t * pRequestData,
-                                                                 IotSerializerEncoderObject_t * pOutermostEncoder,
-                                                                 uint8_t * pSerializationBuffer,
-                                                                 size_t bufferSize )
+static AwsIotProvisioningError_t _serializeRegisterThingRequestPayload( const AwsIotProvisioningRegisterThingRequestInfo_t * pRequestData,
+                                                                        IotSerializerEncoderObject_t * pOutermostEncoder,
+                                                                        uint8_t * pSerializationBuffer,
+                                                                        size_t bufferSize )
 {
     AwsIotProvisioning_Assert( ( pRequestData->pDeviceCertificateId != NULL ) && ( pRequestData->deviceCertificateIdLength > 0 ) );
     AwsIotProvisioning_Assert( ( pRequestData->pCertificateOwnershipToken != NULL ) && ( pRequestData->ownershipTokenLength > 0 ) );
@@ -294,15 +317,14 @@ AwsIotProvisioningError_t _serializeRegisterThingRequestPayload( const AwsIotPro
 
 /*------------------------------------------------------------------*/
 
-AwsIotProvisioningError_t _AwsIotProvisioning_SerializeRegisterThingRequestPayload( const AwsIotProvisioningRegisterThingRequestInfo_t * pRequestData,
-                                                                                    uint8_t ** pSerializationBuffer,
-                                                                                    size_t * pBufferSize )
+AwsIotProvisioningError_t _AwsIotProvisioning_SerializeCreateKeysAndCertificateRequestPayload( uint8_t ** pSerializationBuffer,
+                                                                                               size_t * pBufferSize )
 {
     IOT_FUNCTION_ENTRY( AwsIotProvisioningError_t, AWS_IOT_PROVISIONING_SUCCESS );
     IotSerializerEncoderObject_t outermostPayloadEncoder = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_STREAM;
     *pBufferSize = 0;
 
-    status = _SerializeRegisterThingRequestPayload( pRequestData, &outermostPayloadEncoder, NULL, 0 );
+    status = _serializeCreateKeysAndCertificateRequestPayload( &outermostPayloadEncoder, NULL, 0 );
 
     if( status != AWS_IOT_PROVISIONING_SUCCESS )
     {
@@ -317,11 +339,49 @@ AwsIotProvisioningError_t _AwsIotProvisioning_SerializeRegisterThingRequestPaylo
     _pAwsIotProvisioningEncoder->destroy( &outermostPayloadEncoder );
 
     /* Allocate memory for the request payload based on the size required from the dry-run of serialization */
-    pSerializationBuffer = AwsIotProvisioning_MallocPayload( *pBufferSize * sizeof( uint8_t ) );
+    *pSerializationBuffer = AwsIotProvisioning_MallocPayload( *pBufferSize * sizeof( uint8_t ) );
+
+    status = _serializeCreateKeysAndCertificateRequestPayload( &outermostPayloadEncoder,
+                                                               *pSerializationBuffer,
+                                                               *pBufferSize );
+
+    IOT_FUNCTION_CLEANUP_BEGIN();
+
+    _pAwsIotProvisioningEncoder->destroy( &outermostPayloadEncoder );
+
+    IOT_FUNCTION_CLEANUP_END();
+}
+
+/*------------------------------------------------------------------*/
+
+AwsIotProvisioningError_t _AwsIotProvisioning_SerializeRegisterThingRequestPayload( const AwsIotProvisioningRegisterThingRequestInfo_t * pRequestData,
+                                                                                    uint8_t ** pSerializationBuffer,
+                                                                                    size_t * pBufferSize )
+{
+    IOT_FUNCTION_ENTRY( AwsIotProvisioningError_t, AWS_IOT_PROVISIONING_SUCCESS );
+    IotSerializerEncoderObject_t outermostPayloadEncoder = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_STREAM;
+    *pBufferSize = 0;
+
+    status = _serializeRegisterThingRequestPayload( pRequestData, &outermostPayloadEncoder, NULL, 0 );
+
+    if( status != AWS_IOT_PROVISIONING_SUCCESS )
+    {
+        IOT_GOTO_CLEANUP();
+    }
+
+    /* Get the calculated required size. */
+    *pBufferSize = _pAwsIotProvisioningEncoder->getExtraBufferSizeNeeded( &outermostPayloadEncoder );
+    AwsIotProvisioning_Assert( *pBufferSize != 0 );
+
+    /* Clean the encoder object handle. */
+    _pAwsIotProvisioningEncoder->destroy( &outermostPayloadEncoder );
+
+    /* Allocate memory for the request payload based on the size required from the dry-run of serialization */
+    *pSerializationBuffer = AwsIotProvisioning_MallocPayload( *pBufferSize * sizeof( uint8_t ) );
 
     status = _serializeRegisterThingRequestPayload( pRequestData,
                                                     &outermostPayloadEncoder,
-                                                    pSerializationBuffer,
+                                                    *pSerializationBuffer,
                                                     *pBufferSize );
 
     IOT_FUNCTION_CLEANUP_BEGIN();

--- a/libraries/aws/provisioning/src/aws_iot_provisioning_serializer.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_serializer.c
@@ -80,6 +80,7 @@ static AwsIotProvisioningError_t _serializeCreateKeysAndCertificateRequestPayloa
 
 /**
  * @brief Performs serializes operations on the passed buffer for creating the MQTT request payload for the RegisterThing operation.
+ * @param[in] pRequestData The data that will be serialized for sending with the request.
  * @param[in] pOutermostEncoder The outermost encoder object to use for serialization.
  * @param[out] pSerializationBuffer The buffer to store the serialized payload data.
  * @param[in] bufferSize The size of the serialization buffer.

--- a/libraries/aws/provisioning/src/private/aws_iot_provisioning_internal.h
+++ b/libraries/aws/provisioning/src/private/aws_iot_provisioning_internal.h
@@ -519,7 +519,7 @@ AwsIotProvisioningError_t _AwsIotProvisioning_ParseRegisterThingResponse( AwsIot
  *
  * @param[out] pSerializationBuffer This will be assigned to a buffer that will be allocated and populated with the
  * serialized payload data.
- * @param[out] bufferSize This will be populated with the size of the allocated payload data buffer.
+ * @param[out] pBufferSize This will be populated with the size of the allocated payload data buffer.
  * @return #AWS_IOT_PROVISIONING_SUCCESS if serialization is successful; otherwise* #AWS_IOT_PROVISIONING_INTERNAL_FAILURE
  * for any serialization error.
  */
@@ -534,7 +534,7 @@ AwsIotProvisioningError_t _AwsIotProvisioning_SerializeCreateKeysAndCertificateR
  * serialized payload data.
  *
  * @note The calling code is responsible for de-allocation of the buffer memory.
- * @param[out] bufferSize This will be populated with the size of the allocated payload data buffer.
+ * @param[out] pBufferSize This will be populated with the size of the allocated payload data buffer.
  * @return #AWS_IOT_PROVISIONING_SUCCESS if serialization is successful; otherwise #AWS_IOT_PROVISIONING_INTERNAL_FAILURE
  * for any serialization error.
  */

--- a/libraries/aws/provisioning/src/private/aws_iot_provisioning_internal.h
+++ b/libraries/aws/provisioning/src/private/aws_iot_provisioning_internal.h
@@ -531,15 +531,16 @@ AwsIotProvisioningError_t _AwsIotProvisioning_SerializeCreateKeysAndCertificateR
  * @brief Serializes for payload of MQTT request to the Provisioning RegisterThing service API.
  *
  * @param[in] pRequestData The data that will be serialized for sending with the request.
- * @param[in] pOutermostEncoder The encoder object to use for serializing payload.
- * @param[in,out] pSerializationBuffer The pre-allocated buffer for storing the serialized data.
- * @param[in] bufferSize The size of the serialization buffer.
- * @return #AWS_IOT_PROVISIONING_SUCCESS if serialization is successful; otherwise
- * #AWS_IOT_PROVISIONING_INTERNAL_FAILURE for any serialization error.
+ * @param[out] pSerializationBuffer This will be assigned to a buffer that will be allocated and populated with the
+ * serialized payload data.
+ *
+ * @note The calling code is responsible for de-allocation of the buffer memory.
+ * @param[out] bufferSize The size of the serialization buffer.
+ * @return #AWS_IOT_PROVISIONING_SUCCESS if serialization is successful; otherwise #AWS_IOT_PROVISIONING_INTERNAL_FAILURE
+ * for any serialization error.
  */
 AwsIotProvisioningError_t _AwsIotProvisioning_SerializeRegisterThingRequestPayload( const AwsIotProvisioningRegisterThingRequestInfo_t * pRequestData,
-                                                                                    IotSerializerEncoderObject_t * pOutermostEncoder,
-                                                                                    uint8_t * pSerializationBuffer,
-                                                                                    size_t bufferSize );
+                                                                                    uint8_t ** pSerializationBuffer,
+                                                                                    size_t * bufferSize );
 
 #endif /* ifndef AWS_IOT_PROVISIONING_INTERNAL_H_ */

--- a/libraries/aws/provisioning/src/private/aws_iot_provisioning_internal.h
+++ b/libraries/aws/provisioning/src/private/aws_iot_provisioning_internal.h
@@ -515,32 +515,31 @@ AwsIotProvisioningError_t _AwsIotProvisioning_ParseRegisterThingResponse( AwsIot
                                                                           const _provisioningCallbackInfo_t * userCallbackInfo );
 
 /**
- * @brief Serializes for payload of MQTT request to the Provisioning CreateKeysAndCertificate service API.
+ * @brief Serializes payload data for MQTT request to the Provisioning CreateKeysAndCertificate service API.
  *
- * @param[in] pOutermostEncoder The encoder object to use for serializing payload.
- * @param[in,out] pSerializationBuffer The pre-allocated buffer for storing the serialized data.
- * @param[in] bufferSize The size of the serialization buffer.
- * @return #AWS_IOT_PROVISIONING_SUCCESS if serialization is successful; otherwise
- * #AWS_IOT_PROVISIONING_INTERNAL_FAILURE for any serialization error.
+ * @param[out] pSerializationBuffer This will be assigned to a buffer that will be allocated and populated with the
+ * serialized payload data.
+ * @param[out] bufferSize This will be populated with the size of the allocated payload data buffer.
+ * @return #AWS_IOT_PROVISIONING_SUCCESS if serialization is successful; otherwise* #AWS_IOT_PROVISIONING_INTERNAL_FAILURE
+ * for any serialization error.
  */
-AwsIotProvisioningError_t _AwsIotProvisioning_SerializeCreateKeysAndCertificateRequestPayload( IotSerializerEncoderObject_t * pOutermostEncoder,
-                                                                                               uint8_t * pSerializationBuffer,
-                                                                                               size_t bufferSize );
+AwsIotProvisioningError_t _AwsIotProvisioning_SerializeCreateKeysAndCertificateRequestPayload( uint8_t ** pSerializationBuffer,
+                                                                                               size_t * pBufferSize );
 
 /**
- * @brief Serializes for payload of MQTT request to the Provisioning RegisterThing service API.
+ * @brief Serializes payload data for MQTT request to the Provisioning RegisterThing service API.
  *
  * @param[in] pRequestData The data that will be serialized for sending with the request.
  * @param[out] pSerializationBuffer This will be assigned to a buffer that will be allocated and populated with the
  * serialized payload data.
  *
  * @note The calling code is responsible for de-allocation of the buffer memory.
- * @param[out] bufferSize The size of the serialization buffer.
+ * @param[out] bufferSize This will be populated with the size of the allocated payload data buffer.
  * @return #AWS_IOT_PROVISIONING_SUCCESS if serialization is successful; otherwise #AWS_IOT_PROVISIONING_INTERNAL_FAILURE
  * for any serialization error.
  */
 AwsIotProvisioningError_t _AwsIotProvisioning_SerializeRegisterThingRequestPayload( const AwsIotProvisioningRegisterThingRequestInfo_t * pRequestData,
                                                                                     uint8_t ** pSerializationBuffer,
-                                                                                    size_t * bufferSize );
+                                                                                    size_t * pBufferSize );
 
 #endif /* ifndef AWS_IOT_PROVISIONING_INTERNAL_H_ */

--- a/libraries/aws/provisioning/test/unit/aws_iot_tests_provisioning_serializer.c
+++ b/libraries/aws/provisioning/test/unit/aws_iot_tests_provisioning_serializer.c
@@ -154,8 +154,6 @@ TEST( Provisioning_Unit_Serializer, TestSerializeRegisterThingPayloadNominalCase
     testRequestInfo.pParametersStart = _sampleParameters;
     testRequestInfo.numOfParameters = _numOfSampleParameters;
 
-    IotSerializerEncoderObject_t testEncoder = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_STREAM;
-
     /**
      * @brief The expected serialized payload for Provisioning's RegisterThing API request containing #_sampleParameters and
      * #_testCertificateId.
@@ -223,8 +221,6 @@ TEST( Provisioning_Unit_Serializer, TestSerializeRegisterThingPayloadCaseWithout
     testRequestInfo.ownershipTokenLength = strlen( _testCertificateToken );
     testRequestInfo.pParametersStart = NULL;
     testRequestInfo.numOfParameters = 0;
-
-    IotSerializerEncoderObject_t testEncoder = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_STREAM;
 
     /**
      * @brief The expected serialized payload for Provisioning's RegisterThing API request containing #_sampleParameters and

--- a/libraries/aws/provisioning/test/unit/aws_iot_tests_provisioning_serializer.c
+++ b/libraries/aws/provisioning/test/unit/aws_iot_tests_provisioning_serializer.c
@@ -137,7 +137,8 @@ TEST( Provisioning_Unit_Serializer, TestSerializeCreateKeysAndCertificatePayload
                        memcmp( pExpectedSerialization, pSerializationBuffer,
                                sizeof( pExpectedSerialization ) ) );
 
-    unity_free_mt( pSerializationBuffer );
+    /* Release the buffer that was allocated by the serializer function. */
+    AwsIotProvisioning_FreePayload( pSerializationBuffer );
 }
 
 /**
@@ -189,7 +190,6 @@ TEST( Provisioning_Unit_Serializer, TestSerializeRegisterThingPayloadNominalCase
         /* *INDENT-ON* */
     };
 
-
     uint8_t * pSerializationBuffer = NULL;
     size_t bufferSize = 0;
 
@@ -205,7 +205,8 @@ TEST( Provisioning_Unit_Serializer, TestSerializeRegisterThingPayloadNominalCase
     TEST_ASSERT_EQUAL( 0, memcmp( pExpectedSerialization, pSerializationBuffer,
                                   sizeof( pExpectedSerialization ) ) );
 
-    unity_free_mt( pSerializationBuffer );
+    /* Release the buffer memory that was allocated by the serializer function. */
+    AwsIotProvisioning_FreePayload( pSerializationBuffer );
 }
 
 /**
@@ -257,5 +258,6 @@ TEST( Provisioning_Unit_Serializer, TestSerializeRegisterThingPayloadCaseWithout
     TEST_ASSERT_EQUAL( 0, memcmp( pExpectedSerializationWithoutParameters, pSerializationBuffer,
                                   sizeof( pExpectedSerializationWithoutParameters ) ) );
 
-    unity_free_mt( pSerializationBuffer );
+    /* Release the buffer that was allocated by the serializer function. */
+    AwsIotProvisioning_FreePayload( pSerializationBuffer );
 }

--- a/libraries/aws/provisioning/test/unit/aws_iot_tests_provisioning_serializer.c
+++ b/libraries/aws/provisioning/test/unit/aws_iot_tests_provisioning_serializer.c
@@ -102,9 +102,9 @@ TEST_TEAR_DOWN( Provisioning_Unit_Serializer )
  */
 TEST_GROUP_RUNNER( Provisioning_Unit_Serializer )
 {
-    RUN_TEST_CASE( Provisioning_Unit_Serializer, TestCreateKeysAndCertificateSerializationNominalCase );
-    RUN_TEST_CASE( Provisioning_Unit_Serializer, TestRegisterThingSerializationNominalCase );
-    RUN_TEST_CASE( Provisioning_Unit_Serializer, TestRegisterThingSerializationWithoutParameters );
+    RUN_TEST_CASE( Provisioning_Unit_Serializer, TestSerializeCreateKeysAndCertificatePayloadNominalCase );
+    RUN_TEST_CASE( Provisioning_Unit_Serializer, TestSerializeRegisterThingPayloadNominalCase );
+    RUN_TEST_CASE( Provisioning_Unit_Serializer, TestSerializeRegisterThingPayloadCaseWithoutParameters );
 }
 
 /*-----------------------------------------------------------*/
@@ -114,45 +114,36 @@ TEST_GROUP_RUNNER( Provisioning_Unit_Serializer )
  *"{}" empty
  * payload.
  */
-TEST( Provisioning_Unit_Serializer, TestCreateKeysAndCertificateSerializationNominalCase )
+TEST( Provisioning_Unit_Serializer, TestSerializeCreateKeysAndCertificatePayloadNominalCase )
 {
-    IotSerializerEncoderObject_t testEncoder = IOT_SERIALIZER_ENCODER_CONTAINER_INITIALIZER_STREAM;
-
     /* The request payload is an empty map container that needs. */
     const uint8_t pExpectedSerialization[] =
     {
         0xA0 /*# map( 0 ) */
     };
 
-    uint8_t pSerializationBuffer[ sizeof( pExpectedSerialization ) ] = { 0 };
+    uint8_t * pSerializationBuffer = NULL;
+    size_t bufferSize = 0;
 
-    /* Test the serializer function without a valid buffer. */
+    /* Test the serializer function. */
     TEST_ASSERT_EQUAL( AWS_IOT_PROVISIONING_SUCCESS,
-                       _AwsIotProvisioning_SerializeCreateKeysAndCertificateRequestPayload( &testEncoder,
-                                                                                            NULL,
-                                                                                            0 ) );
-    TEST_ASSERT_EQUAL( sizeof( pExpectedSerialization ),
-                       _pAwsIotProvisioningEncoder->getExtraBufferSizeNeeded( &testEncoder ) );
-    _pAwsIotProvisioningEncoder->destroy( &testEncoder );
-
-
-    /* Test the serializer function without a valid buffer. */
-    TEST_ASSERT_EQUAL( AWS_IOT_PROVISIONING_SUCCESS,
-                       _AwsIotProvisioning_SerializeCreateKeysAndCertificateRequestPayload( &testEncoder,
-                                                                                            pSerializationBuffer,
-                                                                                            sizeof( pSerializationBuffer ) ) );
-
-    _pAwsIotProvisioningEncoder->destroy( &testEncoder );
+                       _AwsIotProvisioning_SerializeCreateKeysAndCertificateRequestPayload( &pSerializationBuffer,
+                                                                                            &bufferSize ) );
+    TEST_ASSERT_NOT_NULL( pSerializationBuffer );
+    TEST_ASSERT_EQUAL( sizeof( pExpectedSerialization ), bufferSize );
 
     /* Make sure that the serializer function generated the expected payload. */
-    TEST_ASSERT_EQUAL( 0, memcmp( pExpectedSerialization, pSerializationBuffer,
-                                  sizeof( pExpectedSerialization ) ) );
+    TEST_ASSERT_EQUAL( 0,
+                       memcmp( pExpectedSerialization, pSerializationBuffer,
+                               sizeof( pExpectedSerialization ) ) );
+
+    unity_free_mt( pSerializationBuffer );
 }
 
 /**
  * @brief Tests the behavior of the serializer for generating a payload containing ONLY the "certificate" data.
  */
-TEST( Provisioning_Unit_Serializer, TestRegisterThingSerializationNominalCase )
+TEST( Provisioning_Unit_Serializer, TestSerializeRegisterThingPayloadNominalCase )
 {
     AwsIotProvisioningRegisterThingRequestInfo_t testRequestInfo;
 
@@ -200,36 +191,29 @@ TEST( Provisioning_Unit_Serializer, TestRegisterThingSerializationNominalCase )
         /* *INDENT-ON* */
     };
 
-    uint8_t pSerializationBuffer[ sizeof( pExpectedSerialization ) ] = { 0 };
 
-    /* Test the serializer function without a valid buffer. */
+    uint8_t * pSerializationBuffer = NULL;
+    size_t bufferSize = 0;
+
+    /* Test the serializer function. */
     TEST_ASSERT_EQUAL( AWS_IOT_PROVISIONING_SUCCESS,
                        _AwsIotProvisioning_SerializeRegisterThingRequestPayload( &testRequestInfo,
-                                                                                 &testEncoder,
-                                                                                 NULL,
-                                                                                 0 ) );
-    TEST_ASSERT_EQUAL( sizeof( pExpectedSerialization ),
-                       _pAwsIotProvisioningEncoder->getExtraBufferSizeNeeded( &testEncoder ) );
-    _pAwsIotProvisioningEncoder->destroy( &testEncoder );
-
-    /* Test the serializer function with a valid buffer. */
-    TEST_ASSERT_EQUAL( AWS_IOT_PROVISIONING_SUCCESS,
-                       _AwsIotProvisioning_SerializeRegisterThingRequestPayload( &testRequestInfo,
-                                                                                 &testEncoder,
-                                                                                 pSerializationBuffer,
-                                                                                 sizeof( pSerializationBuffer ) ) );
-
-    _pAwsIotProvisioningEncoder->destroy( &testEncoder );
+                                                                                 &pSerializationBuffer,
+                                                                                 &bufferSize ) );
+    TEST_ASSERT_NOT_NULL( pSerializationBuffer );
+    TEST_ASSERT_EQUAL( sizeof( pExpectedSerialization ), bufferSize );
 
     /* Make sure that the serializer generated the expected request payload data. */
     TEST_ASSERT_EQUAL( 0, memcmp( pExpectedSerialization, pSerializationBuffer,
                                   sizeof( pExpectedSerialization ) ) );
+
+    unity_free_mt( pSerializationBuffer );
 }
 
 /**
  * @brief Tests the behavior of the serializer for generating a payload containing "certificate" and "parameters".
  */
-TEST( Provisioning_Unit_Serializer, TestRegisterThingSerializationWithoutParameters )
+TEST( Provisioning_Unit_Serializer, TestSerializeRegisterThingPayloadCaseWithoutParameters )
 {
     AwsIotProvisioningRegisterThingRequestInfo_t testRequestInfo;
 
@@ -262,17 +246,20 @@ TEST( Provisioning_Unit_Serializer, TestRegisterThingSerializationWithoutParamet
         /* *INDENT-ON* */
     };
 
-    uint8_t pSerializationBuffer[ sizeof( pExpectedSerializationWithoutParameters ) ] = { 0 };
+    uint8_t * pSerializationBuffer = NULL;
+    size_t bufferSize = 0;
 
+    /* Test the serializer function. */
     TEST_ASSERT_EQUAL( AWS_IOT_PROVISIONING_SUCCESS,
                        _AwsIotProvisioning_SerializeRegisterThingRequestPayload( &testRequestInfo,
-                                                                                 &testEncoder,
-                                                                                 pSerializationBuffer,
-                                                                                 sizeof( pSerializationBuffer ) ) );
-
-    _pAwsIotProvisioningEncoder->destroy( &testEncoder );
+                                                                                 &pSerializationBuffer,
+                                                                                 &bufferSize ) );
+    TEST_ASSERT_NOT_NULL( pSerializationBuffer );
+    TEST_ASSERT_EQUAL( sizeof( pExpectedSerializationWithoutParameters ), bufferSize );
 
     /* Make sure that the serializer generated the expected request payload data. */
     TEST_ASSERT_EQUAL( 0, memcmp( pExpectedSerializationWithoutParameters, pSerializationBuffer,
                                   sizeof( pExpectedSerializationWithoutParameters ) ) );
+
+    unity_free_mt( pSerializationBuffer );
 }


### PR DESCRIPTION
**Issue** - https://issues.amazon.com/issues/TS-10581


*Description of changes:*
* Simplify serialization logic in the Provisioning API functions to reduce their complexity scores by moving the logic to the serializer module 
* Update unit tests 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
