### PR TITLE
chore: Disable MISRA directive 4.9.

### DIFF
--- a/scripts/coverity_misra.config
+++ b/scripts/coverity_misra.config
@@ -15,6 +15,10 @@
             reason: "Allow inclusion of unused types. Header files for a specific port, which are needed by all files, may define types that are not used by a specific file."
         },
         {
+            deviation: "Directive 4.9",
+            reason: "Allow inclusion of function like macros. Logging is done using function like macros."
+        },
+        {
             deviation: "Rule 2.4",
             reason: "Allow unused tags. Some compilers warn if types are not tagged."
         },


### PR DESCRIPTION
Allow use of function like macros.

CSDK repository uses lotLog() macros. We will postpone fixing this
directive till we determin how to handle all these macros.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
