### PR TITLE
Update iot_atomic_gcc.h to annotate Misra Rule 1.2.

### DIFF
--- a/ports/common/include/atomic/iot_atomic_gcc.h
+++ b/ports/common/include/atomic/iot_atomic_gcc.h
@@ -36,7 +36,8 @@
 /**
  * @brief GCC function attribute to always inline a function.
  */
-/* This header file is intended to be used with only the gcc compiler 
+
+/* This header file is intended to be used with only the gcc compiler
  * which will have the __attribute__ language extension available. */
 /* coverity[misra_banned_extension_origin] */
 #define FORCE_INLINE    inline __attribute__( ( always_inline ) )
@@ -52,8 +53,8 @@ static FORCE_INLINE uint32_t Atomic_CompareAndSwap_u32( uint32_t volatile * pDes
 {
     uint32_t swapped = 0;
 
-    /* This header file is intended to be used with only the gcc compiler 
-     * which requires an int parameter for this routine. */ 
+    /* This header file is intended to be used with only the gcc compiler
+     * which requires an int parameter for this routine. */
     /* coverity[misra_c_2012_directive_4_6_violation] */
     if( __atomic_compare_exchange( pDestination,
                                    &comparand,
@@ -78,8 +79,8 @@ static FORCE_INLINE void * Atomic_Swap_Pointer( void * volatile * pDestination,
 {
     void * pOldValue = NULL;
 
-    /* This header file is intended to be used with only the gcc compiler 
-     * which requires an int parameter for this routine. */ 
+    /* This header file is intended to be used with only the gcc compiler
+     * which requires an int parameter for this routine. */
     /* coverity[misra_c_2012_directive_4_6_violation] */
     __atomic_exchange( pDestination, &pNewValue, &pOldValue, __ATOMIC_SEQ_CST );
 
@@ -118,8 +119,8 @@ static FORCE_INLINE uint32_t Atomic_CompareAndSwap_Pointer( void * volatile * pD
 static FORCE_INLINE uint32_t Atomic_Add_u32( uint32_t volatile * pAugend,
                                              uint32_t addend )
 {
-    /* This header file is intended to be used with only the gcc compiler 
-     * which requires an int parameter for this routine. */ 
+    /* This header file is intended to be used with only the gcc compiler
+     * which requires an int parameter for this routine. */
     /* coverity[misra_c_2012_directive_4_6_violation] */
     return __atomic_fetch_add( pAugend, addend, __ATOMIC_SEQ_CST );
 }
@@ -132,8 +133,8 @@ static FORCE_INLINE uint32_t Atomic_Add_u32( uint32_t volatile * pAugend,
 static FORCE_INLINE uint32_t Atomic_Subtract_u32( uint32_t volatile * pMinuend,
                                                   uint32_t subtrahend )
 {
-    /* This header file is intended to be used with only the gcc compiler 
-     * which requires an int parameter for this routine. */ 
+    /* This header file is intended to be used with only the gcc compiler
+     * which requires an int parameter for this routine. */
     /* coverity[misra_c_2012_directive_4_6_violation] */
     return __atomic_fetch_sub( pMinuend, subtrahend, __ATOMIC_SEQ_CST );
 }
@@ -166,8 +167,8 @@ static FORCE_INLINE uint32_t Atomic_Decrement_u32( uint32_t volatile * pMinuend 
 static FORCE_INLINE uint32_t Atomic_OR_u32( uint32_t volatile * pOperand,
                                             uint32_t mask )
 {
-    /* This header file is intended to be used with only the gcc compiler 
-     * which requires an int parameter for this routine. */ 
+    /* This header file is intended to be used with only the gcc compiler
+     * which requires an int parameter for this routine. */
     /* coverity[misra_c_2012_directive_4_6_violation] */
     return __atomic_fetch_or( pOperand, mask, __ATOMIC_SEQ_CST );
 }
@@ -180,8 +181,8 @@ static FORCE_INLINE uint32_t Atomic_OR_u32( uint32_t volatile * pOperand,
 static FORCE_INLINE uint32_t Atomic_XOR_u32( uint32_t volatile * pOperand,
                                              uint32_t mask )
 {
-    /* This header file is intended to be used with only the gcc compiler 
-     * which requires an int parameter for this routine. */ 
+    /* This header file is intended to be used with only the gcc compiler
+     * which requires an int parameter for this routine. */
     /* coverity[misra_c_2012_directive_4_6_violation] */
     return __atomic_fetch_xor( pOperand, mask, __ATOMIC_SEQ_CST );
 }
@@ -194,8 +195,8 @@ static FORCE_INLINE uint32_t Atomic_XOR_u32( uint32_t volatile * pOperand,
 static FORCE_INLINE uint32_t Atomic_AND_u32( uint32_t volatile * pOperand,
                                              uint32_t mask )
 {
-    /* This header file is intended to be used with only the gcc compiler 
-     * which requires an int parameter for this routine. */ 
+    /* This header file is intended to be used with only the gcc compiler
+     * which requires an int parameter for this routine. */
     /* coverity[misra_c_2012_directive_4_6_violation] */
     return __atomic_fetch_and( pOperand, mask, __ATOMIC_SEQ_CST );
 }
@@ -208,8 +209,8 @@ static FORCE_INLINE uint32_t Atomic_AND_u32( uint32_t volatile * pOperand,
 static FORCE_INLINE uint32_t Atomic_NAND_u32( uint32_t volatile * pOperand,
                                               uint32_t mask )
 {
-    /* This header file is intended to be used with only the gcc compiler 
-     * which requires an int parameter for this routine. */ 
+    /* This header file is intended to be used with only the gcc compiler
+     * which requires an int parameter for this routine. */
     /* coverity[misra_c_2012_directive_4_6_violation] */
     return __atomic_fetch_nand( pOperand, mask, __ATOMIC_SEQ_CST );
 }

--- a/ports/common/include/atomic/iot_atomic_gcc.h
+++ b/ports/common/include/atomic/iot_atomic_gcc.h
@@ -36,6 +36,9 @@
 /**
  * @brief GCC function attribute to always inline a function.
  */
+/* This header file is intended to be used with only the gcc compiler 
+ * which will have the __attribute__ language extension available. */
+/* coverity[misra_banned_extension_origin] */
 #define FORCE_INLINE    inline __attribute__( ( always_inline ) )
 
 /*---------------- Swap and compare-and-swap ------------------*/
@@ -43,9 +46,6 @@
 /**
  * @brief Implementation of atomic compare-and-swap for gcc.
  */
-/* This header file is intended to be used with only the gcc compiler 
- * which will have the __attribute__ language extension available. */
-/* coverity[misra_c_2012_rule_1_2_violation] */
 static FORCE_INLINE uint32_t Atomic_CompareAndSwap_u32( uint32_t volatile * pDestination,
                                                         uint32_t newValue,
                                                         uint32_t comparand )
@@ -73,9 +73,6 @@ static FORCE_INLINE uint32_t Atomic_CompareAndSwap_u32( uint32_t volatile * pDes
 /**
  * @brief Implementation of atomic pointer swap for gcc.
  */
-/* This header file is intended to be used with only the gcc compiler 
- * which will have the __attribute__ language extension available. */
-/* coverity[misra_c_2012_rule_1_2_violation] */
 static FORCE_INLINE void * Atomic_Swap_Pointer( void * volatile * pDestination,
                                                 void * pNewValue )
 {
@@ -94,9 +91,6 @@ static FORCE_INLINE void * Atomic_Swap_Pointer( void * volatile * pDestination,
 /**
  * @brief Implementation of atomic pointer compare-and-swap for gcc.
  */
-/* This header file is intended to be used with only the gcc compiler 
- * which will have the __attribute__ language extension available. */
-/* coverity[misra_c_2012_rule_1_2_violation] */
 static FORCE_INLINE uint32_t Atomic_CompareAndSwap_Pointer( void * volatile * pDestination,
                                                             void * pNewValue,
                                                             void * pComparand )
@@ -121,9 +115,6 @@ static FORCE_INLINE uint32_t Atomic_CompareAndSwap_Pointer( void * volatile * pD
 /**
  * @brief Implementation of atomic addition for gcc.
  */
-/* This header file is intended to be used with only the gcc compiler 
- * which will have the __attribute__ language extension available. */
-/* coverity[misra_c_2012_rule_1_2_violation] */
 static FORCE_INLINE uint32_t Atomic_Add_u32( uint32_t volatile * pAugend,
                                              uint32_t addend )
 {
@@ -138,9 +129,6 @@ static FORCE_INLINE uint32_t Atomic_Add_u32( uint32_t volatile * pAugend,
 /**
  * @brief Implementation of atomic subtraction for gcc.
  */
-/* This header file is intended to be used with only the gcc compiler 
- * which will have the __attribute__ language extension available. */
-/* coverity[misra_c_2012_rule_1_2_violation] */
 static FORCE_INLINE uint32_t Atomic_Subtract_u32( uint32_t volatile * pMinuend,
                                                   uint32_t subtrahend )
 {
@@ -155,9 +143,6 @@ static FORCE_INLINE uint32_t Atomic_Subtract_u32( uint32_t volatile * pMinuend,
 /**
  * @brief Implementation of atomic increment for gcc.
  */
-/* This header file is intended to be used with only the gcc compiler 
- * which will have the __attribute__ language extension available. */
-/* coverity[misra_c_2012_rule_1_2_violation] */
 static FORCE_INLINE uint32_t Atomic_Increment_u32( uint32_t volatile * pAugend )
 {
     return __atomic_fetch_add( pAugend, 1, __ATOMIC_SEQ_CST );
@@ -168,9 +153,6 @@ static FORCE_INLINE uint32_t Atomic_Increment_u32( uint32_t volatile * pAugend )
 /**
  * @brief Implementation of atomic decrement for gcc.
  */
-/* This header file is intended to be used with only the gcc compiler 
- * which will have the __attribute__ language extension available. */
-/* coverity[misra_c_2012_rule_1_2_violation] */
 static FORCE_INLINE uint32_t Atomic_Decrement_u32( uint32_t volatile * pMinuend )
 {
     return __atomic_fetch_sub( pMinuend, 1, __ATOMIC_SEQ_CST );
@@ -181,9 +163,6 @@ static FORCE_INLINE uint32_t Atomic_Decrement_u32( uint32_t volatile * pMinuend 
 /**
  * @brief Implementation of atomic OR for gcc.
  */
-/* This header file is intended to be used with only the gcc compiler 
- * which will have the __attribute__ language extension available. */
-/* coverity[misra_c_2012_rule_1_2_violation] */
 static FORCE_INLINE uint32_t Atomic_OR_u32( uint32_t volatile * pOperand,
                                             uint32_t mask )
 {
@@ -198,9 +177,6 @@ static FORCE_INLINE uint32_t Atomic_OR_u32( uint32_t volatile * pOperand,
 /**
  * @brief Implementation of atomic XOR for gcc.
  */
-/* This header file is intended to be used with only the gcc compiler 
- * which will have the __attribute__ language extension available. */
-/* coverity[misra_c_2012_rule_1_2_violation] */
 static FORCE_INLINE uint32_t Atomic_XOR_u32( uint32_t volatile * pOperand,
                                              uint32_t mask )
 {
@@ -215,9 +191,6 @@ static FORCE_INLINE uint32_t Atomic_XOR_u32( uint32_t volatile * pOperand,
 /**
  * @brief Implementation of atomic AND for gcc.
  */
-/* This header file is intended to be used with only the gcc compiler 
- * which will have the __attribute__ language extension available. */
-/* coverity[misra_c_2012_rule_1_2_violation] */
 static FORCE_INLINE uint32_t Atomic_AND_u32( uint32_t volatile * pOperand,
                                              uint32_t mask )
 {
@@ -232,9 +205,6 @@ static FORCE_INLINE uint32_t Atomic_AND_u32( uint32_t volatile * pOperand,
 /**
  * @brief Implementation of atomic NAND for gcc.
  */
-/* This header file is intended to be used with only the gcc compiler 
- * which will have the __attribute__ language extension available. */
-/* coverity[misra_c_2012_rule_1_2_violation] */
 static FORCE_INLINE uint32_t Atomic_NAND_u32( uint32_t volatile * pOperand,
                                               uint32_t mask )
 {

--- a/ports/common/include/atomic/iot_atomic_gcc.h
+++ b/ports/common/include/atomic/iot_atomic_gcc.h
@@ -43,14 +43,17 @@
 /**
  * @brief Implementation of atomic compare-and-swap for gcc.
  */
+/* This header file is intended to be used with only the gcc compiler 
+ * which will have the __attribute__ language extension available. */
+/* coverity[misra_c_2012_rule_1_2_violation] */
 static FORCE_INLINE uint32_t Atomic_CompareAndSwap_u32( uint32_t volatile * pDestination,
                                                         uint32_t newValue,
                                                         uint32_t comparand )
 {
     uint32_t swapped = 0;
 
-    /* This header file is used with only the gcc compiler which 
-     * requires an int parameter for this routine. */ 
+    /* This header file is intended to be used with only the gcc compiler 
+     * which requires an int parameter for this routine. */ 
     /* coverity[misra_c_2012_directive_4_6_violation] */
     if( __atomic_compare_exchange( pDestination,
                                    &comparand,
@@ -70,13 +73,16 @@ static FORCE_INLINE uint32_t Atomic_CompareAndSwap_u32( uint32_t volatile * pDes
 /**
  * @brief Implementation of atomic pointer swap for gcc.
  */
+/* This header file is intended to be used with only the gcc compiler 
+ * which will have the __attribute__ language extension available. */
+/* coverity[misra_c_2012_rule_1_2_violation] */
 static FORCE_INLINE void * Atomic_Swap_Pointer( void * volatile * pDestination,
                                                 void * pNewValue )
 {
     void * pOldValue = NULL;
 
-    /* This header file is used with only the gcc compiler which 
-     * requires an int parameter for this routine. */
+    /* This header file is intended to be used with only the gcc compiler 
+     * which requires an int parameter for this routine. */ 
     /* coverity[misra_c_2012_directive_4_6_violation] */
     __atomic_exchange( pDestination, &pNewValue, &pOldValue, __ATOMIC_SEQ_CST );
 
@@ -88,6 +94,9 @@ static FORCE_INLINE void * Atomic_Swap_Pointer( void * volatile * pDestination,
 /**
  * @brief Implementation of atomic pointer compare-and-swap for gcc.
  */
+/* This header file is intended to be used with only the gcc compiler 
+ * which will have the __attribute__ language extension available. */
+/* coverity[misra_c_2012_rule_1_2_violation] */
 static FORCE_INLINE uint32_t Atomic_CompareAndSwap_Pointer( void * volatile * pDestination,
                                                             void * pNewValue,
                                                             void * pComparand )
@@ -112,11 +121,14 @@ static FORCE_INLINE uint32_t Atomic_CompareAndSwap_Pointer( void * volatile * pD
 /**
  * @brief Implementation of atomic addition for gcc.
  */
+/* This header file is intended to be used with only the gcc compiler 
+ * which will have the __attribute__ language extension available. */
+/* coverity[misra_c_2012_rule_1_2_violation] */
 static FORCE_INLINE uint32_t Atomic_Add_u32( uint32_t volatile * pAugend,
                                              uint32_t addend )
 {
-    /* This header file is used with only the gcc compiler which 
-     * requires an int parameter for this routine. */
+    /* This header file is intended to be used with only the gcc compiler 
+     * which requires an int parameter for this routine. */ 
     /* coverity[misra_c_2012_directive_4_6_violation] */
     return __atomic_fetch_add( pAugend, addend, __ATOMIC_SEQ_CST );
 }
@@ -126,11 +138,14 @@ static FORCE_INLINE uint32_t Atomic_Add_u32( uint32_t volatile * pAugend,
 /**
  * @brief Implementation of atomic subtraction for gcc.
  */
+/* This header file is intended to be used with only the gcc compiler 
+ * which will have the __attribute__ language extension available. */
+/* coverity[misra_c_2012_rule_1_2_violation] */
 static FORCE_INLINE uint32_t Atomic_Subtract_u32( uint32_t volatile * pMinuend,
                                                   uint32_t subtrahend )
 {
-    /* This header file is used with only the gcc compiler which 
-     * requires an int parameter for this routine. */
+    /* This header file is intended to be used with only the gcc compiler 
+     * which requires an int parameter for this routine. */ 
     /* coverity[misra_c_2012_directive_4_6_violation] */
     return __atomic_fetch_sub( pMinuend, subtrahend, __ATOMIC_SEQ_CST );
 }
@@ -140,6 +155,9 @@ static FORCE_INLINE uint32_t Atomic_Subtract_u32( uint32_t volatile * pMinuend,
 /**
  * @brief Implementation of atomic increment for gcc.
  */
+/* This header file is intended to be used with only the gcc compiler 
+ * which will have the __attribute__ language extension available. */
+/* coverity[misra_c_2012_rule_1_2_violation] */
 static FORCE_INLINE uint32_t Atomic_Increment_u32( uint32_t volatile * pAugend )
 {
     return __atomic_fetch_add( pAugend, 1, __ATOMIC_SEQ_CST );
@@ -150,6 +168,9 @@ static FORCE_INLINE uint32_t Atomic_Increment_u32( uint32_t volatile * pAugend )
 /**
  * @brief Implementation of atomic decrement for gcc.
  */
+/* This header file is intended to be used with only the gcc compiler 
+ * which will have the __attribute__ language extension available. */
+/* coverity[misra_c_2012_rule_1_2_violation] */
 static FORCE_INLINE uint32_t Atomic_Decrement_u32( uint32_t volatile * pMinuend )
 {
     return __atomic_fetch_sub( pMinuend, 1, __ATOMIC_SEQ_CST );
@@ -160,11 +181,14 @@ static FORCE_INLINE uint32_t Atomic_Decrement_u32( uint32_t volatile * pMinuend 
 /**
  * @brief Implementation of atomic OR for gcc.
  */
+/* This header file is intended to be used with only the gcc compiler 
+ * which will have the __attribute__ language extension available. */
+/* coverity[misra_c_2012_rule_1_2_violation] */
 static FORCE_INLINE uint32_t Atomic_OR_u32( uint32_t volatile * pOperand,
                                             uint32_t mask )
 {
-    /* This header file is used with only the gcc compiler which 
-     * requires an int parameter for this routine. */
+    /* This header file is intended to be used with only the gcc compiler 
+     * which requires an int parameter for this routine. */ 
     /* coverity[misra_c_2012_directive_4_6_violation] */
     return __atomic_fetch_or( pOperand, mask, __ATOMIC_SEQ_CST );
 }
@@ -174,11 +198,14 @@ static FORCE_INLINE uint32_t Atomic_OR_u32( uint32_t volatile * pOperand,
 /**
  * @brief Implementation of atomic XOR for gcc.
  */
+/* This header file is intended to be used with only the gcc compiler 
+ * which will have the __attribute__ language extension available. */
+/* coverity[misra_c_2012_rule_1_2_violation] */
 static FORCE_INLINE uint32_t Atomic_XOR_u32( uint32_t volatile * pOperand,
                                              uint32_t mask )
 {
-    /* This header file is used with only the gcc compiler which 
-     * requires an int parameter for this routine. */
+    /* This header file is intended to be used with only the gcc compiler 
+     * which requires an int parameter for this routine. */ 
     /* coverity[misra_c_2012_directive_4_6_violation] */
     return __atomic_fetch_xor( pOperand, mask, __ATOMIC_SEQ_CST );
 }
@@ -188,11 +215,14 @@ static FORCE_INLINE uint32_t Atomic_XOR_u32( uint32_t volatile * pOperand,
 /**
  * @brief Implementation of atomic AND for gcc.
  */
+/* This header file is intended to be used with only the gcc compiler 
+ * which will have the __attribute__ language extension available. */
+/* coverity[misra_c_2012_rule_1_2_violation] */
 static FORCE_INLINE uint32_t Atomic_AND_u32( uint32_t volatile * pOperand,
                                              uint32_t mask )
 {
-    /* This header file is used with only the gcc compiler which 
-     * requires an int parameter for this routine. */
+    /* This header file is intended to be used with only the gcc compiler 
+     * which requires an int parameter for this routine. */ 
     /* coverity[misra_c_2012_directive_4_6_violation] */
     return __atomic_fetch_and( pOperand, mask, __ATOMIC_SEQ_CST );
 }
@@ -202,11 +232,14 @@ static FORCE_INLINE uint32_t Atomic_AND_u32( uint32_t volatile * pOperand,
 /**
  * @brief Implementation of atomic NAND for gcc.
  */
+/* This header file is intended to be used with only the gcc compiler 
+ * which will have the __attribute__ language extension available. */
+/* coverity[misra_c_2012_rule_1_2_violation] */
 static FORCE_INLINE uint32_t Atomic_NAND_u32( uint32_t volatile * pOperand,
                                               uint32_t mask )
 {
-    /* This header file is used with only the gcc compiler which 
-     * requires an int parameter for this routine. */
+    /* This header file is intended to be used with only the gcc compiler 
+     * which requires an int parameter for this routine. */ 
     /* coverity[misra_c_2012_directive_4_6_violation] */
     return __atomic_fetch_nand( pOperand, mask, __ATOMIC_SEQ_CST );
 }

--- a/ports/common/include/atomic/iot_atomic_gcc.h
+++ b/ports/common/include/atomic/iot_atomic_gcc.h
@@ -54,7 +54,7 @@ static FORCE_INLINE uint32_t Atomic_CompareAndSwap_u32( uint32_t volatile * pDes
     uint32_t swapped = 0;
 
     /* This header file is intended to be used with only the gcc compiler
-     * which requires an int parameter for this routine. */
+     * which requires an int parameter for this routine.
      * This routine is built into gcc and defined to return a bool
      * type. */
     /* coverity[misra_c_2012_directive_4_6_violation] */


### PR DESCRIPTION
*Issue #, if available:* https://issues.amazon.com/issues/TS-10705

*Description of changes:*
Annotate MISRA Rule 1.2 in iot_atomic_gcc.h in order to clean up complete coverity MISRA results for MQTT.

iot_atomic_gcc.h is intended to be used with only the GCC compiler, which will have the language extension \_\_attribute\_\_ available.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
