### PR TITLE
Address MISRA Rule 11.2 violations

### DIFF
--- a/libraries/standard/mqtt/include/iot_mqtt_serialize.h
+++ b/libraries/standard/mqtt/include/iot_mqtt_serialize.h
@@ -547,11 +547,11 @@ IotMqttError_t IotMqtt_SerializePingreq( uint8_t * pBuffer,
  * <b>Example</b>
  * @code{c}
  * // Example code below shows how to implement getNextByte function with posix sockets.
- * // Note: IotMqttGetNextByte_t typedef IotMqttError_t (* IotMqttGetNextByte_t)( void * pNetworkContext,
+ * // Note: IotMqttGetNextByte_t typedef IotMqttError_t (* IotMqttGetNextByte_t)( IotNetworkConnection_t pNetworkContext,
  * //                                              uint8_t * pNextByte );
  * // Note: It is assumed that socket is already created and connected,
  *
- * IotMqttError_t getNextByte( void * pContext,
+ * IotMqttError_t getNextByte( IotNetworkConnection_t pContext,
  *                           uint8_t * pNextByte )
  * {
  *      int socket = ( int ) ( *pvContext );
@@ -578,7 +578,7 @@ IotMqttError_t IotMqtt_SerializePingreq( uint8_t * pBuffer,
  * void getTypeAndLengthFromIncomingMQTTPingResponse( int xMQTTSocket )
  * {
  *    IotMqttPacketInfo_t xIncomingPacket;
- *    IotMqttError_t xResult = IotMqtt_GetIncomingMQTTPacketTypeAndLength( &xIncomingPacket, getNextByte, ( void * ) xMQTTSocket );
+ *    IotMqttError_t xResult = IotMqtt_GetIncomingMQTTPacketTypeAndLength( &xIncomingPacket, getNextByte, ( IotNetworkConnection_t ) xMQTTSocket );
  *	  IotMqtt_Assert( xResult == IOT_MQTT_SUCCESS );
  *    IotMqtt_Assert( xIncomingPacket.type == MQTT_PACKET_TYPE_PINGRESP );
  * }
@@ -588,7 +588,7 @@ IotMqttError_t IotMqtt_SerializePingreq( uint8_t * pBuffer,
 /* @[declare_mqtt_getincomingmqttpackettypeandlength] */
 IotMqttError_t IotMqtt_GetIncomingMQTTPacketTypeAndLength( IotMqttPacketInfo_t * pIncomingPacket,
                                                            IotMqttGetNextByte_t getNextByte,
-                                                           void * pNetworkConnection );
+                                                           IotNetworkConnection_t pNetworkConnection );
 /* @[declare_mqtt_getincomingmqttpackettypeandlength] */
 
 /**

--- a/libraries/standard/mqtt/include/types/iot_mqtt_types.h
+++ b/libraries/standard/mqtt/include/types/iot_mqtt_types.h
@@ -721,7 +721,7 @@ struct _mqttPacket;
  * @param[in] pNetworkInterface Function pointers used to interact with the
  * network.
  */
-typedef uint8_t ( * IotMqttGetPacketType_t )( void * pNetworkConnection,
+typedef uint8_t ( * IotMqttGetPacketType_t )( IotNetworkConnection_t pNetworkConnection,
                                               const IotNetworkInterface_t * pNetworkInterface );
 
 /**
@@ -731,7 +731,7 @@ typedef uint8_t ( * IotMqttGetPacketType_t )( void * pNetworkConnection,
  * @param[in] pNetworkInterface Function pointers used to interact with the
  * network.
  */
-typedef size_t ( * IotMqttGetRemainingLength_t )( void * pNetworkConnection,
+typedef size_t ( * IotMqttGetRemainingLength_t )( IotNetworkConnection_t pNetworkConnection,
                                                   const IotNetworkInterface_t * pNetworkInterface );
 
 /**
@@ -828,7 +828,7 @@ typedef void ( * IotMqttPublishSetDup_t )( uint8_t * pPublishPacket,
  * @param[in] pNetworkContext reference to network connection like socket.
  * @param[out] pNextByte Pointer to the byte read from the network.
  */
-typedef IotMqttError_t (* IotMqttGetNextByte_t)( void * pNetworkContext,
+typedef IotMqttError_t (* IotMqttGetNextByte_t)( IotNetworkConnection_t pNetworkContext,
                                                  uint8_t * pNextByte );
 
 #if IOT_MQTT_ENABLE_SERIALIZER_OVERRIDES == 1

--- a/libraries/standard/mqtt/src/iot_mqtt_network.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_network.c
@@ -61,7 +61,7 @@ static bool _incomingPacketValid( uint8_t packetType );
  *
  * @return #IOT_MQTT_SUCCESS, #IOT_MQTT_NO_MEMORY or #IOT_MQTT_BAD_RESPONSE.
  */
-static IotMqttError_t _getIncomingPacket( void * pNetworkConnection,
+static IotMqttError_t _getIncomingPacket( IotNetworkConnection_t pNetworkConnection,
                                           const _mqttConnection_t * pMqttConnection,
                                           _mqttPacket_t * pIncomingPacket );
 
@@ -139,7 +139,7 @@ static void _sendPuback( _mqttConnection_t * pMqttConnection,
  * @param[in] pMqttConnection The associated MQTT connection.
  * @param[in] length The length of the packet to flush.
  */
-static void _flushPacket( void * pNetworkConnection,
+static void _flushPacket( IotNetworkConnection_t pNetworkConnection,
                           const _mqttConnection_t * pMqttConnection,
                           size_t length );
 
@@ -233,7 +233,7 @@ static bool _incomingPacketValid( uint8_t packetType )
 
 /*-----------------------------------------------------------*/
 
-static IotMqttError_t _getIncomingPacket( void * pNetworkConnection,
+static IotMqttError_t _getIncomingPacket( IotNetworkConnection_t pNetworkConnection,
                                           const _mqttConnection_t * pMqttConnection,
                                           _mqttPacket_t * pIncomingPacket )
 {
@@ -644,7 +644,7 @@ static void _sendPuback( _mqttConnection_t * pMqttConnection,
 
 /*-----------------------------------------------------------*/
 
-static void _flushPacket( void * pNetworkConnection,
+static void _flushPacket( IotNetworkConnection_t pNetworkConnection,
                           const _mqttConnection_t * pMqttConnection,
                           size_t length )
 {
@@ -661,7 +661,7 @@ static void _flushPacket( void * pNetworkConnection,
 
 /*-----------------------------------------------------------*/
 
-bool _IotMqtt_GetNextByte( void * pNetworkConnection,
+bool _IotMqtt_GetNextByte( IotNetworkConnection_t pNetworkConnection,
                            const IotNetworkInterface_t * pNetworkInterface,
                            uint8_t * pIncomingByte )
 {
@@ -697,7 +697,8 @@ void _IotMqtt_CloseNetworkConnection( IotMqttDisconnectReason_t disconnectReason
     IotTaskPoolError_t taskPoolStatus = IOT_TASKPOOL_SUCCESS;
     IotNetworkError_t closeStatus = IOT_NETWORK_SUCCESS;
     IotMqttCallbackParam_t callbackParam = { .u.message = { 0 } };
-    void * pNetworkConnection = NULL, * pDisconnectCallbackContext = NULL;
+    IotNetworkConnection_t pNetworkConnection = NULL;
+    void * pDisconnectCallbackContext = NULL;
 
     /* Disconnect callback function. */
     void ( * disconnectCallback )( void *,
@@ -835,7 +836,7 @@ void IotMqtt_ReceiveCallback( IotNetworkConnection_t pNetworkConnection,
 
 IotMqttError_t IotMqtt_GetIncomingMQTTPacketTypeAndLength( IotMqttPacketInfo_t * pIncomingPacket,
                                                            IotMqttGetNextByte_t getNextByte,
-                                                           void * pNetworkConnection )
+                                                           IotNetworkConnection_t pNetworkConnection )
 {
     IotMqttError_t status = IOT_MQTT_SUCCESS;
 

--- a/libraries/standard/mqtt/src/iot_mqtt_serialize.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_serialize.c
@@ -1178,7 +1178,7 @@ static IotMqttError_t _checkRemainingLength( _mqttPacket_t * pPublish,
 
 /*-----------------------------------------------------------*/
 
-uint8_t _IotMqtt_GetPacketType( void * pNetworkConnection,
+uint8_t _IotMqtt_GetPacketType( IotNetworkConnection_t pNetworkConnection,
                                 const IotNetworkInterface_t * pNetworkInterface )
 {
     uint8_t packetType = 0xff;
@@ -1193,7 +1193,7 @@ uint8_t _IotMqtt_GetPacketType( void * pNetworkConnection,
 
 /*-----------------------------------------------------------*/
 
-size_t _IotMqtt_GetRemainingLength( void * pNetworkConnection,
+size_t _IotMqtt_GetRemainingLength( IotNetworkConnection_t pNetworkConnection,
                                     const IotNetworkInterface_t * pNetworkInterface )
 {
     uint8_t encodedByte = 0;
@@ -1246,7 +1246,7 @@ size_t _IotMqtt_GetRemainingLength( void * pNetworkConnection,
 
 /*-----------------------------------------------------------*/
 
-size_t _IotMqtt_GetRemainingLength_Generic( void * pNetworkConnection,
+size_t _IotMqtt_GetRemainingLength_Generic( IotNetworkConnection_t pNetworkConnection,
                                             IotMqttGetNextByte_t getNextByte )
 {
     uint8_t encodedByte = 0;

--- a/libraries/standard/mqtt/src/private/iot_mqtt_internal.h
+++ b/libraries/standard/mqtt/src/private/iot_mqtt_internal.h
@@ -374,7 +374,7 @@ typedef struct _mqttConnection
 {
     bool awsIotMqttMode;                             /**< @brief Specifies if this connection is to an AWS IoT MQTT server. */
     bool ownNetworkConnection;                       /**< @brief Whether this MQTT connection owns its network connection. */
-    void * pNetworkConnection;                       /**< @brief References the transport-layer network connection. */
+    IotNetworkConnection_t pNetworkConnection;       /**< @brief References the transport-layer network connection. */
     const IotNetworkInterface_t * pNetworkInterface; /**< @brief Network interface provided to @ref mqtt_function_connect. */
     IotMqttCallbackInfo_t disconnectCallback;        /**< @brief A function to invoke when this connection is disconnected. */
 
@@ -533,7 +533,7 @@ bool _IotMqtt_ValidateSubscriptionList( IotMqttOperationType_t operation,
  * @note This function is only used for incoming packets, and may not work
  * correctly for outgoing packets.
  */
-uint8_t _IotMqtt_GetPacketType( void * pNetworkConnection,
+uint8_t _IotMqtt_GetPacketType( IotNetworkConnection_t pNetworkConnection,
                                 const IotNetworkInterface_t * pNetworkInterface );
 
 /**
@@ -545,7 +545,7 @@ uint8_t _IotMqtt_GetPacketType( void * pNetworkConnection,
  *
  * @return The remaining length; #MQTT_REMAINING_LENGTH_INVALID on error.
  */
-size_t _IotMqtt_GetRemainingLength( void * pNetworkConnection,
+size_t _IotMqtt_GetRemainingLength( IotNetworkConnection_t pNetworkConnection,
                                     const IotNetworkInterface_t * pNetworkInterface );
 
 /**
@@ -563,7 +563,7 @@ size_t _IotMqtt_GetRemainingLength( void * pNetworkConnection,
  * user provided function makes use of it.
  *
  */
-size_t _IotMqtt_GetRemainingLength_Generic( void * pNetworkConnection,
+size_t _IotMqtt_GetRemainingLength_Generic( IotNetworkConnection_t pNetworkConnection,
                                             IotMqttGetNextByte_t getNextByte );
 
 /**
@@ -983,7 +983,7 @@ void _IotMqtt_DecrementConnectionReferences( _mqttConnection_t * pMqttConnection
  * @return `true` if a byte was successfully received from the network; `false`
  * otherwise.
  */
-bool _IotMqtt_GetNextByte( void * pNetworkConnection,
+bool _IotMqtt_GetNextByte( IotNetworkConnection_t pNetworkConnection,
                            const IotNetworkInterface_t * pNetworkInterface,
                            uint8_t * pIncomingByte );
 

--- a/libraries/standard/mqtt/test/mock/iot_tests_mqtt_mock.c
+++ b/libraries/standard/mqtt/test/mock/iot_tests_mqtt_mock.c
@@ -200,7 +200,7 @@ static size_t _sendSuccess( IotNetworkConnection_t pNetworkConnection,
     IotMutex_Lock( &_lastPacketMutex );
 
     /* Read the remaining length. */
-    mqttPacket.remainingLength = _IotMqtt_GetRemainingLength( &receiveContext,
+    mqttPacket.remainingLength = _IotMqtt_GetRemainingLength( ( IotNetworkConnection_t ) &receiveContext,
                                                               &_networkInterface );
     IotTest_Assert( mqttPacket.remainingLength != MQTT_REMAINING_LENGTH_INVALID );
 

--- a/libraries/standard/mqtt/test/unit/iot_tests_mqtt_api.c
+++ b/libraries/standard/mqtt/test/unit/iot_tests_mqtt_api.c
@@ -555,7 +555,7 @@ static void _decrementReferencesJob( IotTaskPool_t pTaskPool,
 /**
  * @brief get next byte mock function to test MQTT serializer API
  */
-static IotMqttError_t _getNextByte( void * pNetworkInterface,
+static IotMqttError_t _getNextByte( IotNetworkConnection_t pNetworkInterface,
                                     uint8_t * nextByte )
 {
     uint8_t * buffer;
@@ -854,7 +854,7 @@ TEST( MQTT_Unit_API, OperationWaitTimeout )
         TEST_ASSERT_NOT_NULL( _pMqttConnection );
 
         /* Set parameter to network send function. */
-        _pMqttConnection->pNetworkConnection = &waitSem;
+        _pMqttConnection->pNetworkConnection = ( IotNetworkConnection_t ) &waitSem;
 
         /* Create a new operation referencing the MQTT connection. */
         TEST_ASSERT_EQUAL( IOT_MQTT_SUCCESS, _IotMqtt_CreateOperation( _pMqttConnection,
@@ -1362,7 +1362,7 @@ TEST( MQTT_Unit_API, PublishDuplicates )
     TEST_ASSERT_NOT_NULL( _pMqttConnection );
 
     /* Set the serializers and parameter to the send function. */
-    _pMqttConnection->pNetworkConnection = &dupCheckResult;
+    _pMqttConnection->pNetworkConnection = ( IotNetworkConnection_t ) &dupCheckResult;
     _pMqttConnection->pSerializer = &serializer;
 
     /* Set the publish info. */
@@ -1734,7 +1734,7 @@ TEST( MQTT_Unit_API, KeepAliveJobCleanup )
         TEST_ASSERT_NOT_NULL( _pMqttConnection );
 
         /* Set the parameter to the send function. */
-        _pMqttConnection->pNetworkConnection = &waitSem;
+        _pMqttConnection->pNetworkConnection = ( IotNetworkConnection_t ) &waitSem;
 
         /* Set a short keep-alive interval so this test runs faster. */
         _pMqttConnection->pingreq.u.operation.periodic.ping.keepAliveMs = SHORT_KEEP_ALIVE_MS;
@@ -2268,7 +2268,7 @@ TEST( MQTT_Unit_API, GetIncomingMQTTPacketTypeAndLengthChecks )
     uint8_t * bufPtr = buffer;
 
     /* Dummy network interface - pointer to pointer to a buffer. */
-    void * pNetworkInterface = ( void * ) &bufPtr;
+    IotNetworkConnection_t pNetworkInterface = ( IotNetworkConnection_t ) &bufPtr;
 
     buffer[ 0 ] = 0x20; /* CONN ACK */
     buffer[ 1 ] = 0x02; /* Remaining length. */

--- a/libraries/standard/mqtt/test/unit/iot_tests_mqtt_receive.c
+++ b/libraries/standard/mqtt/test/unit/iot_tests_mqtt_receive.c
@@ -187,7 +187,7 @@ static bool _disconnectCallbackCalled = false;
 /**
  * @brief Get packet type function override.
  */
-static uint8_t _getPacketType( void * pNetworkConnection,
+static uint8_t _getPacketType( IotNetworkConnection_t pNetworkConnection,
                                const IotNetworkInterface_t * pNetworkInterface )
 {
     _getPacketTypeCalled = true;
@@ -200,7 +200,7 @@ static uint8_t _getPacketType( void * pNetworkConnection,
 /**
  * @brief Get remaining length function override.
  */
-static size_t _getRemainingLength( void * pNetworkConnection,
+static size_t _getRemainingLength( IotNetworkConnection_t pNetworkConnection,
                                    const IotNetworkInterface_t * pNetworkInterface )
 {
     _getRemainingLengthCalled = true;
@@ -663,7 +663,7 @@ TEST( MQTT_Unit_Receive, DecodeRemainingLength )
         receiveContext.dataLength = 4;
 
         TEST_ASSERT_EQUAL( 0,
-                           _IotMqtt_GetRemainingLength( &receiveContext,
+                           _IotMqtt_GetRemainingLength( ( IotNetworkConnection_t ) &receiveContext,
                                                         &_networkInterface ) );
     }
 
@@ -677,7 +677,7 @@ TEST( MQTT_Unit_Receive, DecodeRemainingLength )
         receiveContext.dataLength = 4;
 
         TEST_ASSERT_EQUAL( 129,
-                           _IotMqtt_GetRemainingLength( &receiveContext,
+                           _IotMqtt_GetRemainingLength( ( IotNetworkConnection_t ) &receiveContext,
                                                         &_networkInterface ) );
     }
 
@@ -691,7 +691,7 @@ TEST( MQTT_Unit_Receive, DecodeRemainingLength )
         receiveContext.dataLength = 4;
 
         TEST_ASSERT_EQUAL( 16386,
-                           _IotMqtt_GetRemainingLength( &receiveContext,
+                           _IotMqtt_GetRemainingLength( ( IotNetworkConnection_t ) &receiveContext,
                                                         &_networkInterface ) );
     }
 
@@ -706,7 +706,7 @@ TEST( MQTT_Unit_Receive, DecodeRemainingLength )
         receiveContext.dataLength = 4;
 
         TEST_ASSERT_EQUAL( 268435455,
-                           _IotMqtt_GetRemainingLength( &receiveContext,
+                           _IotMqtt_GetRemainingLength( ( IotNetworkConnection_t ) &receiveContext,
                                                         &_networkInterface ) );
     }
 
@@ -720,7 +720,7 @@ TEST( MQTT_Unit_Receive, DecodeRemainingLength )
         receiveContext.dataLength = 4;
 
         TEST_ASSERT_EQUAL( MQTT_REMAINING_LENGTH_INVALID,
-                           _IotMqtt_GetRemainingLength( &receiveContext,
+                           _IotMqtt_GetRemainingLength( ( IotNetworkConnection_t ) &receiveContext,
                                                         &_networkInterface ) );
     }
 
@@ -735,7 +735,7 @@ TEST( MQTT_Unit_Receive, DecodeRemainingLength )
         receiveContext.dataLength = 4;
 
         TEST_ASSERT_EQUAL( MQTT_REMAINING_LENGTH_INVALID,
-                           _IotMqtt_GetRemainingLength( &receiveContext,
+                           _IotMqtt_GetRemainingLength( ( IotNetworkConnection_t ) &receiveContext,
                                                         &_networkInterface ) );
     }
 


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
MISRA Rule 11.2 prohibits a cast from an incomplete type - such as a `struct _networkConnection *` - to `void *`. This changes instances of `void *` to `IotNetworkConnection_t` when dealing with pointers to network connections.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
