### PR TITLE
Address MQTT MISRA 11.5, 11.8, and 11.9

### DIFF
--- a/libraries/standard/common/include/iot_linear_containers.h
+++ b/libraries/standard/common/include/iot_linear_containers.h
@@ -623,6 +623,7 @@ static inline IotLink_t * IotListDouble_FindFirstMatch( const IotListDouble_t * 
 {
     /* The const must be cast away to match this function's return value. Nevertheless,
      * this function will respect the const-ness of pStartPoint. */
+    /* coverity[misra_c_2012_rule_11_8_violation] */
     IotLink_t * pCurrent = ( IotLink_t * ) pStartPoint, * pMatchedLink = NULL;
     bool matchFound = false;
 

--- a/libraries/standard/mqtt/lexicon.txt
+++ b/libraries/standard/mqtt/lexicon.txt
@@ -132,6 +132,7 @@ pnetworkcontext
 pnetworkinterface
 pnextbyte
 poperation
+poperationlink
 posix
 ppacketidentifier
 ppacketidentifierhigh
@@ -143,6 +144,7 @@ pre
 preceiveddata
 premainingdata
 pserializer
+psubscriptionlink
 ptopicfilter
 ptopicname
 puback

--- a/libraries/standard/mqtt/src/iot_mqtt_api.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_api.c
@@ -1246,7 +1246,7 @@ IotMqttError_t IotMqtt_Connect( const IotMqttNetworkInfo_t * pNetworkInfo,
     IotMqttError_t status = IOT_MQTT_SUCCESS;
     bool ownNetworkConnection = false;
     IotNetworkError_t networkStatus = IOT_NETWORK_SUCCESS;
-    IotNetworkConnection_t pNetworkConnection = { 0 };
+    IotNetworkConnection_t pNetworkConnection = NULL;
     _mqttOperation_t * pOperation = NULL;
     _mqttConnection_t * pNewMqttConnection = NULL;
 

--- a/libraries/standard/mqtt/src/iot_mqtt_api.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_api.c
@@ -370,8 +370,11 @@ static bool _mqttSubscription_setUnsubscribe( const IotLink_t * const pSubscript
      * must never be NULL. */
     IotMqtt_Assert( pSubscriptionLink != NULL );
 
-    /* Adding parentheses to parameters of IotLink_Container is not applicable
+    /* Casting `pSubscriptionLink` to uint8_t * is done only to calculate the
+     * starting address of the struct and does not modify the link it points to.
+     * Adding parentheses to parameters of IotLink_Container is not applicable
      * because it uses type-casting and offsetof, and would cause compiling errors. */
+    /* coverity[misra_c_2012_rule_11_8_violation] */
     /* coverity[misra_c_2012_rule_20_7_violation] */
     /* coverity[caretline] */
     _mqttSubscription_t * pSubscription = IotLink_Container( _mqttSubscription_t,

--- a/libraries/standard/mqtt/src/iot_mqtt_operation.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_operation.c
@@ -167,8 +167,11 @@ static bool _mqttOperation_match( const IotLink_t * const pOperationLink,
      * must never be NULL. */
     IotMqtt_Assert( pOperationLink != NULL );
 
-    /* Adding parentheses to parameters of IotLink_Container is not applicable
+    /* Casting `pOperationLink` to uint8_t * is done only to calculate the
+     * starting address of the struct and does not modify the link it points to.
+     * Adding parentheses to parameters of IotLink_Container is not applicable
      * because it uses type-casting and offsetof, and would cause compiling errors. */
+    /* coverity[misra_c_2012_rule_11_8_violation] */
     /* coverity[misra_c_2012_rule_20_7_violation] */
     /* coverity[caretline] */
     const _mqttOperation_t * pOperation = IotLink_Container( _mqttOperation_t,
@@ -945,7 +948,7 @@ void _IotMqtt_ProcessIncomingPublish( IotTaskPool_t pTaskPool,
 
     /* Free buffers associated with the current PUBLISH message. */
     IotMqtt_Assert( pOperation->u.publish.pReceivedData != NULL );
-    IotMqtt_FreeMessage( ( void * ) pOperation->u.publish.pReceivedData );
+    IotMqtt_FreeMessage( pOperation->u.publish.pReceivedData );
 
     /* Free the incoming PUBLISH operation. */
     IotMqtt_FreeOperation( pOperation );

--- a/libraries/standard/mqtt/src/iot_mqtt_serialize.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_serialize.c
@@ -2060,7 +2060,11 @@ IotMqttError_t _IotMqtt_SerializePingreq( uint8_t ** pPingreqPacket,
                                           size_t * pPacketSize )
 {
     /* PINGREQ packets are always the same. */
-    static const uint8_t pPingreq[ MQTT_PACKET_PINGREQ_SIZE ] =
+    /* It is not necessary to make this array const. Since there are other
+     * types of MQTT packets that are not constant, this array would be
+     * cast to remove the const qualifier anyway. */
+    /* coverity[misra_c_2012_rule_8_13_violation] */
+    static uint8_t pPingreq[ MQTT_PACKET_PINGREQ_SIZE ] =
     {
         MQTT_PACKET_TYPE_PINGREQ,
         0x00
@@ -2116,7 +2120,11 @@ IotMqttError_t _IotMqtt_SerializeDisconnect( uint8_t ** pDisconnectPacket,
                                              size_t * pPacketSize )
 {
     /* DISCONNECT packets are always the same. */
-    static const uint8_t pDisconnect[ MQTT_PACKET_DISCONNECT_SIZE ] =
+    /* It is not necessary to make this array const. Since there are other
+     * types of MQTT packets that are not constant, this array would be
+     * cast to remove the const qualifier anyway. */
+    /* coverity[misra_c_2012_rule_8_13_violation] */
+    static uint8_t pDisconnect[ MQTT_PACKET_DISCONNECT_SIZE ] =
     {
         MQTT_PACKET_TYPE_DISCONNECT,
         0x00

--- a/libraries/standard/mqtt/src/iot_mqtt_subscription.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_subscription.c
@@ -289,8 +289,11 @@ static bool _topicMatch( const IotLink_t * const pSubscriptionLink,
      * will never pass NULL. */
     IotMqtt_Assert( pSubscriptionLink != NULL );
 
-    /* Adding parentheses to parameters of IotLink_Container is not applicable
+    /* Casting `pSubscriptionLink` to uint8_t * is done only to calculate the
+     * starting address of the struct and does not modify the link it points to.
+     * Adding parentheses to parameters of IotLink_Container is not applicable
      * because it uses type-casting and offsetof, and would cause compiling errors. */
+    /* coverity[misra_c_2012_rule_11_8_violation] */
     /* coverity[misra_c_2012_rule_20_7_violation] */
     /* coverity[caretline] */
     const _mqttSubscription_t * pSubscription = IotLink_Container( _mqttSubscription_t,
@@ -331,8 +334,11 @@ static bool _packetMatch( const IotLink_t * const pSubscriptionLink,
      * must never be NULL. */
     IotMqtt_Assert( pSubscriptionLink != NULL );
 
-    /* Adding parentheses to parameters of IotLink_Container is not applicable
+    /* Casting `pSubscriptionLink` to uint8_t * is done only to calculate the
+     * starting address of the struct and does not modify the link it points to.
+     * Adding parentheses to parameters of IotLink_Container is not applicable
      * because it uses type-casting and offsetof, and would cause compiling errors. */
+    /* coverity[misra_c_2012_rule_11_8_violation] */
     /* coverity[misra_c_2012_rule_20_7_violation] */
     /* coverity[caretline] */
     _mqttSubscription_t * pSubscription = IotLink_Container( _mqttSubscription_t,
@@ -671,8 +677,11 @@ bool IotMqtt_IsSubscribed( IotMqttConnection_t mqttConnection,
     /* Check if a matching subscription was found. */
     if( pSubscriptionLink != NULL )
     {
-        /* Adding parentheses to parameters of IotLink_Container is not applicable
+        /* Casting `pSubscriptionLink` to uint8_t * is done only to calculate the
+         * starting address of the struct and does not modify the link it points to.
+         * Adding parentheses to parameters of IotLink_Container is not applicable
          * because it uses type-casting and offsetof, and would cause compiling errors. */
+        /* coverity[misra_c_2012_rule_11_8_violation] */
         /* coverity[misra_c_2012_rule_20_7_violation] */
         /* coverity[caretline] */
         pSubscription = IotLink_Container( _mqttSubscription_t, pSubscriptionLink, link );

--- a/libraries/standard/mqtt/src/private/iot_mqtt_internal.h
+++ b/libraries/standard/mqtt/src/private/iot_mqtt_internal.h
@@ -373,7 +373,7 @@ typedef struct _mqttOperation
         struct
         {
             IotMqttPublishInfo_t publishInfo; /**< @brief Deserialized PUBLISH. */
-            const void * pReceivedData;       /**< @brief Any buffer associated with this PUBLISH that should be freed. */
+            void * pReceivedData;             /**< @brief Any buffer associated with this PUBLISH that should be freed. */
         } publish;
     } u;                                      /**< @brief Valid member depends on _mqttOperation_t.incomingPublish. */
 } _mqttOperation_t;

--- a/scripts/coverity_misra.config
+++ b/scripts/coverity_misra.config
@@ -28,7 +28,7 @@
         },
         {
             deviation: "Rule 11.5",
-            reason: "Allow casts from void *. Casts to and from void * are used for abstractions."
+            reason: "Allow casts from void *. Contexts are passed as void * and must be cast to the correct data type before use."
         },
         {
             deviation: "Rule 21.1",

--- a/scripts/coverity_misra.config
+++ b/scripts/coverity_misra.config
@@ -27,6 +27,10 @@
             reason: "Allow unused macros. Library headers may define macros intended for the application's use, but not used by a specific file."
         },
         {
+            deviation: "Rule 11.5",
+            reason: "Allow casts from void *. Casts to and from void * are used for abstractions."
+        },
+        {
             deviation: "Rule 21.1",
             reason: "Allow use of all names."
         },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes for some violations of MISRA 11.8 and 11.9 and suppressions for other 11.8 violations. Disables 11.5 (cast from void * to object pointer) as `void *` is used for abstractions and passing context.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
