### PR TITLE
Annotate gcc atomic and posix headers for MISRA

### DIFF
--- a/ports/common/include/atomic/iot_atomic_gcc.h
+++ b/ports/common/include/atomic/iot_atomic_gcc.h
@@ -59,6 +59,8 @@ static FORCE_INLINE uint32_t Atomic_CompareAndSwap_u32( uint32_t volatile * pDes
      * type. */
     /* coverity[misra_c_2012_directive_4_6_violation] */
     /* coverity[misra_c_2012_rule_10_4_violation] */
+    /* coverity[misra_c_2012_rule_17_3_violation] */
+    /* coverity[caretline] */
     if( __atomic_compare_exchange( pDestination,
                                    &comparand,
                                    &newValue,
@@ -86,6 +88,8 @@ static FORCE_INLINE void * Atomic_Swap_Pointer( void * volatile * pDestination,
      * which requires an int parameter for this routine. */
     /* coverity[misra_c_2012_directive_4_6_violation] */
     /* coverity[misra_c_2012_rule_17_7_violation] */
+    /* coverity[misra_c_2012_rule_17_3_violation] */
+    /* coverity[caretline] */
     __atomic_exchange( pDestination, &pNewValue, &pOldValue, __ATOMIC_SEQ_CST );
 
     return pOldValue;
@@ -105,6 +109,8 @@ static FORCE_INLINE uint32_t Atomic_CompareAndSwap_Pointer( void * volatile * pD
     /* This routine is built into gcc and defined to return a bool
      * type. */
     /* coverity[misra_c_2012_rule_10_4_violation] */
+    /* coverity[misra_c_2012_rule_17_3_violation] */
+    /* coverity[caretline] */
     if( __atomic_compare_exchange( pDestination,
                                    &pComparand,
                                    &pNewValue,
@@ -129,6 +135,8 @@ static FORCE_INLINE uint32_t Atomic_Add_u32( uint32_t volatile * pAugend,
     /* This header file is intended to be used with only the gcc compiler
      * which requires an int parameter for this routine. */
     /* coverity[misra_c_2012_directive_4_6_violation] */
+    /* coverity[misra_c_2012_rule_17_3_violation] */
+    /* coverity[caretline] */
     return ( uint32_t ) ( __atomic_fetch_add( pAugend, addend, __ATOMIC_SEQ_CST ) );
 }
 
@@ -143,6 +151,8 @@ static FORCE_INLINE uint32_t Atomic_Subtract_u32( uint32_t volatile * pMinuend,
     /* This header file is intended to be used with only the gcc compiler
      * which requires an int parameter for this routine. */
     /* coverity[misra_c_2012_directive_4_6_violation] */
+    /* coverity[misra_c_2012_rule_17_3_violation] */
+    /* coverity[caretline] */
     return ( uint32_t ) ( __atomic_fetch_sub( pMinuend, subtrahend, __ATOMIC_SEQ_CST ) );
 }
 
@@ -153,6 +163,8 @@ static FORCE_INLINE uint32_t Atomic_Subtract_u32( uint32_t volatile * pMinuend,
  */
 static FORCE_INLINE uint32_t Atomic_Increment_u32( uint32_t volatile * pAugend )
 {
+    /* coverity[misra_c_2012_rule_17_3_violation] */
+    /* coverity[caretline] */
     return ( uint32_t ) ( __atomic_fetch_add( pAugend, 1U, __ATOMIC_SEQ_CST ) );
 }
 
@@ -163,6 +175,8 @@ static FORCE_INLINE uint32_t Atomic_Increment_u32( uint32_t volatile * pAugend )
  */
 static FORCE_INLINE uint32_t Atomic_Decrement_u32( uint32_t volatile * pMinuend )
 {
+    /* coverity[misra_c_2012_rule_17_3_violation] */
+    /* coverity[caretline] */
     return ( uint32_t ) ( __atomic_fetch_sub( pMinuend, 1U, __ATOMIC_SEQ_CST ) );
 }
 
@@ -177,6 +191,8 @@ static FORCE_INLINE uint32_t Atomic_OR_u32( uint32_t volatile * pOperand,
     /* This header file is intended to be used with only the gcc compiler
      * which requires an int parameter for this routine. */
     /* coverity[misra_c_2012_directive_4_6_violation] */
+    /* coverity[misra_c_2012_rule_17_3_violation] */
+    /* coverity[caretline] */
     return ( uint32_t ) ( __atomic_fetch_or( pOperand, mask, __ATOMIC_SEQ_CST ) );
 }
 
@@ -191,6 +207,8 @@ static FORCE_INLINE uint32_t Atomic_XOR_u32( uint32_t volatile * pOperand,
     /* This header file is intended to be used with only the gcc compiler
      * which requires an int parameter for this routine. */
     /* coverity[misra_c_2012_directive_4_6_violation] */
+    /* coverity[misra_c_2012_rule_17_3_violation] */
+    /* coverity[caretline] */
     return ( uint32_t ) ( __atomic_fetch_xor( pOperand, mask, __ATOMIC_SEQ_CST ) );
 }
 
@@ -205,6 +223,8 @@ static FORCE_INLINE uint32_t Atomic_AND_u32( uint32_t volatile * pOperand,
     /* This header file is intended to be used with only the gcc compiler
      * which requires an int parameter for this routine. */
     /* coverity[misra_c_2012_directive_4_6_violation] */
+    /* coverity[misra_c_2012_rule_17_3_violation] */
+    /* coverity[caretline] */
     return ( uint32_t ) ( __atomic_fetch_and( pOperand, mask, __ATOMIC_SEQ_CST ) );
 }
 
@@ -219,6 +239,8 @@ static FORCE_INLINE uint32_t Atomic_NAND_u32( uint32_t volatile * pOperand,
     /* This header file is intended to be used with only the gcc compiler
      * which requires an int parameter for this routine. */
     /* coverity[misra_c_2012_directive_4_6_violation] */
+    /* coverity[misra_c_2012_rule_17_3_violation] */
+    /* coverity[caretline] */
     return ( uint32_t ) ( __atomic_fetch_nand( pOperand, mask, __ATOMIC_SEQ_CST ) );
 }
 

--- a/ports/common/include/atomic/iot_atomic_gcc.h
+++ b/ports/common/include/atomic/iot_atomic_gcc.h
@@ -58,6 +58,7 @@ static FORCE_INLINE uint32_t Atomic_CompareAndSwap_u32( uint32_t volatile * pDes
      * This routine is built into gcc and defined to return a bool
      * type. */
     /* coverity[misra_c_2012_directive_4_6_violation] */
+    /* coverity[misra_c_2012_rule_8_5_violation] */
     /* coverity[misra_c_2012_rule_10_4_violation] */
     /* coverity[misra_c_2012_rule_17_3_violation] */
     /* coverity[caretline] */
@@ -111,6 +112,7 @@ static FORCE_INLINE uint32_t Atomic_CompareAndSwap_Pointer( void * volatile * pD
     /* coverity[misra_c_2012_rule_10_4_violation] */
     /* coverity[misra_c_2012_rule_17_3_violation] */
     /* coverity[caretline] */
+    /* coverity[other_declaration] */
     if( __atomic_compare_exchange( pDestination,
                                    &pComparand,
                                    &pNewValue,
@@ -135,6 +137,7 @@ static FORCE_INLINE uint32_t Atomic_Add_u32( uint32_t volatile * pAugend,
     /* This header file is intended to be used with only the gcc compiler
      * which requires an int parameter for this routine. */
     /* coverity[misra_c_2012_directive_4_6_violation] */
+    /* coverity[misra_c_2012_rule_8_5_violation] */
     /* coverity[misra_c_2012_rule_17_3_violation] */
     /* coverity[caretline] */
     return ( uint32_t ) ( __atomic_fetch_add( pAugend, addend, __ATOMIC_SEQ_CST ) );
@@ -151,6 +154,7 @@ static FORCE_INLINE uint32_t Atomic_Subtract_u32( uint32_t volatile * pMinuend,
     /* This header file is intended to be used with only the gcc compiler
      * which requires an int parameter for this routine. */
     /* coverity[misra_c_2012_directive_4_6_violation] */
+    /* coverity[misra_c_2012_rule_8_5_violation] */
     /* coverity[misra_c_2012_rule_17_3_violation] */
     /* coverity[caretline] */
     return ( uint32_t ) ( __atomic_fetch_sub( pMinuend, subtrahend, __ATOMIC_SEQ_CST ) );
@@ -165,6 +169,7 @@ static FORCE_INLINE uint32_t Atomic_Increment_u32( uint32_t volatile * pAugend )
 {
     /* coverity[misra_c_2012_rule_17_3_violation] */
     /* coverity[caretline] */
+    /* coverity[other_declaration] */
     return ( uint32_t ) ( __atomic_fetch_add( pAugend, 1U, __ATOMIC_SEQ_CST ) );
 }
 
@@ -177,6 +182,7 @@ static FORCE_INLINE uint32_t Atomic_Decrement_u32( uint32_t volatile * pMinuend 
 {
     /* coverity[misra_c_2012_rule_17_3_violation] */
     /* coverity[caretline] */
+    /* coverity[other_declaration] */
     return ( uint32_t ) ( __atomic_fetch_sub( pMinuend, 1U, __ATOMIC_SEQ_CST ) );
 }
 

--- a/ports/common/lexicon.txt
+++ b/ports/common/lexicon.txt
@@ -3,6 +3,7 @@ authmode
 bool
 ca
 callbackmutex
+caretline
 clientcert
 closecallback
 compareandswap

--- a/ports/posix/include/iot_platform_types_posix.h
+++ b/ports/posix/include/iot_platform_types_posix.h
@@ -54,9 +54,9 @@ typedef sem_t             _IotSystemSemaphore_t;
  */
 typedef struct _IotSystemTimer
 {
-    timer_t timer;                      /**< @brief Underlying POSIX timer. */
-    void * pArgument;                   /**< @brief First argument to threadRoutine. */
-    void ( * threadRoutine )( void * ); /**< @brief Thread function to run on timer expiration. */
+    timer_t timer;                           /**< @brief Underlying POSIX timer. */
+    void * pArgument;                        /**< @brief First argument to threadRoutine. */
+    void ( * threadRoutine )( void * pArg ); /**< @brief Thread function to run on timer expiration. */
 } _IotSystemTimer_t;
 
 /**

--- a/ports/posix/lexicon.txt
+++ b/ports/posix/lexicon.txt
@@ -12,6 +12,7 @@ mutex
 onlinepubs
 opengroup
 org
+parg
 pargument
 posix
 strftime


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Annotations for the gcc atomic header and posix platform types header for MISRA 17.3, 8.5, and 8.2. Although these files will not be part of FreeRTOS, they are used when running Coverity on Linux and can be suppressed from the report.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
