### PR TITLE
Fix: Unused variable warning.

### DIFF
--- a/libraries/standard/mqtt/src/iot_mqtt_serialize.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_serialize.c
@@ -522,6 +522,9 @@ static uint8_t * _encodeUserName( uint8_t * pDestination,
     uint8_t * pBuffer = pDestination;
     const char * pMetricsUserName = NULL;
 
+    /* Avoid unused variable warning when AWS_IOT_MQTT_ENABLE_METRICS is set to 0 */
+    ( void ) pMetricsUserName;
+
     /* If metrics are enabled, write the metrics username into the CONNECT packet.
      * Otherwise, write the username and password only when not connecting to the
      * AWS IoT MQTT server. */


### PR DESCRIPTION
Unused variable warning when AWS_IOT_MQTT_ENABLE_METRICS is set to 0.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
