### PR TITLE
Disable MISRA Rule 3.1

### DIFF
--- a/scripts/coverity_misra.config
+++ b/scripts/coverity_misra.config
@@ -27,6 +27,10 @@
             reason: "Allow unused macros. Library headers may define macros intended for the application's use, but not used by a specific file."
         },
         {
+            deviation: "Rule 3.1",
+            reason: "Allow nested comments. Documentation blocks contain comments for example code."
+        },
+        {
             deviation: "Rule 11.5",
             reason: "Allow casts from void *. Contexts are passed as void * and must be cast to the correct data type before use."
         },


### PR DESCRIPTION
*Issue #, if available:* SIM: https://sim.amazon.com/issues/TS-11295

*Description of changes:*
Disable MISRA 3.1 as nested comments are used in doxygen blocks

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
