### PR TITLE
Fix MISRA 10.3 violation

### DIFF
--- a/libraries/standard/mqtt/src/iot_mqtt_static_memory.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_static_memory.c
@@ -85,14 +85,14 @@
 /*
  * Static memory buffers and flags, allocated and zeroed at compile-time.
  */
-static uint32_t _pInUseMqttConnections[ IOT_MQTT_CONNECTIONS ] = { 0U };                          /**< @brief MQTT connection in-use flags. */
-static _mqttConnection_t _pMqttConnections[ IOT_MQTT_CONNECTIONS ];                               /**< @brief MQTT connections. */
+static uint32_t _pInUseMqttConnections[ IOT_MQTT_CONNECTIONS ];                      /**< @brief MQTT connection in-use flags. */
+static _mqttConnection_t _pMqttConnections[ IOT_MQTT_CONNECTIONS ];                  /**< @brief MQTT connections. */
 
-static uint32_t _pInUseMqttOperations[ IOT_MQTT_MAX_IN_PROGRESS_OPERATIONS ] = { 0U };                   /**< @brief MQTT operation in-use flags. */
-static _mqttOperation_t _pMqttOperations[ IOT_MQTT_MAX_IN_PROGRESS_OPERATIONS ] = { { .link = { 0 } } }; /**< @brief MQTT operations. */
+static uint32_t _pInUseMqttOperations[ IOT_MQTT_MAX_IN_PROGRESS_OPERATIONS ];        /**< @brief MQTT operation in-use flags. */
+static _mqttOperation_t _pMqttOperations[ IOT_MQTT_MAX_IN_PROGRESS_OPERATIONS ];     /**< @brief MQTT operations. */
 
-static uint32_t _pInUseMqttSubscriptions[ IOT_MQTT_SUBSCRIPTIONS ] = { 0U };                      /**< @brief MQTT subscription in-use flags. */
-static char _pMqttSubscriptions[ IOT_MQTT_SUBSCRIPTIONS ][ MQTT_SUBSCRIPTION_SIZE ] = { { '\0' } };  /**< @brief MQTT subscriptions. */
+static uint32_t _pInUseMqttSubscriptions[ IOT_MQTT_SUBSCRIPTIONS ];                  /**< @brief MQTT subscription in-use flags. */
+static char _pMqttSubscriptions[ IOT_MQTT_SUBSCRIPTIONS ][ MQTT_SUBSCRIPTION_SIZE ]; /**< @brief MQTT subscriptions. */
 
 /*-----------------------------------------------------------*/
 

--- a/libraries/standard/mqtt/src/iot_mqtt_static_memory.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_static_memory.c
@@ -86,7 +86,7 @@
  * Static memory buffers and flags, allocated and zeroed at compile-time.
  */
 static uint32_t _pInUseMqttConnections[ IOT_MQTT_CONNECTIONS ] = { 0U };                          /**< @brief MQTT connection in-use flags. */
-static _mqttConnection_t _pMqttConnections[ IOT_MQTT_CONNECTIONS ] = { { 0 } };                   /**< @brief MQTT connections. */
+static _mqttConnection_t _pMqttConnections[ IOT_MQTT_CONNECTIONS ];                               /**< @brief MQTT connections. */
 
 static uint32_t _pInUseMqttOperations[ IOT_MQTT_MAX_IN_PROGRESS_OPERATIONS ] = { 0U };                   /**< @brief MQTT operation in-use flags. */
 static _mqttOperation_t _pMqttOperations[ IOT_MQTT_MAX_IN_PROGRESS_OPERATIONS ] = { { .link = { 0 } } }; /**< @brief MQTT operations. */


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes a single MISRA 10.3 warning. Removed the explicit initializations from the other static variables in this file for consistency. Per 6.7.8-10 of the [C99 standard](http://www.open-std.org/JTC1/sc22/wg14/www/docs/n1256.pdf), static variables are initialized to NULL or 0, and don't need to be explicitly initialized.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
