### PR TITLE
Add an MQTT state model for CBMC proofs of the MQTT client API.

### DIFF
--- a/cbmc/proofs/mqtt_state.c
+++ b/cbmc/proofs/mqtt_state.c
@@ -9,9 +9,9 @@
  * Model a malloc that can fail and return NULL.
  ****************************************************************/
 
-void *malloc_can_fail(size_t size)
+void *malloc_can_fail( size_t size )
 {
-  __CPROVER_assert(VALID_CBMC_SIZE(size), "malloc_can_fail size too big");
+  __CPROVER_assert( VALID_CBMC_SIZE( size ), "malloc_can_fail size too big" );
   return nondet_bool() ? NULL : malloc( size );
 }
 
@@ -28,8 +28,8 @@ void *allocate_opaque_type()
  * MqttOperation
  ****************************************************************/
 
-IotMqttOperation_t allocate_IotMqttOperation(IotMqttOperation_t pOp,
-					     IotMqttConnection_t pConn)
+IotMqttOperation_t allocate_IotMqttOperation( IotMqttOperation_t pOp,
+					      IotMqttConnection_t pConn )
 {
   // assume a valid connection for the operation
   assert( pConn != NULL );
@@ -42,7 +42,7 @@ IotMqttOperation_t allocate_IotMqttOperation(IotMqttOperation_t pOp,
   if ( pOp->incomingPublish ) {
     // allocate publish member of the union
 
-    allocate_IotMqttPublishInfo( &(pOp->u.publish.publishInfo) );
+    allocate_IotMqttPublishInfo( &(pOp->u.publish.publishInfo ) );
 
     size_t length;
     __CPROVER_assume( VALID_CBMC_SIZE( length ) );
@@ -66,9 +66,9 @@ IotMqttOperation_t allocate_IotMqttOperation(IotMqttOperation_t pOp,
 
 bool valid_IotMqttOperation( const IotMqttOperation_t pOp )
 {
-  if (pOp == NULL) return false;
+  if ( pOp == NULL ) return false;
 
-  // publish member of the union should be valid (pOp->incomingPublish)
+  // publish member of the union should be valid (pOp->incomingPublish )
 
   bool valid_publishinfo =
     valid_IotMqttPublishInfo( &(pOp->u.publish.publishInfo) );
@@ -89,17 +89,18 @@ bool valid_IotMqttOperation( const IotMqttOperation_t pOp )
     IMPLIES( pOp->u.operation.type != IOT_MQTT_PINGREQ,
 	     pOp->u.operation.packetSize > 0 );
   bool waitable =
-    (pOp->u.operation.flags & IOT_MQTT_FLAG_WAITABLE) == IOT_MQTT_FLAG_WAITABLE;
+    ( pOp->u.operation.flags & IOT_MQTT_FLAG_WAITABLE )
+        == IOT_MQTT_FLAG_WAITABLE;
   bool valid_jobReference =
     IMPLIES(  waitable, pOp->u.operation.jobReference == 2 ) &&
     IMPLIES( !waitable, pOp->u.operation.jobReference == 1 );
 
   bool valid_operation_member =
-    IMPLIES(!pOp->incomingPublish,
-	    valid_packet &&
-	    valid_pingreq_packet &&
-	    valid_other_packet &&
-	    valid_jobReference);
+    IMPLIES( !pOp->incomingPublish,
+	     valid_packet &&
+	     valid_pingreq_packet &&
+	     valid_other_packet &&
+	     valid_jobReference );
 
   return
     // assume valid connection
@@ -111,35 +112,35 @@ bool valid_IotMqttOperation( const IotMqttOperation_t pOp )
  * IotMqttConnection
  ****************************************************************/
 
-IotMqttConnection_t allocate_IotMqttConnection(IotMqttConnection_t pConn)
+IotMqttConnection_t allocate_IotMqttConnection( IotMqttConnection_t pConn )
 {
   if ( pConn == NULL ) pConn = malloc_can_fail( sizeof( *pConn ) );
   if ( pConn == NULL ) return NULL;
 
   pConn->pNetworkConnection = allocate_IotNetworkConnection();
   pConn->pNetworkInterface = allocate_IotNetworkInterface();
-  allocate_IotMqttOperation( &(pConn->pingreq), pConn );
+  allocate_IotMqttOperation( &(pConn->pingreq ), pConn );
   return pConn;
 }
 
-void ensure_IotMqttConnection_has_lists(IotMqttConnection_t pConn)
+void ensure_IotMqttConnection_has_lists( IotMqttConnection_t pConn )
 {
   // TODO: add code to make lists nondet nontrivial
   // Consider using allocate_IotMqttSubscriptionList
-  IotListDouble_Create(&pConn->pendingProcessing);
-  IotListDouble_Create(&pConn->pendingResponse);
-  IotListDouble_Create(&pConn->subscriptionList);
+  IotListDouble_Create( &pConn->pendingProcessing );
+  IotListDouble_Create( &pConn->pendingResponse );
+  IotListDouble_Create( &pConn->subscriptionList );
   return pConn;
 }
 
-bool valid_IotMqttConnection(const IotMqttConnection_t pConn)
+bool valid_IotMqttConnection( const IotMqttConnection_t pConn )
 {
   if ( pConn == NULL ) return false;
 
   bool valid_references = pConn->references >= 1;
 
   bool valid_pingreq =
-    ( valid_IotMqttOperation( &(pConn->pingreq) ) ) &&
+    ( valid_IotMqttOperation( &(pConn->pingreq ) ) ) &&
     ( pConn->pingreq.u.operation.type == IOT_MQTT_PINGREQ ) &&
     ( pConn->pingreq.pMqttConnection == pConn ) &&
     ( !pConn->pingreq.incomingPublish ) ;
@@ -154,12 +155,12 @@ bool valid_IotMqttConnection(const IotMqttConnection_t pConn)
  * IotMqttNetworkInfo
  ****************************************************************/
 
-IotMqttNetworkInfo_t *allocate_IotMqttNetworkInfo(IotMqttNetworkInfo_t *pInfo)
+IotMqttNetworkInfo_t *allocate_IotMqttNetworkInfo( IotMqttNetworkInfo_t *pInfo )
 {
   if ( pInfo == NULL ) pInfo = malloc_can_fail( sizeof( *pInfo ) );
   if ( pInfo == NULL ) return NULL;
 
-  if (pInfo->createNetworkConnection) {
+  if ( pInfo->createNetworkConnection ) {
     // allocate setup member of union
     pInfo->u.setup.pNetworkServerInfo = allocate_opaque_type();
     pInfo->u.setup.pNetworkCredentialInfo = allocate_opaque_type();
@@ -171,7 +172,7 @@ IotMqttNetworkInfo_t *allocate_IotMqttNetworkInfo(IotMqttNetworkInfo_t *pInfo)
   return pInfo;
 }
 
-bool valid_IotMqttNetworkInfo(const IotMqttNetworkInfo_t *pInfo)
+bool valid_IotMqttNetworkInfo( const IotMqttNetworkInfo_t *pInfo )
 {
   if ( pInfo == NULL ) return false;
   return true;
@@ -181,32 +182,32 @@ bool valid_IotMqttNetworkInfo(const IotMqttNetworkInfo_t *pInfo)
  * IotMqttConnectInfo
  ****************************************************************/
 
-IotMqttConnectInfo_t *allocate_IotMqttConnectInfo(IotMqttConnectInfo_t *pInfo)
+IotMqttConnectInfo_t *allocate_IotMqttConnectInfo( IotMqttConnectInfo_t *pInfo )
 {
   if ( pInfo == NULL ) pInfo = malloc_can_fail( sizeof( *pInfo ) );
   if ( pInfo == NULL ) return NULL;
 
   pInfo->pPreviousSubscriptions =
-    allocate_IotMqttSubscriptionArray(NULL,
-				     pInfo->previousSubscriptionCount);
-  pInfo->pWillInfo = allocate_IotMqttPublishInfo(NULL);
-  pInfo->pClientIdentifier = malloc_can_fail(pInfo->clientIdentifierLength);
-  pInfo->pUserName = malloc_can_fail(pInfo->userNameLength);
-  pInfo->pPassword = malloc_can_fail(pInfo->passwordLength);
+    allocate_IotMqttSubscriptionArray( NULL,
+				       pInfo->previousSubscriptionCount );
+  pInfo->pWillInfo = allocate_IotMqttPublishInfo( NULL );
+  pInfo->pClientIdentifier = malloc_can_fail( pInfo->clientIdentifierLength );
+  pInfo->pUserName = malloc_can_fail( pInfo->userNameLength );
+  pInfo->pPassword = malloc_can_fail( pInfo->passwordLength );
 }
 
-bool valid_IotMqttConnectInfo(const IotMqttConnectInfo_t *pInfo)
+bool valid_IotMqttConnectInfo( const IotMqttConnectInfo_t *pInfo )
 {
   return
     pInfo &&
 
-    VALID_STRING(pInfo->pClientIdentifier, pInfo->clientIdentifierLength) &&
+    VALID_STRING( pInfo->pClientIdentifier, pInfo->clientIdentifierLength ) &&
     VALID_CBMC_SIZE( pInfo->clientIdentifierLength ) &&
 
-    VALID_STRING(pInfo->pUserName, pInfo->userNameLength) &&
+    VALID_STRING( pInfo->pUserName, pInfo->userNameLength ) &&
     VALID_CBMC_SIZE( pInfo->userNameLength ) &&
 
-    VALID_STRING(pInfo->pPassword, pInfo->passwordLength) &&
+    VALID_STRING( pInfo->pPassword, pInfo->passwordLength ) &&
     VALID_CBMC_SIZE( pInfo->passwordLength ) &&
 
 #ifdef SUBSCRIPTION_COUNT_MAX
@@ -214,15 +215,15 @@ bool valid_IotMqttConnectInfo(const IotMqttConnectInfo_t *pInfo)
 #endif
     IFF( pInfo->pPreviousSubscriptions == NULL,
 	 pInfo->previousSubscriptionCount == 0 ) &&
-    valid_IotMqttSubscriptionArray(pInfo->pPreviousSubscriptions,
-				   pInfo->previousSubscriptionCount);
+    valid_IotMqttSubscriptionArray( pInfo->pPreviousSubscriptions,
+				    pInfo->previousSubscriptionCount );
 }
 
 /****************************************************************
  * IotMqttSubscription
  ****************************************************************/
 
-IotMqttSubscription_t *allocate_IotMqttSubscription(IotMqttSubscription_t *pSub)
+IotMqttSubscription_t *allocate_IotMqttSubscription( IotMqttSubscription_t *pSub )
 {
   if ( pSub == NULL ) pSub = malloc_can_fail( sizeof( *pSub ) );
   if ( pSub == NULL ) return NULL;
@@ -231,7 +232,7 @@ IotMqttSubscription_t *allocate_IotMqttSubscription(IotMqttSubscription_t *pSub)
   return pSub;
 }
 
-bool valid_IotMqttSubscription(const IotMqttSubscription_t *pSub)
+bool valid_IotMqttSubscription( const IotMqttSubscription_t *pSub )
 {
   return
     pSub &&
@@ -249,26 +250,27 @@ bool valid_IotMqttSubscription(const IotMqttSubscription_t *pSub)
  * IotMqttSubscription array list
  ****************************************************************/
 
-IotMqttSubscription_t *allocate_IotMqttSubscriptionArray(IotMqttSubscription_t *pSub, size_t length)
+IotMqttSubscription_t *allocate_IotMqttSubscriptionArray( IotMqttSubscription_t *pSub,
+							  size_t length )
 {
-  if (pSub == NULL ) pSub = malloc_can_fail( length * sizeof( *pSub ) );
-  if (pSub == NULL ) return NULL;
+  if ( pSub == NULL ) pSub = malloc_can_fail( length * sizeof( *pSub ) );
+  if ( pSub == NULL ) return NULL;
 
-  for (int i = 0; i < length; i++)
-    allocate_IotMqttSubscription(pSub + i);
+  for ( int i = 0; i < length; i++ )
+    allocate_IotMqttSubscription( pSub + i );
 
   return pSub;
 }
 
-bool valid_IotMqttSubscriptionArray(const IotMqttSubscription_t *pSub,
-				    const size_t length)
+bool valid_IotMqttSubscriptionArray( const IotMqttSubscription_t *pSub,
+				     const size_t length )
 {
-  if ( !IFF(pSub == NULL, length == 0 ) ) return false;
+  if ( !IFF( pSub == NULL, length == 0 ) ) return false;
   if ( pSub == NULL ) return false;
 
   bool result = 1;
-  for (int i = 0; i < length; i++)
-    result = result && valid_IotMqttSubscription(pSub + i);
+  for ( int i = 0; i < length; i++ )
+    result = result && valid_IotMqttSubscription( pSub + i );
 
   return
 #ifdef SUBSCRIPTION_COUNT_MAX
@@ -283,14 +285,14 @@ bool valid_IotMqttSubscriptionArray(const IotMqttSubscription_t *pSub,
 
 // Subscription linked list elements
 
-_mqttSubscription_t *allocate_IotMqttSubscriptionListElt(_mqttSubscription_t *pElt)
+_mqttSubscription_t *allocate_IotMqttSubscriptionListElt( _mqttSubscription_t *pElt )
 {
   size_t length;
   // Assumption avoids arithmetic overflow in malloc, rechecked in valid_*
   __CPROVER_assume( length <
 		    CBMC_MAX_OBJECT_SIZE - sizeof( _mqttSubscription_t ) );
 
-  if ( pElt == NULL ) pElt = malloc_can_fail( sizeof( *pElt ) + length);
+  if ( pElt == NULL ) pElt = malloc_can_fail( sizeof( *pElt ) + length );
   if ( pElt == NULL ) return NULL;
 
   pElt->link.pPrevious = NULL;
@@ -299,7 +301,7 @@ _mqttSubscription_t *allocate_IotMqttSubscriptionListElt(_mqttSubscription_t *pE
   return pElt;
 }
 
-bool valid_IotMqttSubscriptionListElt(const _mqttSubscription_t *pElt)
+bool valid_IotMqttSubscriptionListElt( const _mqttSubscription_t *pElt )
 {
   if ( pElt == NULL ) return false;
 
@@ -308,29 +310,29 @@ bool valid_IotMqttSubscriptionListElt(const _mqttSubscription_t *pElt)
     pElt->topicFilterLength < TOPIC_LENGTH_MAX &&
 #endif
     pElt->topicFilterLength < CBMC_MAX_OBJECT_SIZE - sizeof( _mqttSubscription_t ) &&
-    __CPROVER_r_ok(pElt->pTopicFilter, pElt->topicFilterLength) &&
-    __CPROVER_w_ok(pElt->pTopicFilter, pElt->topicFilterLength);
+    __CPROVER_r_ok( pElt->pTopicFilter, pElt->topicFilterLength ) &&
+    __CPROVER_w_ok( pElt->pTopicFilter, pElt->topicFilterLength );
 }
 
 // Subscription linked lists
 
-IotListDouble_t *allocate_IotMqttSubscriptionList(IotListDouble_t *pSub,
-						  size_t length)
+IotListDouble_t *allocate_IotMqttSubscriptionList( IotListDouble_t *pSub,
+						   size_t length )
 {
   if ( pSub == NULL ) pSub = malloc_can_fail( sizeof( *pSub ) );
   if ( pSub == NULL ) return NULL;
 
-  IotListDouble_Create(pSub);
-  for (int i = 0; i < length; i++) {
-    _mqttSubscription_t *pElt = allocate_IotMqttSubscriptionListElt(NULL);
-    __CPROVER_assume(pElt);
-    IotListDouble_InsertHead( pSub, &(pElt->link) );
+  IotListDouble_Create( pSub );
+  for ( int i = 0; i < length; i++ ) {
+    _mqttSubscription_t *pElt = allocate_IotMqttSubscriptionListElt( NULL );
+    __CPROVER_assume( pElt );
+    IotListDouble_InsertHead( pSub, &( pElt->link ) );
   }
   return pSub;
 }
 
-bool valid_IotMqttSubscriptionList(const IotListDouble_t *pSub,
-				   const size_t length)
+bool valid_IotMqttSubscriptionList( const IotListDouble_t *pSub,
+				    const size_t length )
 {
   if ( pSub == NULL ) return false;
 
@@ -353,7 +355,7 @@ bool valid_IotMqttSubscriptionList(const IotListDouble_t *pSub,
  * IotMqttPublishInfo
  ****************************************************************/
 
-IotMqttPublishInfo_t *allocate_IotMqttPublishInfo(IotMqttPublishInfo_t *pInfo)
+IotMqttPublishInfo_t *allocate_IotMqttPublishInfo( IotMqttPublishInfo_t *pInfo )
 {
   if ( pInfo == NULL ) pInfo = malloc_can_fail( sizeof( *pInfo ) );
   if ( pInfo == NULL ) return NULL;
@@ -365,16 +367,16 @@ IotMqttPublishInfo_t *allocate_IotMqttPublishInfo(IotMqttPublishInfo_t *pInfo)
   return pInfo;
 }
 
-bool valid_IotMqttPublishInfo(const IotMqttPublishInfo_t *pInfo)
+bool valid_IotMqttPublishInfo( const IotMqttPublishInfo_t *pInfo )
 {
   return
     pInfo &&
 
-    VALID_STRING(pInfo->pTopicName, pInfo->topicNameLength) &&
+    VALID_STRING( pInfo->pTopicName, pInfo->topicNameLength ) &&
     VALID_CBMC_SIZE( pInfo->topicNameLength ) &&
     pInfo->pTopicName != NULL &&
 
-    VALID_STRING(pInfo->pPayload, pInfo->payloadLength) &&
+    VALID_STRING( pInfo->pPayload, pInfo->payloadLength ) &&
     VALID_CBMC_SIZE( pInfo->payloadLength ) &&
 
     pInfo->retryMs <= IOT_MQTT_RETRY_MS_CEILING &&
@@ -403,21 +405,21 @@ IotNetworkInterface_t *allocate_IotNetworkInterface()
   return malloc_can_fail( sizeof( IotNetworkInterface_t ) );
 }
 
-bool valid_IotNetworkInterface(const IotNetworkInterface_t *netif)
+bool valid_IotNetworkInterface( const IotNetworkInterface_t *netif )
 {
   return ( netif != NULL );
 }
 
-bool stubbed_IotNetworkInterface(const IotNetworkInterface_t *netif)
+bool stubbed_IotNetworkInterface( const IotNetworkInterface_t *netif )
 {
   return
-    IS_STUBBED_NETWORKIF_CREATE(netif) &&
-    IS_STUBBED_NETWORKIF_CLOSE(netif) &&
-    IS_STUBBED_NETWORKIF_SEND(netif) &&
-    IS_STUBBED_NETWORKIF_RECEIVE(netif) &&
-    IS_STUBBED_NETWORKIF_SETRECEIVECALLBACK(netif) &&
-    IS_STUBBED_NETWORKIF_SETCLOSECALLBACK(netif) &&
-    IS_STUBBED_NETWORKIF_DESTROY(netif);
+    IS_STUBBED_NETWORKIF_CREATE( netif ) &&
+    IS_STUBBED_NETWORKIF_CLOSE( netif ) &&
+    IS_STUBBED_NETWORKIF_SEND( netif ) &&
+    IS_STUBBED_NETWORKIF_RECEIVE( netif ) &&
+    IS_STUBBED_NETWORKIF_SETRECEIVECALLBACK( netif ) &&
+    IS_STUBBED_NETWORKIF_SETCLOSECALLBACK( netif ) &&
+    IS_STUBBED_NETWORKIF_DESTROY( netif );
 }
 
 /****************************************************************
@@ -430,13 +432,13 @@ IotNetworkError_t IotNetworkInterfaceCreate( void * pConnectionInfo,
 {
   // pCredentialInfo can be null
   // create accepts NULL credentials when there is no TLS configuration.
-  __CPROVER_assert(pConnectionInfo != NULL,
-		   "IotNetworkInterfaceCreate pConnectionInfo is not NULL");
-  __CPROVER_assert(pConnection != NULL,
-		   "IotNetworkInterfaceCreate pConnection is not NULL");
+  __CPROVER_assert( pConnectionInfo != NULL,
+		   "IotNetworkInterfaceCreate pConnectionInfo is not NULL" );
+  __CPROVER_assert( pConnection != NULL,
+		   "IotNetworkInterfaceCreate pConnection is not NULL" );
 
   // create the connection
-  *(void **)pConnection = allocate_IotNetworkConnection();
+  *(void ** )pConnection = allocate_IotNetworkConnection();
 
   IotNetworkError_t error;
   return error;
@@ -450,10 +452,10 @@ size_t IotNetworkInterfaceSend( void * pConnection,
 				const uint8_t * pMessage,
 				size_t messageLength )
 {
-  __CPROVER_assert(pConnection != NULL,
-		   "IotNetworkInterfaceSend pConnection is not NULL");
-  __CPROVER_assert(pMessage != NULL,
-		   "IotNetworkInterfaceSend pMessage is not NULL");
+  __CPROVER_assert( pConnection != NULL,
+		    "IotNetworkInterfaceSend pConnection is not NULL" );
+  __CPROVER_assert( pMessage != NULL,
+		    "IotNetworkInterfaceSend pMessage is not NULL" );
 
   /****************************************************************
    * The send method sends some portion of the message and returns the
@@ -475,7 +477,7 @@ size_t IotNetworkInterfaceSend( void * pConnection,
   // The number of bytes considered sent after this invocation
   size_t size;
 
-  if (tries >= MAX_TRIES || size > messageLength )
+  if ( tries >= MAX_TRIES || size > messageLength )
     {
       tries = 0;
       return messageLength;
@@ -487,8 +489,8 @@ size_t IotNetworkInterfaceSend( void * pConnection,
 
 IotNetworkError_t IotNetworkInterfaceClose( void * pConnection )
 {
-  __CPROVER_assert(pConnection != NULL,
-		   "IotNetworkInterfaceClose pConnection is not NULL");
+  __CPROVER_assert( pConnection != NULL,
+		    "IotNetworkInterfaceClose pConnection is not NULL" );
 
   IotNetworkError_t error;
   return error;
@@ -498,34 +500,34 @@ size_t IotNetworkInterfaceReceive( void * pConnection,
 				   uint8_t * pBuffer,
 				   size_t bytesRequested )
 {
-  __CPROVER_assert(pConnection,
-		   "IotNetworkInterfaceReceive pConnection is not NULL");
-  __CPROVER_assert(pBuffer,
-		   "IotNetworkInterfaceReceive pBuffer is not NULL");
+  __CPROVER_assert( pConnection,
+		    "IotNetworkInterfaceReceive pConnection is not NULL" );
+  __CPROVER_assert( pBuffer,
+		    "IotNetworkInterfaceReceive pBuffer is not NULL" );
 
   // Fill the memory object pointed to by pBuffer with unconstrained
   // data.  What follows a CBMC idiom to do that.
   uint8_t byte;
-  __CPROVER_array_copy(pBuffer,&byte);
+  __CPROVER_array_copy( pBuffer, &byte );
 
   // Choose the number of bytes in pBuffer considered received.
   size_t size;
-  __CPROVER_assume(size <= bytesRequested);
+  __CPROVER_assume( size <= bytesRequested );
 
   return size;
 }
 
 IotNetworkError_t IotNetworkInterfaceReceiveCallback( void * pConnection,
-					       IotNetworkReceiveCallback_t
-					         receiveCallback,
-					       void * pContext )
+						      IotNetworkReceiveCallback_t
+						      receiveCallback,
+						      void * pContext )
 {
-  __CPROVER_assert(pConnection != NULL,
-		   "IotNetworkInterfaceCallback pConnection is not NULL");
-  __CPROVER_assert(receiveCallback != NULL,
-		   "IotNetworkInterfaceCallback receiveCallback is not NULL");
-  __CPROVER_assert(pContext != NULL,
-		   "IotNetworkInterfaceCallback pContext is not NULL");
+  __CPROVER_assert( pConnection != NULL,
+		    "IotNetworkInterfaceCallback pConnection is not NULL" );
+  __CPROVER_assert( receiveCallback != NULL,
+		    "IotNetworkInterfaceCallback receiveCallback is not NULL" );
+  __CPROVER_assert( pContext != NULL,
+		    "IotNetworkInterfaceCallback pContext is not NULL" );
 
   IotNetworkError_t error;
   return error;
@@ -536,12 +538,12 @@ IotNetworkError_t IotNetworkInterfaceCloseCallback( void * pConnection,
 						    closeCallback,
 						    void * pContext )
 {
-  __CPROVER_assert(pConnection != NULL,
-		   "IotNetworkInterfaceCallback pConnection is not NULL");
-  __CPROVER_assert(closeCallback != NULL,
-		   "IotNetworkInterfaceCallback closeCallback is not NULL");
-  __CPROVER_assert(pContext != NULL,
-		   "IotNetworkInterfaceCallback pContext is not NULL");
+  __CPROVER_assert( pConnection != NULL,
+		    "IotNetworkInterfaceCallback pConnection is not NULL" );
+  __CPROVER_assert( closeCallback != NULL,
+		    "IotNetworkInterfaceCallback closeCallback is not NULL" );
+  __CPROVER_assert( pContext != NULL,
+		    "IotNetworkInterfaceCallback pContext is not NULL" );
 
   IotNetworkError_t error;
   return error;
@@ -549,8 +551,8 @@ IotNetworkError_t IotNetworkInterfaceCloseCallback( void * pConnection,
 
 IotNetworkError_t IotNetworkInterfaceDestroy( void * pConnection )
 {
-  __CPROVER_assert(pConnection != NULL,
-		   "IotNetworkInterfaceDestroy pConnection is not NULL");
+  __CPROVER_assert( pConnection != NULL,
+		    "IotNetworkInterfaceDestroy pConnection is not NULL" );
 
   IotNetworkError_t error;
   return error;

--- a/cbmc/proofs/mqtt_state.c
+++ b/cbmc/proofs/mqtt_state.c
@@ -289,8 +289,7 @@ _mqttSubscription_t *allocate_IotMqttSubscriptionListElt( _mqttSubscription_t *p
 {
   size_t length;
   // Assumption avoids arithmetic overflow in malloc, rechecked in valid_*
-  __CPROVER_assume( length <
-		    CBMC_MAX_OBJECT_SIZE - sizeof( _mqttSubscription_t ) );
+  __CPROVER_assume( length < CBMC_MAX_OBJECT_SIZE - sizeof( *pElt ) );
 
   if ( pElt == NULL ) pElt = malloc_can_fail( sizeof( *pElt ) + length );
   if ( pElt == NULL ) return NULL;
@@ -309,7 +308,7 @@ bool valid_IotMqttSubscriptionListElt( const _mqttSubscription_t *pElt )
 #ifdef TOPIC_LENGTH_MAX
     pElt->topicFilterLength < TOPIC_LENGTH_MAX &&
 #endif
-    pElt->topicFilterLength < CBMC_MAX_OBJECT_SIZE - sizeof( _mqttSubscription_t ) &&
+    pElt->topicFilterLength < CBMC_MAX_OBJECT_SIZE - sizeof( *pElt ) &&
     __CPROVER_r_ok( pElt->pTopicFilter, pElt->topicFilterLength ) &&
     __CPROVER_w_ok( pElt->pTopicFilter, pElt->topicFilterLength );
 }

--- a/cbmc/proofs/mqtt_state.c
+++ b/cbmc/proofs/mqtt_state.c
@@ -1,0 +1,556 @@
+#include "iot_config.h"
+#include "private/iot_mqtt_internal.h"
+
+#include <stdlib.h>
+
+#include "mqtt_state.h"
+
+/****************************************************************
+ * Model a malloc that can fail and return NULL.
+ ****************************************************************/
+
+void *malloc_can_fail(size_t size)
+{
+  __CPROVER_assert(VALID_CBMC_SIZE(size), "malloc_can_fail size too big");
+  return nondet_bool() ? NULL : malloc( size );
+}
+
+/****************************************************************
+ * Model an opaque type as nothing but a valid pointer.
+ ****************************************************************/
+
+void *allocate_opaque_type()
+{
+  return malloc( 1 ); // consider using malloc(0)
+}
+
+/****************************************************************
+ * MqttOperation
+ ****************************************************************/
+
+IotMqttOperation_t allocate_IotMqttOperation(IotMqttOperation_t pOp,
+					     IotMqttConnection_t pConn)
+{
+  // assume a valid connection for the operation
+  assert( pConn != NULL );
+
+  if ( pOp == NULL ) pOp = malloc_can_fail( sizeof( *pOp ) );
+  if ( pOp == NULL ) return NULL;
+
+  pOp->pMqttConnection = pConn;
+
+  if ( pOp->incomingPublish ) {
+    // allocate publish member of the union
+
+    allocate_IotMqttPublishInfo( &(pOp->u.publish.publishInfo) );
+
+    size_t length;
+    __CPROVER_assume( VALID_CBMC_SIZE( length ) );
+    pOp->u.publish.pReceivedData = malloc_can_fail( length );
+
+  } else {
+    // allocate operation member of the union
+
+    // assumption here is checked below in valid_*
+    __CPROVER_assume( VALID_CBMC_SIZE( pOp->u.operation.packetSize ) );
+    pOp->u.operation.pMqttPacket =
+      malloc_can_fail( pOp->u.operation.packetSize );
+
+  }
+
+  return pOp;
+}
+
+// TODO: valid_ should have same signature as allocate_,
+// should check that operation points to the connection
+
+bool valid_IotMqttOperation( IotMqttOperation_t pOp )
+{
+  if (pOp == NULL) return 0;
+
+  // check that publish member of the union is valid (pOp->incomingPublish)
+
+  bool valid_publishinfo =
+    valid_IotMqttPublishInfo( &(pOp->u.publish.publishInfo) );
+
+  bool valid_publish_member =
+    IMPLIES( pOp->incomingPublish, valid_publishinfo );
+
+  // check that operation member of the union is valid (!pOp->incomingPublish)
+
+  bool valid_packet =
+    VALID_STRING( pOp->u.operation.pMqttPacket, pOp->u.operation.packetSize ) &&
+    VALID_CBMC_SIZE( pOp->u.operation.packetSize );
+  bool valid_pingreq_packet =
+    IMPLIES( pOp->u.operation.type == IOT_MQTT_PINGREQ,
+	     IFF( pOp->u.operation.periodic.ping.keepAliveMs == 0,
+		  pOp->u.operation.packetSize == 0 ) );
+  bool valid_other_packet =
+    IMPLIES( pOp->u.operation.type != IOT_MQTT_PINGREQ,
+	     pOp->u.operation.packetSize > 0 );
+  bool waitable =
+    (pOp->u.operation.flags & IOT_MQTT_FLAG_WAITABLE) == IOT_MQTT_FLAG_WAITABLE;
+  bool valid_jobReference =
+    IMPLIES(  waitable, pOp->u.operation.jobReference == 2 ) &&
+    IMPLIES( !waitable, pOp->u.operation.jobReference == 1 );
+
+  bool valid_operation_member =
+    IMPLIES(!pOp->incomingPublish,
+	    valid_packet &&
+	    valid_pingreq_packet &&
+	    valid_other_packet &&
+	    valid_jobReference);
+
+  return
+    // assume valid connection
+    valid_publish_member &&
+    valid_operation_member;
+}
+
+/****************************************************************
+ * IotMqttConnection
+ ****************************************************************/
+
+IotMqttConnection_t allocate_IotMqttConnection(IotMqttConnection_t pConn)
+{
+  if ( pConn == NULL ) pConn = malloc_can_fail( sizeof( *pConn ) );
+  if ( pConn == NULL ) return NULL;
+
+  pConn->pNetworkConnection = allocate_IotNetworkConnection();
+  pConn->pNetworkInterface = allocate_IotNetworkInterface();
+  allocate_IotMqttOperation( &(pConn->pingreq), pConn );
+  return pConn;
+}
+
+void ensure_IotMqttConnection_has_lists(IotMqttConnection_t pConn)
+{
+  // TODO: add code to make lists nondet nontrivial
+  // Consider using allocate_IotMqttSubscriptionList
+  IotListDouble_Create(&pConn->pendingProcessing);
+  IotListDouble_Create(&pConn->pendingResponse);
+  IotListDouble_Create(&pConn->subscriptionList);
+  return pConn;
+}
+
+bool valid_IotMqttConnection(IotMqttConnection_t pConn)
+{
+  if ( pConn == NULL ) return 0;
+
+  bool valid_references = pConn->references >= 1;
+
+  bool valid_pingreq =
+    ( valid_IotMqttOperation( &(pConn->pingreq) ) ) &&
+    ( pConn->pingreq.u.operation.type == IOT_MQTT_PINGREQ ) &&
+    ( pConn->pingreq.pMqttConnection == pConn ) &&
+    ( !pConn->pingreq.incomingPublish ) ;
+
+  return
+    valid_IotNetworkInterface( pConn->pNetworkInterface ) &&
+    valid_references &&
+    valid_pingreq;
+}
+
+/****************************************************************
+ * IotMqttNetworkInfo
+ ****************************************************************/
+
+IotMqttNetworkInfo_t *allocate_IotMqttNetworkInfo(IotMqttNetworkInfo_t *pInfo)
+{
+  if ( pInfo == NULL ) pInfo = malloc_can_fail( sizeof( *pInfo ) );
+  if ( pInfo == NULL ) return NULL;
+
+  if (pInfo->createNetworkConnection) {
+    // allocate setup member of union
+    pInfo->u.setup.pNetworkServerInfo = allocate_opaque_type();
+    pInfo->u.setup.pNetworkCredentialInfo = allocate_opaque_type();
+  } else {
+    // allocate network member of union
+    pInfo->u.pNetworkConnection = allocate_IotNetworkConnection();
+  }
+  pInfo->pNetworkInterface = allocate_IotNetworkInterface();
+  return pInfo;
+}
+
+bool valid_IotMqttNetworkInfo(IotMqttNetworkInfo_t *pInfo)
+{
+  if ( pInfo == NULL ) return 0;
+  return 1;
+}
+
+/****************************************************************
+ * IotMqttConnectInfo
+ ****************************************************************/
+
+IotMqttConnectInfo_t *allocate_IotMqttConnectInfo(IotMqttConnectInfo_t *pInfo)
+{
+  if ( pInfo == NULL ) pInfo = malloc_can_fail( sizeof( *pInfo ) );
+  if ( pInfo == NULL ) return NULL;
+
+  pInfo->pPreviousSubscriptions =
+    allocate_IotMqttSubscriptionArray(NULL,
+				     pInfo->previousSubscriptionCount);
+  pInfo->pWillInfo = allocate_IotMqttPublishInfo(NULL);
+  pInfo->pClientIdentifier = malloc_can_fail(pInfo->clientIdentifierLength);
+  pInfo->pUserName = malloc_can_fail(pInfo->userNameLength);
+  pInfo->pPassword = malloc_can_fail(pInfo->passwordLength);
+}
+
+bool valid_IotMqttConnectInfo(IotMqttConnectInfo_t *pInfo)
+{
+  return
+    pInfo &&
+
+    VALID_STRING(pInfo->pClientIdentifier, pInfo->clientIdentifierLength) &&
+    VALID_CBMC_SIZE( pInfo->clientIdentifierLength ) &&
+
+    VALID_STRING(pInfo->pUserName, pInfo->userNameLength) &&
+    VALID_CBMC_SIZE( pInfo->userNameLength ) &&
+
+    VALID_STRING(pInfo->pPassword, pInfo->passwordLength) &&
+    VALID_CBMC_SIZE( pInfo->passwordLength ) &&
+
+#ifdef SUBSCRIPTION_COUNT_MAX
+    pInfo->previousSubscriptionCount < SUBSCRIPTION_COUNT_MAX &&
+#endif
+    IFF( pInfo->pPreviousSubscriptions == NULL,
+	 pInfo->previousSubscriptionCount == 0 ) &&
+    valid_IotMqttSubscriptionArray(pInfo->pPreviousSubscriptions,
+				   pInfo->previousSubscriptionCount);
+}
+
+/****************************************************************
+ * IotMqttSubscription
+ ****************************************************************/
+
+IotMqttSubscription_t *allocate_IotMqttSubscription(IotMqttSubscription_t *pSub)
+{
+  if ( pSub == NULL ) pSub = malloc_can_fail( sizeof( *pSub ) );
+  if ( pSub == NULL ) return NULL;
+
+  pSub->pTopicFilter = malloc_can_fail( pSub->topicFilterLength );
+  return pSub;
+}
+
+bool valid_IotMqttSubscription(IotMqttSubscription_t *pSub)
+{
+  return
+    pSub &&
+
+    VALID_STRING( pSub->pTopicFilter,  pSub->topicFilterLength ) &&
+    VALID_CBMC_SIZE( pSub->topicFilterLength )
+
+#ifdef TOPIC_LENGTH_MAX
+    && pSub->topicFilterLength < TOPIC_LENGTH_MAX
+#endif
+    ;
+}
+
+/****************************************************************
+ * IotMqttSubscription array list
+ ****************************************************************/
+
+IotMqttSubscription_t *allocate_IotMqttSubscriptionArray(IotMqttSubscription_t *pSub, size_t length)
+{
+  if (pSub == NULL ) pSub = malloc_can_fail( length * sizeof( *pSub ) );
+  if (pSub == NULL ) return NULL;
+
+  for (int i = 0; i < length; i++)
+    allocate_IotMqttSubscription(pSub + i);
+
+  return pSub;
+}
+
+bool valid_IotMqttSubscriptionArray(IotMqttSubscription_t *pSub, size_t length)
+{
+  if ( !IFF(pSub == NULL, length == 0 ) ) return 0;
+  if ( pSub == NULL ) return 0;
+
+  bool result = 1;
+  for (int i = 0; i < length; i++)
+    result = result && valid_IotMqttSubscription(pSub + i);
+
+  return
+#ifdef SUBSCRIPTION_COUNT_MAX
+    length < SUBSCRIPTION_COUNT_MAX &&
+#endif
+    result;
+}
+
+/****************************************************************
+ * IotMqttSubscription array list
+ ****************************************************************/
+
+// Subscription linked list elements
+
+_mqttSubscription_t *allocate_IotMqttSubscriptionListElt(_mqttSubscription_t *pElt)
+{
+  size_t length;
+  // Assumption avoids arithmetic overflow in malloc, rechecked in valid_*
+  __CPROVER_assume( length <
+		    CBMC_MAX_OBJECT_SIZE - sizeof( _mqttSubscription_t ) );
+
+  if ( pElt == NULL ) pElt = malloc_can_fail( sizeof( *pElt ) + length);
+  if ( pElt == NULL ) return NULL;
+
+  pElt->link.pPrevious = NULL;
+  pElt->link.pNext = NULL;
+  pElt->topicFilterLength = length;
+  return pElt;
+}
+
+bool valid_IotMqttSubscriptionListElt(_mqttSubscription_t *pElt)
+{
+  if ( pElt == NULL ) return 0;
+
+  return
+#ifdef TOPIC_LENGTH_MAX
+    pElt->topicFilterLength < TOPIC_LENGTH_MAX &&
+#endif
+    pElt->topicFilterLength < CBMC_MAX_OBJECT_SIZE - sizeof( _mqttSubscription_t ) &&
+    __CPROVER_r_ok(pElt->pTopicFilter, pElt->topicFilterLength) &&
+    __CPROVER_w_ok(pElt->pTopicFilter, pElt->topicFilterLength);
+}
+
+// Subscription linked lists
+
+IotListDouble_t *allocate_IotMqttSubscriptionList(IotListDouble_t *pSub,
+						  size_t length)
+{
+  if ( pSub == NULL ) pSub = malloc_can_fail( sizeof( *pSub ) );
+  if ( pSub == NULL ) return NULL;
+
+  IotListDouble_Create(pSub);
+  for (int i = 0; i < length; i++) {
+    _mqttSubscription_t *pElt = allocate_IotMqttSubscriptionListElt(NULL);
+    __CPROVER_assume(pElt);
+    IotListDouble_InsertHead( pSub, &(pElt->link) );
+  }
+  return pSub;
+}
+
+bool valid_IotMqttSubscriptionList(IotListDouble_t *pSub, size_t length)
+{
+  if ( pSub == NULL ) return 0;
+
+  bool result = 1;
+  IotListDouble_t *pLink;
+  IotContainers_ForEach( pSub, pLink ) {
+    _mqttSubscription_t
+      *pElt = IotLink_Container( _mqttSubscription_t, pLink, link );
+    result = result && valid_IotMqttSubscriptionListElt( pElt );
+  }
+
+  return
+#ifdef SUBSCRIPTION_COUNT_MAX
+    length < SUBSCRIPTION_COUNT_MAX &&
+#endif
+    result;
+}
+
+/****************************************************************
+ * IotMqttPublishInfo
+ ****************************************************************/
+
+IotMqttPublishInfo_t *allocate_IotMqttPublishInfo(IotMqttPublishInfo_t *pInfo)
+{
+  if ( pInfo == NULL ) pInfo = malloc_can_fail( sizeof( *pInfo ) );
+  if ( pInfo == NULL ) return NULL;
+
+  pInfo->pTopicName = malloc_can_fail( pInfo->topicNameLength );
+  // assumption here is checked below in valid_
+  __CPROVER_assume( VALID_CBMC_SIZE( pInfo->payloadLength ) );
+  pInfo->pPayload = malloc_can_fail( pInfo->payloadLength );
+  return pInfo;
+}
+
+bool valid_IotMqttPublishInfo(IotMqttPublishInfo_t *pInfo)
+{
+  return
+    pInfo &&
+
+    VALID_STRING(pInfo->pTopicName, pInfo->topicNameLength) &&
+    VALID_CBMC_SIZE( pInfo->topicNameLength ) &&
+    pInfo->pTopicName != NULL &&
+
+    VALID_STRING(pInfo->pPayload, pInfo->payloadLength) &&
+    VALID_CBMC_SIZE( pInfo->payloadLength ) &&
+
+    pInfo->retryMs <= IOT_MQTT_RETRY_MS_CEILING &&
+    pInfo->retryMs > 0  &&
+
+    // BUG: try without this name length assumption
+    pInfo->topicNameLength < 0xFFFF &&
+    // BUG: try without this name length assumption
+    pInfo->payloadLength > 0;
+}
+
+/****************************************************************
+ * IotNetworkConnection
+ ****************************************************************/
+
+void *allocate_IotNetworkConnection()
+{
+  return allocate_opaque_type();
+}
+
+/****************************************************************
+ * IotNetworkInterface
+ ****************************************************************/
+
+IotNetworkInterface_t *allocate_IotNetworkInterface()
+{
+  return malloc_can_fail( sizeof( IotNetworkInterface_t ) );
+}
+
+bool valid_IotNetworkInterface(IotNetworkInterface_t *netif)
+{
+  return ( netif != NULL );
+}
+
+bool stubbed_IotNetworkInterface(IotNetworkInterface_t *netif)
+{
+  return
+    IS_STUBBED_NETWORKIF_CREATE(netif) &&
+    IS_STUBBED_NETWORKIF_CLOSE(netif) &&
+    IS_STUBBED_NETWORKIF_SEND(netif) &&
+    IS_STUBBED_NETWORKIF_RECEIVE(netif) &&
+    IS_STUBBED_NETWORKIF_SETRECEIVECALLBACK(netif) &&
+    IS_STUBBED_NETWORKIF_SETCLOSECALLBACK(netif) &&
+    IS_STUBBED_NETWORKIF_DESTROY(netif);
+}
+
+/****************************************************************
+ * IotNetworkInterface stubs
+ ****************************************************************/
+
+IotNetworkError_t IotNetworkInterfaceCreate( void * pConnectionInfo,
+					     void * pCredentialInfo,
+					     void * pConnection )
+{
+  // pCredentialInfo can be null
+  // create accepts NULL credentials when there is no TLS configuration.
+  __CPROVER_assert(pConnectionInfo != NULL,
+		   "IotNetworkInterfaceCreate pConnectionInfo is not NULL");
+  __CPROVER_assert(pConnection != NULL,
+		   "IotNetworkInterfaceCreate pConnection is not NULL");
+
+  // create the connection
+  *(void **)pConnection = allocate_IotNetworkConnection();
+
+  IotNetworkError_t error;
+  return error;
+}
+
+#define MAX_TRIES 2
+
+size_t IotNetworkInterfaceSend( void * pConnection,
+				const uint8_t * pMessage,
+				size_t messageLength )
+{
+  __CPROVER_assert(pConnection != NULL,
+		   "IotNetworkInterfaceSend pConnection is not NULL");
+  __CPROVER_assert(pMessage != NULL,
+		   "IotNetworkInterfaceSend pMessage is not NULL");
+
+  /****************************************************************
+   * The send method sends some portion of the message and returns the
+   * total number of bytes in the prefix sent so far.  The send method
+   * is used in a loop of the form
+   *
+   *   while ( send( conn, msg, len )  < len ) { ... }
+   *
+   * We need to bound the number of loop iterations, so we need to
+   * bound the number of times it takes for send to finish sending the
+   * message.  We use a static variable 'tries' to count the number of
+   * times send has tried to send the message, and we force send to
+   * finish the message after MAX_TRIES tries.
+   ****************************************************************/
+
+  // The number of tries to send the message before this invocation
+  static size_t tries;
+
+  // The number of bytes considered sent after this invocation
+  size_t size;
+
+  if (tries >= MAX_TRIES || size > messageLength )
+    {
+      tries = 0;
+      return messageLength;
+    }
+
+  tries++;
+  return size;
+}
+
+IotNetworkError_t IotNetworkInterfaceClose( void * pConnection )
+{
+  __CPROVER_assert(pConnection != NULL,
+		   "IotNetworkInterfaceClose pConnection is not NULL");
+
+  IotNetworkError_t error;
+  return error;
+}
+
+size_t IotNetworkInterfaceReceive( void * pConnection,
+				   uint8_t * pBuffer,
+				   size_t bytesRequested )
+{
+  __CPROVER_assert(pConnection,
+		   "IotNetworkInterfaceReceive pConnection is not NULL");
+  __CPROVER_assert(pBuffer,
+		   "IotNetworkInterfaceReceive pBuffer is not NULL");
+
+  // Fill the memory object pointed to by pBuffer with unconstrained
+  // data.  What follows a CBMC idiom to do that.
+  uint8_t byte;
+  __CPROVER_array_copy(pBuffer,&byte);
+
+  // Choose the number of bytes in pBuffer considered received.
+  size_t size;
+  __CPROVER_assume(size <= bytesRequested);
+
+  return size;
+}
+
+IotNetworkError_t IotNetworkInterfaceReceiveCallback( void * pConnection,
+					       IotNetworkReceiveCallback_t
+					         receiveCallback,
+					       void * pContext )
+{
+  __CPROVER_assert(pConnection != NULL,
+		   "IotNetworkInterfaceCallback pConnection is not NULL");
+  __CPROVER_assert(receiveCallback != NULL,
+		   "IotNetworkInterfaceCallback receiveCallback is not NULL");
+  __CPROVER_assert(pContext != NULL,
+		   "IotNetworkInterfaceCallback pContext is not NULL");
+
+  IotNetworkError_t error;
+  return error;
+}
+
+IotNetworkError_t IotNetworkInterfaceCloseCallback( void * pConnection,
+						    IotNetworkCloseCallback_t
+						    closeCallback,
+						    void * pContext )
+{
+  __CPROVER_assert(pConnection != NULL,
+		   "IotNetworkInterfaceCallback pConnection is not NULL");
+  __CPROVER_assert(closeCallback != NULL,
+		   "IotNetworkInterfaceCallback closeCallback is not NULL");
+  __CPROVER_assert(pContext != NULL,
+		   "IotNetworkInterfaceCallback pContext is not NULL");
+
+  IotNetworkError_t error;
+  return error;
+}
+
+IotNetworkError_t IotNetworkInterfaceDestroy( void * pConnection )
+{
+  __CPROVER_assert(pConnection != NULL,
+		   "IotNetworkInterfaceDestroy pConnection is not NULL");
+
+  IotNetworkError_t error;
+  return error;
+}
+
+/****************************************************************/

--- a/cbmc/proofs/mqtt_state.c
+++ b/cbmc/proofs/mqtt_state.c
@@ -273,8 +273,7 @@ IotMqttNetworkInfo_t *allocate_IotMqttNetworkInfo( IotMqttNetworkInfo_t *pInfo )
 
 bool valid_IotMqttNetworkInfo( const IotMqttNetworkInfo_t *pInfo )
 {
-  if ( pInfo == NULL ) return false;
-  return true;
+  return pInfo != NULL;
 }
 
 /****************************************************************
@@ -298,7 +297,7 @@ IotMqttConnectInfo_t *allocate_IotMqttConnectInfo( IotMqttConnectInfo_t *pInfo )
 bool valid_IotMqttConnectInfo( const IotMqttConnectInfo_t *pInfo )
 {
   return
-    pInfo &&
+    pInfo != NULL &&
 
     VALID_STRING( pInfo->pClientIdentifier, pInfo->clientIdentifierLength ) &&
     VALID_CBMC_SIZE( pInfo->clientIdentifierLength ) &&

--- a/cbmc/proofs/mqtt_state.c
+++ b/cbmc/proofs/mqtt_state.c
@@ -500,7 +500,7 @@ bool valid_IotMqttPublishInfo( const IotMqttPublishInfo_t *pInfo )
 
     // TODO: experiment with removing these assumptions
     // topicNameLength is a unint16
-    pInfo->topicNameLength < 0xFFFF &&
+    pInfo->topicNameLength <= UINT16_MAX &&
     pInfo->payloadLength > 0;
 }
 

--- a/cbmc/proofs/mqtt_state.c
+++ b/cbmc/proofs/mqtt_state.c
@@ -64,11 +64,11 @@ IotMqttOperation_t allocate_IotMqttOperation(IotMqttOperation_t pOp,
 // TODO: valid_ should have same signature as allocate_,
 // should check that operation points to the connection
 
-bool valid_IotMqttOperation( IotMqttOperation_t pOp )
+bool valid_IotMqttOperation( const IotMqttOperation_t pOp )
 {
-  if (pOp == NULL) return 0;
+  if (pOp == NULL) return false;
 
-  // check that publish member of the union is valid (pOp->incomingPublish)
+  // publish member of the union should be valid (pOp->incomingPublish)
 
   bool valid_publishinfo =
     valid_IotMqttPublishInfo( &(pOp->u.publish.publishInfo) );
@@ -76,7 +76,7 @@ bool valid_IotMqttOperation( IotMqttOperation_t pOp )
   bool valid_publish_member =
     IMPLIES( pOp->incomingPublish, valid_publishinfo );
 
-  // check that operation member of the union is valid (!pOp->incomingPublish)
+  // operation member of the union should be valid (!pOp->incomingPublish)
 
   bool valid_packet =
     VALID_STRING( pOp->u.operation.pMqttPacket, pOp->u.operation.packetSize ) &&
@@ -132,9 +132,9 @@ void ensure_IotMqttConnection_has_lists(IotMqttConnection_t pConn)
   return pConn;
 }
 
-bool valid_IotMqttConnection(IotMqttConnection_t pConn)
+bool valid_IotMqttConnection(const IotMqttConnection_t pConn)
 {
-  if ( pConn == NULL ) return 0;
+  if ( pConn == NULL ) return false;
 
   bool valid_references = pConn->references >= 1;
 
@@ -171,10 +171,10 @@ IotMqttNetworkInfo_t *allocate_IotMqttNetworkInfo(IotMqttNetworkInfo_t *pInfo)
   return pInfo;
 }
 
-bool valid_IotMqttNetworkInfo(IotMqttNetworkInfo_t *pInfo)
+bool valid_IotMqttNetworkInfo(const IotMqttNetworkInfo_t *pInfo)
 {
-  if ( pInfo == NULL ) return 0;
-  return 1;
+  if ( pInfo == NULL ) return false;
+  return true;
 }
 
 /****************************************************************
@@ -195,7 +195,7 @@ IotMqttConnectInfo_t *allocate_IotMqttConnectInfo(IotMqttConnectInfo_t *pInfo)
   pInfo->pPassword = malloc_can_fail(pInfo->passwordLength);
 }
 
-bool valid_IotMqttConnectInfo(IotMqttConnectInfo_t *pInfo)
+bool valid_IotMqttConnectInfo(const IotMqttConnectInfo_t *pInfo)
 {
   return
     pInfo &&
@@ -231,7 +231,7 @@ IotMqttSubscription_t *allocate_IotMqttSubscription(IotMqttSubscription_t *pSub)
   return pSub;
 }
 
-bool valid_IotMqttSubscription(IotMqttSubscription_t *pSub)
+bool valid_IotMqttSubscription(const IotMqttSubscription_t *pSub)
 {
   return
     pSub &&
@@ -260,10 +260,11 @@ IotMqttSubscription_t *allocate_IotMqttSubscriptionArray(IotMqttSubscription_t *
   return pSub;
 }
 
-bool valid_IotMqttSubscriptionArray(IotMqttSubscription_t *pSub, size_t length)
+bool valid_IotMqttSubscriptionArray(const IotMqttSubscription_t *pSub,
+				    const size_t length)
 {
-  if ( !IFF(pSub == NULL, length == 0 ) ) return 0;
-  if ( pSub == NULL ) return 0;
+  if ( !IFF(pSub == NULL, length == 0 ) ) return false;
+  if ( pSub == NULL ) return false;
 
   bool result = 1;
   for (int i = 0; i < length; i++)
@@ -298,9 +299,9 @@ _mqttSubscription_t *allocate_IotMqttSubscriptionListElt(_mqttSubscription_t *pE
   return pElt;
 }
 
-bool valid_IotMqttSubscriptionListElt(_mqttSubscription_t *pElt)
+bool valid_IotMqttSubscriptionListElt(const _mqttSubscription_t *pElt)
 {
-  if ( pElt == NULL ) return 0;
+  if ( pElt == NULL ) return false;
 
   return
 #ifdef TOPIC_LENGTH_MAX
@@ -328,9 +329,10 @@ IotListDouble_t *allocate_IotMqttSubscriptionList(IotListDouble_t *pSub,
   return pSub;
 }
 
-bool valid_IotMqttSubscriptionList(IotListDouble_t *pSub, size_t length)
+bool valid_IotMqttSubscriptionList(const IotListDouble_t *pSub,
+				   const size_t length)
 {
-  if ( pSub == NULL ) return 0;
+  if ( pSub == NULL ) return false;
 
   bool result = 1;
   IotListDouble_t *pLink;
@@ -363,7 +365,7 @@ IotMqttPublishInfo_t *allocate_IotMqttPublishInfo(IotMqttPublishInfo_t *pInfo)
   return pInfo;
 }
 
-bool valid_IotMqttPublishInfo(IotMqttPublishInfo_t *pInfo)
+bool valid_IotMqttPublishInfo(const IotMqttPublishInfo_t *pInfo)
 {
   return
     pInfo &&
@@ -378,9 +380,8 @@ bool valid_IotMqttPublishInfo(IotMqttPublishInfo_t *pInfo)
     pInfo->retryMs <= IOT_MQTT_RETRY_MS_CEILING &&
     pInfo->retryMs > 0  &&
 
-    // BUG: try without this name length assumption
+    // TODO: experiment with removing these assumptions
     pInfo->topicNameLength < 0xFFFF &&
-    // BUG: try without this name length assumption
     pInfo->payloadLength > 0;
 }
 
@@ -402,12 +403,12 @@ IotNetworkInterface_t *allocate_IotNetworkInterface()
   return malloc_can_fail( sizeof( IotNetworkInterface_t ) );
 }
 
-bool valid_IotNetworkInterface(IotNetworkInterface_t *netif)
+bool valid_IotNetworkInterface(const IotNetworkInterface_t *netif)
 {
   return ( netif != NULL );
 }
 
-bool stubbed_IotNetworkInterface(IotNetworkInterface_t *netif)
+bool stubbed_IotNetworkInterface(const IotNetworkInterface_t *netif)
 {
   return
     IS_STUBBED_NETWORKIF_CREATE(netif) &&
@@ -441,7 +442,9 @@ IotNetworkError_t IotNetworkInterfaceCreate( void * pConnectionInfo,
   return error;
 }
 
-#define MAX_TRIES 2
+#ifndef MAX_TRIES
+  #define MAX_TRIES 2
+#endif
 
 size_t IotNetworkInterfaceSend( void * pConnection,
 				const uint8_t * pMessage,

--- a/cbmc/proofs/mqtt_state.h
+++ b/cbmc/proofs/mqtt_state.h
@@ -71,7 +71,7 @@ void *malloc_can_fail(size_t size);
  ****************************************************************/
 
 IotMqttConnection_t allocate_IotMqttConnection( IotMqttConnection_t pConn );
-bool valid_IotMqttConnection( IotMqttConnection_t pConn );
+bool valid_IotMqttConnection( const IotMqttConnection_t pConn );
 IotMqttConnection_t
   ensure_IotMqttConnection_has_lists( IotMqttConnection_t pConn );
 
@@ -87,21 +87,21 @@ IotMqttConnection_t
 
 IotMqttOperation_t allocate_IotMqttOperation( IotMqttOperation_t pOp,
 					       IotMqttConnection_t pConn );
-bool valid_IotMqttOperation( IotMqttOperation_t pOp );
+bool valid_IotMqttOperation( const IotMqttOperation_t pOp );
 
 /****************************************************************
  * IotMqttNetworkInfo
  ****************************************************************/
 
 IotMqttNetworkInfo_t *allocate_IotMqttNetworkInfo(IotMqttNetworkInfo_t *pInfo);
-bool valid_IotMqttNetworkInfo(IotMqttNetworkInfo_t *pInfo);
+bool valid_IotMqttNetworkInfo(const IotMqttNetworkInfo_t *pInfo);
 
 /****************************************************************
  * IotMqttConnectInfo
  ****************************************************************/
 
 IotMqttConnectInfo_t *allocate_IotMqttConnectInfo(IotMqttConnectInfo_t *pInfo);
-bool valid_IotMqttConnectInfo(IotMqttConnectInfo_t *pInfo);
+bool valid_IotMqttConnectInfo(const IotMqttConnectInfo_t *pInfo);
 
 /****************************************************************
  * IotMqttSubscription
@@ -114,7 +114,7 @@ bool valid_IotMqttConnectInfo(IotMqttConnectInfo_t *pInfo);
  ****************************************************************/
 
 IotMqttSubscription_t *allocate_IotMqttSubscription(IotMqttSubscription_t *pSub);
-bool valid_IotMqttSubscription(IotMqttSubscription_t *pSub);
+bool valid_IotMqttSubscription(const IotMqttSubscription_t *pSub);
 
 /****************************************************************
  * IotMqttSubscription list
@@ -130,21 +130,23 @@ bool valid_IotMqttSubscription(IotMqttSubscription_t *pSub);
 // Array lists
 
 IotMqttSubscription_t *allocate_IotMqttSubscriptionArray(IotMqttSubscription_t *pSub, size_t length);
-bool valid_IotMqttSubscriptionArray(IotMqttSubscription_t *pSub, size_t length);
+bool valid_IotMqttSubscriptionArray(const IotMqttSubscription_t *pSub,
+				    const size_t length);
 
 // Linked lists
 
 _mqttSubscription_t *allocate_IotMqttSubscriptionListElt(_mqttSubscription_t *pElt);
-bool valid_IotMqttSubscriptionListElt(_mqttSubscription_t *pElt);
+bool valid_IotMqttSubscriptionListElt(const _mqttSubscription_t *pElt);
 IotListDouble_t *allocate_IotMqttSubscriptionList(IotListDouble_t *pSub, size_t length);
-bool valid_IotMqttSubscriptionList(IotListDouble_t *pSub, size_t length);
+bool valid_IotMqttSubscriptionList(const IotListDouble_t *pSub,
+				   const size_t length);
 
 /****************************************************************
  * IotMqttPublishInfo
  ****************************************************************/
 
 IotMqttPublishInfo_t *allocate_IotMqttPublishInfo(IotMqttPublishInfo_t *pInfo);
-bool valid_IotMqttPublishInfo(IotMqttPublishInfo_t *pInfo);
+bool valid_IotMqttPublishInfo(const IotMqttPublishInfo_t *pInfo);
 
 /****************************************************************
  * IotNetworkConnection
@@ -174,8 +176,8 @@ void *allocate_IotNetworkConnection();
  ****************************************************************/
 
 IotNetworkInterface_t *allocate_IotNetworkInterface();
-int valid_IotNetworkInterface(IotNetworkInterface_t *netif);
-int stubbed_IotNetworkInterface(IotNetworkInterface_t *netif);
+bool valid_IotNetworkInterface(const IotNetworkInterface_t *netif);
+bool stubbed_IotNetworkInterface(const IotNetworkInterface_t *netif);
 
 #define IS_STUBBED_NETWORKIF_CREATE(netif) \
   (netif->create == IotNetworkInterfaceCreate)

--- a/cbmc/proofs/mqtt_state.h
+++ b/cbmc/proofs/mqtt_state.h
@@ -1,0 +1,215 @@
+#include <stdlib.h>
+
+/****************************************************************
+ * Logical connectives useful in assuptions
+ ****************************************************************/
+
+#define IMPLIES(a, b) (!(a) || (b))
+#define IFF(a, b) (IMPLIES(a, b) && IMPLIES(b, a))
+//#define IFF(a, b) ((a) == (b))
+
+/****************************************************************
+ * String pointers satisfy an invariant that the pointer is null
+ * iff the length is zero.  The string and length are typically
+ * members of a struct, and this invariant is part of a validity
+ * condition for the struct.
+ ****************************************************************/
+
+#define VALID_STRING(string, length) IFF((string) == NULL, (length) == 0)
+
+/****************************************************************
+ * There is a bound on the size of an object that can be modeled in
+ * CBMC.  A point in CBMC consists of an object id and an offset
+ * into the object.  The top few bits of a pointer are used to encode
+ * the object id, leaving only the bottom remaining bits to encode
+ * the object offset.  The number of bits used for the object id,
+ * that thus the bound on the size of the object, is defined in the
+ * Makefile.
+ ****************************************************************/
+
+#define VALID_CBMC_SIZE(size) ((size) < CBMC_MAX_OBJECT_SIZE)
+
+/****************************************************************
+ * Model a malloc that can fail and return NULL.  CBMC currently
+ * models malloc as an allocator that never fails.  CBMC will soon
+ * have an option to let malloc fail.
+ ****************************************************************/
+
+void *malloc_can_fail(size_t size);
+
+/****************************************************************
+ * Type allocators and validators
+ *
+ * For every type used by MQTT, like a connection or an operation, we
+ * provide an allocator and a validator.  The purpose of the allocator
+ * is simply to allocate on the heap the space for an unconstrained
+ * value of the right shape.  The purpose of the validator is to state
+ * restrictions on the possible values of the object.
+ *
+ * A type is typically a tree of structs and buffers and arrays.  The
+ * allocator lays out space on the heap for this tree.  The allocator
+ * may, however, prune the tree in arbitrary ways by inserting NULL
+ * into a pointer in a struct intended to point to the children of the
+ * struct.  The allocator may even prune away the entire tree and
+ * return nothing but a NULL pointer.  If a proof requires that some
+ * portion of the tree is not pruned away (that some pointer is not
+ * NULL), this assumption must be made explicitly, either in the
+ * validator or in the proof harness itself.
+ *
+ * Each allocator takes a pointer to the struct at the root of the
+ * tree.  If that pointer is NULL, the allocator allocates the root
+ * struct and the result of the tree.  If it points to an existing
+ * root struct, the allocators uses that root and fills in the rest of
+ * the tree.  The pointer is usually NULL.  In constrast, because a
+ * connection struct includes an ping request operation struct as a
+ * substruct, we allocate that ping request operation by passing a
+ * pointer to the connection's operation substruct.
+ ****************************************************************/
+
+/****************************************************************
+ * IotMqttConnection
+ ****************************************************************/
+
+IotMqttConnection_t allocate_IotMqttConnection( IotMqttConnection_t pConn );
+bool valid_IotMqttConnection( IotMqttConnection_t pConn );
+IotMqttConnection_t
+  ensure_IotMqttConnection_has_lists( IotMqttConnection_t pConn );
+
+/****************************************************************
+ * MqttOperation
+ *
+ * A pending operation includes a pointer to its connection.  A
+ * connection includes a list of all of its pending operations.  All
+ * operations pending on a connection include a pointer to this
+ * connection.  For this reason, the allocator for an operation takes
+ * a reference to a connection.
+ ****************************************************************/
+
+IotMqttOperation_t allocate_IotMqttOperation( IotMqttOperation_t pOp,
+					       IotMqttConnection_t pConn );
+bool valid_IotMqttOperation( IotMqttOperation_t pOp );
+
+/****************************************************************
+ * IotMqttNetworkInfo
+ ****************************************************************/
+
+IotMqttNetworkInfo_t *allocate_IotMqttNetworkInfo(IotMqttNetworkInfo_t *pInfo);
+bool valid_IotMqttNetworkInfo(IotMqttNetworkInfo_t *pInfo);
+
+/****************************************************************
+ * IotMqttConnectInfo
+ ****************************************************************/
+
+IotMqttConnectInfo_t *allocate_IotMqttConnectInfo(IotMqttConnectInfo_t *pInfo);
+bool valid_IotMqttConnectInfo(IotMqttConnectInfo_t *pInfo);
+
+/****************************************************************
+ * IotMqttSubscription
+ *
+ * A client subscribes to a topic represented by a string.  For some
+ * proofs, we need to bound the length of this string (for example,
+ * when we have to unwind a loop in a function that iterates over the
+ * string).  When we need to bound the length for a proof, we define
+ * TOPIC_LENGTH_MAX in the proof's Makefile.
+ ****************************************************************/
+
+IotMqttSubscription_t *allocate_IotMqttSubscription(IotMqttSubscription_t *pSub);
+bool valid_IotMqttSubscription(IotMqttSubscription_t *pSub);
+
+/****************************************************************
+ * IotMqttSubscription list
+ *
+ * There are two kinds of subscription lists in MQTT: array lists and
+ * linked lists.
+ *
+ * For some proofs, we need to bound the length of the list.  For
+ * these proofs, we define SUBSCRIPTION_COUNT_MAX in the proof
+ * Makefile.
+ ****************************************************************/
+
+// Array lists
+
+IotMqttSubscription_t *allocate_IotMqttSubscriptionArray(IotMqttSubscription_t *pSub, size_t length);
+bool valid_IotMqttSubscriptionArray(IotMqttSubscription_t *pSub, size_t length);
+
+// Linked lists
+
+_mqttSubscription_t *allocate_IotMqttSubscriptionListElt(_mqttSubscription_t *pElt);
+bool valid_IotMqttSubscriptionListElt(_mqttSubscription_t *pElt);
+IotListDouble_t *allocate_IotMqttSubscriptionList(IotListDouble_t *pSub, size_t length);
+bool valid_IotMqttSubscriptionList(IotListDouble_t *pSub, size_t length);
+
+/****************************************************************
+ * IotMqttPublishInfo
+ ****************************************************************/
+
+IotMqttPublishInfo_t *allocate_IotMqttPublishInfo(IotMqttPublishInfo_t *pInfo);
+bool valid_IotMqttPublishInfo(IotMqttPublishInfo_t *pInfo);
+
+/****************************************************************
+ * IotNetworkConnection
+ ****************************************************************/
+
+void *allocate_IotNetworkConnection();
+
+/****************************************************************
+ * IotNetworkInterface
+ *
+ * The network interface is a struct of fuction pointers that point to
+ * implementions of the network API.  We define a collection of stubs
+ * for these implementations that do little more that check the
+ * validity of arguments and generate some minor side effects.
+ *
+ * The presence of these stubs can play havoc on CBMC function pointer
+ * elimination.  CBMC considers all functions whose address has been
+ * taken to be a candiate for the value of a function pointer.  So we
+ * have to be careful not to take the address of these stubs unless we
+ * have to.  In particular, we don't assign them in the allocator or
+ * validator.
+ *
+ * Instead, when a proof requires a stub, we make an explicit
+ * assumption that the needed struct member is pointing to the correct
+ * stub.  The macro IS_STUBBED_NETWORKIF_XXX(IF) states that the
+ * method XXX in the interface IF points to the correct stub.
+ ****************************************************************/
+
+IotNetworkInterface_t *allocate_IotNetworkInterface();
+int valid_IotNetworkInterface(IotNetworkInterface_t *netif);
+int stubbed_IotNetworkInterface(IotNetworkInterface_t *netif);
+
+#define IS_STUBBED_NETWORKIF_CREATE(netif) \
+  (netif->create == IotNetworkInterfaceCreate)
+#define IS_STUBBED_NETWORKIF_CLOSE(netif) \
+  (netif->close == IotNetworkInterfaceClose)
+#define IS_STUBBED_NETWORKIF_SEND(netif) \
+  (netif->send == IotNetworkInterfaceSend)
+#define IS_STUBBED_NETWORKIF_RECEIVE(netif) \
+  (netif->receive == IotNetworkInterfaceReceive)
+#define IS_STUBBED_NETWORKIF_SETRECEIVECALLBACK(netif) \
+  (netif->setReceiveCallback == IotNetworkInterfaceReceiveCallback)
+#define IS_STUBBED_NETWORKIF_SETCLOSECALLBACK(netif) \
+  (netif->setCloseCallback == IotNetworkInterfaceCloseCallback)
+#define IS_STUBBED_NETWORKIF_DESTROY(netif) \
+  (netif->destroy == IotNetworkInterfaceDestroy)
+
+IotNetworkError_t IotNetworkInterfaceCreate( void * pConnectionInfo,
+					       void * pCredentialInfo,
+					       void * pConnection );
+size_t IotNetworkInterfaceSend( void * pConnection,
+				const uint8_t * pMessage,
+				size_t messageLength );
+IotNetworkError_t IotNetworkInterfaceClose( void * pConnection );
+size_t IotNetworkInterfaceReceive( void * pConnection,
+				   uint8_t * pBuffer,
+				   size_t bytesRequested );
+IotNetworkError_t IotNetworkInterfaceReceiveCallback( void * pConnection,
+					       IotNetworkReceiveCallback_t
+					       receiveCallback,
+					       void * pContext );
+IotNetworkError_t IotNetworkInterfaceCloseCallback( void * pConnection,
+					       IotNetworkCloseCallback_t
+					       closeCallback,
+					       void * pContext );
+IotNetworkError_t IotNetworkInterfaceDestroy( void * pConnection );
+
+/****************************************************************/

--- a/cbmc/proofs/mqtt_state.h
+++ b/cbmc/proofs/mqtt_state.h
@@ -35,7 +35,7 @@
  * have an option to let malloc fail.
  ****************************************************************/
 
-void *malloc_can_fail(size_t size);
+void *malloc_can_fail(size_t size );
 
 /****************************************************************
  * Type allocators and validators
@@ -86,22 +86,22 @@ IotMqttConnection_t
  ****************************************************************/
 
 IotMqttOperation_t allocate_IotMqttOperation( IotMqttOperation_t pOp,
-					       IotMqttConnection_t pConn );
+					      IotMqttConnection_t pConn );
 bool valid_IotMqttOperation( const IotMqttOperation_t pOp );
 
 /****************************************************************
  * IotMqttNetworkInfo
  ****************************************************************/
 
-IotMqttNetworkInfo_t *allocate_IotMqttNetworkInfo(IotMqttNetworkInfo_t *pInfo);
-bool valid_IotMqttNetworkInfo(const IotMqttNetworkInfo_t *pInfo);
+IotMqttNetworkInfo_t *allocate_IotMqttNetworkInfo( IotMqttNetworkInfo_t *pInfo );
+bool valid_IotMqttNetworkInfo( const IotMqttNetworkInfo_t *pInfo );
 
 /****************************************************************
  * IotMqttConnectInfo
  ****************************************************************/
 
-IotMqttConnectInfo_t *allocate_IotMqttConnectInfo(IotMqttConnectInfo_t *pInfo);
-bool valid_IotMqttConnectInfo(const IotMqttConnectInfo_t *pInfo);
+IotMqttConnectInfo_t *allocate_IotMqttConnectInfo( IotMqttConnectInfo_t *pInfo );
+bool valid_IotMqttConnectInfo( const IotMqttConnectInfo_t *pInfo );
 
 /****************************************************************
  * IotMqttSubscription
@@ -113,8 +113,8 @@ bool valid_IotMqttConnectInfo(const IotMqttConnectInfo_t *pInfo);
  * TOPIC_LENGTH_MAX in the proof's Makefile.
  ****************************************************************/
 
-IotMqttSubscription_t *allocate_IotMqttSubscription(IotMqttSubscription_t *pSub);
-bool valid_IotMqttSubscription(const IotMqttSubscription_t *pSub);
+IotMqttSubscription_t *allocate_IotMqttSubscription( IotMqttSubscription_t *pSub );
+bool valid_IotMqttSubscription( const IotMqttSubscription_t *pSub );
 
 /****************************************************************
  * IotMqttSubscription list
@@ -129,24 +129,26 @@ bool valid_IotMqttSubscription(const IotMqttSubscription_t *pSub);
 
 // Array lists
 
-IotMqttSubscription_t *allocate_IotMqttSubscriptionArray(IotMqttSubscription_t *pSub, size_t length);
-bool valid_IotMqttSubscriptionArray(const IotMqttSubscription_t *pSub,
-				    const size_t length);
+IotMqttSubscription_t *allocate_IotMqttSubscriptionArray( IotMqttSubscription_t *pSub,
+							  size_t length );
+bool valid_IotMqttSubscriptionArray( const IotMqttSubscription_t *pSub,
+				     const size_t length );
 
 // Linked lists
 
-_mqttSubscription_t *allocate_IotMqttSubscriptionListElt(_mqttSubscription_t *pElt);
-bool valid_IotMqttSubscriptionListElt(const _mqttSubscription_t *pElt);
-IotListDouble_t *allocate_IotMqttSubscriptionList(IotListDouble_t *pSub, size_t length);
-bool valid_IotMqttSubscriptionList(const IotListDouble_t *pSub,
-				   const size_t length);
+_mqttSubscription_t *allocate_IotMqttSubscriptionListElt( _mqttSubscription_t *pElt );
+bool valid_IotMqttSubscriptionListElt( const _mqttSubscription_t *pElt );
+IotListDouble_t *allocate_IotMqttSubscriptionList( IotListDouble_t *pSub,
+						   size_t length );
+bool valid_IotMqttSubscriptionList( const IotListDouble_t *pSub,
+				   const size_t length );
 
 /****************************************************************
  * IotMqttPublishInfo
  ****************************************************************/
 
-IotMqttPublishInfo_t *allocate_IotMqttPublishInfo(IotMqttPublishInfo_t *pInfo);
-bool valid_IotMqttPublishInfo(const IotMqttPublishInfo_t *pInfo);
+IotMqttPublishInfo_t *allocate_IotMqttPublishInfo( IotMqttPublishInfo_t *pInfo );
+bool valid_IotMqttPublishInfo( const IotMqttPublishInfo_t *pInfo );
 
 /****************************************************************
  * IotNetworkConnection
@@ -176,8 +178,8 @@ void *allocate_IotNetworkConnection();
  ****************************************************************/
 
 IotNetworkInterface_t *allocate_IotNetworkInterface();
-bool valid_IotNetworkInterface(const IotNetworkInterface_t *netif);
-bool stubbed_IotNetworkInterface(const IotNetworkInterface_t *netif);
+bool valid_IotNetworkInterface( const IotNetworkInterface_t *netif );
+bool stubbed_IotNetworkInterface( const IotNetworkInterface_t *netif );
 
 #define IS_STUBBED_NETWORKIF_CREATE(netif) \
   (netif->create == IotNetworkInterfaceCreate)
@@ -195,8 +197,8 @@ bool stubbed_IotNetworkInterface(const IotNetworkInterface_t *netif);
   (netif->destroy == IotNetworkInterfaceDestroy)
 
 IotNetworkError_t IotNetworkInterfaceCreate( void * pConnectionInfo,
-					       void * pCredentialInfo,
-					       void * pConnection );
+					     void * pCredentialInfo,
+					     void * pConnection );
 size_t IotNetworkInterfaceSend( void * pConnection,
 				const uint8_t * pMessage,
 				size_t messageLength );
@@ -205,13 +207,13 @@ size_t IotNetworkInterfaceReceive( void * pConnection,
 				   uint8_t * pBuffer,
 				   size_t bytesRequested );
 IotNetworkError_t IotNetworkInterfaceReceiveCallback( void * pConnection,
-					       IotNetworkReceiveCallback_t
-					       receiveCallback,
-					       void * pContext );
+						      IotNetworkReceiveCallback_t
+						      receiveCallback,
+						      void * pContext );
 IotNetworkError_t IotNetworkInterfaceCloseCallback( void * pConnection,
-					       IotNetworkCloseCallback_t
-					       closeCallback,
-					       void * pContext );
+						    IotNetworkCloseCallback_t
+						    closeCallback,
+						    void * pContext );
 IotNetworkError_t IotNetworkInterfaceDestroy( void * pConnection );
 
 /****************************************************************/

--- a/cbmc/proofs/mqtt_state.h
+++ b/cbmc/proofs/mqtt_state.h
@@ -217,3 +217,7 @@ IotNetworkError_t IotNetworkInterfaceCloseCallback( void * pConnection,
 IotNetworkError_t IotNetworkInterfaceDestroy( void * pConnection );
 
 /****************************************************************/
+
+IotMqttCallbackInfo_t *allocate_IotMqttCallbackInfo(IotMqttCallbackInfo_t *pCb);
+void IotUserCallback( void * pCallbackContext,
+		      IotMqttCallbackParam_t * pCallbackParam );


### PR DESCRIPTION
This patch adds a model of MQTT data structures for the CBMC proofs of the MQTT client API.  The model gives for each of the major types an allocator that allocates space on the heap for the right shape, and a validator that describes assumptions about the value of the data structure used in the CBMC proofs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
