### PR TITLE
Adds a proof harness for the IotMqtt_Init function

### DIFF
--- a/cbmc/.gitignore
+++ b/cbmc/.gitignore
@@ -1,0 +1,6 @@
+proofs/ninja.py
+build.ninja
+.ninja_deps
+.ninja_log
+*.csv
+*.log

--- a/cbmc/.gitignore
+++ b/cbmc/.gitignore
@@ -1,6 +1,2 @@
-proofs/ninja.py
-build.ninja
-.ninja_deps
-.ninja_log
 *.csv
 *.log

--- a/cbmc/proofs/IotMqtt_Init/IotMqtt_Init_harness.c
+++ b/cbmc/proofs/IotMqtt_Init/IotMqtt_Init_harness.c
@@ -6,5 +6,6 @@
 
 void harness()
 {
-  IotMqtt_Init();
+  IotMqttError_t status = IotMqtt_Init();
+  assert(status == IOT_MQTT_SUCCESS || status == IOT_MQTT_NOT_INITIALIZED);
 }

--- a/cbmc/proofs/IotMqtt_Init/IotMqtt_Init_harness.c
+++ b/cbmc/proofs/IotMqtt_Init/IotMqtt_Init_harness.c
@@ -8,7 +8,3 @@ void harness()
 {
   IotMqtt_Init();
 }
-
-
-
-

--- a/cbmc/proofs/IotMqtt_Init/IotMqtt_Init_harness.c
+++ b/cbmc/proofs/IotMqtt_Init/IotMqtt_Init_harness.c
@@ -1,0 +1,14 @@
+#include "iot_config.h"
+#include "private/iot_mqtt_internal.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+void harness()
+{
+  IotMqtt_Init();
+}
+
+
+
+

--- a/cbmc/proofs/IotMqtt_Init/Makefile
+++ b/cbmc/proofs/IotMqtt_Init/Makefile
@@ -1,0 +1,12 @@
+ENTRY=IotMqtt_Init
+
+ABSTRACTIONS += --remove-function-body IotLog_Generic
+ABSTRACTIONS += --remove-function-body Iot_EnterCritical
+ABSTRACTIONS += --remove-function-body Iot_ExitCritical
+
+OBJS += $(ENTRY)_harness.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_api.goto
+
+UNWINDING += --unwind 1
+
+include ../Makefile.common

--- a/cbmc/proofs/IotMqtt_Init/Makefile
+++ b/cbmc/proofs/IotMqtt_Init/Makefile
@@ -2,9 +2,9 @@ ENTRY=IotMqtt_Init
 
 # We abstract all the log and concurrency related functions in this proof
 # and assume their implementation is correct
-ABSTRACTIONS += --remove-function-body IotLog_Generic
 ABSTRACTIONS += --remove-function-body Iot_EnterCritical
 ABSTRACTIONS += --remove-function-body Iot_ExitCritical
+ABSTRACTIONS += --remove-function-body IotLog_Generic
 
 OBJS += $(ENTRY)_harness.goto
 OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_api.goto

--- a/cbmc/proofs/IotMqtt_Init/Makefile
+++ b/cbmc/proofs/IotMqtt_Init/Makefile
@@ -2,31 +2,11 @@ ENTRY=IotMqtt_Init
 
 # We abstract all the log and concurrency related functions in this proof
 # and assume their implementation is correct
-ABSTRACTIONS += --remove-function-body Iot_EnterCritical
-ABSTRACTIONS += --remove-function-body Iot_ExitCritical
 ABSTRACTIONS += --remove-function-body IotLog_Generic
 
 OBJS += $(ENTRY)_harness.goto
 OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_api.goto
 
 UNWINDING += --unwind 1
-
-default: report
-
-# Use the generic implementations of atomic operations.
-# Using the gcc atomic intrinsics causes coverage computation to fail.
-# Define the generic flag here, and replace *_gcc.h with *_generic.h below.
-DEF += -DIOT_ATOMIC_GENERIC=1
-
-install_atomic:
-	mv $(MQTT)/ports/common/include/atomic/iot_atomic_gcc.h $(MQTT)/ports/common/include/atomic/iot_atomic_gcc_disable.h
-	cp $(MQTT)/ports/common/include/atomic/iot_atomic_generic.h \
-	   $(MQTT)/ports/common/include/atomic/iot_atomic_gcc.h
-
-uninstall_atomic:
-	rm $(MQTT)/ports/common/include/atomic/iot_atomic_gcc.h \
-	mv $(MQTT)/ports/common/include/atomic/iot_atomic_gcc_disable.h $(MQTT)/ports/common/include/atomic/iot_atomic_gcc.h 
-
-.PHONY: install_atomic uninstall_atomic
 
 include ../Makefile.common

--- a/cbmc/proofs/IotMqtt_Init/Makefile
+++ b/cbmc/proofs/IotMqtt_Init/Makefile
@@ -1,5 +1,7 @@
 ENTRY=IotMqtt_Init
 
+# We abstract all the log and concurrency related functions in this proof
+# and assume their implementation is correct
 ABSTRACTIONS += --remove-function-body IotLog_Generic
 ABSTRACTIONS += --remove-function-body Iot_EnterCritical
 ABSTRACTIONS += --remove-function-body Iot_ExitCritical

--- a/cbmc/proofs/IotMqtt_Init/Makefile
+++ b/cbmc/proofs/IotMqtt_Init/Makefile
@@ -9,4 +9,22 @@ OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_api.goto
 
 UNWINDING += --unwind 1
 
+default: report
+
+# Use the generic implementations of atomic operations.
+# Using the gcc atomic intrinsics causes coverage computation to fail.
+# Define the generic flag here, and replace *_gcc.h with *_generic.h below.
+DEF += -DIOT_ATOMIC_GENERIC=1
+
+install_atomic:
+	mv $(MQTT)/ports/common/include/atomic/iot_atomic_gcc.h $(MQTT)/ports/common/include/atomic/iot_atomic_gcc_disable.h
+	cp $(MQTT)/ports/common/include/atomic/iot_atomic_generic.h \
+	   $(MQTT)/ports/common/include/atomic/iot_atomic_gcc.h
+
+uninstall_atomic:
+	rm $(MQTT)/ports/common/include/atomic/iot_atomic_gcc.h \
+	mv $(MQTT)/ports/common/include/atomic/iot_atomic_gcc_disable.h $(MQTT)/ports/common/include/atomic/iot_atomic_gcc.h 
+
+.PHONY: install_atomic uninstall_atomic
+
 include ../Makefile.common

--- a/cbmc/proofs/IotMqtt_Init/cbmc-batch.yaml
+++ b/cbmc/proofs/IotMqtt_Init/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-jobos: ubuntu16
-cbmcflags: '=--object-bits;8;--unwind;1;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-overflow-check;--undefined-shift-check;--signed-overflow-check;--unsigned-overflow-check='
-goto: IotMqtt_Init.goto
+cbmcflags: "--object-bits;8;--unwind;1;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-overflow-check;--undefined-shift-check;--signed-overflow-check;--unsigned-overflow-check"
 expected: SUCCESSFUL
+goto: IotMqtt_Init.goto
+jobos: ubuntu16

--- a/cbmc/proofs/IotMqtt_Init/cbmc-batch.yaml
+++ b/cbmc/proofs/IotMqtt_Init/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags:        '=--unwind;1;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static='
+cbmcflags: '=--object-bits;8;--unwind;1;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-overflow-check;--undefined-shift-check;--signed-overflow-check;--unsigned-overflow-check='
 goto: IotMqtt_Init.goto
 expected: SUCCESSFUL

--- a/cbmc/proofs/IotMqtt_Init/cbmc-batch.yaml
+++ b/cbmc/proofs/IotMqtt_Init/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags:        '=--unwind;1;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static='
+goto: IotMqtt_Init.goto
+expected: SUCCESSFUL

--- a/cbmc/proofs/IotMqtt_Init/cbmc-viewer.json
+++ b/cbmc/proofs/IotMqtt_Init/cbmc-viewer.json
@@ -1,0 +1,22 @@
+{ "expected-missing-functions":
+  [
+    "IotLog_Generic",
+    "IotMqtt_Wait",
+    "IotMutex_Create",
+    "IotMutex_Destroy",
+    "IotMutex_Lock",
+    "IotMutex_Unlock",
+    "IotSemaphore_Create",
+    "IotSemaphore_Destroy",
+    "IotSemaphore_Post",
+    "IotSemaphore_TimedWait",
+    "IotSemaphore_Wait",
+    "IotTaskPool_CreateJob",
+    "IotTaskPool_GetSystemTaskPool",
+    "IotTaskPool_ScheduleDeferred",
+    "IotTaskPool_strerror",
+    "IotTaskPool_TryCancel"
+  ],
+  "proof-name": "IotMqtt_Init",
+  "proof-root": "cbmc/proofs"
+}

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -19,14 +19,13 @@ VIEWER ?= cbmc-viewer
 # Build goto binary for cbmc
 # Build goto binaries with options taken from top-level cmake
 
-INC = \
+INC += \
 	-I$(MQTT)/libraries/standard/mqtt/include \
 	-I$(MQTT)/demos \
 	-I$(MQTT)/libraries/platform/.. \
 	-I$(MQTT)/libraries/platform \
 	-I$(MQTT)/ports/common/include \
 	-I$(MQTT)/libraries/standard/common/include \
-	\
 	-I$(MQTT)/libraries/standard/mqtt/src \
 
 DEF += \
@@ -120,7 +119,7 @@ clean:
 	$(RM) *~ \#*
 
 veryclean: clean
-	$(RM) -r html
+	$(RM) -r html TAGS-*
 
 .PHONY: cbmc property coverage report clean veryclean
 

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -14,6 +14,9 @@ GOTO_ANALYZER ?= goto-analyzer
 BATCH ?= cbmc-batch
 VIEWER ?= cbmc-viewer
 
+CBMC_OBJECT_BITS = 8
+CBMC_MAX_OBJECT_SIZE = "(SIZE_MAX>>(CBMC_OBJECT_BITS+1))"
+
 ################################################################
 # Build goto binary for cbmc
 # Build goto binaries with options taken from top-level cmake
@@ -31,29 +34,35 @@ INC = \
 DEF += \
 	-DIOT_SYSTEM_TYPES_FILE=\"$(MQTT)/ports/posix/include/iot_platform_types_posix.h\" \
 	-Diotmqtt_EXPORTS \
+	-DCBMC_OBJECT_BITS=$(CBMC_OBJECT_BITS) \
+	-DCBMC_MAX_OBJECT_SIZE=$(CBMC_MAX_OBJECT_SIZE) \
 
 CFLAGS += $(CFLAGS2) $(INC) $(DEF) -std=gnu99
 
 %.goto : %.c
 	$(GOTO_CC) -o $@ $(CFLAGS) $<
 
+# Use the generic implementations of atomic operations.
+# Using the gcc atomic intrinsics causes coverage computation to fail.
+# Define the generic flag here, and replace *_gcc.h with *_generic.h below.
+DEF += -DIOT_ATOMIC_GENERIC=1
+
 $(MQTT)/build:
-	(mkdir -p $(MQTT)/build; cd $(MQTT)/build; cmake ..) 2>&1 \
-		| tee $(ENTRY)0.txt \
-		; exit $${PIPESTATUS[0]}
+	(mkdir -p $(MQTT)/build; cd $(MQTT)/build; cmake ..) \
+	       > $(ENTRY)0.txt 2>&1
+	cp $(MQTT)/ports/common/include/atomic/iot_atomic_generic.h \
+	   $(MQTT)/ports/common/include/atomic/iot_atomic_gcc.h
 
 $(ENTRY)1.goto: $(MQTT)/build $(OBJS)
-	$(GOTO_CC) --function harness -o $@ $(OBJS) 2>&1 \
-		| tee $(ENTRY)1.txt \
-		; exit $${PIPESTATUS[0]}
+	$(GOTO_CC) --function harness -o $@ $(OBJS)
+		> $(ENTRY)1.txt 2>&1
 
 $(ENTRY)2.goto: $(ENTRY)1.goto
 	 $(GOTO_INSTRUMENT) \
 			$(ABSTRACTIONS) \
 			--drop-unused-functions \
-			--slice-global-inits $< $@ 2>&1 \
-		| tee $(ENTRY)2.txt \
-		; exit $${PIPESTATUS[0]}
+			--slice-global-inits $< $@ \
+		> $(ENTRY)2.txt  2>&1
 
 $(ENTRY).goto: $(ENTRY)2.goto
 	cp $< $@
@@ -62,10 +71,23 @@ $(ENTRY).goto: $(ENTRY)2.goto
 # Run cbmc and build html report
 
 CBMCFLAGS += \
+	--object-bits $(CBMC_OBJECT_BITS) \
 	$(UNWINDING) \
 	--bounds-check \
 	--pointer-check \
 	--unwinding-assertions \
+
+CBMCFLAGS += \
+	--nondet-static \
+
+CBMCFLAGS += \
+	--div-by-zero-check \
+	--float-overflow-check \
+	--nan-check \
+	--pointer-overflow-check \
+	--undefined-shift-check \
+	--signed-overflow-check \
+	--unsigned-overflow-check \
 
 goto: $(ENTRY).goto
 

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -14,8 +14,6 @@ GOTO_ANALYZER ?= goto-analyzer
 BATCH ?= cbmc-batch
 VIEWER ?= cbmc-viewer
 
-CBMC_OBJECT_BITS = 8
-CBMC_MAX_OBJECT_SIZE = "(SIZE_MAX>>(CBMC_OBJECT_BITS+1))"
 
 ################################################################
 # Build goto binary for cbmc
@@ -60,20 +58,24 @@ $(ENTRY)2.goto: $(ENTRY)1.goto
 $(ENTRY).goto: $(ENTRY)2.goto
 	cp $< $@
 
+
+################################################################
+# Set C compiler defines
+
+CBMC_OBJECT_BITS ?= 8
+CBMCFLAGS += --object-bits $(CBMC_OBJECT_BITS)
+CBMC_MAX_OBJECT_SIZE = "(SIZE_MAX>>(CBMC_OBJECT_BITS+1))"
+
+
 ################################################################
 # Run cbmc and build html report
 
 CBMCFLAGS += \
-	--object-bits $(CBMC_OBJECT_BITS) \
 	$(UNWINDING) \
 	--bounds-check \
 	--pointer-check \
 	--unwinding-assertions \
-
-CBMCFLAGS += \
 	--nondet-static \
-
-CBMCFLAGS += \
 	--div-by-zero-check \
 	--float-overflow-check \
 	--nan-check \
@@ -201,9 +203,9 @@ launch-veryclean: launch-clean
 cbmc-batch.yaml: Makefile ../Makefile.common
 	@echo "Building $@"
 	@$(RM) $@
-	@echo "jobos: $(JOBOS)" >> $@
-	@echo "cbmcflags: $(call encode_options,$(CBMCFLAGS))" >> $@
-	@echo "goto: $(ENTRY).goto" >> $@
+	@echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CBMCFLAGS)))' > $@
 	@echo "expected: SUCCESSFUL" >> $@
+	@echo "goto: $(ENTRY).goto" >> $@
+	@echo "jobos: $(JOBOS)" >> $@
 
 ################################################################

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -42,16 +42,9 @@ CFLAGS += $(CFLAGS2) $(INC) $(DEF) -std=gnu99
 %.goto : %.c
 	$(GOTO_CC) -o $@ $(CFLAGS) $<
 
-# Use the generic implementations of atomic operations.
-# Using the gcc atomic intrinsics causes coverage computation to fail.
-# Define the generic flag here, and replace *_gcc.h with *_generic.h below.
-DEF += -DIOT_ATOMIC_GENERIC=1
-
 $(MQTT)/build:
 	(mkdir -p $(MQTT)/build; cd $(MQTT)/build; cmake ..) \
 	       > $(ENTRY)0.txt 2>&1
-	cp $(MQTT)/ports/common/include/atomic/iot_atomic_generic.h \
-	   $(MQTT)/ports/common/include/atomic/iot_atomic_gcc.h
 
 $(ENTRY)1.goto: $(MQTT)/build $(OBJS)
 	$(GOTO_CC) --function harness -o $@ $(OBJS)


### PR DESCRIPTION
*Description of changes:*

This PR depends on https://github.com/aws/aws-iot-device-sdk-embedded-C/pull/780!

- Adds `.gitignore` file on cbmc directory;
- Updates CBMC flags in the `Makefile.common`;
- Adds a new proof harness for the `IotMqtt_Init` function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
