### PR TITLE
Set proper state in disconnect handler

### DIFF
--- a/samples/linux/subscribe_publish_sample/subscribe_publish_sample.c
+++ b/samples/linux/subscribe_publish_sample/subscribe_publish_sample.c
@@ -78,16 +78,13 @@ static void disconnectCallbackHandler(AWS_IoT_Client *pClient, void *data) {
 
 	if(aws_iot_is_autoreconnect_enabled(pClient)) {
 		IOT_INFO("Auto Reconnect is enabled, Reconnecting attempt will start now");
-		pClient->clientStatus.clientState = CLIENT_STATE_PENDING_RECONNECT;
 	} else {
 		IOT_WARN("Auto Reconnect not enabled. Starting manual reconnect...");
 		rc = aws_iot_mqtt_attempt_reconnect(pClient);
 		if(NETWORK_RECONNECTED == rc) {
 			IOT_WARN("Manual Reconnect Successful");
-			pClient->clientStatus.clientState = CLIENT_STATE_CONNECTED_IDLE;
 		} else {
 			IOT_WARN("Manual Reconnect Failed - %d", rc);
-			pClient->clientStatus.clientState = CLIENT_STATE_DISCONNECTED_ERROR;
 		}
 	}
 }

--- a/samples/linux/subscribe_publish_sample/subscribe_publish_sample.c
+++ b/samples/linux/subscribe_publish_sample/subscribe_publish_sample.c
@@ -75,18 +75,6 @@ static void disconnectCallbackHandler(AWS_IoT_Client *pClient, void *data) {
 	}
 
 	IOT_UNUSED(data);
-
-	if(aws_iot_is_autoreconnect_enabled(pClient)) {
-		IOT_INFO("Auto Reconnect is enabled, Reconnecting attempt will start now");
-	} else {
-		IOT_WARN("Auto Reconnect not enabled. Starting manual reconnect...");
-		rc = aws_iot_mqtt_attempt_reconnect(pClient);
-		if(NETWORK_RECONNECTED == rc) {
-			IOT_WARN("Manual Reconnect Successful");
-		} else {
-			IOT_WARN("Manual Reconnect Failed - %d", rc);
-		}
-	}
 }
 
 static void parseInputArgsForConnectParams(int argc, char **argv) {

--- a/samples/linux/subscribe_publish_sample/subscribe_publish_sample.c
+++ b/samples/linux/subscribe_publish_sample/subscribe_publish_sample.c
@@ -75,6 +75,21 @@ static void disconnectCallbackHandler(AWS_IoT_Client *pClient, void *data) {
 	}
 
 	IOT_UNUSED(data);
+
+	if(aws_iot_is_autoreconnect_enabled(pClient)) {
+		IOT_INFO("Auto Reconnect is enabled, Reconnecting attempt will start now");
+		pClient->clientStatus.clientState = CLIENT_STATE_PENDING_RECONNECT;
+	} else {
+		IOT_WARN("Auto Reconnect not enabled. Starting manual reconnect...");
+		rc = aws_iot_mqtt_attempt_reconnect(pClient);
+		if(NETWORK_RECONNECTED == rc) {
+			IOT_WARN("Manual Reconnect Successful");
+			pClient->clientStatus.clientState = CLIENT_STATE_CONNECTED_IDLE;
+		} else {
+			IOT_WARN("Manual Reconnect Failed - %d", rc);
+			pClient->clientStatus.clientState = CLIENT_STATE_DISCONNECTED_ERROR;
+		}
+	}
 }
 
 static void parseInputArgsForConnectParams(int argc, char **argv) {

--- a/src/aws_iot_mqtt_client_yield.c
+++ b/src/aws_iot_mqtt_client_yield.c
@@ -67,6 +67,10 @@ static IoT_Error_t _aws_iot_mqtt_handle_disconnect(AWS_IoT_Client *pClient) {
 		pClient->clientData.disconnectHandler(pClient, pClient->clientData.disconnectHandlerData);
 	}
 
+	if (pClient->clientStatus.clientState == CLIENT_STATE_CONNECTED_IDLE) {
+		FUNC_EXIT_RC(NETWORK_RECONNECTED);
+	}
+
 	FUNC_EXIT_RC(NETWORK_DISCONNECTED_ERROR);
 }
 

--- a/src/aws_iot_mqtt_client_yield.c
+++ b/src/aws_iot_mqtt_client_yield.c
@@ -68,7 +68,7 @@ static IoT_Error_t _aws_iot_mqtt_handle_disconnect(AWS_IoT_Client *pClient) {
 	}
 
 	if (pClient->clientStatus.clientState == CLIENT_STATE_CONNECTED_IDLE) {
-		FUNC_EXIT_RC(NETWORK_RECONNECTED);
+		FUNC_EXIT_RC(SUCCESS);
 	}
 
 	FUNC_EXIT_RC(NETWORK_DISCONNECTED_ERROR);

--- a/src/aws_iot_mqtt_client_yield.c
+++ b/src/aws_iot_mqtt_client_yield.c
@@ -61,12 +61,12 @@ static IoT_Error_t _aws_iot_mqtt_handle_disconnect(AWS_IoT_Client *pClient) {
 		_aws_iot_mqtt_force_client_disconnect(pClient);
 	}
 
+	pClient->clientStatus.clientState = CLIENT_STATE_DISCONNECTED_ERROR;
+
 	if(NULL != pClient->clientData.disconnectHandler) {
 		pClient->clientData.disconnectHandler(pClient, pClient->clientData.disconnectHandlerData);
 	}
 
-	/* Reset to 0 since this was not a manual disconnect */
-	pClient->clientStatus.clientState = CLIENT_STATE_DISCONNECTED_ERROR;
 	FUNC_EXIT_RC(NETWORK_DISCONNECTED_ERROR);
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Set proper state in disconnect handler

Even if aws_iot_mqtt_attempt_reconnect() is successful in the disconnect handler, the client state is set to CLIENT_STATE_DISCONNECTED_ERROR and this result in the next aws_iot_mqtt_yield() call returns NETWORK_DISCONNECTED_ERROR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
