### PR TITLE
Adds a proof harness for the IotMqtt_IsSubscribed function

### DIFF
--- a/cbmc/proofs/IotMqtt_IsSubscribed/IotMqtt_IsSubscribed_harness.c
+++ b/cbmc/proofs/IotMqtt_IsSubscribed/IotMqtt_IsSubscribed_harness.c
@@ -26,5 +26,5 @@ void harness()
   IotMqtt_IsSubscribed( mqttConnection,
 			TopicFilter,
 			topicFilterLength,
-                        nondet_boo() ? NULL : &result );
+                        nondet_bool() ? NULL : &result );
 }

--- a/cbmc/proofs/IotMqtt_IsSubscribed/IotMqtt_IsSubscribed_harness.c
+++ b/cbmc/proofs/IotMqtt_IsSubscribed/IotMqtt_IsSubscribed_harness.c
@@ -23,7 +23,7 @@ void harness()
 
   IotMqttSubscription_t result;
 
-  IotMqtt_IsSubscribed( nondet_bool() ? NULL : mqttConnection,
+  IotMqtt_IsSubscribed( mqttConnection,
 			TopicFilter,
 			topicFilterLength,
                         nondet_boo() ? NULL : &result );

--- a/cbmc/proofs/IotMqtt_IsSubscribed/IotMqtt_IsSubscribed_harness.c
+++ b/cbmc/proofs/IotMqtt_IsSubscribed/IotMqtt_IsSubscribed_harness.c
@@ -1,0 +1,40 @@
+#include "iot_config.h"
+#include "private/iot_mqtt_internal.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "mqtt_state.h"
+
+/*
+
+bool IotMqtt_IsSubscribed( IotMqttConnection_t mqttConnection,
+                           const char * pTopicFilter,
+                           uint16_t topicFilterLength,
+                           IotMqttSubscription_t * pCurrentSubscription );
+
+*/
+
+void harness()
+{
+  IotMqttConnection_t mqttConnection = allocate_IotMqttConnection(NULL);
+  __CPROVER_assume(mqttConnection);
+  ensure_IotMqttConnection_has_lists(mqttConnection);
+  __CPROVER_assume(valid_IotMqttConnection(mqttConnection));
+
+  // Move to allocation and valid connection?
+  allocate_IotMqttSubscriptionList(&(mqttConnection->subscriptionList), 1);
+  __CPROVER_assume(valid_IotMqttSubscriptionList(&(mqttConnection->subscriptionList), 1));
+
+  uint16_t topicFilterLength;
+  __CPROVER_assume(topicFilterLength < TOPIC_LENGTH_MAX);
+
+  char* TopicFilter = malloc_can_fail(topicFilterLength);
+
+  IotMqttSubscription_t result;
+
+  IotMqtt_IsSubscribed( nondet_bool() ? NULL : mqttConnection,
+			TopicFilter,
+			topicFilterLength,
+                        nondet_boo() ? NULL : &result );
+}

--- a/cbmc/proofs/IotMqtt_IsSubscribed/IotMqtt_IsSubscribed_harness.c
+++ b/cbmc/proofs/IotMqtt_IsSubscribed/IotMqtt_IsSubscribed_harness.c
@@ -6,15 +6,6 @@
 
 #include "mqtt_state.h"
 
-/*
-
-bool IotMqtt_IsSubscribed( IotMqttConnection_t mqttConnection,
-                           const char * pTopicFilter,
-                           uint16_t topicFilterLength,
-                           IotMqttSubscription_t * pCurrentSubscription );
-
-*/
-
 void harness()
 {
   IotMqttConnection_t mqttConnection = allocate_IotMqttConnection(NULL);
@@ -22,7 +13,6 @@ void harness()
   ensure_IotMqttConnection_has_lists(mqttConnection);
   __CPROVER_assume(valid_IotMqttConnection(mqttConnection));
 
-  // Move to allocation and valid connection?
   allocate_IotMqttSubscriptionList(&(mqttConnection->subscriptionList), 1);
   __CPROVER_assume(valid_IotMqttSubscriptionList(&(mqttConnection->subscriptionList), 1));
 

--- a/cbmc/proofs/IotMqtt_IsSubscribed/IotMqtt_IsSubscribed_harness.c
+++ b/cbmc/proofs/IotMqtt_IsSubscribed/IotMqtt_IsSubscribed_harness.c
@@ -20,6 +20,7 @@ void harness()
   __CPROVER_assume(topicFilterLength < TOPIC_LENGTH_MAX);
 
   char* TopicFilter = malloc_can_fail(topicFilterLength);
+  __CPROVER_assume( VALID_STRING(TopicFilter, topicFilterLength) );
 
   IotMqttSubscription_t result;
 

--- a/cbmc/proofs/IotMqtt_IsSubscribed/Makefile
+++ b/cbmc/proofs/IotMqtt_IsSubscribed/Makefile
@@ -15,9 +15,11 @@ OBJS += $(MQTT)/cbmc/proofs/mqtt_state.goto
 OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_api.goto
 OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_subscription.goto
 
-# One more than actual number of subscriptions
+# One more than actual number of subscriptions in a subscription list
 SUBSCRIPTION_COUNT_MAX=4
 DEF += -DSUBSCRIPTION_COUNT_MAX=$(SUBSCRIPTION_COUNT_MAX)
+
+# One more than actual number of operations in an operation list
 OPERATION_COUNT_MAX=4
 DEF += -DOPERATION_COUNT_MAX=$(OPERATION_COUNT_MAX)
 

--- a/cbmc/proofs/IotMqtt_IsSubscribed/Makefile
+++ b/cbmc/proofs/IotMqtt_IsSubscribed/Makefile
@@ -1,0 +1,43 @@
+ENTRY=IotMqtt_IsSubscribed
+
+ABSTRACTIONS += --remove-function-body IotLog_Generic
+
+# Remove for coverage
+ABSTRACTIONS += --remove-function-body _mqttSubscription_setUnsubscribe
+ABSTRACTIONS += --remove-function-body _matchEndWildcards
+ABSTRACTIONS += --remove-function-body _matchWildcards
+ABSTRACTIONS += --remove-function-body _packetMatch
+ABSTRACTIONS += --remove-function-body _topicFilterMatch
+
+
+OBJS += $(ENTRY)_harness.goto
+OBJS += $(MQTT)/cbmc/proofs/mqtt_state.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_api.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_subscription.goto
+
+# One more than actual number of subscriptions
+SUBSCRIPTION_COUNT_MAX=4
+DEF += -DSUBSCRIPTION_COUNT_MAX=$(SUBSCRIPTION_COUNT_MAX)
+OPERATION_COUNT_MAX=4
+DEF += -DOPERATION_COUNT_MAX=$(OPERATION_COUNT_MAX)
+
+# One more than actual length of topics
+TOPIC_LENGTH_MAX=6
+DEF += -DTOPIC_LENGTH_MAX=$(TOPIC_LENGTH_MAX)
+
+# Should be 2*SUBSCRIPTION_COUNT_MAX-1
+SUBSCRIPTION_LIST_MAX=6
+DEF += -DSUBSCRIPTION_LIST_MAX=$(SUBSCRIPTION_LIST_MAX)
+
+LOOP += allocate_IotMqttSubscriptionArray.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += valid_IotMqttSubscriptionArray.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += allocate_IotMqttSubscriptionList.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += valid_IotMqttSubscriptionList.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += valid_IotMqttOperationList.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += IotListDouble_FindFirstMatch\$$link1.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += strncmp.0:$(TOPIC_LENGTH_MAX)
+
+UNWINDING += --unwind 1
+UNWINDING += --unwindset '$(shell echo $(LOOP) | sed 's/ /,/g')'
+
+include ../Makefile.common

--- a/cbmc/proofs/IotMqtt_IsSubscribed/cbmc-batch.yaml
+++ b/cbmc/proofs/IotMqtt_IsSubscribed/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags:        '=--unwind;1;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static='
+cbmcflags:        '=--object-bits;8;--unwind;1;--unwindset;allocate_IotMqttSubscriptionArray.0:4,valid_IotMqttSubscriptionArray.0:4,allocate_IotMqttSubscriptionList.0:4,valid_IotMqttSubscriptionList.0:4,valid_IotMqttOperationList.0:4,IotListDouble_FindFirstMatch.0:4,strncmp.0:6;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-overflow-check;--undefined-shift-check;--signed-overflow-check;--unsigned-overflow-check='
 goto: IotMqtt_IsSubscribed.goto
 expected: SUCCESSFUL

--- a/cbmc/proofs/IotMqtt_IsSubscribed/cbmc-batch.yaml
+++ b/cbmc/proofs/IotMqtt_IsSubscribed/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: ' =--object-bits;8;--unwind;1;--unwindset;allocate_IotMqttSubscriptionArray.0:4,valid_IotMqttSubscriptionArray.0:4,allocate_IotMqttSubscriptionList.0:4,valid_IotMqttSubscriptionList.0:4,valid_IotMqttOperationList.0:4,IotListDouble_FindFirstMatch$link1.0:4,strncmp.0:6;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-overflow-check;--undefined-shift-check;--signed-overflow-check;--unsigned-overflow-check='
+cbmcflags: "--object-bits;8;--unwind;1;--unwindset;allocate_IotMqttSubscriptionArray.0:4,valid_IotMqttSubscriptionArray.0:4,allocate_IotMqttSubscriptionList.0:4,valid_IotMqttSubscriptionList.0:4,valid_IotMqttOperationList.0:4,IotListDouble_FindFirstMatch$link1.0:4,strncmp.0:6;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-overflow-check;--undefined-shift-check;--signed-overflow-check;--unsigned-overflow-check"
 goto: IotMqtt_IsSubscribed.goto
 expected: SUCCESSFUL

--- a/cbmc/proofs/IotMqtt_IsSubscribed/cbmc-batch.yaml
+++ b/cbmc/proofs/IotMqtt_IsSubscribed/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags:        '=--object-bits;8;--unwind;1;--unwindset;allocate_IotMqttSubscriptionArray.0:4,valid_IotMqttSubscriptionArray.0:4,allocate_IotMqttSubscriptionList.0:4,valid_IotMqttSubscriptionList.0:4,valid_IotMqttOperationList.0:4,IotListDouble_FindFirstMatch.0:4,strncmp.0:6;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-overflow-check;--undefined-shift-check;--signed-overflow-check;--unsigned-overflow-check='
+cbmcflags: ' =--object-bits;8;--unwind;1;--unwindset;allocate_IotMqttSubscriptionArray.0:4,valid_IotMqttSubscriptionArray.0:4,allocate_IotMqttSubscriptionList.0:4,valid_IotMqttSubscriptionList.0:4,valid_IotMqttOperationList.0:4,IotListDouble_FindFirstMatch$link1.0:4,strncmp.0:6;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-overflow-check;--undefined-shift-check;--signed-overflow-check;--unsigned-overflow-check='
 goto: IotMqtt_IsSubscribed.goto
 expected: SUCCESSFUL

--- a/cbmc/proofs/IotMqtt_IsSubscribed/cbmc-batch.yaml
+++ b/cbmc/proofs/IotMqtt_IsSubscribed/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags:        '=--unwind;1;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static='
+goto: IotMqtt_IsSubscribed.goto
+expected: SUCCESSFUL

--- a/cbmc/proofs/IotMqtt_IsSubscribed/cbmc-viewer.json
+++ b/cbmc/proofs/IotMqtt_IsSubscribed/cbmc-viewer.json
@@ -1,0 +1,22 @@
+{ "expected-missing-functions":
+  [
+    "IotLog_Generic",
+    "IotMqtt_Wait",
+    "IotMutex_Create",
+    "IotMutex_Destroy",
+    "IotMutex_Lock",
+    "IotMutex_Unlock",
+    "IotSemaphore_Create",
+    "IotSemaphore_Destroy",
+    "IotSemaphore_Post",
+    "IotSemaphore_TimedWait",
+    "IotSemaphore_Wait",
+    "IotTaskPool_CreateJob",
+    "IotTaskPool_GetSystemTaskPool",
+    "IotTaskPool_ScheduleDeferred",
+    "IotTaskPool_strerror",
+    "IotTaskPool_TryCancel"
+  ],
+  "proof-name": "IotMqtt_IsSubscribed",
+  "proof-root": "cbmc/proofs"
+}

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -27,6 +27,7 @@ INC += \
 	-I$(MQTT)/ports/common/include \
 	-I$(MQTT)/libraries/standard/common/include \
 	-I$(MQTT)/libraries/standard/mqtt/src \
+	-I$(MQTT)/cbmc/proofs \
 
 DEF += \
 	-DIOT_SYSTEM_TYPES_FILE=\"$(MQTT)/ports/posix/include/iot_platform_types_posix.h\" \

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -87,7 +87,8 @@ CBMCFLAGS += \
 goto: $(ENTRY).goto
 
 cbmc.txt: $(ENTRY).goto
-	cbmc $(CBMCFLAGS) --trace $< 2>&1 | tee $@
+	@echo cbmc $(CBMCFLAGS) --trace $< 2>&1 | tee $@
+	cbmc $(CBMCFLAGS) --trace $< 2>&1 | tee -a $@
 
 property.xml: $(ENTRY).goto
 	cbmc $(CBMCFLAGS) --show-properties --xml-ui $< 2>&1 > $@
@@ -200,6 +201,7 @@ launch-veryclean: launch-clean
 ################################################################
 # Build configuration file to run cbmc under cbmc-batch in CI
 
+CBMC_FLAGS =  '$(call encode_options,$(CBMCFLAGS))'
 cbmc-batch.yaml: Makefile ../Makefile.common
 	@echo "Building $@"
 	@$(RM) $@

--- a/libraries/standard/mqtt/src/iot_mqtt_subscription.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_subscription.c
@@ -305,10 +305,6 @@ static bool _topicMatch( const IotLink_t * const pSubscriptionLink,
     /* Extract the relevant strings and lengths from parameters. */
     const char * pTopicName = pParam->pTopicName;
     const char * pTopicFilter = pSubscription->pTopicFilter;
-    if ( pTopicName == NULL || pTopicFilter == NULL )
-    {
-        return status;
-    }
     const uint16_t topicNameLength = pParam->topicNameLength;
     const uint16_t topicFilterLength = pSubscription->topicFilterLength;
  

--- a/libraries/standard/mqtt/src/iot_mqtt_subscription.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_subscription.c
@@ -661,7 +661,7 @@ bool IotMqtt_IsSubscribed( IotMqttConnection_t mqttConnection,
 {
     bool status = false;
     
-    if( mqttConnection == NULL || pTopicFilter == NULL )
+    if( pTopicFilter == NULL )
     {
     	return status;
     }

--- a/libraries/standard/mqtt/src/iot_mqtt_subscription.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_subscription.c
@@ -299,14 +299,19 @@ static bool _topicMatch( const IotLink_t * const pSubscriptionLink,
     const _mqttSubscription_t * pSubscription = IotLink_Container( _mqttSubscription_t,
                                                                    pSubscriptionLink,
                                                                    link );
-    const _topicMatchParams_t * pParam = ( _topicMatchParams_t * ) pMatch;
 
+    const _topicMatchParams_t * pParam = ( _topicMatchParams_t * ) pMatch;
+ 
     /* Extract the relevant strings and lengths from parameters. */
     const char * pTopicName = pParam->pTopicName;
     const char * pTopicFilter = pSubscription->pTopicFilter;
+    if ( pTopicName == NULL || pTopicFilter == NULL )
+    {
+        return status;
+    }
     const uint16_t topicNameLength = pParam->topicNameLength;
     const uint16_t topicFilterLength = pSubscription->topicFilterLength;
-
+ 
     /* Check for an exact match. */
     if( topicNameLength == topicFilterLength )
     {
@@ -655,6 +660,12 @@ bool IotMqtt_IsSubscribed( IotMqttConnection_t mqttConnection,
                            IotMqttSubscription_t * const pCurrentSubscription )
 {
     bool status = false;
+    
+    if( mqttConnection == NULL || pTopicFilter == NULL )
+    {
+    	return status;
+    }
+    
     const _mqttSubscription_t * pSubscription = NULL;
     const IotLink_t * pSubscriptionLink = NULL;
     _topicMatchParams_t topicMatchParams = { 0 };

--- a/libraries/standard/mqtt/src/iot_mqtt_subscription.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_subscription.c
@@ -299,15 +299,14 @@ static bool _topicMatch( const IotLink_t * const pSubscriptionLink,
     const _mqttSubscription_t * pSubscription = IotLink_Container( _mqttSubscription_t,
                                                                    pSubscriptionLink,
                                                                    link );
-
     const _topicMatchParams_t * pParam = ( _topicMatchParams_t * ) pMatch;
- 
+
     /* Extract the relevant strings and lengths from parameters. */
     const char * pTopicName = pParam->pTopicName;
     const char * pTopicFilter = pSubscription->pTopicFilter;
     const uint16_t topicNameLength = pParam->topicNameLength;
     const uint16_t topicFilterLength = pSubscription->topicFilterLength;
- 
+
     /* Check for an exact match. */
     if( topicNameLength == topicFilterLength )
     {
@@ -656,12 +655,6 @@ bool IotMqtt_IsSubscribed( IotMqttConnection_t mqttConnection,
                            IotMqttSubscription_t * const pCurrentSubscription )
 {
     bool status = false;
-    
-    if( pTopicFilter == NULL )
-    {
-    	return status;
-    }
-    
     const _mqttSubscription_t * pSubscription = NULL;
     const IotLink_t * pSubscriptionLink = NULL;
     _topicMatchParams_t topicMatchParams = { 0 };


### PR DESCRIPTION
*Description of changes:*

This PR depends on https://github.com/aws/aws-iot-device-sdk-embedded-C/pull/788!!!

- Adds a new proof harness for the `IotMqtt_IsSubscribed` function.
- Add a fix to avoid undefined behavior when calling `strncmp` function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
