### PR TITLE
Apply patches before running proofs

### DIFF
--- a/cbmc/patches/README.md
+++ b/cbmc/patches/README.md
@@ -1,0 +1,6 @@
+Patches for Proofs
+==================
+
+This directory contains patch files that must be applied to the codebase
+before running CBMC proofs. The `cbmc/proofs/prepare.py` script takes
+care of applying these patches.


### PR DESCRIPTION
prepare.py will now apply any patch files in the cbmc/patches directory
before starting the proof. Patches to the codebase are necessary for
some of the proofs to run.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
