### PR TITLE
Adds a proof harness for the IotMqtt_Wait function

### DIFF
--- a/cbmc/proofs/IotMqtt_Wait/IotMqtt_Wait_harness.c
+++ b/cbmc/proofs/IotMqtt_Wait/IotMqtt_Wait_harness.c
@@ -1,0 +1,28 @@
+#include "iot_config.h"
+#include "private/iot_mqtt_internal.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "mqtt_state.h"
+
+void harness()
+{
+  IotMqttConnection_t mqttConnection = allocate_IotMqttConnection(NULL);
+  __CPROVER_assume(mqttConnection != NULL);
+  __CPROVER_assume(mqttConnection->pNetworkInterface != NULL);
+  __CPROVER_assume( IS_STUBBED_NETWORKIF_DESTROY( mqttConnection->pNetworkInterface ) );
+  ensure_IotMqttConnection_has_lists(mqttConnection);
+  __CPROVER_assume(valid_IotMqttConnection(mqttConnection));
+
+  IotMqttOperation_t publishOperation = allocate_IotMqttOperation(NULL, mqttConnection);
+  __CPROVER_assume(valid_IotMqttOperation(publishOperation));
+
+  __CPROVER_assume(publishOperation->link.pNext == NULL);
+  __CPROVER_assume(publishOperation->link.pPrevious == NULL);
+
+  uint32_t timeoutMs;
+
+  IotMqtt_Wait( nondet_bool() ? publishOperation : NULL, timeoutMs );
+}
+

--- a/cbmc/proofs/IotMqtt_Wait/IotMqtt_Wait_harness.c
+++ b/cbmc/proofs/IotMqtt_Wait/IotMqtt_Wait_harness.c
@@ -18,11 +18,17 @@ void harness()
   IotMqttOperation_t publishOperation = allocate_IotMqttOperation(NULL, mqttConnection);
   __CPROVER_assume(valid_IotMqttOperation(publishOperation));
 
-  __CPROVER_assume(publishOperation->link.pNext == NULL);
-  __CPROVER_assume(publishOperation->link.pPrevious == NULL);
-
+  if (nondet_bool())
+  {
+    __CPROVER_assume(publishOperation->link.pNext == NULL);
+    __CPROVER_assume(publishOperation->link.pPrevious == NULL);
+  }
+  else
+  {
+    IotListDouble_InsertHead( &( mqttConnection->pendingProcessing ), &( publishOperation->link ));
+  }
+  
   uint32_t timeoutMs;
-
   IotMqtt_Wait( nondet_bool() ? publishOperation : NULL, timeoutMs );
 }
 

--- a/cbmc/proofs/IotMqtt_Wait/IotMqtt_Wait_harness.c
+++ b/cbmc/proofs/IotMqtt_Wait/IotMqtt_Wait_harness.c
@@ -18,12 +18,9 @@ void harness()
   IotMqttOperation_t publishOperation = allocate_IotMqttOperation(NULL, mqttConnection);
   __CPROVER_assume(valid_IotMqttOperation(publishOperation));
 
+  IotListDouble_Create( &( publishOperation->link ));
+  
   if (nondet_bool())
-  {
-    __CPROVER_assume(publishOperation->link.pNext == NULL);
-    __CPROVER_assume(publishOperation->link.pPrevious == NULL);
-  }
-  else
   {
     IotListDouble_InsertHead( &( mqttConnection->pendingProcessing ), &( publishOperation->link ));
   }

--- a/cbmc/proofs/IotMqtt_Wait/Makefile
+++ b/cbmc/proofs/IotMqtt_Wait/Makefile
@@ -1,21 +1,17 @@
 ENTRY=IotMqtt_Wait
 
-ABSTRACTIONS += --remove-function-body IotNetworkInterfaceClose
-ABSTRACTIONS += --remove-function-body IotLog_Generic
-ABSTRACTIONS += --remove-function-body IotListDouble_Remove
-ABSTRACTIONS += --remove-function-body _mqttOperation_tryDestroy
-ABSTRACTIONS += --remove-function-body _mqttSubscription_setUnsubscribe
-ABSTRACTIONS += --remove-function-body _mqttSubscription_tryDestroy
 ABSTRACTIONS += --remove-function-body _IotMqtt_ProcessIncomingPublish
-ABSTRACTIONS += --remove-function-body _mqttOperation_match
-ABSTRACTIONS += --remove-function-body IotListDouble_Remove
 ABSTRACTIONS += --remove-function-body _matchEndWildcards
 ABSTRACTIONS += --remove-function-body _matchWildcards
+ABSTRACTIONS += --remove-function-body _mqttOperation_match
+ABSTRACTIONS += --remove-function-body _mqttOperation_tryDestroy
 ABSTRACTIONS += --remove-function-body _packetMatch
 ABSTRACTIONS += --remove-function-body _topicFilterMatch
 ABSTRACTIONS += --remove-function-body _topicMatch
 ABSTRACTIONS += --remove-function-body IotListDouble_Remove
 ABSTRACTIONS += --remove-function-body 'IotListDouble_Remove$$link3'
+ABSTRACTIONS += --remove-function-body IotLog_Generic
+ABSTRACTIONS += --remove-function-body IotNetworkInterfaceClose
 
 OBJS += $(ENTRY)_harness.goto
 OBJS += $(MQTT)/cbmc/proofs/mqtt_state.goto
@@ -37,6 +33,7 @@ DEF += -DTOPIC_LENGTH_MAX=$(TOPIC_LENGTH_MAX)
 
 LOOP += valid_IotMqttSubscriptionList.0:$(SUBSCRIPTION_COUNT_MAX)
 LOOP += valid_IotMqttOperationList.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += IotListDouble_RemoveAllMatches.0:$(SUBSCRIPTION_COUNT_MAX)
 
 UNWINDING += --unwind 1
 UNWINDING += --unwindset '$(shell echo $(LOOP) | sed 's/ /,/g')'

--- a/cbmc/proofs/IotMqtt_Wait/Makefile
+++ b/cbmc/proofs/IotMqtt_Wait/Makefile
@@ -1,0 +1,44 @@
+ENTRY=IotMqtt_Wait
+
+ABSTRACTIONS += --remove-function-body IotNetworkInterfaceClose
+ABSTRACTIONS += --remove-function-body IotLog_Generic
+ABSTRACTIONS += --remove-function-body IotListDouble_Remove
+ABSTRACTIONS += --remove-function-body _mqttOperation_tryDestroy
+ABSTRACTIONS += --remove-function-body _mqttSubscription_setUnsubscribe
+ABSTRACTIONS += --remove-function-body _mqttSubscription_tryDestroy
+ABSTRACTIONS += --remove-function-body _IotMqtt_ProcessIncomingPublish
+ABSTRACTIONS += --remove-function-body _mqttOperation_match
+ABSTRACTIONS += --remove-function-body IotListDouble_Remove
+ABSTRACTIONS += --remove-function-body _matchEndWildcards
+ABSTRACTIONS += --remove-function-body _matchWildcards
+ABSTRACTIONS += --remove-function-body _packetMatch
+ABSTRACTIONS += --remove-function-body _topicFilterMatch
+ABSTRACTIONS += --remove-function-body _topicMatch
+ABSTRACTIONS += --remove-function-body IotListDouble_Remove
+ABSTRACTIONS += --remove-function-body 'IotListDouble_Remove$$link3'
+
+OBJS += $(ENTRY)_harness.goto
+OBJS += $(MQTT)/cbmc/proofs/mqtt_state.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_api.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_operation.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_serialize.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_subscription.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_validate.goto
+
+# One more than actual number of subscriptions
+SUBSCRIPTION_COUNT_MAX=4
+DEF += -DSUBSCRIPTION_COUNT_MAX=$(SUBSCRIPTION_COUNT_MAX)
+OPERATION_COUNT_MAX=4
+DEF += -DOPERATION_COUNT_MAX=$(OPERATION_COUNT_MAX)
+
+# One more than actual length of topics
+TOPIC_LENGTH_MAX=6
+DEF += -DTOPIC_LENGTH_MAX=$(TOPIC_LENGTH_MAX)
+
+LOOP += valid_IotMqttSubscriptionList.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += valid_IotMqttOperationList.0:$(SUBSCRIPTION_COUNT_MAX)
+
+UNWINDING += --unwind 1
+UNWINDING += --unwindset '$(shell echo $(LOOP) | sed 's/ /,/g')'
+
+include ../Makefile.common

--- a/cbmc/proofs/IotMqtt_Wait/Makefile
+++ b/cbmc/proofs/IotMqtt_Wait/Makefile
@@ -1,5 +1,7 @@
 ENTRY=IotMqtt_Wait
 
+# We abstract all the log and concurrency related functions in this proof
+# and assume their implementation is correct
 ABSTRACTIONS += --remove-function-body _IotMqtt_ProcessIncomingPublish
 ABSTRACTIONS += --remove-function-body _matchEndWildcards
 ABSTRACTIONS += --remove-function-body _matchWildcards
@@ -21,9 +23,11 @@ OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_serialize.goto
 OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_subscription.goto
 OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_validate.goto
 
-# One more than actual number of subscriptions
+# One more than actual number of subscriptions in a subscription list
 SUBSCRIPTION_COUNT_MAX=4
 DEF += -DSUBSCRIPTION_COUNT_MAX=$(SUBSCRIPTION_COUNT_MAX)
+
+# One more than actual number of operations in an operation list
 OPERATION_COUNT_MAX=4
 DEF += -DOPERATION_COUNT_MAX=$(OPERATION_COUNT_MAX)
 

--- a/cbmc/proofs/IotMqtt_Wait/cbmc-batch.yaml
+++ b/cbmc/proofs/IotMqtt_Wait/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-jobos: ubuntu16
-cbmcflags:        '=--unwind;1;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static='
-goto: IotMqtt_Wait.goto
+cbmcflags: "--object-bits;8;--unwind;1;--unwindset;valid_IotMqttSubscriptionList.0:4,valid_IotMqttOperationList.0:4,IotListDouble_RemoveAllMatches.0:4;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-overflow-check;--undefined-shift-check;--signed-overflow-check;--unsigned-overflow-check"
 expected: SUCCESSFUL
+goto: IotMqtt_Wait.goto
+jobos: ubuntu16

--- a/cbmc/proofs/IotMqtt_Wait/cbmc-batch.yaml
+++ b/cbmc/proofs/IotMqtt_Wait/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags:        '=--unwind;1;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static='
+goto: IotMqtt_Wait.goto
+expected: SUCCESSFUL

--- a/cbmc/proofs/IotMqtt_Wait/cbmc-viewer.json
+++ b/cbmc/proofs/IotMqtt_Wait/cbmc-viewer.json
@@ -1,0 +1,22 @@
+{ "expected-missing-functions":
+  [
+    "IotLog_Generic",
+    "IotMqtt_Wait",
+    "IotMutex_Create",
+    "IotMutex_Destroy",
+    "IotMutex_Lock",
+    "IotMutex_Unlock",
+    "IotSemaphore_Create",
+    "IotSemaphore_Destroy",
+    "IotSemaphore_Post",
+    "IotSemaphore_TimedWait",
+    "IotSemaphore_Wait",
+    "IotTaskPool_CreateJob",
+    "IotTaskPool_GetSystemTaskPool",
+    "IotTaskPool_ScheduleDeferred",
+    "IotTaskPool_strerror",
+    "IotTaskPool_TryCancel"
+  ],
+  "proof-name": "IotMqtt_Wait",
+  "proof-root": "cbmc/proofs"
+}

--- a/cbmc/proofs/mqtt_state.c
+++ b/cbmc/proofs/mqtt_state.c
@@ -388,6 +388,8 @@ _mqttSubscription_t *allocate_IotMqttSubscriptionListElt( _mqttSubscription_t *p
   if ( pElt == NULL ) pElt = malloc_can_fail( sizeof( *pElt ) + length );
   if ( pElt == NULL ) return NULL;
 
+  // References must never be negative
+  __CPROVER_assume( pElt->references >= 0 );
   pElt->link.pPrevious = NULL;
   pElt->link.pNext = NULL;
   pElt->topicFilterLength = length;


### PR DESCRIPTION
*Description of changes:*

This PR depends on https://github.com/aws/aws-iot-device-sdk-embedded-C/pull/788!

- Adds a new proof harness for the `IotMqtt_Wait` function.
- Improve assumptions in the `mqtt_state` module.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
