### PR TITLE
Add CBMC proof for DeserializeSuback

### DIFF
--- a/cbmc/.gitignore
+++ b/cbmc/.gitignore
@@ -1,0 +1,6 @@
+proofs/ninja.py
+build.ninja
+.ninja_deps
+.ninja_log
+*.csv
+*.log

--- a/cbmc/proofs/DeserializeSuback/DeserializeSuback_harness.c
+++ b/cbmc/proofs/DeserializeSuback/DeserializeSuback_harness.c
@@ -3,15 +3,84 @@
 
 #include <stdlib.h>
 
-/*-----------------------------------------------------------*/
+#include "mqtt_state.h"
+
+/****************************************************************
+ * Stub out RemoveAllMatches.
+ *
+ * The only invocation of RemoveAllMatches in DeserializeSuback is to
+ * remove subscriptions from the connection's subscription list.  This
+ * stub abstracts RemoveAllMatches by replacing the list with an
+ * unconstrained list of subscriptions.  We don't even bother to fill
+ * in the topic subscription filters.  By design, any actual use of
+ * the list in subsequent code (there is none) will trigger pointer
+ * errors.
+/****************************************************************/
+
+void IotListDouble_RemoveAllMatches( const IotListDouble_t * const pList,
+				     bool ( *isMatch )( const IotLink_t * const pOperationLink,
+							void * pCompare ),
+				     void * pMatch,
+				     void ( *freeElement )( void * pData ),
+				     size_t linkOffset )
+{
+  IotListDouble_t *sentinal = pList->pNext->pPrevious;
+
+  size_t num_elts;
+  __CPROVER_assume(num_elts < SUBSCRIPTION_COUNT_MAX);
+
+  // Allocate lists of length at most 3
+  __CPROVER_assert(SUBSCRIPTION_COUNT_MAX <= 4,
+		   "Subscription lists limited to 3 elements");
+
+  if (1 <= num_elts)
+    {
+      _mqttSubscription_t *pElt = malloc(sizeof(*pElt));
+      sentinal->pNext = &pElt->link;
+      pElt->link.pPrevious = sentinal;
+      pElt->link.pNext = sentinal;
+      sentinal->pPrevious = &pElt->link;
+    }
+  if (2 <= num_elts)
+    {
+      _mqttSubscription_t *pElt = malloc(sizeof(*pElt));
+      sentinal->pNext = &pElt->link;
+      pElt->link.pPrevious = sentinal;
+      pElt->link.pNext = sentinal;
+      sentinal->pPrevious = &pElt->link;
+    }
+  if (3 <= num_elts)
+    {
+      _mqttSubscription_t *pElt = malloc(sizeof(*pElt));
+      sentinal->pNext = &pElt->link;
+      pElt->link.pPrevious = sentinal;
+      pElt->link.pNext = sentinal;
+      sentinal->pPrevious = &pElt->link;
+    }
+}
+
+/****************************************************************
+ * Proof harness
+ ****************************************************************/
 
 void harness()
 {
     _mqttPacket_t suback;
 
-    suback.pRemainingData = malloc( sizeof( uint8_t ) * suback.remainingLength );
-
+    // Create packet data
     __CPROVER_assume( suback.remainingLength <= BUFFER_SIZE );
+    suback.pRemainingData = malloc( sizeof( uint8_t )
+				    * suback.remainingLength );
 
+    // Create packet connection
+    IotMqttConnection_t pConn = allocate_IotMqttConnection(NULL);
+    __CPROVER_assume(pConn);
+    ensure_IotMqttConnection_has_lists(pConn);
+    __CPROVER_assume(valid_IotMqttConnection(pConn));
+    suback.u.pMqttConnection = pConn;
+
+    // Argument must be a nonnull pointer
     _IotMqtt_DeserializeSuback( &suback );
 }
+
+/****************************************************************/

--- a/cbmc/proofs/DeserializeSuback/Makefile
+++ b/cbmc/proofs/DeserializeSuback/Makefile
@@ -1,19 +1,53 @@
 ENTRY=DeserializeSuback
 
-BUFFER_SIZE = 100
+################################################################
+# Proof assumptions
 
-ABSTRACTIONS = \
-	--remove-function-body IotLog_Generic \
-	--remove-function-body _IotMqtt_RemoveSubscriptionByPacket \
+# Bound the number of subscriptions in a list (BOUND = MAX-1)
+SUBSCRIPTION_COUNT_MAX=2
+DEF += -DSUBSCRIPTION_COUNT_MAX=$(SUBSCRIPTION_COUNT_MAX)
 
-UNWINDING = \
-	--unwindset _decodeSubackStatus.0:$(BUFFER_SIZE) \
+# Bound the number of operations in a list (BOUND = MAX-1)
+OPERATION_COUNT_MAX=2
+DEF += -DOPERATION_COUNT_MAX=$(OPERATION_COUNT_MAX)
 
-OBJS = \
-	$(ENTRY)_harness.goto \
-	$(MQTT)/libraries/standard/mqtt/src/iot_mqtt_subscription.goto \
-	$(MQTT)/libraries/standard/mqtt/src/iot_mqtt_serialize.goto \
+#BUFFER_SIZE = 100
+BUFFER_SIZE = 15
+DEF += -DBUFFER_SIZE=$(BUFFER_SIZE)
 
-DEF = -DBUFFER_SIZE=$(BUFFER_SIZE)
+################################################################
+# Function omitted from the proof
+
+ABSTRACTIONS += --remove-function-body IotLog_Generic
+
+# Functions removed to make coverage calculation accurate
+# None
+
+# These defines have the effect of removing RemoveAllMatches from the
+# linear containers header so that our stub will be used.
+DEF += -DCBMC=1 -DCBMC_PROOF_DESERIALIZE_SUBACK=1
+
+################################################################
+# Loop unwinding
+
+LOOP += valid_IotMqttSubscriptionList.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += valid_IotMqttOperationList.0:$(OPERATION_COUNT_MAX)
+
+LOOP += _decodeSubackStatus.0:$(BUFFER_SIZE)
+
+UNWINDING += --unwind 1
+UNWINDING += --unwindset '$(shell echo $(LOOP) | sed 's/ /,/g')'
+
+################################################################
+
+OBJS += $(ENTRY)_harness.goto
+OBJS += $(MQTT)/cbmc/proofs/mqtt_state.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_serialize.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_subscription.goto
+
+CBMCFLAGS += --flush
+
+################################################################
 
 include ../Makefile.common
+

--- a/cbmc/proofs/DeserializeSuback/cbmc-batch.yaml
+++ b/cbmc/proofs/DeserializeSuback/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags:        '=--unwindset;_decodeSubackStatus.0:100;--bounds-check;--pointer-check;--unwinding-assertions='
+cbmcflags:        '=--unwindset;_decodeSubackStatus.0:100;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static='
 goto: DeserializeSuback.goto
 expected: SUCCESSFUL

--- a/cbmc/proofs/DeserializeSuback/cbmc-viewer.json
+++ b/cbmc/proofs/DeserializeSuback/cbmc-viewer.json
@@ -1,0 +1,22 @@
+{ "expected-missing-functions":
+  [
+    "IotLog_Generic",
+    "IotMqtt_Wait",
+    "IotMutex_Create",
+    "IotMutex_Destroy",
+    "IotMutex_Lock",
+    "IotMutex_Unlock",
+    "IotSemaphore_Create",
+    "IotSemaphore_Destroy",
+    "IotSemaphore_Post",
+    "IotSemaphore_TimedWait",
+    "IotSemaphore_Wait",
+    "IotTaskPool_CreateJob",
+    "IotTaskPool_GetSystemTaskPool",
+    "IotTaskPool_ScheduleDeferred",
+    "IotTaskPool_strerror",
+    "IotTaskPool_TryCancel"
+  ],
+  "proof-name": "DeserializeSuback",
+  "proof-root": "cbmc/proofs"
+}

--- a/cbmc/proofs/IotMqtt_Init/IotMqtt_Init_harness.c
+++ b/cbmc/proofs/IotMqtt_Init/IotMqtt_Init_harness.c
@@ -6,5 +6,6 @@
 
 void harness()
 {
-  IotMqtt_Init();
+  IotMqttError_t status = IotMqtt_Init();
+  assert(status == IOT_MQTT_SUCCESS || status == IOT_MQTT_NOT_INITIALIZED);
 }

--- a/cbmc/proofs/IotMqtt_Init/IotMqtt_Init_harness.c
+++ b/cbmc/proofs/IotMqtt_Init/IotMqtt_Init_harness.c
@@ -8,7 +8,3 @@ void harness()
 {
   IotMqtt_Init();
 }
-
-
-
-

--- a/cbmc/proofs/IotMqtt_Init/IotMqtt_Init_harness.c
+++ b/cbmc/proofs/IotMqtt_Init/IotMqtt_Init_harness.c
@@ -1,0 +1,14 @@
+#include "iot_config.h"
+#include "private/iot_mqtt_internal.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+void harness()
+{
+  IotMqtt_Init();
+}
+
+
+
+

--- a/cbmc/proofs/IotMqtt_Init/Makefile
+++ b/cbmc/proofs/IotMqtt_Init/Makefile
@@ -1,0 +1,12 @@
+ENTRY=IotMqtt_Init
+
+ABSTRACTIONS += --remove-function-body IotLog_Generic
+ABSTRACTIONS += --remove-function-body Iot_EnterCritical
+ABSTRACTIONS += --remove-function-body Iot_ExitCritical
+
+OBJS += $(ENTRY)_harness.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_api.goto
+
+UNWINDING += --unwind 1
+
+include ../Makefile.common

--- a/cbmc/proofs/IotMqtt_Init/Makefile
+++ b/cbmc/proofs/IotMqtt_Init/Makefile
@@ -2,9 +2,9 @@ ENTRY=IotMqtt_Init
 
 # We abstract all the log and concurrency related functions in this proof
 # and assume their implementation is correct
-ABSTRACTIONS += --remove-function-body IotLog_Generic
 ABSTRACTIONS += --remove-function-body Iot_EnterCritical
 ABSTRACTIONS += --remove-function-body Iot_ExitCritical
+ABSTRACTIONS += --remove-function-body IotLog_Generic
 
 OBJS += $(ENTRY)_harness.goto
 OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_api.goto

--- a/cbmc/proofs/IotMqtt_Init/Makefile
+++ b/cbmc/proofs/IotMqtt_Init/Makefile
@@ -2,31 +2,11 @@ ENTRY=IotMqtt_Init
 
 # We abstract all the log and concurrency related functions in this proof
 # and assume their implementation is correct
-ABSTRACTIONS += --remove-function-body Iot_EnterCritical
-ABSTRACTIONS += --remove-function-body Iot_ExitCritical
 ABSTRACTIONS += --remove-function-body IotLog_Generic
 
 OBJS += $(ENTRY)_harness.goto
 OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_api.goto
 
 UNWINDING += --unwind 1
-
-default: report
-
-# Use the generic implementations of atomic operations.
-# Using the gcc atomic intrinsics causes coverage computation to fail.
-# Define the generic flag here, and replace *_gcc.h with *_generic.h below.
-DEF += -DIOT_ATOMIC_GENERIC=1
-
-install_atomic:
-	mv $(MQTT)/ports/common/include/atomic/iot_atomic_gcc.h $(MQTT)/ports/common/include/atomic/iot_atomic_gcc_disable.h
-	cp $(MQTT)/ports/common/include/atomic/iot_atomic_generic.h \
-	   $(MQTT)/ports/common/include/atomic/iot_atomic_gcc.h
-
-uninstall_atomic:
-	rm $(MQTT)/ports/common/include/atomic/iot_atomic_gcc.h \
-	mv $(MQTT)/ports/common/include/atomic/iot_atomic_gcc_disable.h $(MQTT)/ports/common/include/atomic/iot_atomic_gcc.h 
-
-.PHONY: install_atomic uninstall_atomic
 
 include ../Makefile.common

--- a/cbmc/proofs/IotMqtt_Init/Makefile
+++ b/cbmc/proofs/IotMqtt_Init/Makefile
@@ -1,5 +1,7 @@
 ENTRY=IotMqtt_Init
 
+# We abstract all the log and concurrency related functions in this proof
+# and assume their implementation is correct
 ABSTRACTIONS += --remove-function-body IotLog_Generic
 ABSTRACTIONS += --remove-function-body Iot_EnterCritical
 ABSTRACTIONS += --remove-function-body Iot_ExitCritical

--- a/cbmc/proofs/IotMqtt_Init/Makefile
+++ b/cbmc/proofs/IotMqtt_Init/Makefile
@@ -9,4 +9,22 @@ OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_api.goto
 
 UNWINDING += --unwind 1
 
+default: report
+
+# Use the generic implementations of atomic operations.
+# Using the gcc atomic intrinsics causes coverage computation to fail.
+# Define the generic flag here, and replace *_gcc.h with *_generic.h below.
+DEF += -DIOT_ATOMIC_GENERIC=1
+
+install_atomic:
+	mv $(MQTT)/ports/common/include/atomic/iot_atomic_gcc.h $(MQTT)/ports/common/include/atomic/iot_atomic_gcc_disable.h
+	cp $(MQTT)/ports/common/include/atomic/iot_atomic_generic.h \
+	   $(MQTT)/ports/common/include/atomic/iot_atomic_gcc.h
+
+uninstall_atomic:
+	rm $(MQTT)/ports/common/include/atomic/iot_atomic_gcc.h \
+	mv $(MQTT)/ports/common/include/atomic/iot_atomic_gcc_disable.h $(MQTT)/ports/common/include/atomic/iot_atomic_gcc.h 
+
+.PHONY: install_atomic uninstall_atomic
+
 include ../Makefile.common

--- a/cbmc/proofs/IotMqtt_Init/cbmc-batch.yaml
+++ b/cbmc/proofs/IotMqtt_Init/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-jobos: ubuntu16
-cbmcflags: '=--object-bits;8;--unwind;1;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-overflow-check;--undefined-shift-check;--signed-overflow-check;--unsigned-overflow-check='
-goto: IotMqtt_Init.goto
+cbmcflags: "--object-bits;8;--unwind;1;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-overflow-check;--undefined-shift-check;--signed-overflow-check;--unsigned-overflow-check"
 expected: SUCCESSFUL
+goto: IotMqtt_Init.goto
+jobos: ubuntu16

--- a/cbmc/proofs/IotMqtt_Init/cbmc-batch.yaml
+++ b/cbmc/proofs/IotMqtt_Init/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags:        '=--unwind;1;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static='
+cbmcflags: '=--object-bits;8;--unwind;1;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-overflow-check;--undefined-shift-check;--signed-overflow-check;--unsigned-overflow-check='
 goto: IotMqtt_Init.goto
 expected: SUCCESSFUL

--- a/cbmc/proofs/IotMqtt_Init/cbmc-batch.yaml
+++ b/cbmc/proofs/IotMqtt_Init/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags:        '=--unwind;1;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static='
+goto: IotMqtt_Init.goto
+expected: SUCCESSFUL

--- a/cbmc/proofs/IotMqtt_Init/cbmc-viewer.json
+++ b/cbmc/proofs/IotMqtt_Init/cbmc-viewer.json
@@ -1,0 +1,22 @@
+{ "expected-missing-functions":
+  [
+    "IotLog_Generic",
+    "IotMqtt_Wait",
+    "IotMutex_Create",
+    "IotMutex_Destroy",
+    "IotMutex_Lock",
+    "IotMutex_Unlock",
+    "IotSemaphore_Create",
+    "IotSemaphore_Destroy",
+    "IotSemaphore_Post",
+    "IotSemaphore_TimedWait",
+    "IotSemaphore_Wait",
+    "IotTaskPool_CreateJob",
+    "IotTaskPool_GetSystemTaskPool",
+    "IotTaskPool_ScheduleDeferred",
+    "IotTaskPool_strerror",
+    "IotTaskPool_TryCancel"
+  ],
+  "proof-name": "IotMqtt_Init",
+  "proof-root": "cbmc/proofs"
+}

--- a/cbmc/proofs/IotMqtt_IsSubscribed/IotMqtt_IsSubscribed_harness.c
+++ b/cbmc/proofs/IotMqtt_IsSubscribed/IotMqtt_IsSubscribed_harness.c
@@ -26,5 +26,5 @@ void harness()
   IotMqtt_IsSubscribed( mqttConnection,
 			TopicFilter,
 			topicFilterLength,
-                        nondet_boo() ? NULL : &result );
+                        nondet_bool() ? NULL : &result );
 }

--- a/cbmc/proofs/IotMqtt_IsSubscribed/IotMqtt_IsSubscribed_harness.c
+++ b/cbmc/proofs/IotMqtt_IsSubscribed/IotMqtt_IsSubscribed_harness.c
@@ -23,7 +23,7 @@ void harness()
 
   IotMqttSubscription_t result;
 
-  IotMqtt_IsSubscribed( nondet_bool() ? NULL : mqttConnection,
+  IotMqtt_IsSubscribed( mqttConnection,
 			TopicFilter,
 			topicFilterLength,
                         nondet_boo() ? NULL : &result );

--- a/cbmc/proofs/IotMqtt_IsSubscribed/IotMqtt_IsSubscribed_harness.c
+++ b/cbmc/proofs/IotMqtt_IsSubscribed/IotMqtt_IsSubscribed_harness.c
@@ -1,0 +1,40 @@
+#include "iot_config.h"
+#include "private/iot_mqtt_internal.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "mqtt_state.h"
+
+/*
+
+bool IotMqtt_IsSubscribed( IotMqttConnection_t mqttConnection,
+                           const char * pTopicFilter,
+                           uint16_t topicFilterLength,
+                           IotMqttSubscription_t * pCurrentSubscription );
+
+*/
+
+void harness()
+{
+  IotMqttConnection_t mqttConnection = allocate_IotMqttConnection(NULL);
+  __CPROVER_assume(mqttConnection);
+  ensure_IotMqttConnection_has_lists(mqttConnection);
+  __CPROVER_assume(valid_IotMqttConnection(mqttConnection));
+
+  // Move to allocation and valid connection?
+  allocate_IotMqttSubscriptionList(&(mqttConnection->subscriptionList), 1);
+  __CPROVER_assume(valid_IotMqttSubscriptionList(&(mqttConnection->subscriptionList), 1));
+
+  uint16_t topicFilterLength;
+  __CPROVER_assume(topicFilterLength < TOPIC_LENGTH_MAX);
+
+  char* TopicFilter = malloc_can_fail(topicFilterLength);
+
+  IotMqttSubscription_t result;
+
+  IotMqtt_IsSubscribed( nondet_bool() ? NULL : mqttConnection,
+			TopicFilter,
+			topicFilterLength,
+                        nondet_boo() ? NULL : &result );
+}

--- a/cbmc/proofs/IotMqtt_IsSubscribed/IotMqtt_IsSubscribed_harness.c
+++ b/cbmc/proofs/IotMqtt_IsSubscribed/IotMqtt_IsSubscribed_harness.c
@@ -6,15 +6,6 @@
 
 #include "mqtt_state.h"
 
-/*
-
-bool IotMqtt_IsSubscribed( IotMqttConnection_t mqttConnection,
-                           const char * pTopicFilter,
-                           uint16_t topicFilterLength,
-                           IotMqttSubscription_t * pCurrentSubscription );
-
-*/
-
 void harness()
 {
   IotMqttConnection_t mqttConnection = allocate_IotMqttConnection(NULL);
@@ -22,7 +13,6 @@ void harness()
   ensure_IotMqttConnection_has_lists(mqttConnection);
   __CPROVER_assume(valid_IotMqttConnection(mqttConnection));
 
-  // Move to allocation and valid connection?
   allocate_IotMqttSubscriptionList(&(mqttConnection->subscriptionList), 1);
   __CPROVER_assume(valid_IotMqttSubscriptionList(&(mqttConnection->subscriptionList), 1));
 

--- a/cbmc/proofs/IotMqtt_IsSubscribed/Makefile
+++ b/cbmc/proofs/IotMqtt_IsSubscribed/Makefile
@@ -1,0 +1,43 @@
+ENTRY=IotMqtt_IsSubscribed
+
+ABSTRACTIONS += --remove-function-body IotLog_Generic
+
+# Remove for coverage
+ABSTRACTIONS += --remove-function-body _mqttSubscription_setUnsubscribe
+ABSTRACTIONS += --remove-function-body _matchEndWildcards
+ABSTRACTIONS += --remove-function-body _matchWildcards
+ABSTRACTIONS += --remove-function-body _packetMatch
+ABSTRACTIONS += --remove-function-body _topicFilterMatch
+
+
+OBJS += $(ENTRY)_harness.goto
+OBJS += $(MQTT)/cbmc/proofs/mqtt_state.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_api.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_subscription.goto
+
+# One more than actual number of subscriptions
+SUBSCRIPTION_COUNT_MAX=4
+DEF += -DSUBSCRIPTION_COUNT_MAX=$(SUBSCRIPTION_COUNT_MAX)
+OPERATION_COUNT_MAX=4
+DEF += -DOPERATION_COUNT_MAX=$(OPERATION_COUNT_MAX)
+
+# One more than actual length of topics
+TOPIC_LENGTH_MAX=6
+DEF += -DTOPIC_LENGTH_MAX=$(TOPIC_LENGTH_MAX)
+
+# Should be 2*SUBSCRIPTION_COUNT_MAX-1
+SUBSCRIPTION_LIST_MAX=6
+DEF += -DSUBSCRIPTION_LIST_MAX=$(SUBSCRIPTION_LIST_MAX)
+
+LOOP += allocate_IotMqttSubscriptionArray.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += valid_IotMqttSubscriptionArray.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += allocate_IotMqttSubscriptionList.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += valid_IotMqttSubscriptionList.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += valid_IotMqttOperationList.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += IotListDouble_FindFirstMatch\$$link1.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += strncmp.0:$(TOPIC_LENGTH_MAX)
+
+UNWINDING += --unwind 1
+UNWINDING += --unwindset '$(shell echo $(LOOP) | sed 's/ /,/g')'
+
+include ../Makefile.common

--- a/cbmc/proofs/IotMqtt_IsSubscribed/cbmc-batch.yaml
+++ b/cbmc/proofs/IotMqtt_IsSubscribed/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags:        '=--unwind;1;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static='
+cbmcflags:        '=--object-bits;8;--unwind;1;--unwindset;allocate_IotMqttSubscriptionArray.0:4,valid_IotMqttSubscriptionArray.0:4,allocate_IotMqttSubscriptionList.0:4,valid_IotMqttSubscriptionList.0:4,valid_IotMqttOperationList.0:4,IotListDouble_FindFirstMatch.0:4,strncmp.0:6;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-overflow-check;--undefined-shift-check;--signed-overflow-check;--unsigned-overflow-check='
 goto: IotMqtt_IsSubscribed.goto
 expected: SUCCESSFUL

--- a/cbmc/proofs/IotMqtt_IsSubscribed/cbmc-batch.yaml
+++ b/cbmc/proofs/IotMqtt_IsSubscribed/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: ' =--object-bits;8;--unwind;1;--unwindset;allocate_IotMqttSubscriptionArray.0:4,valid_IotMqttSubscriptionArray.0:4,allocate_IotMqttSubscriptionList.0:4,valid_IotMqttSubscriptionList.0:4,valid_IotMqttOperationList.0:4,IotListDouble_FindFirstMatch$link1.0:4,strncmp.0:6;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-overflow-check;--undefined-shift-check;--signed-overflow-check;--unsigned-overflow-check='
+cbmcflags: "--object-bits;8;--unwind;1;--unwindset;allocate_IotMqttSubscriptionArray.0:4,valid_IotMqttSubscriptionArray.0:4,allocate_IotMqttSubscriptionList.0:4,valid_IotMqttSubscriptionList.0:4,valid_IotMqttOperationList.0:4,IotListDouble_FindFirstMatch$link1.0:4,strncmp.0:6;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-overflow-check;--undefined-shift-check;--signed-overflow-check;--unsigned-overflow-check"
 goto: IotMqtt_IsSubscribed.goto
 expected: SUCCESSFUL

--- a/cbmc/proofs/IotMqtt_IsSubscribed/cbmc-batch.yaml
+++ b/cbmc/proofs/IotMqtt_IsSubscribed/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags:        '=--object-bits;8;--unwind;1;--unwindset;allocate_IotMqttSubscriptionArray.0:4,valid_IotMqttSubscriptionArray.0:4,allocate_IotMqttSubscriptionList.0:4,valid_IotMqttSubscriptionList.0:4,valid_IotMqttOperationList.0:4,IotListDouble_FindFirstMatch.0:4,strncmp.0:6;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-overflow-check;--undefined-shift-check;--signed-overflow-check;--unsigned-overflow-check='
+cbmcflags: ' =--object-bits;8;--unwind;1;--unwindset;allocate_IotMqttSubscriptionArray.0:4,valid_IotMqttSubscriptionArray.0:4,allocate_IotMqttSubscriptionList.0:4,valid_IotMqttSubscriptionList.0:4,valid_IotMqttOperationList.0:4,IotListDouble_FindFirstMatch$link1.0:4,strncmp.0:6;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-overflow-check;--undefined-shift-check;--signed-overflow-check;--unsigned-overflow-check='
 goto: IotMqtt_IsSubscribed.goto
 expected: SUCCESSFUL

--- a/cbmc/proofs/IotMqtt_IsSubscribed/cbmc-batch.yaml
+++ b/cbmc/proofs/IotMqtt_IsSubscribed/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags:        '=--unwind;1;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static='
+goto: IotMqtt_IsSubscribed.goto
+expected: SUCCESSFUL

--- a/cbmc/proofs/IotMqtt_IsSubscribed/cbmc-viewer.json
+++ b/cbmc/proofs/IotMqtt_IsSubscribed/cbmc-viewer.json
@@ -1,0 +1,22 @@
+{ "expected-missing-functions":
+  [
+    "IotLog_Generic",
+    "IotMqtt_Wait",
+    "IotMutex_Create",
+    "IotMutex_Destroy",
+    "IotMutex_Lock",
+    "IotMutex_Unlock",
+    "IotSemaphore_Create",
+    "IotSemaphore_Destroy",
+    "IotSemaphore_Post",
+    "IotSemaphore_TimedWait",
+    "IotSemaphore_Wait",
+    "IotTaskPool_CreateJob",
+    "IotTaskPool_GetSystemTaskPool",
+    "IotTaskPool_ScheduleDeferred",
+    "IotTaskPool_strerror",
+    "IotTaskPool_TryCancel"
+  ],
+  "proof-name": "IotMqtt_IsSubscribed",
+  "proof-root": "cbmc/proofs"
+}

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -19,14 +19,13 @@ VIEWER ?= cbmc-viewer
 # Build goto binary for cbmc
 # Build goto binaries with options taken from top-level cmake
 
-INC = \
+INC += \
 	-I$(MQTT)/libraries/standard/mqtt/include \
 	-I$(MQTT)/demos \
 	-I$(MQTT)/libraries/platform/.. \
 	-I$(MQTT)/libraries/platform \
 	-I$(MQTT)/ports/common/include \
 	-I$(MQTT)/libraries/standard/common/include \
-	\
 	-I$(MQTT)/libraries/standard/mqtt/src \
 
 DEF += \
@@ -120,7 +119,7 @@ clean:
 	$(RM) *~ \#*
 
 veryclean: clean
-	$(RM) -r html
+	$(RM) -r html TAGS-*
 
 .PHONY: cbmc property coverage report clean veryclean
 

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -75,9 +75,6 @@ CBMCFLAGS += \
 	--bounds-check \
 	--pointer-check \
 	--unwinding-assertions \
-	--flush \
-
-CBMCFLAGS += \
 	--nondet-static \
 	--div-by-zero-check \
 	--float-overflow-check \
@@ -86,6 +83,7 @@ CBMCFLAGS += \
 	--undefined-shift-check \
 	--signed-overflow-check \
 	--unsigned-overflow-check \
+	--flush \
 
 goto: $(ENTRY).goto
 

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -14,6 +14,9 @@ GOTO_ANALYZER ?= goto-analyzer
 BATCH ?= cbmc-batch
 VIEWER ?= cbmc-viewer
 
+CBMC_OBJECT_BITS = 8
+CBMC_MAX_OBJECT_SIZE = "(SIZE_MAX>>(CBMC_OBJECT_BITS+1))"
+
 ################################################################
 # Build goto binary for cbmc
 # Build goto binaries with options taken from top-level cmake
@@ -31,29 +34,35 @@ INC = \
 DEF += \
 	-DIOT_SYSTEM_TYPES_FILE=\"$(MQTT)/ports/posix/include/iot_platform_types_posix.h\" \
 	-Diotmqtt_EXPORTS \
+	-DCBMC_OBJECT_BITS=$(CBMC_OBJECT_BITS) \
+	-DCBMC_MAX_OBJECT_SIZE=$(CBMC_MAX_OBJECT_SIZE) \
 
 CFLAGS += $(CFLAGS2) $(INC) $(DEF) -std=gnu99
 
 %.goto : %.c
 	$(GOTO_CC) -o $@ $(CFLAGS) $<
 
+# Use the generic implementations of atomic operations.
+# Using the gcc atomic intrinsics causes coverage computation to fail.
+# Define the generic flag here, and replace *_gcc.h with *_generic.h below.
+DEF += -DIOT_ATOMIC_GENERIC=1
+
 $(MQTT)/build:
-	(mkdir -p $(MQTT)/build; cd $(MQTT)/build; cmake ..) 2>&1 \
-		| tee $(ENTRY)0.txt \
-		; exit $${PIPESTATUS[0]}
+	(mkdir -p $(MQTT)/build; cd $(MQTT)/build; cmake ..) \
+	       > $(ENTRY)0.txt 2>&1
+	cp $(MQTT)/ports/common/include/atomic/iot_atomic_generic.h \
+	   $(MQTT)/ports/common/include/atomic/iot_atomic_gcc.h
 
 $(ENTRY)1.goto: $(MQTT)/build $(OBJS)
-	$(GOTO_CC) --function harness -o $@ $(OBJS) 2>&1 \
-		| tee $(ENTRY)1.txt \
-		; exit $${PIPESTATUS[0]}
+	$(GOTO_CC) --function harness -o $@ $(OBJS)
+		> $(ENTRY)1.txt 2>&1
 
 $(ENTRY)2.goto: $(ENTRY)1.goto
 	 $(GOTO_INSTRUMENT) \
 			$(ABSTRACTIONS) \
 			--drop-unused-functions \
-			--slice-global-inits $< $@ 2>&1 \
-		| tee $(ENTRY)2.txt \
-		; exit $${PIPESTATUS[0]}
+			--slice-global-inits $< $@ \
+		> $(ENTRY)2.txt  2>&1
 
 $(ENTRY).goto: $(ENTRY)2.goto
 	cp $< $@
@@ -62,10 +71,23 @@ $(ENTRY).goto: $(ENTRY)2.goto
 # Run cbmc and build html report
 
 CBMCFLAGS += \
+	--object-bits $(CBMC_OBJECT_BITS) \
 	$(UNWINDING) \
 	--bounds-check \
 	--pointer-check \
 	--unwinding-assertions \
+
+CBMCFLAGS += \
+	--nondet-static \
+
+CBMCFLAGS += \
+	--div-by-zero-check \
+	--float-overflow-check \
+	--nan-check \
+	--pointer-overflow-check \
+	--undefined-shift-check \
+	--signed-overflow-check \
+	--unsigned-overflow-check \
 
 goto: $(ENTRY).goto
 

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -27,6 +27,7 @@ INC += \
 	-I$(MQTT)/ports/common/include \
 	-I$(MQTT)/libraries/standard/common/include \
 	-I$(MQTT)/libraries/standard/mqtt/src \
+	-I$(MQTT)/cbmc/proofs \
 
 DEF += \
 	-DIOT_SYSTEM_TYPES_FILE=\"$(MQTT)/ports/posix/include/iot_platform_types_posix.h\" \

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -75,6 +75,9 @@ CBMCFLAGS += \
 	--bounds-check \
 	--pointer-check \
 	--unwinding-assertions \
+	--flush \
+
+CBMCFLAGS += \
 	--nondet-static \
 	--div-by-zero-check \
 	--float-overflow-check \
@@ -117,7 +120,7 @@ report: cbmc.txt property.xml coverage.xml
 clean:
 	$(RM) $(OBJS) $(ENTRY).goto
 	$(RM) $(ENTRY)[0-9].goto $(ENTRY)[0-9].txt
-	$(RM) cbmc.txt property.xml coverage.xml TAGS
+	$(RM) cbmc.txt property.xml coverage.xml TAGS TAGS-*
 	$(RM) *~ \#*
 
 veryclean: clean

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -14,8 +14,6 @@ GOTO_ANALYZER ?= goto-analyzer
 BATCH ?= cbmc-batch
 VIEWER ?= cbmc-viewer
 
-CBMC_OBJECT_BITS = 8
-CBMC_MAX_OBJECT_SIZE = "(SIZE_MAX>>(CBMC_OBJECT_BITS+1))"
 
 ################################################################
 # Build goto binary for cbmc
@@ -60,20 +58,24 @@ $(ENTRY)2.goto: $(ENTRY)1.goto
 $(ENTRY).goto: $(ENTRY)2.goto
 	cp $< $@
 
+
+################################################################
+# Set C compiler defines
+
+CBMC_OBJECT_BITS ?= 8
+CBMCFLAGS += --object-bits $(CBMC_OBJECT_BITS)
+CBMC_MAX_OBJECT_SIZE = "(SIZE_MAX>>(CBMC_OBJECT_BITS+1))"
+
+
 ################################################################
 # Run cbmc and build html report
 
 CBMCFLAGS += \
-	--object-bits $(CBMC_OBJECT_BITS) \
 	$(UNWINDING) \
 	--bounds-check \
 	--pointer-check \
 	--unwinding-assertions \
-
-CBMCFLAGS += \
 	--nondet-static \
-
-CBMCFLAGS += \
 	--div-by-zero-check \
 	--float-overflow-check \
 	--nan-check \
@@ -201,9 +203,9 @@ launch-veryclean: launch-clean
 cbmc-batch.yaml: Makefile ../Makefile.common
 	@echo "Building $@"
 	@$(RM) $@
-	@echo "jobos: $(JOBOS)" >> $@
-	@echo "cbmcflags: $(call encode_options,$(CBMCFLAGS))" >> $@
-	@echo "goto: $(ENTRY).goto" >> $@
+	@echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CBMCFLAGS)))' > $@
 	@echo "expected: SUCCESSFUL" >> $@
+	@echo "goto: $(ENTRY).goto" >> $@
+	@echo "jobos: $(JOBOS)" >> $@
 
 ################################################################

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -42,16 +42,9 @@ CFLAGS += $(CFLAGS2) $(INC) $(DEF) -std=gnu99
 %.goto : %.c
 	$(GOTO_CC) -o $@ $(CFLAGS) $<
 
-# Use the generic implementations of atomic operations.
-# Using the gcc atomic intrinsics causes coverage computation to fail.
-# Define the generic flag here, and replace *_gcc.h with *_generic.h below.
-DEF += -DIOT_ATOMIC_GENERIC=1
-
 $(MQTT)/build:
 	(mkdir -p $(MQTT)/build; cd $(MQTT)/build; cmake ..) \
 	       > $(ENTRY)0.txt 2>&1
-	cp $(MQTT)/ports/common/include/atomic/iot_atomic_generic.h \
-	   $(MQTT)/ports/common/include/atomic/iot_atomic_gcc.h
 
 $(ENTRY)1.goto: $(MQTT)/build $(OBJS)
 	$(GOTO_CC) --function harness -o $@ $(OBJS)

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -87,7 +87,8 @@ CBMCFLAGS += \
 goto: $(ENTRY).goto
 
 cbmc.txt: $(ENTRY).goto
-	cbmc $(CBMCFLAGS) --trace $< 2>&1 | tee $@
+	@echo cbmc $(CBMCFLAGS) --trace $< 2>&1 | tee $@
+	cbmc $(CBMCFLAGS) --trace $< 2>&1 | tee -a $@
 
 property.xml: $(ENTRY).goto
 	cbmc $(CBMCFLAGS) --show-properties --xml-ui $< 2>&1 > $@
@@ -200,6 +201,7 @@ launch-veryclean: launch-clean
 ################################################################
 # Build configuration file to run cbmc under cbmc-batch in CI
 
+CBMC_FLAGS =  '$(call encode_options,$(CBMCFLAGS))'
 cbmc-batch.yaml: Makefile ../Makefile.common
 	@echo "Building $@"
 	@$(RM) $@

--- a/cbmc/proofs/mqtt_state.c
+++ b/cbmc/proofs/mqtt_state.c
@@ -308,6 +308,10 @@ bool valid_IotMqttConnectInfo( const IotMqttConnectInfo_t *pInfo )
     VALID_STRING( pInfo->pPassword, pInfo->passwordLength ) &&
     VALID_CBMC_SIZE( pInfo->passwordLength ) &&
 
+#ifdef SUBSCRIPTION_COUNT_MAX
+    pInfo->previousSubscriptionCount < SUBSCRIPTION_COUNT_MAX &&
+#endif
+
     // MAX is one greater than the maximum length
     pInfo->previousSubscriptionCount < SUBSCRIPTION_COUNT_MAX &&
     IFF( pInfo->pPreviousSubscriptions == NULL,
@@ -536,7 +540,6 @@ bool stubbed_IotNetworkInterface( const IotNetworkInterface_t *netif )
     IS_STUBBED_NETWORKIF_SETRECEIVECALLBACK( netif ) &&
     IS_STUBBED_NETWORKIF_SETCLOSECALLBACK( netif ) &&
     IS_STUBBED_NETWORKIF_DESTROY( netif );
-}
 
 /****************************************************************
  * IotNetworkInterface stubs

--- a/cbmc/proofs/mqtt_state.c
+++ b/cbmc/proofs/mqtt_state.c
@@ -308,13 +308,9 @@ bool valid_IotMqttConnectInfo( const IotMqttConnectInfo_t *pInfo )
     VALID_STRING( pInfo->pPassword, pInfo->passwordLength ) &&
     VALID_CBMC_SIZE( pInfo->passwordLength ) &&
 
-#ifdef SUBSCRIPTION_COUNT_MAX
     // MAX is one greater than the maximum length
     pInfo->previousSubscriptionCount < SUBSCRIPTION_COUNT_MAX &&
-#endif
 
-    // MAX is one greater than the maximum length
-    pInfo->previousSubscriptionCount < SUBSCRIPTION_COUNT_MAX &&
     IFF( pInfo->pPreviousSubscriptions == NULL,
 	 pInfo->previousSubscriptionCount == 0 ) &&
     valid_IotMqttSubscriptionArray( pInfo->pPreviousSubscriptions,

--- a/cbmc/proofs/mqtt_state.c
+++ b/cbmc/proofs/mqtt_state.c
@@ -540,6 +540,7 @@ bool stubbed_IotNetworkInterface( const IotNetworkInterface_t *netif )
     IS_STUBBED_NETWORKIF_SETRECEIVECALLBACK( netif ) &&
     IS_STUBBED_NETWORKIF_SETCLOSECALLBACK( netif ) &&
     IS_STUBBED_NETWORKIF_DESTROY( netif );
+}
 
 /****************************************************************
  * IotNetworkInterface stubs

--- a/cbmc/proofs/mqtt_state.c
+++ b/cbmc/proofs/mqtt_state.c
@@ -309,6 +309,7 @@ bool valid_IotMqttConnectInfo( const IotMqttConnectInfo_t *pInfo )
     VALID_CBMC_SIZE( pInfo->passwordLength ) &&
 
 #ifdef SUBSCRIPTION_COUNT_MAX
+    // MAX is one greater than the maximum length
     pInfo->previousSubscriptionCount < SUBSCRIPTION_COUNT_MAX &&
 #endif
 

--- a/libraries/standard/common/include/iot_linear_containers.h
+++ b/libraries/standard/common/include/iot_linear_containers.h
@@ -719,6 +719,13 @@ static inline IotLink_t * IotListDouble_RemoveFirstMatch( const IotListDouble_t 
  * or its value is `0`.
  */
 /* @[declare_linear_containers_list_double_removeallmatches] */
+#ifdef CBMC_PROOF_DESERIALIZE_SUBACK
+void IotListDouble_RemoveAllMatches( const IotListDouble_t * const pList,
+				     bool ( *isMatch )( const IotLink_t * const pOperationLink, void * pCompare ),
+				     void * pMatch,
+				     void ( *freeElement )( void * pData ),
+				     size_t linkOffset );
+#else
 static inline void IotListDouble_RemoveAllMatches( const IotListDouble_t * const pList,
                                                    bool ( *isMatch )( const IotLink_t * const pOperationLink, void * pCompare ),
                                                    void * pMatch,
@@ -754,6 +761,7 @@ static inline void IotListDouble_RemoveAllMatches( const IotListDouble_t * const
         }
     } while( pMatchedElement != NULL );
 }
+#endif
 
 /**
  * @brief Create a new queue.

--- a/libraries/standard/mqtt/src/iot_mqtt_subscription.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_subscription.c
@@ -305,10 +305,6 @@ static bool _topicMatch( const IotLink_t * const pSubscriptionLink,
     /* Extract the relevant strings and lengths from parameters. */
     const char * pTopicName = pParam->pTopicName;
     const char * pTopicFilter = pSubscription->pTopicFilter;
-    if ( pTopicName == NULL || pTopicFilter == NULL )
-    {
-        return status;
-    }
     const uint16_t topicNameLength = pParam->topicNameLength;
     const uint16_t topicFilterLength = pSubscription->topicFilterLength;
  

--- a/libraries/standard/mqtt/src/iot_mqtt_subscription.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_subscription.c
@@ -661,7 +661,7 @@ bool IotMqtt_IsSubscribed( IotMqttConnection_t mqttConnection,
 {
     bool status = false;
     
-    if( mqttConnection == NULL || pTopicFilter == NULL )
+    if( pTopicFilter == NULL )
     {
     	return status;
     }

--- a/libraries/standard/mqtt/src/iot_mqtt_subscription.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_subscription.c
@@ -299,14 +299,19 @@ static bool _topicMatch( const IotLink_t * const pSubscriptionLink,
     const _mqttSubscription_t * pSubscription = IotLink_Container( _mqttSubscription_t,
                                                                    pSubscriptionLink,
                                                                    link );
-    const _topicMatchParams_t * pParam = ( _topicMatchParams_t * ) pMatch;
 
+    const _topicMatchParams_t * pParam = ( _topicMatchParams_t * ) pMatch;
+ 
     /* Extract the relevant strings and lengths from parameters. */
     const char * pTopicName = pParam->pTopicName;
     const char * pTopicFilter = pSubscription->pTopicFilter;
+    if ( pTopicName == NULL || pTopicFilter == NULL )
+    {
+        return status;
+    }
     const uint16_t topicNameLength = pParam->topicNameLength;
     const uint16_t topicFilterLength = pSubscription->topicFilterLength;
-
+ 
     /* Check for an exact match. */
     if( topicNameLength == topicFilterLength )
     {
@@ -655,6 +660,12 @@ bool IotMqtt_IsSubscribed( IotMqttConnection_t mqttConnection,
                            IotMqttSubscription_t * const pCurrentSubscription )
 {
     bool status = false;
+    
+    if( mqttConnection == NULL || pTopicFilter == NULL )
+    {
+    	return status;
+    }
+    
     const _mqttSubscription_t * pSubscription = NULL;
     const IotLink_t * pSubscriptionLink = NULL;
     _topicMatchParams_t topicMatchParams = { 0 };


### PR DESCRIPTION
This adds a new CBMC proof for the _IotMqtt_DeserializeSuback method that removes some assumptions made in the prior proof.

This depends on https://github.com/aws/aws-iot-device-sdk-embedded-C/pull/794 which in turn depends on https://github.com/aws/aws-iot-device-sdk-embedded-C/pull/788.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
