### PR TITLE
CBMC proof for DeserializeSuback

### DIFF
--- a/cbmc/patches/0001-Modify-MQTT-to-let-CBMC-proofs-stub-out-RemoveAllMat.patch
+++ b/cbmc/patches/0001-Modify-MQTT-to-let-CBMC-proofs-stub-out-RemoveAllMat.patch
@@ -1,0 +1,38 @@
+From a1455991c02aa6d7db1d4333e2cdc5add392c105 Mon Sep 17 00:00:00 2001
+From: Mark R Tuttle <mrtuttle@amazon.com>
+Date: Thu, 13 Feb 2020 17:39:51 +0000
+Subject: [PATCH] Modify MQTT to let CBMC proofs stub out RemoveAllMatches
+
+---
+ libraries/standard/common/include/iot_linear_containers.h | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/libraries/standard/common/include/iot_linear_containers.h b/libraries/standard/common/include/iot_linear_containers.h
+index 689ea5e..ffb3469 100644
+--- a/libraries/standard/common/include/iot_linear_containers.h
++++ b/libraries/standard/common/include/iot_linear_containers.h
+@@ -719,6 +719,13 @@ static inline IotLink_t * IotListDouble_RemoveFirstMatch( const IotListDouble_t
+  * or its value is `0`.
+  */
+ /* @[declare_linear_containers_list_double_removeallmatches] */
++#ifdef CBMC_PROOF_DESERIALIZE_SUBACK
++void IotListDouble_RemoveAllMatches( const IotListDouble_t * const pList,
++				     bool ( *isMatch )( const IotLink_t * const pOperationLink, void * pCompare ),
++				     void * pMatch,
++				     void ( *freeElement )( void * pData ),
++				     size_t linkOffset );
++#else
+ static inline void IotListDouble_RemoveAllMatches( const IotListDouble_t * const pList,
+                                                    bool ( *isMatch )( const IotLink_t * const pOperationLink, void * pCompare ),
+                                                    void * pMatch,
+@@ -754,6 +761,7 @@ static inline void IotListDouble_RemoveAllMatches( const IotListDouble_t * const
+         }
+     } while( pMatchedElement != NULL );
+ }
++#endif
+ 
+ /**
+  * @brief Create a new queue.
+-- 
+2.7.4
+

--- a/cbmc/proofs/DeserializeSuback/DeserializeSuback_harness.c
+++ b/cbmc/proofs/DeserializeSuback/DeserializeSuback_harness.c
@@ -3,15 +3,84 @@
 
 #include <stdlib.h>
 
-/*-----------------------------------------------------------*/
+#include "mqtt_state.h"
+
+/****************************************************************
+ * Stub out RemoveAllMatches.
+ *
+ * The only invocation of RemoveAllMatches in DeserializeSuback is to
+ * remove subscriptions from the connection's subscription list.  This
+ * stub abstracts RemoveAllMatches by replacing the list with an
+ * unconstrained list of subscriptions.  We don't even bother to fill
+ * in the topic subscription filters.  By design, any actual use of
+ * the list in subsequent code (there is none) will trigger pointer
+ * errors.
+/****************************************************************/
+
+void IotListDouble_RemoveAllMatches( const IotListDouble_t * const pList,
+				     bool ( *isMatch )( const IotLink_t * const pOperationLink,
+							void * pCompare ),
+				     void * pMatch,
+				     void ( *freeElement )( void * pData ),
+				     size_t linkOffset )
+{
+  IotListDouble_t *sentinal = pList->pNext->pPrevious;
+
+  size_t num_elts;
+  __CPROVER_assume(num_elts < SUBSCRIPTION_COUNT_MAX);
+
+  // Allocate lists of length at most 3
+  __CPROVER_assert(SUBSCRIPTION_COUNT_MAX <= 4,
+		   "Subscription lists limited to 3 elements");
+
+  if (1 <= num_elts)
+    {
+      _mqttSubscription_t *pElt = malloc(sizeof(*pElt));
+      sentinal->pNext = &pElt->link;
+      pElt->link.pPrevious = sentinal;
+      pElt->link.pNext = sentinal;
+      sentinal->pPrevious = &pElt->link;
+    }
+  if (2 <= num_elts)
+    {
+      _mqttSubscription_t *pElt = malloc(sizeof(*pElt));
+      sentinal->pNext = &pElt->link;
+      pElt->link.pPrevious = sentinal;
+      pElt->link.pNext = sentinal;
+      sentinal->pPrevious = &pElt->link;
+    }
+  if (3 <= num_elts)
+    {
+      _mqttSubscription_t *pElt = malloc(sizeof(*pElt));
+      sentinal->pNext = &pElt->link;
+      pElt->link.pPrevious = sentinal;
+      pElt->link.pNext = sentinal;
+      sentinal->pPrevious = &pElt->link;
+    }
+}
+
+/****************************************************************
+ * Proof harness
+ ****************************************************************/
 
 void harness()
 {
     _mqttPacket_t suback;
 
-    suback.pRemainingData = malloc( sizeof( uint8_t ) * suback.remainingLength );
-
+    // Create packet data
     __CPROVER_assume( suback.remainingLength <= BUFFER_SIZE );
+    suback.pRemainingData = malloc( sizeof( uint8_t )
+				    * suback.remainingLength );
 
+    // Create packet connection
+    IotMqttConnection_t pConn = allocate_IotMqttConnection(NULL);
+    __CPROVER_assume(pConn);
+    ensure_IotMqttConnection_has_lists(pConn);
+    __CPROVER_assume(valid_IotMqttConnection(pConn));
+    suback.u.pMqttConnection = pConn;
+
+    // Argument must be a nonnull pointer
     _IotMqtt_DeserializeSuback( &suback );
 }
+
+/****************************************************************/

--- a/cbmc/proofs/DeserializeSuback/DeserializeSuback_harness.c
+++ b/cbmc/proofs/DeserializeSuback/DeserializeSuback_harness.c
@@ -74,7 +74,7 @@ void harness()
 
     // Create packet connection
     IotMqttConnection_t pConn = allocate_IotMqttConnection(NULL);
-    __CPROVER_assume(pConn);
+    __CPROVER_assume(pConn != NULL);
     ensure_IotMqttConnection_has_lists(pConn);
     __CPROVER_assume(valid_IotMqttConnection(pConn));
     suback.u.pMqttConnection = pConn;

--- a/cbmc/proofs/DeserializeSuback/DeserializeSuback_harness.c
+++ b/cbmc/proofs/DeserializeSuback/DeserializeSuback_harness.c
@@ -24,7 +24,7 @@ void IotListDouble_RemoveAllMatches( const IotListDouble_t * const pList,
 				     void ( *freeElement )( void * pData ),
 				     size_t linkOffset )
 {
-  IotListDouble_t *sentinal = pList->pNext->pPrevious;
+  IotListDouble_t *sentinel = pList->pNext->pPrevious;
 
   size_t num_elts;
   __CPROVER_assume(num_elts < SUBSCRIPTION_COUNT_MAX);
@@ -36,26 +36,26 @@ void IotListDouble_RemoveAllMatches( const IotListDouble_t * const pList,
   if (1 <= num_elts)
     {
       _mqttSubscription_t *pElt = malloc(sizeof(*pElt));
-      sentinal->pNext = &pElt->link;
-      pElt->link.pPrevious = sentinal;
-      pElt->link.pNext = sentinal;
-      sentinal->pPrevious = &pElt->link;
+      sentinel->pNext = &pElt->link;
+      pElt->link.pPrevious = sentinel;
+      pElt->link.pNext = sentinel;
+      sentinel->pPrevious = &pElt->link;
     }
   if (2 <= num_elts)
     {
       _mqttSubscription_t *pElt = malloc(sizeof(*pElt));
-      sentinal->pNext = &pElt->link;
-      pElt->link.pPrevious = sentinal;
-      pElt->link.pNext = sentinal;
-      sentinal->pPrevious = &pElt->link;
+      sentinel->pNext = &pElt->link;
+      pElt->link.pPrevious = sentinel;
+      pElt->link.pNext = sentinel;
+      sentinel->pPrevious = &pElt->link;
     }
   if (3 <= num_elts)
     {
       _mqttSubscription_t *pElt = malloc(sizeof(*pElt));
-      sentinal->pNext = &pElt->link;
-      pElt->link.pPrevious = sentinal;
-      pElt->link.pNext = sentinal;
-      sentinal->pPrevious = &pElt->link;
+      sentinel->pNext = &pElt->link;
+      pElt->link.pPrevious = sentinel;
+      pElt->link.pNext = sentinel;
+      sentinel->pPrevious = &pElt->link;
     }
 }
 

--- a/cbmc/proofs/DeserializeSuback/Makefile
+++ b/cbmc/proofs/DeserializeSuback/Makefile
@@ -11,17 +11,15 @@ DEF += -DSUBSCRIPTION_COUNT_MAX=$(SUBSCRIPTION_COUNT_MAX)
 OPERATION_COUNT_MAX=2
 DEF += -DOPERATION_COUNT_MAX=$(OPERATION_COUNT_MAX)
 
-#BUFFER_SIZE = 100
 BUFFER_SIZE = 15
 DEF += -DBUFFER_SIZE=$(BUFFER_SIZE)
 
 ################################################################
 # Function omitted from the proof
 
+# We abstract all the log and concurrency related functions in this
+# proof and assume their implementation is correct
 ABSTRACTIONS += --remove-function-body IotLog_Generic
-
-# Functions removed to make coverage calculation accurate
-# None
 
 # These defines have the effect of removing RemoveAllMatches from the
 # linear containers header so that our stub will be used.
@@ -44,8 +42,6 @@ OBJS += $(ENTRY)_harness.goto
 OBJS += $(MQTT)/cbmc/proofs/mqtt_state.goto
 OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_serialize.goto
 OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_subscription.goto
-
-CBMCFLAGS += --flush
 
 ################################################################
 

--- a/cbmc/proofs/DeserializeSuback/Makefile
+++ b/cbmc/proofs/DeserializeSuback/Makefile
@@ -1,19 +1,53 @@
 ENTRY=DeserializeSuback
 
-BUFFER_SIZE = 100
+################################################################
+# Proof assumptions
 
-ABSTRACTIONS = \
-	--remove-function-body IotLog_Generic \
-	--remove-function-body _IotMqtt_RemoveSubscriptionByPacket \
+# Bound the number of subscriptions in a list (BOUND = MAX-1)
+SUBSCRIPTION_COUNT_MAX=2
+DEF += -DSUBSCRIPTION_COUNT_MAX=$(SUBSCRIPTION_COUNT_MAX)
 
-UNWINDING = \
-	--unwindset _decodeSubackStatus.0:$(BUFFER_SIZE) \
+# Bound the number of operations in a list (BOUND = MAX-1)
+OPERATION_COUNT_MAX=2
+DEF += -DOPERATION_COUNT_MAX=$(OPERATION_COUNT_MAX)
 
-OBJS = \
-	$(ENTRY)_harness.goto \
-	$(MQTT)/libraries/standard/mqtt/src/iot_mqtt_subscription.goto \
-	$(MQTT)/libraries/standard/mqtt/src/iot_mqtt_serialize.goto \
+#BUFFER_SIZE = 100
+BUFFER_SIZE = 15
+DEF += -DBUFFER_SIZE=$(BUFFER_SIZE)
 
-DEF = -DBUFFER_SIZE=$(BUFFER_SIZE)
+################################################################
+# Function omitted from the proof
+
+ABSTRACTIONS += --remove-function-body IotLog_Generic
+
+# Functions removed to make coverage calculation accurate
+# None
+
+# These defines have the effect of removing RemoveAllMatches from the
+# linear containers header so that our stub will be used.
+DEF += -DCBMC=1 -DCBMC_PROOF_DESERIALIZE_SUBACK=1
+
+################################################################
+# Loop unwinding
+
+LOOP += valid_IotMqttSubscriptionList.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += valid_IotMqttOperationList.0:$(OPERATION_COUNT_MAX)
+
+LOOP += _decodeSubackStatus.0:$(BUFFER_SIZE)
+
+UNWINDING += --unwind 1
+UNWINDING += --unwindset '$(shell echo $(LOOP) | sed 's/ /,/g')'
+
+################################################################
+
+OBJS += $(ENTRY)_harness.goto
+OBJS += $(MQTT)/cbmc/proofs/mqtt_state.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_serialize.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_subscription.goto
+
+CBMCFLAGS += --flush
+
+################################################################
 
 include ../Makefile.common
+

--- a/cbmc/proofs/DeserializeSuback/cbmc-batch.yaml
+++ b/cbmc/proofs/DeserializeSuback/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-jobos: ubuntu16
-cbmcflags:        '=--unwindset;_decodeSubackStatus.0:100;--bounds-check;--pointer-check;--unwinding-assertions='
-goto: DeserializeSuback.goto
+cbmcflags: "--flush;--object-bits;8;--unwind;1;--unwindset;valid_IotMqttSubscriptionList.0:2,valid_IotMqttOperationList.0:2,_decodeSubackStatus.0:15;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-overflow-check;--undefined-shift-check;--signed-overflow-check;--unsigned-overflow-check;--flush"
 expected: SUCCESSFUL
+goto: DeserializeSuback.goto
+jobos: ubuntu16

--- a/cbmc/proofs/DeserializeSuback/cbmc-batch.yaml
+++ b/cbmc/proofs/DeserializeSuback/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--flush;--object-bits;8;--unwind;1;--unwindset;valid_IotMqttSubscriptionList.0:2,valid_IotMqttOperationList.0:2,_decodeSubackStatus.0:15;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-overflow-check;--undefined-shift-check;--signed-overflow-check;--unsigned-overflow-check;--flush"
+cbmcflags: "--object-bits;8;--unwind;1;--unwindset;valid_IotMqttSubscriptionList.0:2,valid_IotMqttOperationList.0:2,_decodeSubackStatus.0:15;--bounds-check;--pointer-check;--unwinding-assertions;--nondet-static;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-overflow-check;--undefined-shift-check;--signed-overflow-check;--unsigned-overflow-check;--flush"
 expected: SUCCESSFUL
 goto: DeserializeSuback.goto
 jobos: ubuntu16

--- a/cbmc/proofs/DeserializeSuback/cbmc-viewer.json
+++ b/cbmc/proofs/DeserializeSuback/cbmc-viewer.json
@@ -1,0 +1,22 @@
+{ "expected-missing-functions":
+  [
+    "IotLog_Generic",
+    "IotMqtt_Wait",
+    "IotMutex_Create",
+    "IotMutex_Destroy",
+    "IotMutex_Lock",
+    "IotMutex_Unlock",
+    "IotSemaphore_Create",
+    "IotSemaphore_Destroy",
+    "IotSemaphore_Post",
+    "IotSemaphore_TimedWait",
+    "IotSemaphore_Wait",
+    "IotTaskPool_CreateJob",
+    "IotTaskPool_GetSystemTaskPool",
+    "IotTaskPool_ScheduleDeferred",
+    "IotTaskPool_strerror",
+    "IotTaskPool_TryCancel"
+  ],
+  "proof-name": "DeserializeSuback",
+  "proof-root": "cbmc/proofs"
+}

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -122,7 +122,7 @@ clean:
 	$(RM) *~ \#*
 
 veryclean: clean
-	$(RM) -r html TAGS-*
+	$(RM) -r html
 
 .PHONY: cbmc property coverage report clean veryclean
 

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -211,4 +211,6 @@ cbmc-batch.yaml: Makefile ../Makefile.common
 	@echo "goto: $(ENTRY).goto" >> $@
 	@echo "jobos: $(JOBOS)" >> $@
 
+.PHONY: cbmc-batch.yaml
+
 ################################################################

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -83,6 +83,7 @@ CBMCFLAGS += \
 	--undefined-shift-check \
 	--signed-overflow-check \
 	--unsigned-overflow-check \
+	--flush \
 
 goto: $(ENTRY).goto
 
@@ -117,7 +118,7 @@ report: cbmc.txt property.xml coverage.xml
 clean:
 	$(RM) $(OBJS) $(ENTRY).goto
 	$(RM) $(ENTRY)[0-9].goto $(ENTRY)[0-9].txt
-	$(RM) cbmc.txt property.xml coverage.xml TAGS
+	$(RM) cbmc.txt property.xml coverage.xml TAGS TAGS-*
 	$(RM) *~ \#*
 
 veryclean: clean

--- a/cbmc/proofs/mqtt_state.c
+++ b/cbmc/proofs/mqtt_state.c
@@ -310,6 +310,7 @@ bool valid_IotMqttConnectInfo( const IotMqttConnectInfo_t *pInfo )
 
     // MAX is one greater than the maximum length
     pInfo->previousSubscriptionCount < SUBSCRIPTION_COUNT_MAX &&
+
     IFF( pInfo->pPreviousSubscriptions == NULL,
 	 pInfo->previousSubscriptionCount == 0 ) &&
     valid_IotMqttSubscriptionArray( pInfo->pPreviousSubscriptions,

--- a/cbmc/proofs/prepare.py
+++ b/cbmc/proofs/prepare.py
@@ -51,7 +51,8 @@ def apply_patches():
         logging.info("Checking patch '%s'", fyle.name)
         cmd = ["git", "apply", "--check", str(fyle)]
         proc = subprocess.run(
-            cmd, cwd=proj_dir, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            cmd, cwd=str(proj_dir),
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
             universal_newlines=True)
         if proc.returncode:
             logging.warning(
@@ -60,7 +61,7 @@ def apply_patches():
 
         logging.info("Applying patch '%s'", fyle.name)
         cmd = ["git", "apply", str(fyle)]
-        proc = subprocess.run(cmd, cwd=proj_dir)
+        proc = subprocess.run(cmd, cwd=str(proj_dir))
         if proc.returncode:
             logging.error("Failed to apply patch '%s'", fyle.name)
             sys.exit(1)


### PR DESCRIPTION
Add a new proof of memory safety for DeserializeSuback.

This pull request depends on https://github.com/aws/aws-iot-device-sdk-embedded-C/pull/794 which in turn depends on https://github.com/aws/aws-iot-device-sdk-embedded-C/pull/788.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
