### PR TITLE
CBMC: Correct type used in mqtt_state for operation list allocation.

### DIFF
--- a/cbmc/proofs/mqtt_state.c
+++ b/cbmc/proofs/mqtt_state.c
@@ -182,7 +182,7 @@ bool valid_IotMqttOperationList( const IotListDouble_t *pOp,
   IotListDouble_t *pLink;
   IotContainers_ForEach( pOp, pLink ) {
     IotMqttOperation_t
-      *pElt = IotLink_Container( _mqttSubscription_t, pLink, link );
+      *pElt = IotLink_Container( struct _mqttOperation, pLink, link );
     if (! valid_IotMqttOperation( pElt ) ) return false;
   }
 

--- a/cbmc/proofs/mqtt_state.c
+++ b/cbmc/proofs/mqtt_state.c
@@ -181,8 +181,7 @@ bool valid_IotMqttOperationList( const IotListDouble_t *pOp,
 
   IotListDouble_t *pLink;
   IotContainers_ForEach( pOp, pLink ) {
-    IotMqttOperation_t
-      *pElt = IotLink_Container( struct _mqttOperation, pLink, link );
+    IotMqttOperation_t *pElt = IotLink_Container( struct _mqttOperation, pLink, link );
     if (! valid_IotMqttOperation( pElt ) ) return false;
   }
 


### PR DESCRIPTION
This patch repairs a type used in operation list allocation for the CBMC proofs.  Since the offset of the link struct in the two types are both 0, this won't change any results.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
