### PR TITLE
Move doxygen tags to output/ folder instead of extra tag/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Ignore documentation output.
 doc/output/*
-doc/tag/*
 
 # Ignore CMake build directory.
 build/

--- a/doc/config/defender
+++ b/doc/config/defender
@@ -10,7 +10,7 @@ PROJECT_BRIEF = "AWS IoT Device Defender library"
 HTML_OUTPUT = defender
 
 # Generate Doxygen tag file for this library.
-GENERATE_TAGFILE = doc/tag/defender.tag
+GENERATE_TAGFILE = doc/output/defender.tag
 
 # Directories containing library source code.
 INPUT = doc/lib/ \
@@ -24,10 +24,10 @@ INPUT = doc/lib/ \
 FILE_PATTERNS = *defender*.h *defender*.txt
 
 # External tag files required by this library.
-TAGFILES = doc/tag/main.tag=../main \
-           doc/tag/mqtt.tag=../mqtt \
-           doc/tag/logging.tag=../logging \
-           doc/tag/static_memory.tag=../static_memory \
-           doc/tag/taskpool.tag=../taskpool \
-           doc/tag/platform.tag=../platform \
-           doc/tag/linear_containers.tag=../linear_containers
+TAGFILES = doc/output/main.tag=../main \
+           doc/output/mqtt.tag=../mqtt \
+           doc/output/logging.tag=../logging \
+           doc/output/static_memory.tag=../static_memory \
+           doc/output/taskpool.tag=../taskpool \
+           doc/output/platform.tag=../platform \
+           doc/output/linear_containers.tag=../linear_containers

--- a/doc/config/jobs
+++ b/doc/config/jobs
@@ -10,7 +10,7 @@ PROJECT_BRIEF = "AWS IoT Jobs library"
 HTML_OUTPUT = jobs
 
 # Generate Doxygen tag file for this library.
-GENERATE_TAGFILE = doc/tag/jobs.tag
+GENERATE_TAGFILE = doc/output/jobs.tag
 
 # Directories containing library source code.
 INPUT = doc/lib/ \
@@ -25,9 +25,9 @@ INPUT = doc/lib/ \
 FILE_PATTERNS = *jobs*.h *jobs*.c *jobs*.txt
 
 # External tag files required by this library.
-TAGFILES = doc/tag/main.tag=../main \
-           doc/tag/mqtt.tag=../mqtt \
-           doc/tag/logging.tag=../logging \
-           doc/tag/linear_containers.tag=../linear_containers \
-           doc/tag/static_memory.tag=../static_memory \
-           doc/tag/platform.tag=../platform
+TAGFILES = doc/output/main.tag=../main \
+           doc/output/mqtt.tag=../mqtt \
+           doc/output/logging.tag=../logging \
+           doc/output/linear_containers.tag=../linear_containers \
+           doc/output/static_memory.tag=../static_memory \
+           doc/output/platform.tag=../platform

--- a/doc/config/linear_containers
+++ b/doc/config/linear_containers
@@ -10,7 +10,7 @@ PROJECT_BRIEF = "Linked lists and Queues"
 HTML_OUTPUT = linear_containers
 
 # Generate Doxygen tag file for this library.
-GENERATE_TAGFILE = doc/tag/linear_containers.tag
+GENERATE_TAGFILE = doc/output/linear_containers.tag
 
 # Directories containing library source code.
 INPUT = doc/lib \
@@ -20,4 +20,4 @@ INPUT = doc/lib \
 FILE_PATTERNS = *linear_containers*.h *linear_containers*.txt
 
 # External tag files required by this library.
-TAGFILES = doc/tag/main.tag=../main
+TAGFILES = doc/output/main.tag=../main

--- a/doc/config/logging
+++ b/doc/config/logging
@@ -10,7 +10,7 @@ PROJECT_BRIEF = "Generate and print log messages"
 HTML_OUTPUT = logging
 
 # Generate Doxygen tag file for this library.
-GENERATE_TAGFILE = doc/tag/logging.tag
+GENERATE_TAGFILE = doc/output/logging.tag
 
 # Directories containing library source code.
 INPUT = doc/lib \
@@ -21,6 +21,6 @@ INPUT = doc/lib \
 FILE_PATTERNS = *logging*.c *logging*.h *logging*.txt
 
 # External tag files required by this library.
-TAGFILES = doc/tag/main.tag=../main \
-           doc/tag/static_memory.tag=../static_memory \
-           doc/tag/platform.tag=../platform
+TAGFILES = doc/output/main.tag=../main \
+           doc/output/static_memory.tag=../static_memory \
+           doc/output/platform.tag=../platform

--- a/doc/config/main
+++ b/doc/config/main
@@ -9,7 +9,7 @@ PROJECT_NAME = "Main"
 HTML_OUTPUT = main
 
 # Generate Doxygen tag file for this library.
-GENERATE_TAGFILE = doc/tag/main.tag
+GENERATE_TAGFILE = doc/output/main.tag
 
 # Input directories.
 INPUT = doc/ \
@@ -27,11 +27,11 @@ FILE_PATTERNS = *.txt
 AUTOLINK_SUPPORT = NO
 
 # External tag files required by this library.
-TAGFILES = doc/tag/logging.tag=../logging \
-           doc/tag/platform.tag=../platform \
-           doc/tag/mqtt.tag=../mqtt \
-           doc/tag/shadow.tag=../shadow \
-           doc/tag/jobs.tag=../jobs
+TAGFILES = doc/output/logging.tag=../logging \
+           doc/output/platform.tag=../platform \
+           doc/output/mqtt.tag=../mqtt \
+           doc/output/shadow.tag=../shadow \
+           doc/output/jobs.tag=../jobs
 
 # Use the Main page layout file
 LAYOUT_FILE = doc/config/layout_main.xml

--- a/doc/config/mqtt
+++ b/doc/config/mqtt
@@ -13,7 +13,7 @@ HTML_OUTPUT = mqtt
 PREDEFINED += "IOT_MQTT_ENABLE_SERIALIZER_OVERRIDES=1"
 
 # Generate Doxygen tag file for this library.
-GENERATE_TAGFILE = doc/tag/mqtt.tag
+GENERATE_TAGFILE = doc/output/mqtt.tag
 
 # Directories containing library source code.
 INPUT = doc/lib \
@@ -31,9 +31,9 @@ INPUT = doc/lib \
 FILE_PATTERNS = *mqtt*.c *mqtt*.h *mqtt*.txt
 
 # External tag files required by this library.
-TAGFILES = doc/tag/main.tag=../main \
-           doc/tag/logging.tag=../logging \
-           doc/tag/static_memory.tag=../static_memory \
-           doc/tag/platform.tag=../platform \
-           doc/tag/linear_containers.tag=../linear_containers \
-           doc/tag/taskpool.tag=../taskpool
+TAGFILES = doc/output/main.tag=../main \
+           doc/output/logging.tag=../logging \
+           doc/output/static_memory.tag=../static_memory \
+           doc/output/platform.tag=../platform \
+           doc/output/linear_containers.tag=../linear_containers \
+           doc/output/taskpool.tag=../taskpool

--- a/doc/config/platform
+++ b/doc/config/platform
@@ -10,7 +10,7 @@ PROJECT_BRIEF = "Platform portability layer"
 HTML_OUTPUT = platform
 
 # Generate Doxygen tag file for this library.
-GENERATE_TAGFILE = doc/tag/platform.tag
+GENERATE_TAGFILE = doc/output/platform.tag
 
 # Directories containing library source code.
 INPUT = doc/lib \
@@ -28,8 +28,8 @@ FILE_PATTERNS = platform.txt \
                 iot_atomic_generic.h
 
 # External tag files required by this library.
-TAGFILES = doc/tag/main.tag=../main \
-           doc/tag/logging.tag=../logging \
-           doc/tag/mqtt.tag=../mqtt \
-           doc/tag/shadow.tag=../shadow \
-           doc/tag/defender.tag=../defender
+TAGFILES = doc/output/main.tag=../main \
+           doc/output/logging.tag=../logging \
+           doc/output/mqtt.tag=../mqtt \
+           doc/output/shadow.tag=../shadow \
+           doc/output/defender.tag=../defender

--- a/doc/config/shadow
+++ b/doc/config/shadow
@@ -10,7 +10,7 @@ PROJECT_BRIEF = "AWS IoT Device Shadow library"
 HTML_OUTPUT = shadow
 
 # Generate Doxygen tag file for this library.
-GENERATE_TAGFILE = doc/tag/shadow.tag
+GENERATE_TAGFILE = doc/output/shadow.tag
 
 # Directories containing library source code.
 INPUT = doc/lib/ \
@@ -27,9 +27,9 @@ INPUT = doc/lib/ \
 FILE_PATTERNS = *shadow*.h *shadow*.c *shadow*.txt
 
 # External tag files required by this library.
-TAGFILES = doc/tag/main.tag=../main \
-           doc/tag/mqtt.tag=../mqtt \
-           doc/tag/logging.tag=../logging \
-           doc/tag/static_memory.tag=../static_memory \
-           doc/tag/platform.tag=../platform \
-           doc/tag/linear_containers.tag=../linear_containers
+TAGFILES = doc/output/main.tag=../main \
+           doc/output/mqtt.tag=../mqtt \
+           doc/output/logging.tag=../logging \
+           doc/output/static_memory.tag=../static_memory \
+           doc/output/platform.tag=../platform \
+           doc/output/linear_containers.tag=../linear_containers

--- a/doc/config/static_memory
+++ b/doc/config/static_memory
@@ -10,7 +10,7 @@ PROJECT_BRIEF = "Statically-allocated buffer pools"
 HTML_OUTPUT = static_memory
 
 # Generate Doxygen tag file for this library.
-GENERATE_TAGFILE = doc/tag/static_memory.tag
+GENERATE_TAGFILE = doc/output/static_memory.tag
 
 # Directories containing library source code.
 INPUT = doc/lib \
@@ -21,5 +21,5 @@ INPUT = doc/lib \
 FILE_PATTERNS = *static_memory*.h *static_memory_common*.c *static_memory*.txt
 
 # External tag files required by this library.
-TAGFILES = doc/tag/main.tag=../main \
-           doc/tag/platform.tag=../platform
+TAGFILES = doc/output/main.tag=../main \
+           doc/output/platform.tag=../platform

--- a/doc/config/taskpool
+++ b/doc/config/taskpool
@@ -10,7 +10,7 @@ PROJECT_BRIEF = "Task pool library"
 HTML_OUTPUT = taskpool
 
 # Generate Doxygen tag file for this library.
-GENERATE_TAGFILE = doc/tag/taskpool.tag
+GENERATE_TAGFILE = doc/output/taskpool.tag
 
 # Directories containing library source code.
 INPUT = doc \
@@ -26,8 +26,8 @@ INPUT = doc \
 FILE_PATTERNS = *taskpool*.c *taskpool*.h *taskpool*.txt
 
 # External tag files required by this library.
-TAGFILES = doc/tag/main.tag=../main \
-           doc/tag/linear_containers.tag=../linear_containers \
-           doc/tag/logging.tag=../logging \
-           doc/tag/platform.tag=../platform \
-           doc/tag/static_memory.tag=../static_memory \
+TAGFILES = doc/output/main.tag=../main \
+           doc/output/linear_containers.tag=../linear_containers \
+           doc/output/logging.tag=../logging \
+           doc/output/platform.tag=../platform \
+           doc/output/static_memory.tag=../static_memory \

--- a/scripts/ci_test_doc.sh
+++ b/scripts/ci_test_doc.sh
@@ -23,9 +23,6 @@ fi
 # Check for doxygen.
 command -v doxygen > /dev/null || { echo "Doxygen not found. Exiting."; exit 1; }
 
-# Create tag directory if needed.
-mkdir -p doc/tag
-
 # Doxygen must be run twice: once to generate tags and once more to link tags.
 i=0; while [ $i -le 1 ]; do
     # Run for each library config file.


### PR DESCRIPTION
*Issue #, if available:* https://issues.amazon.com/issues/TS-9616

*Description of changes:*
As part of the effort to get all the doxygen docs similiar this small task moves all of the tags from the tags/ folder to the output/ folder. This is as is done in Amazon FreeRTOS and FreeRTOS.org. 
Creating a separate tag/ folder was unnecessary. 

Tested and generated output from ci_: 
[output.zip](https://github.com/aws/aws-iot-device-sdk-embedded-C/files/4246828/output.zip)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
