### PR TITLE
Adds --conversion-check flag to CBMC Makefile

### DIFF
--- a/cbmc/proofs/IotMqtt_DeserializeSuback/Makefile
+++ b/cbmc/proofs/IotMqtt_DeserializeSuback/Makefile
@@ -28,10 +28,11 @@ DEF += -DCBMC=1 -DCBMC_PROOF_DESERIALIZE_SUBACK=1
 ################################################################
 # Loop unwinding
 
+LOOP += _decodeSubackStatus.0:$(BUFFER_SIZE)
+LOOP += IotListDouble_FindFirstMatch.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += IotListDouble_RemoveAllMatches\$$link1.0:$(SUBSCRIPTION_COUNT_MAX)
 LOOP += valid_IotMqttSubscriptionList.0:$(SUBSCRIPTION_COUNT_MAX)
 LOOP += valid_IotMqttOperationList.0:$(OPERATION_COUNT_MAX)
-
-LOOP += _decodeSubackStatus.0:$(BUFFER_SIZE)
 
 UNWINDING += --unwind 1
 UNWINDING += --unwindset '$(shell echo $(LOOP) | sed 's/ /,/g')'

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -75,17 +75,18 @@ CBMC_MAX_OBJECT_SIZE = "(SIZE_MAX>>(CBMC_OBJECT_BITS+1))"
 CBMCFLAGS += \
 	$(UNWINDING) \
 	--bounds-check \
-	--pointer-check \
-	--unwinding-assertions \
-	--nondet-static \
+	--conversion-check \
 	--div-by-zero-check \
 	--float-overflow-check \
-	--nan-check \
-	--pointer-overflow-check \
-	--undefined-shift-check \
-	--signed-overflow-check \
-	--unsigned-overflow-check \
 	--flush \
+	--nan-check \
+	--nondet-static \
+	--pointer-check \
+	--pointer-overflow-check \
+	--signed-overflow-check \
+	--undefined-shift-check \
+	--unsigned-overflow-check \
+	--unwinding-assertions \
 
 goto: $(ENTRY).goto
 

--- a/cbmc/proofs/mqtt_state.c
+++ b/cbmc/proofs/mqtt_state.c
@@ -380,9 +380,7 @@ bool valid_IotMqttSubscriptionArray( const IotMqttSubscription_t *pSub,
 
 _mqttSubscription_t *allocate_IotMqttSubscriptionListElt( _mqttSubscription_t *pElt )
 {
-  size_t length;
-  // Assumption avoids arithmetic overflow in malloc, rechecked in valid_*
-  __CPROVER_assume( length < CBMC_MAX_OBJECT_SIZE - sizeof( *pElt ) );
+  uint16_t length;
 
   if ( pElt == NULL ) pElt = malloc_can_fail( sizeof( *pElt ) + length );
   if ( pElt == NULL ) return NULL;


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*

1. Adds the `--conversion-check` flag to all CBMC proof harnesses (and sort them by lexicographical order).
2. Update proofs to avoid conversion errors.
3. Adds loop unwindings for `IotMqtt_DeserializeSuback`proof harness.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
