### PR TITLE
Avoid undefined behaviour in IotMqtt_IsSubscribed function

### DIFF
--- a/cbmc/proofs/IotMqtt_IsSubscribed/IotMqtt_IsSubscribed_harness.c
+++ b/cbmc/proofs/IotMqtt_IsSubscribed/IotMqtt_IsSubscribed_harness.c
@@ -25,7 +25,7 @@ void harness()
   IotMqttSubscription_t result;
 
   IotMqtt_IsSubscribed( mqttConnection,
-			TopicFilter,
-			topicFilterLength,
+                        nondet_bool() ? NULL : TopicFilter,
+                        topicFilterLength,
                         nondet_bool() ? NULL : &result );
 }

--- a/libraries/standard/mqtt/src/iot_mqtt_subscription.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_subscription.c
@@ -655,13 +655,6 @@ bool IotMqtt_IsSubscribed( IotMqttConnection_t mqttConnection,
                            IotMqttSubscription_t * const pCurrentSubscription )
 {
     bool status = false;
-
-    if( pTopicFilter == NULL )
-    {
-        IotLogError( "Topic filter must be set." );
-        return status;
-    }
-
     const _mqttSubscription_t * pSubscription = NULL;
     const IotLink_t * pSubscriptionLink = NULL;
     _topicMatchParams_t topicMatchParams = { 0 };
@@ -675,11 +668,18 @@ bool IotMqtt_IsSubscribed( IotMqttConnection_t mqttConnection,
      * function is running. */
     IotMutex_Lock( &( mqttConnection->subscriptionMutex ) );
 
-    /* Search for a matching subscription. */
-    pSubscriptionLink = IotListDouble_FindFirstMatch( &( mqttConnection->subscriptionList ),
-                                                      NULL,
-                                                      _topicMatch,
-                                                      &topicMatchParams );
+    if( pTopicFilter == NULL )
+    {
+        IotLogError( "Topic filter must be set." );
+    }
+    else
+    {
+        /* Search for a matching subscription. */
+        pSubscriptionLink = IotListDouble_FindFirstMatch( &( mqttConnection->subscriptionList ),
+                                                          NULL,
+                                                          _topicMatch,
+                                                          &topicMatchParams );
+    }
 
     /* Check if a matching subscription was found. */
     if( pSubscriptionLink != NULL )

--- a/libraries/standard/mqtt/src/iot_mqtt_subscription.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_subscription.c
@@ -655,6 +655,13 @@ bool IotMqtt_IsSubscribed( IotMqttConnection_t mqttConnection,
                            IotMqttSubscription_t * const pCurrentSubscription )
 {
     bool status = false;
+
+    if( pTopicFilter == NULL )
+    {
+        IotLogError( "Topic filter must be set." );
+        return status;
+    }
+
     const _mqttSubscription_t * pSubscription = NULL;
     const IotLink_t * pSubscriptionLink = NULL;
     _topicMatchParams_t topicMatchParams = { 0 };


### PR DESCRIPTION
*Description of changes:*

This PR adds a nullness check for the `pTopicFilter` parameter in `IotMqtt_IsSubscribed` function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
