### PR TITLE
Avoid null dereference in IotMqtt_PublishSync

### DIFF
--- a/libraries/standard/mqtt/src/iot_mqtt_api.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_api.c
@@ -1765,37 +1765,43 @@ IotMqttError_t IotMqtt_PublishSync( IotMqttConnection_t mqttConnection,
                                     uint32_t timeoutMs )
 {
     IotMqttError_t status = IOT_MQTT_STATUS_PENDING;
-    IotMqttOperation_t publishOperation = IOT_MQTT_OPERATION_INITIALIZER,
-                       * pPublishOperation = NULL;
-    /* Set only the "serial" flag. */
-    uint32_t syncFlags = MQTT_INTERNAL_FLAG_BLOCK_ON_SEND;
-
-    /* Flags are currently ignored. */
-    ( void ) flags;
-
-    /* Set the waitable flag and reference for QoS 1 PUBLISH. */
-    if( pPublishInfo->qos == IOT_MQTT_QOS_1 )
+    if( pPublishInfo == NULL )
     {
-        syncFlags |= IOT_MQTT_FLAG_WAITABLE;
-        pPublishOperation = &publishOperation;
+        status = IOT_MQTT_BAD_PARAMETER;
     }
-
-    /* Call the asynchronous PUBLISH function. */
-    status = IotMqtt_PublishAsync( mqttConnection,
-                                   pPublishInfo,
-                                   syncFlags,
-                                   NULL,
-                                   pPublishOperation );
-
-    /* Wait for a queued QoS 1 PUBLISH to complete. */
-    if( pPublishInfo->qos == IOT_MQTT_QOS_1 )
+    else
     {
-        if( status == IOT_MQTT_STATUS_PENDING )
+        IotMqttOperation_t publishOperation = IOT_MQTT_OPERATION_INITIALIZER,
+                           * pPublishOperation = NULL;
+        /* Set only the "serial" flag. */
+        uint32_t syncFlags = MQTT_INTERNAL_FLAG_BLOCK_ON_SEND;
+
+        /* Flags are currently ignored. */
+        ( void ) flags;
+
+        /* Set the waitable flag and reference for QoS 1 PUBLISH. */
+        if( pPublishInfo->qos == IOT_MQTT_QOS_1 )
         {
-            status = IotMqtt_Wait( publishOperation, timeoutMs );
+            syncFlags |= IOT_MQTT_FLAG_WAITABLE;
+            pPublishOperation = &publishOperation;
+        }
+
+        /* Call the asynchronous PUBLISH function. */
+        status = IotMqtt_PublishAsync( mqttConnection,
+                                       pPublishInfo,
+                                       syncFlags,
+                                       NULL,
+                                       pPublishOperation );
+
+        /* Wait for a queued QoS 1 PUBLISH to complete. */
+        if( pPublishInfo->qos == IOT_MQTT_QOS_1 )
+        {
+            if( status == IOT_MQTT_STATUS_PENDING )
+            {
+                status = IotMqtt_Wait( publishOperation, timeoutMs );
+            }
         }
     }
-
     return status;
 }
 

--- a/libraries/standard/mqtt/src/iot_mqtt_api.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_api.c
@@ -1765,20 +1765,20 @@ IotMqttError_t IotMqtt_PublishSync( IotMqttConnection_t mqttConnection,
                                     uint32_t timeoutMs )
 {
     IotMqttError_t status = IOT_MQTT_STATUS_PENDING;
+    IotMqttOperation_t publishOperation = IOT_MQTT_OPERATION_INITIALIZER,
+                       * pPublishOperation = NULL;
+    /* Set only the "serial" flag. */
+    uint32_t syncFlags = MQTT_INTERNAL_FLAG_BLOCK_ON_SEND;
+
+    /* Flags are currently ignored. */
+    ( void ) flags;
+
     if( pPublishInfo == NULL )
     {
         status = IOT_MQTT_BAD_PARAMETER;
     }
     else
     {
-        IotMqttOperation_t publishOperation = IOT_MQTT_OPERATION_INITIALIZER,
-                           * pPublishOperation = NULL;
-        /* Set only the "serial" flag. */
-        uint32_t syncFlags = MQTT_INTERNAL_FLAG_BLOCK_ON_SEND;
-
-        /* Flags are currently ignored. */
-        ( void ) flags;
-
         /* Set the waitable flag and reference for QoS 1 PUBLISH. */
         if( pPublishInfo->qos == IOT_MQTT_QOS_1 )
         {


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*

In the IotMqtt_PublishSync function, set the status to IOT_MQTT_BAD_PARAMETER in case the `pPublishInfo` is NULL. This will later avoid null dereferences.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
