### PR TITLE
Adds a proof harness for IotMqtt_PublishSync function

### DIFF
--- a/cbmc/patches/0001-Modify-MQTT-to-let-CBMC-proofs-stub-out-RemoveAllMat.patch
+++ b/cbmc/patches/0001-Modify-MQTT-to-let-CBMC-proofs-stub-out-RemoveAllMat.patch
@@ -15,7 +15,7 @@ index 689ea5e..ffb3469 100644
   * or its value is `0`.
   */
  /* @[declare_linear_containers_list_double_removeallmatches] */
-+#ifdef CBMC_PROOF_DESERIALIZE_SUBACK
++#ifdef CBMC_STUB_REMOVEALLMATCHES
 +void IotListDouble_RemoveAllMatches( const IotListDouble_t * const pList,
 +				     bool ( *isMatch )( const IotLink_t * const pOperationLink, void * pCompare ),
 +				     void * pMatch,
@@ -35,4 +35,3 @@ index 689ea5e..ffb3469 100644
   * @brief Create a new queue.
 -- 
 2.7.4
-

--- a/cbmc/proofs/IotMqtt_PublishSync/IotMqtt_PublishSync_harness.c
+++ b/cbmc/proofs/IotMqtt_PublishSync/IotMqtt_PublishSync_harness.c
@@ -1,0 +1,135 @@
+#include "iot_config.h"
+#include "private/iot_mqtt_internal.h"
+#include "platform/iot_threads.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "mqtt_state.h"
+
+/**
+ * We abstract all functions related to concurrency and assume they are correct.
+ * Thus, we add these stub to increase coverage.
+ */
+IotTaskPoolError_t IotTaskPool_CreateJob( IotTaskPoolRoutine_t userCallback,
+                                          void * pUserContext,
+                                          IotTaskPoolJobStorage_t * const pJobStorage,
+                                          IotTaskPoolJob_t * const pJob )
+{
+  assert( userCallback != NULL );
+  assert( pJobStorage != NULL );
+  assert( pJob != NULL );
+
+  /* _IotMqtt_ScheduleOperation asserts this */
+  return IOT_TASKPOOL_SUCCESS;
+}
+
+IotTaskPoolError_t IotTaskPool_ScheduleDeferred( IotTaskPool_t taskPool,
+                                                 IotTaskPoolJob_t job,
+                                                 uint32_t timeMs )
+{
+  IotTaskPoolError_t error;
+
+  /* _IotMqtt_ScheduleOperation asserts this */
+  __CPROVER_assume( error != IOT_TASKPOOL_BAD_PARAMETER &&
+                    error != IOT_TASKPOOL_ILLEGAL_OPERATION );
+  return error;
+}
+
+IotTaskPoolError_t IotTaskPool_TryCancel( IotTaskPool_t taskPool,
+                                          IotTaskPoolJob_t job,
+                                          IotTaskPoolJobStatus_t * const pStatus )
+{
+  if( taskPool == NULL || job == NULL )
+  {
+    return IOT_TASKPOOL_BAD_PARAMETER;
+  }
+  return IOT_TASKPOOL_SUCCESS;
+}
+
+/**
+ * _IotMqtt_NextPacketIdentifier calls Atomic_Add_u32, which receives
+ * a volatile variable as input. Thus, CBMC will always consider that
+ * Atomic_Add_u32 will operate over nondetermistic values and raises
+ * a unsigned integer overflow failure. However, developers have reported
+ * that the use of this overflow is part of the function implementation.
+ * In order to mirror _IotMqtt_NextPacketIdentifier behaviour and avoid
+ * spurious alarms, we stub out this function to always
+ * return a nondetermistic odd value.
+ */
+uint16_t _IotMqtt_NextPacketIdentifier( void ) {
+  uint16_t id;
+
+  /* Packet identifiers will follow the sequence 1,3,5...65535,1,3,5... */
+  __CPROVER_assume(id % 2 == 1);
+
+  return id;
+}
+
+/**
+ * We abstract this function for performance reasons. In its original
+ * implementation, CBMC ended up creating byte extracts for all possible
+ * objects, due to the polymorphic nature of the linked list. We assume
+ * that the function is memory safe, and we free and havoc the list to
+ * demonstrate that no subsequent code makes use of the values in the list.
+ */
+void IotListDouble_RemoveAllMatches( const IotListDouble_t * const pList,
+				     bool ( *isMatch )( const IotLink_t * const pOperationLink, void * pCompare ),
+				     void * pMatch,
+				     void ( *freeElement )( void * pData ),
+				     size_t linkOffset )
+{
+  free_IotMqttSubscriptionList( pList );
+  allocate_IotMqttSubscriptionList( pList, SUBSCRIPTION_COUNT_MAX-1 );
+}
+
+
+/**
+ * We abstract these functions to map the expected behavior of
+ * IotSemaphore_TimedWait. If IotSemaphore_Post is called, the
+ * semaphore is positive. IotSemaphore_TimedWait should always
+ * return true if the semaphore is positive at some time during the wait.
+ */
+static bool flagSemaphore;
+
+void IotSemaphore_Post( IotSemaphore_t * pSemaphore )
+{
+  assert(pSemaphore != NULL);
+  flagSemaphore = true;
+}
+
+bool IotSemaphore_TimedWait( IotSemaphore_t * pSemaphore,
+                             uint32_t timeoutMs )
+{
+  assert(pSemaphore != NULL);
+  return flagSemaphore;
+}
+
+void harness()
+{
+  /* assume a valid MQTT connection */
+  IotMqttConnection_t mqttConnection = allocate_IotMqttConnection( NULL );
+  __CPROVER_assume( mqttConnection != NULL );
+  __CPROVER_assume( mqttConnection->pNetworkInterface != NULL );
+  __CPROVER_assume( IS_STUBBED_NETWORKIF_SEND( mqttConnection->pNetworkInterface ) );
+  __CPROVER_assume( IS_STUBBED_NETWORKIF_DESTROY( mqttConnection->pNetworkInterface ) );
+  ensure_IotMqttConnection_has_lists( mqttConnection );
+  __CPROVER_assume(valid_IotMqttConnection( mqttConnection ));
+ 
+  /* assume a valid publish info */
+  IotMqttPublishInfo_t *pPublishInfo = allocate_IotMqttPublishInfo( NULL );
+  __CPROVER_assume( valid_IotMqttPublishInfo( pPublishInfo ) );
+  
+  /* assume unconstrained inputs */
+  uint32_t flags;
+  uint32_t timeoutMs;
+
+  /* initialize semaphore flag */
+  flagSemaphore = false;
+
+  /* function under verification */
+  IotMqtt_PublishSync( mqttConnection, /* always assume a valid connection */
+                       nondet_bool() ? NULL : pPublishInfo,
+                       flags,
+                       timeoutMs );
+}

--- a/cbmc/proofs/IotMqtt_PublishSync/IotMqtt_PublishSync_harness.c
+++ b/cbmc/proofs/IotMqtt_PublishSync/IotMqtt_PublishSync_harness.c
@@ -89,19 +89,24 @@ void IotListDouble_RemoveAllMatches( const IotListDouble_t * const pList,
  * But the semaphore API assures us that TimedWait called after Post will
  * never fail. Our abstraction of the semaphores models this behavior.
  */
-static bool flagSemaphore;
+static unsigned int flagSemaphore;
 
 void IotSemaphore_Post( IotSemaphore_t * pSemaphore )
 {
   assert(pSemaphore != NULL);
-  flagSemaphore = true;
+  flagSemaphore++;
 }
 
 bool IotSemaphore_TimedWait( IotSemaphore_t * pSemaphore,
                              uint32_t timeoutMs )
 {
   assert(pSemaphore != NULL);
-  return flagSemaphore;
+  if( flagSemaphore > 0 )
+  {
+    flagSemaphore--;
+    return true;
+  }
+  return false;
 }
 
 void harness()
@@ -124,7 +129,7 @@ void harness()
   uint32_t timeoutMs;
 
   /* initialize semaphore flag */
-  flagSemaphore = false;
+  flagSemaphore = 0;
 
   /* function under verification */
   IotMqtt_PublishSync( mqttConnection, /* always assume a valid connection */

--- a/cbmc/proofs/IotMqtt_PublishSync/IotMqtt_PublishSync_harness.c
+++ b/cbmc/proofs/IotMqtt_PublishSync/IotMqtt_PublishSync_harness.c
@@ -1,3 +1,30 @@
+/*
+ * IoT MQTT V2.1.0
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file IotMqtt_PublishSync_harness.c
+ * @brief Implements the proof harness for IotMqtt_PublishSync function.
+ */
+
 #include "iot_config.h"
 #include "private/iot_mqtt_internal.h"
 #include "platform/iot_threads.h"
@@ -6,6 +33,11 @@
 #include <string.h>
 
 #include "mqtt_state.h"
+
+typedef bool ( * MatchFunction_t )( const IotLink_t * const pOperationLink,
+                                    void * pCompare );
+
+static unsigned int flagSemaphore;
 
 /**
  * We constrain the return values of these functions because they
@@ -16,54 +48,56 @@ IotTaskPoolError_t IotTaskPool_CreateJob( IotTaskPoolRoutine_t userCallback,
                                           IotTaskPoolJobStorage_t * const pJobStorage,
                                           IotTaskPoolJob_t * const pJob )
 {
-  assert( userCallback != NULL );
-  assert( pJobStorage != NULL );
-  assert( pJob != NULL );
+    assert( userCallback != NULL );
+    assert( pJobStorage != NULL );
+    assert( pJob != NULL );
 
-  /* _IotMqtt_ScheduleOperation asserts this */
-  return IOT_TASKPOOL_SUCCESS;
+    /* _IotMqtt_ScheduleOperation asserts this. */
+    return IOT_TASKPOOL_SUCCESS;
 }
 
 IotTaskPoolError_t IotTaskPool_ScheduleDeferred( IotTaskPool_t taskPool,
                                                  IotTaskPoolJob_t job,
                                                  uint32_t timeMs )
 {
-  IotTaskPoolError_t error;
+    IotTaskPoolError_t error;
 
-  /* _IotMqtt_ScheduleOperation asserts this */
-  __CPROVER_assume( error != IOT_TASKPOOL_BAD_PARAMETER &&
-                    error != IOT_TASKPOOL_ILLEGAL_OPERATION );
-  return error;
+    /* _IotMqtt_ScheduleOperation asserts this. */
+    __CPROVER_assume( error != IOT_TASKPOOL_BAD_PARAMETER &&
+                      error != IOT_TASKPOOL_ILLEGAL_OPERATION );
+    return error;
 }
 
 IotTaskPoolError_t IotTaskPool_TryCancel( IotTaskPool_t taskPool,
                                           IotTaskPoolJob_t job,
                                           IotTaskPoolJobStatus_t * const pStatus )
 {
-  if( taskPool == NULL || job == NULL )
-  {
-    return IOT_TASKPOOL_BAD_PARAMETER;
-  }
-  return IOT_TASKPOOL_SUCCESS;
+    if( ( taskPool == NULL ) || ( job == NULL ) )
+    {
+        return IOT_TASKPOOL_BAD_PARAMETER;
+    }
+
+    return IOT_TASKPOOL_SUCCESS;
 }
 
 /**
  * _IotMqtt_NextPacketIdentifier calls Atomic_Add_u32, which receives
  * a volatile variable as input. Thus, CBMC will always consider that
- * Atomic_Add_u32 will operate over nondetermistic values and raises
+ * Atomic_Add_u32 will operate over nondetermistic values and raise
  * a unsigned integer overflow failure. However, developers have reported
  * that the use of this overflow is part of the function implementation.
  * In order to mirror _IotMqtt_NextPacketIdentifier behaviour and avoid
  * spurious alarms, we stub out this function to always
  * return a nondetermistic odd value.
  */
-uint16_t _IotMqtt_NextPacketIdentifier( void ) {
-  uint16_t id;
+uint16_t _IotMqtt_NextPacketIdentifier( void )
+{
+    uint16_t id;
 
-  /* Packet identifiers will follow the sequence 1,3,5...65535,1,3,5... */
-  __CPROVER_assume(id % 2 == 1);
+    /* Packet identifiers will follow the sequence 1,3,5...65535,1,3,5... */
+    __CPROVER_assume( id % 2 == 1 );
 
-  return id;
+    return id;
 }
 
 /**
@@ -74,13 +108,13 @@ uint16_t _IotMqtt_NextPacketIdentifier( void ) {
  * demonstrate that no subsequent code makes use of the values in the list.
  */
 void IotListDouble_RemoveAllMatches( const IotListDouble_t * const pList,
-				     bool ( *isMatch )( const IotLink_t * const pOperationLink, void * pCompare ),
-				     void * pMatch,
-				     void ( *freeElement )( void * pData ),
-				     size_t linkOffset )
+                                     MatchFunction_t isMatch,
+                                     void * pMatch,
+                                     void ( *freeElement )( void * pData ),
+                                     size_t linkOffset )
 {
-  free_IotMqttSubscriptionList( pList );
-  allocate_IotMqttSubscriptionList( pList, SUBSCRIPTION_COUNT_MAX-1 );
+    free_IotMqttSubscriptionList( pList );
+    allocate_IotMqttSubscriptionList( pList, SUBSCRIPTION_COUNT_MAX - 1 );
 }
 
 
@@ -89,51 +123,52 @@ void IotListDouble_RemoveAllMatches( const IotListDouble_t * const pList,
  * But the semaphore API assures us that TimedWait called after Post will
  * never fail. Our abstraction of the semaphores models this behavior.
  */
-static unsigned int flagSemaphore;
-
 void IotSemaphore_Post( IotSemaphore_t * pSemaphore )
 {
-  assert(pSemaphore != NULL);
-  flagSemaphore++;
+    assert( pSemaphore != NULL );
+    flagSemaphore++;
 }
 
 bool IotSemaphore_TimedWait( IotSemaphore_t * pSemaphore,
                              uint32_t timeoutMs )
 {
-  assert(pSemaphore != NULL);
-  if( flagSemaphore > 0 )
-  {
-    flagSemaphore--;
-    return true;
-  }
-  return false;
+    assert( pSemaphore != NULL );
+
+    if( flagSemaphore > 0 )
+    {
+        flagSemaphore--;
+        return true;
+    }
+
+    return false;
 }
 
 void harness()
 {
-  /* assume a valid MQTT connection */
-  IotMqttConnection_t mqttConnection = allocate_IotMqttConnection( NULL );
-  __CPROVER_assume( mqttConnection != NULL );
-  __CPROVER_assume( mqttConnection->pNetworkInterface != NULL );
-  __CPROVER_assume( IS_STUBBED_NETWORKIF_SEND( mqttConnection->pNetworkInterface ) );
-  __CPROVER_assume( IS_STUBBED_NETWORKIF_DESTROY( mqttConnection->pNetworkInterface ) );
-  ensure_IotMqttConnection_has_lists( mqttConnection );
-  __CPROVER_assume(valid_IotMqttConnection( mqttConnection ));
- 
-  /* assume a valid publish info */
-  IotMqttPublishInfo_t *pPublishInfo = allocate_IotMqttPublishInfo( NULL );
-  __CPROVER_assume( IMPLIES( pPublishInfo != NULL, valid_IotMqttPublishInfo( pPublishInfo ) ) );
-  
-  /* assume unconstrained inputs */
-  uint32_t flags;
-  uint32_t timeoutMs;
+    /* Assume a valid MQTT connection. */
+    IotMqttConnection_t mqttConnection = allocate_IotMqttConnection( NULL );
 
-  /* initialize semaphore flag */
-  flagSemaphore = 0;
+    __CPROVER_assume( mqttConnection != NULL );
+    __CPROVER_assume( mqttConnection->pNetworkInterface != NULL );
+    __CPROVER_assume( IS_STUBBED_NETWORKIF_SEND( mqttConnection->pNetworkInterface ) );
+    __CPROVER_assume( IS_STUBBED_NETWORKIF_DESTROY( mqttConnection->pNetworkInterface ) );
+    ensure_IotMqttConnection_has_lists( mqttConnection );
+    __CPROVER_assume( valid_IotMqttConnection( mqttConnection ) );
 
-  /* function under verification */
-  IotMqtt_PublishSync( mqttConnection, /* always assume a valid connection */
-                       pPublishInfo,
-                       flags,
-                       timeoutMs );
+    /* Assume a valid publish info. */
+    IotMqttPublishInfo_t * pPublishInfo = allocate_IotMqttPublishInfo( NULL );
+    __CPROVER_assume( IMPLIES( pPublishInfo != NULL, valid_IotMqttPublishInfo( pPublishInfo ) ) );
+
+    /* Assume unconstrained inputs. */
+    uint32_t flags;
+    uint32_t timeoutMs;
+
+    /* Initialize semaphore flag. */
+    flagSemaphore = 0;
+
+    /* Function under verification. */
+    IotMqtt_PublishSync( mqttConnection, /* Always assume a valid connection. */
+                         pPublishInfo,
+                         flags,
+                         timeoutMs );
 }

--- a/cbmc/proofs/IotMqtt_PublishSync/Makefile
+++ b/cbmc/proofs/IotMqtt_PublishSync/Makefile
@@ -4,7 +4,7 @@ ENTRY=IotMqtt_PublishSync
 # and assume their implementation is correct
 ABSTRACTIONS += --remove-function-body IotLog_Generic
 
-# We abstract this function because manual inspection suggest it is unreachable
+# We abstract this function because manual inspection demonstrates that it is unreachable
 ABSTRACTIONS += --remove-function-body _IotMqtt_RemoveSubscriptionByPacket
 
 # We also abstract unreachable functions to improve coverage metrics

--- a/cbmc/proofs/IotMqtt_PublishSync/Makefile
+++ b/cbmc/proofs/IotMqtt_PublishSync/Makefile
@@ -1,0 +1,58 @@
+ENTRY=IotMqtt_PublishSync
+
+# We abstract all the log and concurrency related functions in this proof
+# and assume their implementation is correct
+ABSTRACTIONS += --remove-function-body IotLog_Generic
+
+# We also abstract unreachable functions to improve coverage metrics
+ABSTRACTIONS += --remove-function-body _IotMqtt_ProcessIncomingPublish
+ABSTRACTIONS += --remove-function-body _IotMqtt_RemoveSubscriptionByPacket
+ABSTRACTIONS += --remove-function-body IotNetworkInterfaceClose
+ABSTRACTIONS += --remove-function-body IotNetworkInterfaceReceive
+
+OBJS += $(ENTRY)_harness.goto
+OBJS += $(MQTT)/cbmc/proofs/mqtt_state.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_api.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_helper.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_operation.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_serialize.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_subscription.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_validate.goto
+
+# One more than actual number of subscriptions
+SUBSCRIPTION_COUNT_MAX=4
+DEF += -DSUBSCRIPTION_COUNT_MAX=$(SUBSCRIPTION_COUNT_MAX)
+
+# One more than actual number of operations
+OPERATION_COUNT_MAX=4
+DEF += -DOPERATION_COUNT_MAX=$(OPERATION_COUNT_MAX)
+
+# One more than actual length of topics
+TOPIC_LENGTH_MAX=6
+DEF += -DTOPIC_LENGTH_MAX=$(TOPIC_LENGTH_MAX)
+
+# One more than actual length of payload
+PAYLOAD_LENGTH_MAX=6
+DEF += -DPAYLOAD_LENGTH_MAX=$(PAYLOAD_LENGTH_MAX)
+
+# Enables CBMC stub for RemoveAllMatches function
+DEF += -DCBMC_STUB_REMOVEALLMATCHES=1
+
+# Allow MQTT allocations to fail for coverage
+DEF += -include mqtt_state.h
+DEF += -DIotMqtt_MallocMessage=malloc_can_fail
+DEF += -DIotMqtt_MallocOperation=malloc_can_fail
+
+LOOP += _encodeRemainingLength.0:$(PAYLOAD_LENGTH_MAX)
+LOOP += _IotMqtt_InvokeSubscriptionCallback.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += _matchWildcards.0:$(TOPIC_LENGTH_MAX)
+LOOP += _topicFilterMatch.0:$(TOPIC_LENGTH_MAX)
+LOOP += IotListDouble_RemoveAllMatches.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += IotListDouble_RemoveAllMatches$$link2.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += valid_IotMqttOperationList.0:$(OPERATION_COUNT_MAX)
+LOOP += valid_IotMqttSubscriptionList.0:$(SUBSCRIPTION_COUNT_MAX)
+
+UNWINDING += --unwind 1
+UNWINDING += --unwindset '$(shell echo $(LOOP) | sed 's/ /,/g')'
+
+include ../Makefile.common

--- a/cbmc/proofs/IotMqtt_PublishSync/Makefile
+++ b/cbmc/proofs/IotMqtt_PublishSync/Makefile
@@ -4,9 +4,11 @@ ENTRY=IotMqtt_PublishSync
 # and assume their implementation is correct
 ABSTRACTIONS += --remove-function-body IotLog_Generic
 
+# We abstract this function because manual inspection suggest it is unreachable
+ABSTRACTIONS += --remove-function-body _IotMqtt_RemoveSubscriptionByPacket
+
 # We also abstract unreachable functions to improve coverage metrics
 ABSTRACTIONS += --remove-function-body _IotMqtt_ProcessIncomingPublish
-ABSTRACTIONS += --remove-function-body _IotMqtt_RemoveSubscriptionByPacket
 ABSTRACTIONS += --remove-function-body IotNetworkInterfaceClose
 ABSTRACTIONS += --remove-function-body IotNetworkInterfaceReceive
 

--- a/cbmc/proofs/IotMqtt_PublishSync/cbmc-batch.yaml
+++ b/cbmc/proofs/IotMqtt_PublishSync/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--object-bits;8;--unwind;1;--unwindset;_encodeRemainingLength.0:6,_IotMqtt_InvokeSubscriptionCallback.0:4,_matchWildcards.0:6,_topicFilterMatch.0:6,IotListDouble_RemoveAllMatches.0:4,IotListDouble_RemoveAllMatches.0:4,valid_IotMqttOperationList.0:4,valid_IotMqttSubscriptionList.0:4;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--flush;--nan-check;--nondet-static;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
+expected: SUCCESSFUL
+goto: IotMqtt_PublishSync.goto
+jobos: ubuntu16

--- a/cbmc/proofs/IotMqtt_PublishSync/cbmc-viewer.json
+++ b/cbmc/proofs/IotMqtt_PublishSync/cbmc-viewer.json
@@ -1,19 +1,15 @@
 { "expected-missing-functions":
   [
+    "IotClock_GetTimeMs",
     "IotLog_Generic",
-    "IotMqtt_Wait",
-    "IotMutex_Create",
     "IotMutex_Destroy",
     "IotMutex_Lock",
     "IotMutex_Unlock",
     "IotSemaphore_Create",
     "IotSemaphore_Destroy",
-    "IotSemaphore_Wait",
-    "IotTaskPool_CreateJob",
     "IotTaskPool_GetSystemTaskPool",
-    "IotTaskPool_ScheduleDeferred",
     "IotTaskPool_strerror",
-    "IotTaskPool_TryCancel"
+    "_IotMqtt_RemoveSubscriptionByPacket"
   ],
   "proof-name": "IotMqtt_PublishSync",
   "proof-root": "cbmc/proofs"

--- a/cbmc/proofs/IotMqtt_PublishSync/cbmc-viewer.json
+++ b/cbmc/proofs/IotMqtt_PublishSync/cbmc-viewer.json
@@ -1,0 +1,20 @@
+{ "expected-missing-functions":
+  [
+    "IotLog_Generic",
+    "IotMqtt_Wait",
+    "IotMutex_Create",
+    "IotMutex_Destroy",
+    "IotMutex_Lock",
+    "IotMutex_Unlock",
+    "IotSemaphore_Create",
+    "IotSemaphore_Destroy",
+    "IotSemaphore_Wait",
+    "IotTaskPool_CreateJob",
+    "IotTaskPool_GetSystemTaskPool",
+    "IotTaskPool_ScheduleDeferred",
+    "IotTaskPool_strerror",
+    "IotTaskPool_TryCancel"
+  ],
+  "proof-name": "IotMqtt_PublishSync",
+  "proof-root": "cbmc/proofs"
+}

--- a/cbmc/proofs/mqtt_state.c
+++ b/cbmc/proofs/mqtt_state.c
@@ -149,11 +149,11 @@ IotListDouble_t *allocate_IotMqttOperationList( IotListDouble_t *pOp,
 
   IotListDouble_Create( pOp );
 
-  size_t num_elts;
-  __CPROVER_assume(num_elts <= length);
+  size_t numElts;
+  __CPROVER_assume(numElts <= length);
 
   IotMqttOperation_t pElt;
-  switch (num_elts) {
+  switch (numElts) {
 #if 3 < OPERATION_COUNT_MAX
   case 3:
     pElt = allocate_IotMqttOperation( NULL, pConn );
@@ -450,11 +450,11 @@ IotListDouble_t *allocate_IotMqttSubscriptionList( IotListDouble_t *pSub,
 
   IotListDouble_Create( pSub );
 
-  size_t num_elts;
-  __CPROVER_assume(num_elts <= length);
+  size_t numElts;
+  __CPROVER_assume(numElts <= length);
 
   _mqttSubscription_t *pElt;
-  switch (num_elts) {
+  switch (numElts) {
 #if 3 < SUBSCRIPTION_COUNT_MAX
   case 3:
       pElt = allocate_IotMqttSubscriptionListElt( NULL );
@@ -473,10 +473,8 @@ IotListDouble_t *allocate_IotMqttSubscriptionList( IotListDouble_t *pSub,
       __CPROVER_assume( pElt );
       IotListDouble_InsertHead( pSub, &( pElt->link ) );
 #endif
-#if 0 < SUBSCRIPTION_COUNT_MAX
   default:
     ;
-#endif
   }
 
   return pSub;
@@ -537,7 +535,8 @@ void free_IotMqttSubscriptionList( IotListDouble_t *pSub )
   pThis = pNext;
 #endif
 
-  assert( pThis == pSub );
+  /* The being freed could be longer than SUBSCRIPTION_COUNT_MAX:
+   * Allocate a list of maximal length, then add one subscription, then free it. */
   return;
 }
 

--- a/cbmc/proofs/mqtt_state.c
+++ b/cbmc/proofs/mqtt_state.c
@@ -511,32 +511,33 @@ void free_IotMqttSubscriptionList( IotListDouble_t *pSub )
   IotListDouble_t *pThis;
   IotListDouble_t *pNext;
 
-  if (pSub == NULL) return;
+  if ( pSub == NULL ) return;
   pThis = pSub->pNext;
   pSub->pNext = invalid_pointer();
   pSub->pPrevious = invalid_pointer();
 
 #if 3 < SUBSCRIPTION_COUNT_MAX
-  if (pThis == pSub) return;
+  if ( pThis == pSub ) return;
   pNext = pThis->pNext;
   free( IotLink_Container( _mqttSubscription_t, pThis, link ) );
   pThis = pNext;
 #endif
 
 #if 2 < SUBSCRIPTION_COUNT_MAX
-  if (pThis == pSub) return;
+  if ( pThis == pSub ) return;
   pNext = pThis->pNext;
   free( IotLink_Container( _mqttSubscription_t, pThis, link ) );
   pThis = pNext;
 #endif
 
 #if 1 < SUBSCRIPTION_COUNT_MAX
-  if (pThis == pSub) return;
+  if ( pThis == pSub ) return;
   pNext = pThis->pNext;
   free( IotLink_Container( _mqttSubscription_t, pThis, link ) );
   pThis = pNext;
 #endif
 
+  assert( pThis == pSub );
   return;
 }
 

--- a/cbmc/proofs/mqtt_state.h
+++ b/cbmc/proofs/mqtt_state.h
@@ -1,3 +1,6 @@
+#include "iot_config.h"
+#include "private/iot_mqtt_internal.h"
+
 #include <stdlib.h>
 
 /****************************************************************
@@ -151,6 +154,7 @@ IotListDouble_t *allocate_IotMqttSubscriptionList( IotListDouble_t *pSub,
 						   size_t length );
 bool valid_IotMqttSubscriptionList( const IotListDouble_t *pSub,
 				   const size_t length );
+void free_IotMqttSubscriptionList( IotListDouble_t *pSub );
 
 /****************************************************************
  * IotMqttPublishInfo


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*

- Adds a new proof harness for the `IotMqtt_PublishSync` function;
- Improve assumptions in the `mqtt_state` module;
- Update patch to stub out `RemoveAllMatches` function;

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
