### PR TITLE
Add constness to input params of serializer interface

### DIFF
--- a/libraries/standard/serializer/include/iot_serializer.h
+++ b/libraries/standard/serializer/include/iot_serializer.h
@@ -19,6 +19,7 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+
 /*
  * This library is to provide a consistent layer for serializing JSON-like format.
  * The implementations can be CBOR or JSON.
@@ -410,6 +411,7 @@ typedef struct IotSerializerDecodeInterface
      * @param pDecoderObject Pointer to the decoder object allocated by user.
      * @param pDataBuffer Pointer to the buffer containing data to be decoded.
      * @param maxSize Maximum length of the buffer containing data to be decoded.
+     *
      * @return IOT_SERIALIZER_SUCCESS if successful
      */
     IotSerializerError_t ( * init )( IotSerializerDecoderObject_t * pDecoderObject,
@@ -429,9 +431,10 @@ typedef struct IotSerializerDecodeInterface
      *
      * @param[in] pDecoderObject Pointer to the decoder object representing the container
      * @param[out] pIterator Pointer to iterator which can be used for the traversing the container by calling next()
+     *
      * @return IOT_SERIALIZER_SUCCESS if successful
      */
-    IotSerializerError_t ( * stepIn )( IotSerializerDecoderObject_t * pDecoderObject,
+    IotSerializerError_t ( * stepIn )( const IotSerializerDecoderObject_t * pDecoderObject,
                                        IotSerializerDecoderIterator_t * pIterator );
 
 
@@ -439,6 +442,7 @@ typedef struct IotSerializerDecodeInterface
      * @brief Gets the object value currently pointed to by an iterator.
      * @param iterator The iterator handle
      * @param pValueObject Value of the object pointed to by the iterator.
+     *
      * @return IOT_SERIALIZER_SUCCESS if successful
      */
     IotSerializerError_t ( * get )( IotSerializerDecoderIterator_t iterator,
@@ -452,9 +456,10 @@ typedef struct IotSerializerDecodeInterface
      * @param[in] pDecoderObject Pointer to the decoder object representing  container
      * @param[in] pKey Pointer to the key for which value needs to be found.
      * @param[out] pValueObject Pointer to the value object for the key.
+     *
      * @return IOT_SERIALIZER_SUCCESS if successful
      */
-    IotSerializerError_t ( * find )( IotSerializerDecoderObject_t * pDecoderObject,
+    IotSerializerError_t ( * find )( const IotSerializerDecoderObject_t * pDecoderObject,
                                      const char * pKey,
                                      IotSerializerDecoderObject_t * pValueObject );
 
@@ -470,6 +475,7 @@ typedef struct IotSerializerDecodeInterface
      * If the container is an array, it skips by one array element.
      *
      * @param[in] iterator Pointer to iterator
+     *
      * @return IOT_SERIALIZER_SUCCESS if successful
      */
     IotSerializerError_t ( * next )( IotSerializerDecoderIterator_t iterator );
@@ -485,14 +491,16 @@ typedef struct IotSerializerDecodeInterface
      * @brief Function to obtain the starting buffer address of the raw encoded data (scalar or container type)
      * represented by the passed decoder object.
      * Container SHOULD be of type array or map.
+     *
      * @param[in] pDecoderObject The decoder object whose underlying data's starting location in the buffer
      * is to be returned.
      * @param[out] pEncodedDataStartAddr This will be populated with the starting location of the encoded object
      * in the data buffer.
+     *
      * @return #IOT_SERIALIZER_SUCCESS if successful; otherwise #IOT_SERIALIZER_NOT_SUPPORTED
      * for a non-container type iterator.
      */
-    IotSerializerError_t ( * getBufferAddress )( IotSerializerDecoderObject_t *
+    IotSerializerError_t ( * getBufferAddress )( const IotSerializerDecoderObject_t *
                                                  pDecoderObject,
                                                  const uint8_t **
                                                  pEncodedDataStartAddr );
@@ -508,7 +516,7 @@ typedef struct IotSerializerDecodeInterface
      * @return #IOT_SERIALIZER_SUCCESS if successful; otherwise #IOT_SERIALIZER_NOT_SUPPORTED
      * for a non-container type iterator.
      */
-    IotSerializerError_t ( * getSizeOfEncodedData )( IotSerializerDecoderObject_t * pDecoderObject,
+    IotSerializerError_t ( * getSizeOfEncodedData )( const IotSerializerDecoderObject_t * pDecoderObject,
                                                      size_t * pEncodedDataLength );
 
 

--- a/libraries/standard/serializer/src/cbor/iot_serializer_tinycbor_decoder.c
+++ b/libraries/standard/serializer/src/cbor/iot_serializer_tinycbor_decoder.c
@@ -48,10 +48,10 @@ static IotSerializerError_t _init( IotSerializerDecoderObject_t * pDecoderObject
 static IotSerializerError_t _get( IotSerializerDecoderIterator_t iterator,
                                   IotSerializerDecoderObject_t * pValueObject );
 
-static IotSerializerError_t _find( IotSerializerDecoderObject_t * pDecoderObject,
+static IotSerializerError_t _find( const IotSerializerDecoderObject_t * pDecoderObject,
                                    const char * pKey,
                                    IotSerializerDecoderObject_t * pValueObject );
-static IotSerializerError_t _stepIn( IotSerializerDecoderObject_t * pDecoderObject,
+static IotSerializerError_t _stepIn( const IotSerializerDecoderObject_t * pDecoderObject,
                                      IotSerializerDecoderIterator_t * pIterator );
 static IotSerializerError_t _stepOut( IotSerializerDecoderIterator_t iterator,
                                       IotSerializerDecoderObject_t * pDecoderObject );
@@ -62,12 +62,12 @@ static bool _isEndOfContainer( IotSerializerDecoderIterator_t iterator );
 
 static void _destroy( IotSerializerDecoderObject_t * pDecoderObject );
 
-static IotSerializerError_t _getBufferAddress( IotSerializerDecoderObject_t * pDecoderObject,
+static IotSerializerError_t _getBufferAddress( const IotSerializerDecoderObject_t * pDecoderObject,
                                                const uint8_t ** pEncodedDataStartAddr );
 
 
 
-static IotSerializerError_t _getSizeOfEncodedData( IotSerializerDecoderObject_t * pDecoderObject,
+static IotSerializerError_t _getSizeOfEncodedData( const IotSerializerDecoderObject_t * pDecoderObject,
                                                    size_t * pEncodedDataLength );
 
 
@@ -404,7 +404,7 @@ static IotSerializerError_t _get( IotSerializerDecoderIterator_t iterator,
 
 /*-----------------------------------------------------------*/
 
-static IotSerializerError_t _find( IotSerializerDecoderObject_t * pDecoderObject,
+static IotSerializerError_t _find( const IotSerializerDecoderObject_t * pDecoderObject,
                                    const char * pKey,
                                    IotSerializerDecoderObject_t * pValueObject )
 {
@@ -451,7 +451,7 @@ static IotSerializerError_t _find( IotSerializerDecoderObject_t * pDecoderObject
 
 /*-----------------------------------------------------------*/
 
-static IotSerializerError_t _stepIn( IotSerializerDecoderObject_t * pDecoderObject,
+static IotSerializerError_t _stepIn( const IotSerializerDecoderObject_t * pDecoderObject,
                                      IotSerializerDecoderIterator_t * pIterator )
 {
     IotSerializerError_t returnedError = IOT_SERIALIZER_SUCCESS;
@@ -548,7 +548,7 @@ static bool _isEndOfContainer( IotSerializerDecoderIterator_t iterator )
 }
 /*-----------------------------------------------------------*/
 
-static IotSerializerError_t _getBufferAddress( IotSerializerDecoderObject_t * pDecoderObject,
+static IotSerializerError_t _getBufferAddress( const IotSerializerDecoderObject_t * pDecoderObject,
                                                const uint8_t ** pEncodedDataStartAddr )
 {
     IotSerializer_Assert( pDecoderObject != NULL );
@@ -570,7 +570,7 @@ static IotSerializerError_t _getBufferAddress( IotSerializerDecoderObject_t * pD
 
 /*-----------------------------------------------------------*/
 
-IotSerializerError_t _getSizeOfEncodedData( IotSerializerDecoderObject_t * pDecoderObject,
+IotSerializerError_t _getSizeOfEncodedData( const IotSerializerDecoderObject_t * pDecoderObject,
                                             size_t * pEncodedDataLength )
 {
     IotSerializer_Assert( pDecoderObject != NULL );


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add correctness to serializer decoder interface function signatures by adding `const` qualifications to existing input `IotSerializerDecoderObject_t *` type parameters 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
