### PR TITLE
Ensure that PINGREQ is sent on time when PINGRESP is delayed

### DIFF
--- a/include/aws_iot_mqtt_client.h
+++ b/include/aws_iot_mqtt_client.h
@@ -295,7 +295,8 @@ typedef struct _ClientData {
  *
  */
 struct _Client {
-	Timer pingTimer;
+	Timer pingReqTimer;		/* Timer to keep track of when to send next PINGREQ. */
+	Timer pingRespTimer;	/* Timer to ensure that PINGRESP is received timely. */
 	Timer reconnectDelayTimer;
 
 	ClientStatus clientStatus;

--- a/src/aws_iot_mqtt_client.c
+++ b/src/aws_iot_mqtt_client.c
@@ -274,7 +274,8 @@ IoT_Error_t aws_iot_mqtt_init(AWS_IoT_Client *pClient, IoT_Client_Init_Params *p
 		FUNC_EXIT_RC(rc);
 	}
 
-	init_timer(&(pClient->pingTimer));
+	init_timer(&(pClient->pingReqTimer));
+	init_timer(&(pClient->pingRespTimer));
 	init_timer(&(pClient->reconnectDelayTimer));
 
 	pClient->clientStatus.clientState = CLIENT_STATE_INITIALIZED;

--- a/src/aws_iot_mqtt_client_common_internal.c
+++ b/src/aws_iot_mqtt_client_common_internal.c
@@ -629,8 +629,8 @@ IoT_Error_t aws_iot_mqtt_internal_cycle_read(AWS_IoT_Client *pClient, Timer *pTi
 			/* QoS2 not supported at this time */
 			break;
 		case PINGRESP: {
-			pClient->clientStatus.isPingOutstanding = 0;
-			countdown_sec(&pClient->pingTimer, pClient->clientData.keepAliveInterval);
+			/* There is no outstanding ping request anymore. */
+			pClient->clientStatus.isPingOutstanding = false;
 			break;
 		}
 		default: {

--- a/src/aws_iot_mqtt_client_connect.c
+++ b/src/aws_iot_mqtt_client_connect.c
@@ -437,8 +437,9 @@ static IoT_Error_t _aws_iot_mqtt_internal_connect(AWS_IoT_Client *pClient, IoT_C
 		FUNC_EXIT_RC(connack_rc);
 	}
 
+	/* Ensure that a ping request is sent after keepAliveInterval. */
 	pClient->clientStatus.isPingOutstanding = false;
-	countdown_sec(&pClient->pingTimer, pClient->clientData.keepAliveInterval);
+	countdown_sec(&pClient->pingReqTimer, pClient->clientData.keepAliveInterval);
 
 	FUNC_EXIT_RC(SUCCESS);
 }

--- a/src/aws_iot_mqtt_client_yield.c
+++ b/src/aws_iot_mqtt_client_yield.c
@@ -123,14 +123,27 @@ static IoT_Error_t _aws_iot_mqtt_keep_alive(AWS_IoT_Client *pClient) {
 		FUNC_EXIT_RC(SUCCESS);
 	}
 
-	if(!has_timer_expired(&pClient->pingTimer)) {
-		FUNC_EXIT_RC(SUCCESS);
-	}
-
 	if(pClient->clientStatus.isPingOutstanding) {
-		rc = _aws_iot_mqtt_handle_disconnect(pClient);
-		FUNC_EXIT_RC(rc);
+		/* We are waiting for a PINGRESP from the broker. If the pingRespTimer,
+		 * has expired, it indicates that the transport layer connection is
+		 * lost and therefore, we initiate MQTT disconnect (which will triggger)
+		 * the re-connect workflow, if enabled. If the pingRespTimer is not
+		 * expired, there is nothing to do and we continue waiting for PINGRESP. */
+		if(has_timer_expired(&pClient->pingRespTimer)) {
+			rc = _aws_iot_mqtt_handle_disconnect(pClient);
+			FUNC_EXIT_RC(rc);
+		} else {
+			FUNC_EXIT_RC(SUCCESS);
+		}
+	} else {
+		/* We are not waiting for a PINGRESP from the broker. If the
+		 * pingReqTimer has expired, we send a PINGREQ. Otherwise, there is
+		 * nothing to do. */
+		if(!has_timer_expired(&pClient->pingReqTimer)) {
+			FUNC_EXIT_RC(SUCCESS);
+		}
 	}
+	
 
 	/* there is no ping outstanding - send one */
 	init_timer(&timer);
@@ -152,8 +165,10 @@ static IoT_Error_t _aws_iot_mqtt_keep_alive(AWS_IoT_Client *pClient) {
 	}
 
 	pClient->clientStatus.isPingOutstanding = true;
-	/* start a timer to wait for PINGRESP from server */
-	countdown_sec(&pClient->pingTimer, pClient->clientData.keepAliveInterval);
+	/* Start a timer to wait for PINGRESP from server. */
+	countdown_sec(&pClient->pingRespTimer, pClient->clientData.keepAliveInterval);
+	/* Start a timer to keep track of when to send the next PINGREQ. */
+	countdown_sec(&pClient->pingReqTimer, pClient->clientData.keepAliveInterval);
 
 	FUNC_EXIT_RC(SUCCESS);
 }

--- a/tests/unit/src/aws_iot_tests_unit_yield.cpp
+++ b/tests/unit/src/aws_iot_tests_unit_yield.cpp
@@ -52,3 +52,6 @@ TEST_GROUP_C_WRAPPER(YieldTests, disconnectAutoReconnectSuccess)
 TEST_GROUP_C_WRAPPER(YieldTests, disconnectManualAutoReconnect)
 /* G:12 - Yield, resubscribe to all topics on reconnect */
 TEST_GROUP_C_WRAPPER(YieldTests, resubscribeSuccessfulReconnect)
+
+/* G:13 - Delayed Ping response. */
+TEST_GROUP_C_WRAPPER(YieldTests, delayedPingResponse)


### PR DESCRIPTION
### Problem
The current implementation counts the time to send a PINGREQ from the moment a PINGRESP is received. This can result in a disconnect initiated by the MQTT broker when a PINGRESP is delayed because of network congestion.

###  Detailed Description
In the following examples, the keep alive interval is assumed to be 60 seconds and therefore, AWS IoT Broker will disconnect the client after 1.5x i.e. 90 seconds of inactivity. Consider the following sequence:

```
                 Client          Broker
                    +               +
                    |  1. PINGREQ   |
                 00 +-------------->|
                    |               |
                    |               |
                    |  2. PINGRESP  |
                 50 |<--------------+
                    |               |
                    |               |
                    | 3. DISCONNECT |
                 90 |<--------------+
                    |               |
                    |               |
                    |  4. PINGREQ   |
                110 +-------------->|
                    |               |
                    +               +
```
1. At t=0 seconds, the client sends a PINGREQ.
1. At t=50 seconds, the client receives a PINGRESP from the broker. The client (incorrectly) decides that it will send the next PINGREQ at t=110 (50+60) seconds.
1. At t=90 seconds, the broker determines that the client is dead (because it has not heard from the client since last 90 seconds) and disconnects it.

### Solution
This commit fixes the above unintended disconnect by making sure that the client counts the time to send a PINGREQ from the moment last PINGREQ was sent. In the above mentioned scenario, the sequence will then be:

```
                 Client          Broker
                    +               +
                    |  1. PINGREQ   |
                 00 +-------------->|
                    |               |
                    |               |
                    |  2. PINGRESP  |
                 50 |<--------------+
                    |               |
                    |  3. PINGREQ   |
                 60 +-------------->|
                    |               |
                    +               +
```

1. At t=0 seconds, the client sends a PINGREQ.
1. At t=50 seconds, the client receives a PINGRESP from the broker.
1. At t=60 seconds, the client again sends a PINGREQ as the keep alive interval (which is 60 seconds) has passed since the last PINGREQ was sent.

Signed-off-by: Gaurav Aggarwal <ga286@cornell.edu>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
