### PR TITLE
Avoid null dereferences in IotMqtt_Connect

### DIFF
--- a/libraries/standard/mqtt/src/iot_mqtt_api.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_api.c
@@ -1244,7 +1244,7 @@ IotMqttError_t IotMqtt_Connect( const IotMqttNetworkInfo_t * pNetworkInfo,
         status = IOT_MQTT_NOT_INITIALIZED;
     }
     /* Validate network interface and connect info. */
-    else if( _IotMqtt_ValidateConnect( pConnectInfo ) == false )
+    else if( _IotMqtt_ValidateConnect( pConnectInfo ) == false || pMqttConnection == NULL )
     {
         status = IOT_MQTT_BAD_PARAMETER;
     }

--- a/libraries/standard/mqtt/src/iot_mqtt_validate.c
+++ b/libraries/standard/mqtt/src/iot_mqtt_validate.c
@@ -569,7 +569,9 @@ bool _IotMqtt_ValidateConnect( const IotMqttConnectInfo_t * pConnectInfo )
     bool status = true;
 
     /* Check for NULL. */
-    if( pConnectInfo == NULL )
+    if( pConnectInfo == NULL ||
+      ( pConnectInfo->pUserName == NULL && pConnectInfo->userNameLength != 0 ) ||
+      ( pConnectInfo->pPassword == NULL && pConnectInfo->passwordLength != 0 ) )
     {
         IotLogError( "MQTT connection information cannot be NULL." );
 


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*

In the `IotMqtt_Connect` function, set the status to `IOT_MQTT_BAD_PARAMETER` in case the `pMqttConnection` is null. In the `_IotMqtt_ValidateConnect` function, set the status to `IOT_MQTT_BAD_PARAMETER` in case `pConnectInfo->pUserName` or `pConnectInfo->pPassword` are invalid. These changes will later avoid null dereferences.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.