### PR TITLE
Set mbedTLS version to 2.16.5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,4 @@
 [submodule "third_party/mbedtls/mbedtls"]
 	path = third_party/mbedtls/mbedtls
 	url = https://github.com/ARMmbed/mbedtls.git
+	branch = mbedtls-2.16.5


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Here is the change log between mbedTLS v2.16.0 (Current version) and v2.16.5
# 2.16.1
Features

    (2.16, 2.7) Add MBEDTLS_REMOVE_3DES_CIPHERSUITES to allow removing 3DES ciphersuites from the default list (enabled by default). See https://sweet32.info/SWEET32_CCS16.pdf.

Bugfix

    (2.16) Fix a compilation issue with mbedtls_ecp_restart_ctx not being defined when MBEDTLS_ECP_ALT is defined. Reported by jwhui. Fixes #2242.
    (2.16, 2.7) Run the AD too long test only if MBEDTLS_CCM_ALT is not defined. Raised as a comment in #1996.
    (2.16) Reduce the stack consumption of mbedtls_mpi_fill_random() which could previously lead to a stack overflow on constrained targets.
    (2.16) Add MBEDTLS_SELF_TEST for the mbedtls_self_test functions in the header files, which missed the precompilation check. #971
    (2.16, 2.7) Fix clobber list in MIPS assembly for large integer multiplication. Previously, this could lead to functionally incorrect assembly being produced by some optimizing compilers, showing up as failures in e.g. RSA or ECC signature operations. Reported in #1722, fix suggested by Aurelien Jarno and submitted by Jeffrey Martin.
    (2.16) Fix signed-to-unsigned integer conversion warning in X.509 module. Fixes #2212.
    (2.16, 2.7) Reduce stack usage of mpi_write_hlp() by eliminating recursion. Fixes #2190.
    (2.16, 2.7) Remove a duplicate #include in a sample program. Fixed by Masashi Honma #2326.
    (2.16) Remove the mbedtls namespacing from the header file, to fix a "file not found" build error. Fixed by Haijun Gu #2319.
    (2.16, 2.7) Fix returning the value 1 when mbedtls_ecdsa_genkey() failed.
    (2.16) Fix false failure in all.sh when backup files exist in include/mbedtls (e.g. config.h.bak). Fixed by Peter Kolbus (Garmin) #2407.
    (2.16, 2.7) Ensure that unused bits are zero when writing ASN.1 bitstrings when using mbedtls_asn1_write_bitstring().
    (2.16, 2.7) Fix issue when writing the named bitstrings in KeyUsage and NsCertType extensions in CSRs and CRTs that caused these bitstrings to not be encoded correctly as trailing zeroes were not accounted for as unused bits in the leading content octet. Fixes #1610.

Changes

    (2.16, 2.7) Include configuration file in all header files that use configuration, instead of relying on other header files that they include. Inserted as an enhancement for #1371
    (2.16, 2.7) Add support for alternative CSR headers, as used by Microsoft and defined in RFC 7468. Found by Michael Ernst. Fixes #767.
    (2.16) Fix configuration queries in ssl-opt.h. #2030
    (2.16) Ensure that ssl-opt.h can be run in OS X. #2029
    (2.16, 2.7) Reduce the complexity of the timing tests. They were assuming more than the underlying OS actually guarantees.
    (2.16) Re-enable certain interoperability tests in ssl-opt.sh which had previously been disabled for lack of a sufficiently recent version of GnuTLS on the CI.
    (2.16, 2.7) Ciphersuites based on 3DES now have the lowest priority by default when they are enabled.

# 2.16.2
Security

    (2.16, 2.7) Make mbedtls_ecdh_get_params return an error if the second key belongs to a different group from the first. Before, if an application passed keys that belonged to different group, the first key's data was interpreted according to the second group, which could lead to either an error or a meaningless output from mbedtls_ecdh_get_params. In the latter case, this could expose at most 5 bits of the private key.

Bugfix

    (2.16, 2.7) Server's RSA certificate in certs.c was SHA-1 signed. In the default Mbed TLS configuration only SHA-2 signed certificates are accepted. This certificate is used in the demo server programs, which lead the client programs to fail at the peer's certificate verification due to an unacceptable hash signature. The certificate has been updated to one that is SHA-256 signed. Fix contributed by Illya Gerasymchuk.
    (2.16, 2.7) Fix private key DER output in the key_app_writer example. File contents were shifted by one byte, creating an invalid ASN.1 tag. Fixed by Christian Walther in #2239.
    (2.16, 2.7) Fix potential memory leak in X.509 self test. Found and fixed by Junhwan Park, #2106.
    (2.16) Reduce stack usage of HKDF tests. Fixes #2195.
    (2.16, 2.7) Fix 1-byte buffer overflow in mbedtls_mpi_write_string() when used with negative inputs. Found by Guido Vranken in #2404. Credit to OSS-Fuzz.
    (2.16, 2.7) Fix bugs in the AEAD test suite which would be exposed by ciphers which either used both encrypt and decrypt key schedules, or which perform padding. GCM and CCM were not affected. Fixed by Jack Lloyd.
    (2.16, 2.7) Fix incorrect default port number in ssl_mail_client example's usage. Found and fixed by irwir. #2337
    (2.16, 2.7) Add missing parentheses around parameters in the definition of the public macro MBEDTLS_X509_ID_FLAG. This could lead to invalid evaluation in case operators binding less strongly than subtraction were used for the parameter.
    (2.16, 2.7) Add a check for MBEDTLS_X509_CRL_PARSE_C in ssl_server2, guarding the crl sni entry parameter. Reported by inestlerode in #560.
    (2.16, 2.7) Fix missing bounds checks in X.509 parsing functions that could lead to successful parsing of ill-formed X.509 CRTs. Fixes #2437.
    (2.16, 2.7) Fix multiple X.509 functions previously returning ASN.1 low-level error codes to always wrap these codes into X.509 high level error codes before returning. Fixes #2431.
    (2.16) Add DER-encoded test CRTs to library/certs.c, allowing the example programs ssl_server2 and ssl_client2 to be run if MBEDTLS_FS_IO and MBEDTLS_PEM_PARSE_C are unset. Fixes #2254.

Changes

    (2.16, 2.7) Return from various debugging routines immediately if the provided SSL context is unset.
    (2.16, 2.7) Remove dead code from bignum.c in the default configuration. Found by Coverity, reported and fixed by Peter Kolbus (Garmin). Fixes #2309.
    (2.16, 2.7) Add test for minimal value of MBEDTLS_MPI_WINDOW_SIZE to all.sh. Contributed by Peter Kolbus (Garmin).
    (2.16, 2.7) Change wording in the mbedtls_ssl_conf_max_frag_len()'s documentation to improve clarity. Fixes #2258.
    (2.16, 2.7) Replace multiple uses of MD2 by SHA-256 in X.509 test suite. Fixes #821.
    (2.7) Improve debug output of ssl_client2 and ssl_server2 in case suitable test CRTs are available because MBEDTLS_PEM_PARSE_C is disabled. Fixes #2254.

# 2.16.3
Security

    (2.16, 2.7) Fix a missing error detection in ECJPAKE. This could have caused a predictable shared secret if a hardware accelerator failed and the other side of the key exchange had a similar bug.
    (2.16, 2.7) When writing a private EC key, use a constant size for the private value, as specified in RFC 5915. Previously, the value was written as an ASN.1 INTEGER, which caused the size of the key to leak about 1 bit of information on average and could cause the value to be 1 byte too large for the output buffer.
    (2.16, 2.7) The deterministic ECDSA calculation reused the scheme's HMAC-DRBG to implement blinding. Because of this for the same key and message the same blinding value was generated. This reduced the effectiveness of the countermeasure and leaked information about the private key through side channels. Reported by Jack Lloyd.

API Changes

    (2.16, 2.7) The new function mbedtls_ecdsa_sign_det_ext() is similar to mbedtls_ecdsa_sign_det() but allows passing an external RNG for the purpose of blinding.
    (2.7) The new function mbedtls_ecp_gen_privkey() allows to generate a private key without generating the public part of the pair.

Bugfix

    (2.16, 2.7) Fix to allow building test suites with any warning that detects unused functions. Fixes #1628.
    (2.16, 2.7) Fix typo in net_would_block(). Fixes #528 reported by github-monoculture.
    (2.16, 2.7) Remove redundant include file in timing.c. Fixes #2640 reported by irwir.
    (2.16, 2.7) Fix Visual Studio Release x64 build configuration by inheriting PlatformToolset from the project configuration. Fixes #1430 reported by irwir.
    (2.16, 2.7) Enable Suite B with subset of ECP curves. Make sure the code compiles even if some curves are not defined. Fixes #1591 reported by dbedev.
    (2.16, 2.7) Fix misuse of signed arithmetic in the HAVEGE module. #2598
    (2.16, 2.7) Update test certificates that were about to expire. Reported by Bernhard M. Wiedemann in #2357.
    (2.16) Fix the build on ARMv5TE in ARM mode to not use assembly instructions that are only available in Thumb mode. Fix contributed by Aurelien Jarno in #2169.
    (2.16) Fix propagation of restart contexts in restartable EC operations. This could previously lead to segmentation faults in builds using an address-sanitizer and enabling but not using MBEDTLS_ECP_RESTARTABLE.
    (2.16, 2.7) Fix memory leak in in mpi_miller_rabin(). Contributed by Jens Wiklander jens.wiklander@linaro.org in #2363.
    (2.16) Improve code clarity in x509_crt module, removing false-positive uninitialized variable warnings on some recent toolchains (GCC8, etc). Discovered and fixed by Andy Gross (Linaro), #2392.
    (2.16) Fix bug in endianness conversion in bignum module. This lead to functionally incorrect code on bigendian systems which don't have BYTE_ORDER defined. Reported by Brendan Shanks. Fixes #2622.
    (2.16) Fix undefined memset(NULL) call in test_suite_nist_kw.
    (2.16, 2.7) Make NV seed test support MBEDTLS_ENTROPY_FORCE_SHA256.
    (2.16) Zero length buffer check for undefined behavior in mbedtls_platform_zeroize(). Fixes ARMmbed/mbed-crypto#49.

# 2.16.5
Mbed TLS 2.16.5 is a maintenance release of the Mbed TLS 2.16 branch, and provides bug fixes and minor enhancements. This release brings fixes for a security issue, as described in more detail in our security advisory.
Security

    Fix potential memory overread when performing an ECDSA signature operation. The overread only happens with cryptographically low probability (of the order of 2^-n where n is the bitsize of the curve) unless the RNG is broken, and could result in information disclosure or denial of service (application crash or extra resource consumption). Found by Auke Zeilstra and Peter Schwabe, using static analysis.
    To avoid a side channel vulnerability when parsing an RSA private key, read all the CRT parameters from the DER structure rather than reconstructing them. Found by Alejandro Cabrera Aldaya and Billy Bob Brumley. Reported and fix contributed by Jack Lloyd. ARMmbed/mbed-crypto#352

Bugfix

    Fix an unchecked call to mbedtls_md() in the x509write module.
    Fix a bug in mbedtls_pk_parse_key() that would cause it to accept some RSA keys that would later be rejected by functions expecting private keys. Found by Catena cyber using oss-fuzz (issue 20467).
    Fix a bug in mbedtls_pk_parse_key() that would cause it to accept some RSA keys with invalid values by silently fixing those values.


Changes

    (2.16) Make it easier to define MBEDTLS_PARAM_FAILED as assert (which config.h suggests). #2671
    (2.16, 2.7) Make make clean clean all programs always. Fixes #1862.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
