### PR TITLE
Add back to CBMC Makefiles definitions for CI

### DIFF
--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -155,7 +155,17 @@ veryclean: clean
 ################################################################
 # Build configuration file to run cbmc under cbmc-batch in CI
 
-CBMC_FLAGS =  '$(call encode_options,$(CBMCFLAGS))'
+JOBOS ?= ubuntu16
+PROOFMEM ?= 32000
+
+define yaml_encode_options
+       "$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')"
+endef
+
+define encode_options
+       '=$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')='
+endef
+
 cbmc-batch.yaml: Makefile ../Makefile.common
 	@echo "Building $@"
 	@$(RM) $@


### PR DESCRIPTION
Add back to CBMC Makefile some definitions needed for CI that were deleted in https://github.com/aws/aws-iot-device-sdk-embedded-C/pull/861.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
