### PR TITLE
Add CBMC proof for MQTT ReceiveCallback

### DIFF
--- a/cbmc/.gitignore
+++ b/cbmc/.gitignore
@@ -1,2 +1,6 @@
 *.csv
 *.log
+__pycache__
+.ninja_deps
+.ninja_log
+build.ninja

--- a/cbmc/patches/Stub-network-function-pointers.patch
+++ b/cbmc/patches/Stub-network-function-pointers.patch
@@ -1,0 +1,48 @@
+diff --git a/libraries/standard/mqtt/src/iot_mqtt_network.c b/libraries/standard/mqtt/src/iot_mqtt_network.c
+index f39eb98..6b7d13d 100644
+--- a/libraries/standard/mqtt/src/iot_mqtt_network.c
++++ b/libraries/standard/mqtt/src/iot_mqtt_network.c
+@@ -281,6 +281,10 @@ static IotMqttError_t _allocateAndReceivePacket( IotNetworkConnection_t pNetwork
+ 
+         if( status == IOT_MQTT_SUCCESS )
+         {
++#ifdef CBMC
++	  assert( IS_STUBBED_NETWORKIF_RECEIVE( pMqttConnection->pNetworkInterface ) );
++	  __CPROVER_assume( IS_STUBBED_NETWORKIF_RECEIVE( pMqttConnection->pNetworkInterface ) );
++#endif
+             dataBytesRead = pMqttConnection->pNetworkInterface->receive( pNetworkConnection,
+                                                                          pIncomingPacket->pRemainingData,
+                                                                          pIncomingPacket->remainingLength );
+@@ -701,6 +705,10 @@ bool _IotMqtt_GetNextByte( IotNetworkConnection_t pNetworkConnection,
+     size_t bytesReceived = 0;
+ 
+     /* Attempt to read 1 byte. */
++#ifdef CBMC
++    assert( IS_STUBBED_NETWORKIF_RECEIVE( pNetworkInterface ) );
++    __CPROVER_assume( IS_STUBBED_NETWORKIF_RECEIVE( pNetworkInterface ) );
++#endif
+     bytesReceived = pNetworkInterface->receive( pNetworkConnection,
+                                                 &incomingByte,
+                                                 1 );
+@@ -792,6 +800,10 @@ void _IotMqtt_CloseNetworkConnection( IotMqttDisconnectReason_t disconnectReason
+     /* Close the network connection. */
+     if( closeConnection != NULL )
+     {
++#ifdef CBMC
++      assert( closeConnection == IotNetworkInterfaceClose );
++    __CPROVER_assume( closeConnection == IotNetworkInterfaceClose );
++#endif
+         closeStatus = closeConnection( pNetworkConnection );
+ 
+         if( closeStatus == IOT_NETWORK_SUCCESS )
+@@ -818,6 +830,10 @@ void _IotMqtt_CloseNetworkConnection( IotMqttDisconnectReason_t disconnectReason
+         callbackParam.mqttConnection = pMqttConnection;
+         callbackParam.u.disconnectReason = disconnectReason;
+ 
++#ifdef CBMC
++	assert( IS_STUBBED_USER_CALLBACK( disconnectCallback ) );
++	__CPROVER_assume( IS_STUBBED_USER_CALLBACK( disconnectCallback ) );
++#endif
+         disconnectCallback( pDisconnectCallbackContext,
+                             &callbackParam );
+     }

--- a/cbmc/patches/bound-packet-remaining-length.patch
+++ b/cbmc/patches/bound-packet-remaining-length.patch
@@ -1,0 +1,17 @@
+diff --git a/libraries/standard/mqtt/src/iot_mqtt_network.c b/libraries/standard/mqtt/src/iot_mqtt_network.c
+index f39eb98..805eca7 100644
+--- a/libraries/standard/mqtt/src/iot_mqtt_network.c
++++ b/libraries/standard/mqtt/src/iot_mqtt_network.c
+@@ -256,6 +256,12 @@ static IotMqttError_t _allocateAndReceivePacket( IotNetworkConnection_t pNetwork
+     IotMqtt_Assert( pMqttConnection != NULL );
+     IotMqtt_Assert( pIncomingPacket != NULL );
+
++#ifdef CBMC
++#ifdef REMAINING_LENGTH_BOUND
++    __CPROVER_assume( pIncomingPacket->remainingLength < REMAINING_LENGTH_BOUND );
++#endif
++#endif
++
+     /* Allocate a buffer for the remaining data and read the data. */
+     if( pIncomingPacket->remainingLength > 0U )
+     {

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_CONNACK/Makefile
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_CONNACK/Makefile
@@ -1,0 +1,32 @@
+PACKET=CONNACK
+
+ENTRY=IotMqtt_ReceiveCallback
+MQTT = $(abspath ../../../..)
+
+################################################################
+# Functions made unreachable by the case split
+
+#ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializeConnack
+ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializePuback
+ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializeSuback
+ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializeUnsuback
+
+ABSTRACTIONS += --remove-function-body _deserializePingResp
+ABSTRACTIONS += --remove-function-body _deserializePublishPacket
+
+################################################################
+# Functions the solver can prove are unreachable
+
+ABSTRACTIONS += --remove-function-body Atomic_CompareAndSwap_u32
+ABSTRACTIONS += --remove-function-body Atomic_CompareAndSwap_u32
+ABSTRACTIONS += --remove-function-body IotNetworkInterfaceDestroy
+ABSTRACTIONS += --remove-function-body IotNetworkInterfaceSend
+ABSTRACTIONS += --remove-function-body _matchEndWildcards
+ABSTRACTIONS += --remove-function-body _matchWildcards
+ABSTRACTIONS += --remove-function-body _mqttSubscription_setUnsubscribe
+ABSTRACTIONS += --remove-function-body _packetMatch
+ABSTRACTIONS += --remove-function-body _topicFilterMatch
+ABSTRACTIONS += --remove-function-body _topicMatch
+
+include ../Makefile
+include ../../Makefile.common

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_CONNACK/cbmc-batch.yaml
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_CONNACK/cbmc-batch.yaml
@@ -1,0 +1,8 @@
+build_memory: 32000
+cbmcflags: "--flush;--object-bits;8;--unwind;1;--unwindset;IotListDouble_FindFirstMatch.0:2,IotListDouble_FindFirstMatch$link1.0:2,IotListDouble_FindFirstMatch$link2.0:2,IotListDouble_FindFirstMatch$link3.0:2,IotListDouble_FindFirstMatch$link4.0:2,IotListDouble_FindFirstMatch$link5.0:2,_IotMqtt_GetRemainingLength.0:5,_decodeSubackStatus.0:15,valid_IotMqttOperationList.0:2,valid_IotMqttSubscriptionList.0:2;--object-bits;8;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--flush;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
+coverage_memory: 32000
+expected: SUCCESSFUL
+goto: IotMqtt_ReceiveCallback.goto
+jobos: ubuntu16
+property_memory: 32000
+report_memory: 32000

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_CONNACK/cbmc-viewer.json
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_CONNACK/cbmc-viewer.json
@@ -1,0 +1,24 @@
+{ "expected-missing-functions":
+  [
+    "IotLog_Generic",
+    "IotMqtt_Wait",
+    "IotMutex_Create",
+    "IotMutex_Destroy",
+    "IotMutex_Lock",
+    "IotMutex_Unlock",
+    "IotSemaphore_Create",
+    "IotSemaphore_Destroy",
+    "IotSemaphore_Post",
+    "IotSemaphore_TimedWait",
+    "IotSemaphore_Wait",
+    "IotTaskPool_CreateJob",
+    "IotTaskPool_GetSystemTaskPool",
+    "IotTaskPool_ScheduleDeferred",
+    "IotTaskPool_strerror",
+    "IotTaskPool_TryCancel",
+    "Iot_EnterCritical",
+    "Iot_ExitCritical"
+  ],
+  "proof-name": "IotMqtt_ReceiveCallback_CONNACK",
+  "proof-root": "cbmc/proofs"
+}

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_OTHER/Makefile
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_OTHER/Makefile
@@ -1,0 +1,37 @@
+# Leave PACKET undefined for the OTHER case.
+#PACKET=
+
+# Note: We should be able to abstract all of the functions below, but
+# symbolic execution wants _deserializePublishPacket for the OTHER
+# case.  The constraint solver is able to prove that the function is
+# unreachable in the OTHER case.
+
+ENTRY=IotMqtt_ReceiveCallback
+MQTT = $(abspath ../../../..)
+
+################################################################
+# Functions made unreachable by the case split
+
+ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializeConnack
+ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializePuback
+ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializeSuback
+ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializeUnsuback
+
+ABSTRACTIONS += --remove-function-body _deserializeAck
+ABSTRACTIONS += --remove-function-body _deserializePublishPacket
+
+################################################################
+# Functions the solver can prove are unreachable
+
+ABSTRACTIONS += --remove-function-body IotNetworkInterfaceDestroy
+ABSTRACTIONS += --remove-function-body IotNetworkInterfaceSend
+ABSTRACTIONS += --remove-function-body _matchEndWildcards
+ABSTRACTIONS += --remove-function-body _matchWildcards
+ABSTRACTIONS += --remove-function-body _mqttOperation_match
+ABSTRACTIONS += --remove-function-body _mqttSubscription_setUnsubscribe
+ABSTRACTIONS += --remove-function-body _packetMatch
+ABSTRACTIONS += --remove-function-body _topicFilterMatch
+ABSTRACTIONS += --remove-function-body _topicMatch
+
+include ../Makefile
+include ../../Makefile.common

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_OTHER/cbmc-batch.yaml
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_OTHER/cbmc-batch.yaml
@@ -1,0 +1,8 @@
+build_memory: 32000
+cbmcflags: "--flush;--object-bits;8;--unwind;1;--unwindset;IotListDouble_FindFirstMatch.0:2,IotListDouble_FindFirstMatch$link1.0:2,IotListDouble_FindFirstMatch$link2.0:2,IotListDouble_FindFirstMatch$link3.0:2,IotListDouble_FindFirstMatch$link4.0:2,IotListDouble_FindFirstMatch$link5.0:2,_IotMqtt_GetRemainingLength.0:5,_decodeSubackStatus.0:15,valid_IotMqttOperationList.0:2,valid_IotMqttSubscriptionList.0:2;--object-bits;8;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--flush;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
+coverage_memory: 32000
+expected: SUCCESSFUL
+goto: IotMqtt_ReceiveCallback.goto
+jobos: ubuntu16
+property_memory: 32000
+report_memory: 32000

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_OTHER/cbmc-viewer.json
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_OTHER/cbmc-viewer.json
@@ -1,0 +1,24 @@
+{ "expected-missing-functions":
+  [
+    "IotLog_Generic",
+    "IotMqtt_Wait",
+    "IotMutex_Create",
+    "IotMutex_Destroy",
+    "IotMutex_Lock",
+    "IotMutex_Unlock",
+    "IotSemaphore_Create",
+    "IotSemaphore_Destroy",
+    "IotSemaphore_Post",
+    "IotSemaphore_TimedWait",
+    "IotSemaphore_Wait",
+    "IotTaskPool_CreateJob",
+    "IotTaskPool_GetSystemTaskPool",
+    "IotTaskPool_ScheduleDeferred",
+    "IotTaskPool_strerror",
+    "IotTaskPool_TryCancel",
+    "Iot_EnterCritical",
+    "Iot_ExitCritical"
+  ],
+  "proof-name": "IotMqtt_ReceiveCallback_OTHER",
+  "proof-root": "cbmc/proofs"
+}

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_PUBACK/Makefile
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_PUBACK/Makefile
@@ -1,0 +1,32 @@
+PACKET=PUBACK
+
+ENTRY=IotMqtt_ReceiveCallback
+MQTT = $(abspath ../../../..)
+
+################################################################
+# Functions made unreachable by the case split
+
+ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializeConnack
+#ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializePuback
+ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializeSuback
+ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializeUnsuback
+
+ABSTRACTIONS += --remove-function-body _deserializePingResp
+ABSTRACTIONS += --remove-function-body _deserializePublishPacket
+
+################################################################
+# Functions the solver can prove are unreachable
+
+ABSTRACTIONS += --remove-function-body Atomic_CompareAndSwap_u32
+ABSTRACTIONS += --remove-function-body Atomic_CompareAndSwap_u32
+ABSTRACTIONS += --remove-function-body IotNetworkInterfaceDestroy
+ABSTRACTIONS += --remove-function-body IotNetworkInterfaceSend
+ABSTRACTIONS += --remove-function-body _matchEndWildcards
+ABSTRACTIONS += --remove-function-body _matchWildcards
+ABSTRACTIONS += --remove-function-body _mqttSubscription_setUnsubscribe
+ABSTRACTIONS += --remove-function-body _packetMatch
+ABSTRACTIONS += --remove-function-body _topicFilterMatch
+ABSTRACTIONS += --remove-function-body _topicMatch
+
+include ../Makefile
+include ../../Makefile.common

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_PUBACK/cbmc-batch.yaml
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_PUBACK/cbmc-batch.yaml
@@ -1,0 +1,8 @@
+build_memory: 32000
+cbmcflags: "--flush;--object-bits;8;--unwind;1;--unwindset;IotListDouble_FindFirstMatch.0:2,IotListDouble_FindFirstMatch$link1.0:2,IotListDouble_FindFirstMatch$link2.0:2,IotListDouble_FindFirstMatch$link3.0:2,IotListDouble_FindFirstMatch$link4.0:2,IotListDouble_FindFirstMatch$link5.0:2,_IotMqtt_GetRemainingLength.0:5,_decodeSubackStatus.0:15,valid_IotMqttOperationList.0:2,valid_IotMqttSubscriptionList.0:2;--object-bits;8;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--flush;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
+coverage_memory: 32000
+expected: SUCCESSFUL
+goto: IotMqtt_ReceiveCallback.goto
+jobos: ubuntu16
+property_memory: 32000
+report_memory: 32000

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_PUBACK/cbmc-viewer.json
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_PUBACK/cbmc-viewer.json
@@ -1,0 +1,24 @@
+{ "expected-missing-functions":
+  [
+    "IotLog_Generic",
+    "IotMqtt_Wait",
+    "IotMutex_Create",
+    "IotMutex_Destroy",
+    "IotMutex_Lock",
+    "IotMutex_Unlock",
+    "IotSemaphore_Create",
+    "IotSemaphore_Destroy",
+    "IotSemaphore_Post",
+    "IotSemaphore_TimedWait",
+    "IotSemaphore_Wait",
+    "IotTaskPool_CreateJob",
+    "IotTaskPool_GetSystemTaskPool",
+    "IotTaskPool_ScheduleDeferred",
+    "IotTaskPool_strerror",
+    "IotTaskPool_TryCancel",
+    "Iot_EnterCritical",
+    "Iot_ExitCritical"
+  ],
+  "proof-name": "IotMqtt_ReceiveCallback_PUBACK",
+  "proof-root": "cbmc/proofs"
+}

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_PUBLISH/Makefile
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_PUBLISH/Makefile
@@ -1,0 +1,41 @@
+PACKET=PUBLISH
+
+ENTRY=IotMqtt_ReceiveCallback
+MQTT = $(abspath ../../../..)
+
+################################################################
+# Functions made unreachable by the case split
+
+ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializeConnack
+ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializePuback
+ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializeSuback
+ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializeUnsuback
+
+ABSTRACTIONS += --remove-function-body _deserializeAck
+ABSTRACTIONS += --remove-function-body _deserializePingResp
+
+################################################################
+# Functions the solver can prove are unreachable
+
+ABSTRACTIONS += --remove-function-body Atomic_CompareAndSwap_u32
+ABSTRACTIONS += --remove-function-body Atomic_CompareAndSwap_u32
+ABSTRACTIONS += --remove-function-body IotListDouble_FindFirstMatch
+ABSTRACTIONS += --remove-function-body IotNetworkInterfaceDestroy
+ABSTRACTIONS += --remove-function-body IotNetworkInterfaceSend
+ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializePingresp
+ABSTRACTIONS += --remove-function-body _IotMqtt_FindOperation
+ABSTRACTIONS += --remove-function-body _IotMqtt_Notify
+ABSTRACTIONS += --remove-function-body _matchEndWildcards
+ABSTRACTIONS += --remove-function-body _matchWildcards
+ABSTRACTIONS += --remove-function-body _mqttOperation_match
+ABSTRACTIONS += --remove-function-body _mqttSubscription_setUnsubscribe
+ABSTRACTIONS += --remove-function-body _packetMatch
+ABSTRACTIONS += --remove-function-body _topicFilterMatch
+ABSTRACTIONS += --remove-function-body _topicMatch
+ABSTRACTIONS += --remove-function-body destroy_operation_list
+ABSTRACTIONS += --remove-function-body destroy_operation_list_element
+ABSTRACTIONS += --remove-function-body destroy_subscription_list
+ABSTRACTIONS += --remove-function-body destroy_subscription_list_element
+
+include ../Makefile
+include ../../Makefile.common

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_PUBLISH/cbmc-batch.yaml
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_PUBLISH/cbmc-batch.yaml
@@ -1,0 +1,8 @@
+build_memory: 32000
+cbmcflags: "--flush;--object-bits;8;--unwind;1;--unwindset;IotListDouble_FindFirstMatch.0:2,IotListDouble_FindFirstMatch$link1.0:2,IotListDouble_FindFirstMatch$link2.0:2,IotListDouble_FindFirstMatch$link3.0:2,IotListDouble_FindFirstMatch$link4.0:2,IotListDouble_FindFirstMatch$link5.0:2,_IotMqtt_GetRemainingLength.0:5,_decodeSubackStatus.0:15,valid_IotMqttOperationList.0:2,valid_IotMqttSubscriptionList.0:2;--object-bits;8;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--flush;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
+coverage_memory: 32000
+expected: SUCCESSFUL
+goto: IotMqtt_ReceiveCallback.goto
+jobos: ubuntu16
+property_memory: 32000
+report_memory: 32000

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_PUBLISH/cbmc-viewer.json
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_PUBLISH/cbmc-viewer.json
@@ -1,0 +1,24 @@
+{ "expected-missing-functions":
+  [
+    "IotLog_Generic",
+    "IotMqtt_Wait",
+    "IotMutex_Create",
+    "IotMutex_Destroy",
+    "IotMutex_Lock",
+    "IotMutex_Unlock",
+    "IotSemaphore_Create",
+    "IotSemaphore_Destroy",
+    "IotSemaphore_Post",
+    "IotSemaphore_TimedWait",
+    "IotSemaphore_Wait",
+    "IotTaskPool_CreateJob",
+    "IotTaskPool_GetSystemTaskPool",
+    "IotTaskPool_ScheduleDeferred",
+    "IotTaskPool_strerror",
+    "IotTaskPool_TryCancel",
+    "Iot_EnterCritical",
+    "Iot_ExitCritical"
+  ],
+  "proof-name": "IotMqtt_ReceiveCallback_PUBLISH",
+  "proof-root": "cbmc/proofs"
+}

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_SUBACK/Makefile
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_SUBACK/Makefile
@@ -1,0 +1,33 @@
+PACKET=SUBACK
+
+ENTRY=IotMqtt_ReceiveCallback
+MQTT = $(abspath ../../../..)
+
+################################################################
+# Functions made unreachable by the case split
+
+ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializeConnack
+ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializePuback
+#ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializeSuback
+ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializeUnsuback
+
+ABSTRACTIONS += --remove-function-body _deserializePingResp
+ABSTRACTIONS += --remove-function-body _deserializePublishPacket
+
+################################################################
+# Functions the solver can prove are unreachable
+
+ABSTRACTIONS += --remove-function-body Atomic_CompareAndSwap_u32
+ABSTRACTIONS += --remove-function-body Atomic_CompareAndSwap_u32
+ABSTRACTIONS += --remove-function-body IotNetworkInterfaceDestroy
+ABSTRACTIONS += --remove-function-body IotNetworkInterfaceSend
+ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializePingresp
+ABSTRACTIONS += --remove-function-body _matchEndWildcards
+ABSTRACTIONS += --remove-function-body _matchWildcards
+ABSTRACTIONS += --remove-function-body _mqttSubscription_setUnsubscribe
+ABSTRACTIONS += --remove-function-body _packetMatch
+ABSTRACTIONS += --remove-function-body _topicFilterMatch
+ABSTRACTIONS += --remove-function-body _topicMatch
+
+include ../Makefile
+include ../../Makefile.common

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_SUBACK/cbmc-batch.yaml
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_SUBACK/cbmc-batch.yaml
@@ -1,0 +1,8 @@
+build_memory: 32000
+cbmcflags: "--flush;--object-bits;8;--unwind;1;--unwindset;IotListDouble_FindFirstMatch.0:2,IotListDouble_FindFirstMatch$link1.0:2,IotListDouble_FindFirstMatch$link2.0:2,IotListDouble_FindFirstMatch$link3.0:2,IotListDouble_FindFirstMatch$link4.0:2,IotListDouble_FindFirstMatch$link5.0:2,_IotMqtt_GetRemainingLength.0:5,_decodeSubackStatus.0:15,valid_IotMqttOperationList.0:2,valid_IotMqttSubscriptionList.0:2;--object-bits;8;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--flush;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
+coverage_memory: 32000
+expected: SUCCESSFUL
+goto: IotMqtt_ReceiveCallback.goto
+jobos: ubuntu16
+property_memory: 32000
+report_memory: 32000

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_SUBACK/cbmc-viewer.json
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_SUBACK/cbmc-viewer.json
@@ -1,0 +1,24 @@
+{ "expected-missing-functions":
+  [
+    "IotLog_Generic",
+    "IotMqtt_Wait",
+    "IotMutex_Create",
+    "IotMutex_Destroy",
+    "IotMutex_Lock",
+    "IotMutex_Unlock",
+    "IotSemaphore_Create",
+    "IotSemaphore_Destroy",
+    "IotSemaphore_Post",
+    "IotSemaphore_TimedWait",
+    "IotSemaphore_Wait",
+    "IotTaskPool_CreateJob",
+    "IotTaskPool_GetSystemTaskPool",
+    "IotTaskPool_ScheduleDeferred",
+    "IotTaskPool_strerror",
+    "IotTaskPool_TryCancel",
+    "Iot_EnterCritical",
+    "Iot_ExitCritical"
+  ],
+  "proof-name": "IotMqtt_ReceiveCallback_SUBACK",
+  "proof-root": "cbmc/proofs"
+}

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_UNSUBACK/Makefile
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_UNSUBACK/Makefile
@@ -1,0 +1,33 @@
+PACKET=UNSUBACK
+
+ENTRY=IotMqtt_ReceiveCallback
+MQTT = $(abspath ../../../..)
+
+################################################################
+# Functions made unreachable by the case split
+
+ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializeConnack
+ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializePuback
+ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializeSuback
+#ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializeUnsuback
+
+ABSTRACTIONS += --remove-function-body _deserializePingResp
+ABSTRACTIONS += --remove-function-body _deserializePublishPacket
+
+################################################################
+# Functions the solver can prove are unreachable
+
+ABSTRACTIONS += --remove-function-body Atomic_CompareAndSwap_u32
+ABSTRACTIONS += --remove-function-body Atomic_CompareAndSwap_u32
+ABSTRACTIONS += --remove-function-body IotNetworkInterfaceDestroy
+ABSTRACTIONS += --remove-function-body IotNetworkInterfaceSend
+ABSTRACTIONS += --remove-function-body _IotMqtt_DeserializePingresp
+ABSTRACTIONS += --remove-function-body _matchEndWildcards
+ABSTRACTIONS += --remove-function-body _matchWildcards
+ABSTRACTIONS += --remove-function-body _mqttSubscription_setUnsubscribe
+ABSTRACTIONS += --remove-function-body _packetMatch
+ABSTRACTIONS += --remove-function-body _topicFilterMatch
+ABSTRACTIONS += --remove-function-body _topicMatch
+
+include ../Makefile
+include ../../Makefile.common

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_UNSUBACK/cbmc-batch.yaml
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_UNSUBACK/cbmc-batch.yaml
@@ -1,0 +1,8 @@
+build_memory: 32000
+cbmcflags: "--flush;--object-bits;8;--unwind;1;--unwindset;IotListDouble_FindFirstMatch.0:2,IotListDouble_FindFirstMatch$link1.0:2,IotListDouble_FindFirstMatch$link2.0:2,IotListDouble_FindFirstMatch$link3.0:2,IotListDouble_FindFirstMatch$link4.0:2,IotListDouble_FindFirstMatch$link5.0:2,_IotMqtt_GetRemainingLength.0:5,_decodeSubackStatus.0:15,valid_IotMqttOperationList.0:2,valid_IotMqttSubscriptionList.0:2;--object-bits;8;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--flush;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
+coverage_memory: 32000
+expected: SUCCESSFUL
+goto: IotMqtt_ReceiveCallback.goto
+jobos: ubuntu16
+property_memory: 32000
+report_memory: 32000

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_UNSUBACK/cbmc-viewer.json
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_UNSUBACK/cbmc-viewer.json
@@ -1,0 +1,24 @@
+{ "expected-missing-functions":
+  [
+    "IotLog_Generic",
+    "IotMqtt_Wait",
+    "IotMutex_Create",
+    "IotMutex_Destroy",
+    "IotMutex_Lock",
+    "IotMutex_Unlock",
+    "IotSemaphore_Create",
+    "IotSemaphore_Destroy",
+    "IotSemaphore_Post",
+    "IotSemaphore_TimedWait",
+    "IotSemaphore_Wait",
+    "IotTaskPool_CreateJob",
+    "IotTaskPool_GetSystemTaskPool",
+    "IotTaskPool_ScheduleDeferred",
+    "IotTaskPool_strerror",
+    "IotTaskPool_TryCancel",
+    "Iot_EnterCritical",
+    "Iot_ExitCritical"
+  ],
+  "proof-name": "IotMqtt_ReceiveCallback_UNSUBACK",
+  "proof-root": "cbmc/proofs"
+}

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_harness.c
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/IotMqtt_ReceiveCallback_harness.c
@@ -1,0 +1,352 @@
+#include "iot_config.h"
+#include "private/iot_mqtt_internal.h"
+
+#include <stdlib.h>
+
+#include "mqtt_state.h"
+
+/****************************************************************
+* This proof works by splitting into cases based on incoming packet
+* type.  There are six valid incoming packet types:
+*
+*     MQTT_PACKET_TYPE_CONNACK
+*     MQTT_PACKET_TYPE_PUBLISH
+*     MQTT_PACKET_TYPE_PUBACK
+*     MQTT_PACKET_TYPE_SUBACK
+*     MQTT_PACKET_TYPE_UNSUBACK
+* and
+*     MQTT_PACKET_TYPE_PINGRESP
+*
+* We split these cases into the first 5 and everything else by
+* modifying the function that reads the byte from the network
+* connection that includes the packet type.  This byte consists of 4
+* bits giving the packet type and 4 bits giving the packet flags like
+* quality of service.
+*
+* Note: We break coding conventions by placing this function at the
+* head of the proof harness because it is the heart of the proof and
+* explains what is going on.
+****************************************************************/
+
+uint8_t _IotMqtt_GetPacketType( IotNetworkConnection_t pNetworkConnection,
+                                const IotNetworkInterface_t * pNetworkInterface )
+{
+    uint8_t byte;
+
+    /* Top 4 bits are packet type, the bottom 4 bits are flags */
+    uint8_t type = byte & 0xf0U;
+
+    #ifdef CBMC_PACKET
+        __CPROVER_assume( type == CBMC_PACKET );
+        assert( type == MQTT_PACKET_TYPE_CONNACK ||
+		type == MQTT_PACKET_TYPE_PUBLISH ||
+		type == MQTT_PACKET_TYPE_PUBACK ||
+		type == MQTT_PACKET_TYPE_SUBACK ||
+		type == MQTT_PACKET_TYPE_UNSUBACK );
+    #else
+        __CPROVER_assume( type != MQTT_PACKET_TYPE_CONNACK &&
+                          type != MQTT_PACKET_TYPE_PUBLISH &&
+                          type != MQTT_PACKET_TYPE_PUBACK &&
+                          type != MQTT_PACKET_TYPE_SUBACK &&
+                          type != MQTT_PACKET_TYPE_UNSUBACK );
+    #endif
+
+    return byte;
+}
+
+/****************************************************************
+ * Type definitions used by the IoT List Double remove functions
+ ****************************************************************/
+
+typedef bool ( *MatchFunction_t )( const IotLink_t * const pOperationLink,
+                                   void * pCompare );
+typedef void ( *FreeElementFunction_t )( void * pData );
+
+/****************************************************************
+ * We assume the IoT List Double remove functions are memory safe.
+ *
+ * We abstract the list remove functions for performance reasons.  Our
+ * abstraction replaces the original list with an unconstrained list.
+ * Our abstraction proves that none of the elements on the original
+ * list are accessed after the remove: We free all elements on the
+ * original list, so that any later access will be caught as a
+ * use-after-free error.
+ ****************************************************************/
+
+void IotListDouble_RemoveAllMatches( const IotListDouble_t * const pList,
+                                     MatchFunction_t isMatch,
+                                     void * pMatch,
+                                     FreeElementFunction_t freeElement,
+                                     size_t linkOffset )
+{
+    free_IotMqttSubscriptionList( pList );
+    allocate_IotMqttSubscriptionList( pList, SUBSCRIPTION_COUNT_MAX - 1 );
+}
+
+/****************************************************************/
+
+void IotListDouble_RemoveAll( const IotListDouble_t * const pList,
+                              FreeElementFunction_t freeElement,
+                              size_t linkOffset )
+{
+    free_IotMqttSubscriptionList( pList );
+    allocate_IotMqttSubscriptionList( pList, SUBSCRIPTION_COUNT_MAX - 1 );
+}
+
+/****************************************************************
+* We assume the TaskPool functions are memory safe.
+*
+* We abstract the task pool functions (we assume they have no side
+* effects and return an unconstrained value), but there are some
+* assertions in the code that the task pool functions return a
+* constrained set of values.  We model these functions as simply
+* returning one of those values.
+****************************************************************/
+
+IotTaskPoolError_t IotTaskPool_CreateJob( const IotTaskPoolRoutine_t userCallback,
+                                          void * const pUserContext,
+                                          IotTaskPoolJob_t * const pJob )
+{
+    /*
+     * *_IotMqtt_ScheduleOperation says creating a new job should
+     * never fail when parameters are valid.
+     */
+    return IOT_TASKPOOL_SUCCESS;
+}
+
+/****************************************************************/
+
+IotTaskPoolError_t IotTaskPool_ScheduleDeferred( IotTaskPool_t * const pTaskPool,
+                                                 IotTaskPoolJob_t * const pJob,
+                                                 uint32_t timeMs )
+{
+    /*
+     * *_IotMqtt_ScheduleOperation says a newly created job should
+     * never be invalid or illegal.
+     */
+    IotTaskPoolError_t error;
+
+    __CPROVER_assume( error != IOT_TASKPOOL_BAD_PARAMETER );
+    __CPROVER_assume( error != IOT_TASKPOOL_ILLEGAL_OPERATION );
+    return error;
+}
+
+/****************************************************************
+* We abstract the Notify method by assuming it havocs subscription and
+* operation lists.
+*
+* These functions are used to havoc the lists.  The lists are written
+* and then never again read.  We model these updates by simply freeing
+* the lists, and trusting CBMC to flag a use-after-free error if an
+* element of the list is accessed.
+****************************************************************/
+
+void * invalid_pointer();
+
+IotListDouble_t * destroy_subscription_list_element( IotListDouble_t * pElt )
+{
+    if( pElt == NULL )
+    {
+        return NULL;
+    }
+
+    IotListDouble_t * pNext = pElt->pNext;
+    free( IotLink_Container( _mqttSubscription_t, pElt, link ) );
+    return pNext;
+}
+
+void destroy_subscription_list( IotListDouble_t * pList )
+{
+    if( pList == NULL )
+    {
+        return;
+    }
+
+    /* Assuming lists are of length at most 3 */
+
+    IotListDouble_t * pElt = pList->pNext;
+
+    if( pElt != pList )
+    {
+        pElt = destroy_subscription_list_element( pElt );
+    }
+
+    if( pElt != pList )
+    {
+        pElt = destroy_subscription_list_element( pElt );
+    }
+
+    if( pElt != pList )
+    {
+        pElt = destroy_subscription_list_element( pElt );
+    }
+
+    pList->pNext = invalid_pointer();
+    pList->pPrevious = invalid_pointer();
+}
+
+IotListDouble_t * destroy_operation_list_element( IotListDouble_t * pElt )
+{
+    if( pElt == NULL )
+    {
+        return NULL;
+    }
+
+    IotListDouble_t * pNext = pElt->pNext;
+    free( IotLink_Container( struct _mqttOperation, pElt, link ) );
+    return pNext;
+}
+
+void destroy_operation_list( IotListDouble_t * pList )
+{
+    if( pList == NULL )
+    {
+        return;
+    }
+
+    /* Assuming lists are of length at most 3 */
+
+    IotListDouble_t * pElt = pList->pNext;
+
+    if( pElt != pList )
+    {
+        pElt = destroy_operation_list_element( pElt );
+    }
+
+    if( pElt != pList )
+    {
+        pElt = destroy_operation_list_element( pElt );
+    }
+
+    if( pElt != pList )
+    {
+        pElt = destroy_operation_list_element( pElt );
+    }
+
+    pList->pNext = invalid_pointer();
+    pList->pPrevious = invalid_pointer();
+}
+
+/****************************************************************
+* Abstract the Notify method
+*
+* This abstraction assumes that the write set of Notify is just the
+* subscription and operation lists in the connection, and it models
+* Notify by simply havocing these lists.
+****************************************************************/
+
+void _IotMqtt_Notify( _mqttOperation_t * pOperation )
+{
+    destroy_subscription_list( &pOperation->pMqttConnection->subscriptionList );
+    destroy_operation_list( &pOperation->pMqttConnection->pendingProcessing );
+    destroy_operation_list( &pOperation->pMqttConnection->pendingResponse );
+}
+
+/****************************************************************
+* A predicate asserting that an operation on the pending list with no
+* retry has a job reference of 1.  This property is asserted by
+* _IotMqtt_FindOperation.
+*
+* Notice that this predicate tests members of a union guaranteed to
+* be valid only when the operation's incomingPublish is false.  This
+* condition not tested by _IotMqtt_FindOperation and thus not tested
+* by this predicate.
+*
+* This predicate is implemented using straight line code to avoid
+* loop unwinding.  It assumes that the operation list has length at
+* most 3.
+****************************************************************/
+
+bool pending_operation_has_valid_jobreference( IotLink_t * pElt )
+{
+    _mqttOperation_t * pOp = IotLink_Container( _mqttOperation_t, pElt, link );
+
+    return IMPLIES( pOp->u.operation.periodic.retry.limit == 0,
+                    pOp->u.operation.jobReference == 1 );
+}
+
+bool pending_operations_have_valid_jobreference( IotMqttConnection_t pConn )
+{
+    if( pConn == NULL )
+    {
+        return false;
+    }
+
+    IotLink_t * pHead = &pConn->pendingResponse;
+    IotLink_t * pElt = pHead->pNext;
+    bool status = true;
+
+    if( pElt != pHead )
+    {
+        status = status && pending_operation_has_valid_jobreference( pElt );
+        pElt = pElt->pNext;
+    }
+
+    if( pElt != pHead )
+    {
+        status = status && pending_operation_has_valid_jobreference( pElt );
+        pElt = pElt->pNext;
+    }
+
+    if( pElt != pHead )
+    {
+        status = status && pending_operation_has_valid_jobreference( pElt );
+        pElt = pElt->pNext;
+    }
+
+    status = status && pElt == pHead;
+
+    return status;
+}
+
+/****************************************************************
+* The proof harness
+****************************************************************/
+
+void harness()
+{
+    IotMqttConnection_t ReceiveContext = allocate_IotMqttConnection( NULL );
+
+    __CPROVER_assume( ReceiveContext );
+    ensure_IotMqttConnection_has_lists( ReceiveContext );
+    __CPROVER_assume( valid_IotMqttConnection( ReceiveContext ) );
+
+    __CPROVER_assume(
+        pending_operations_have_valid_jobreference( ReceiveContext ) );
+
+    __CPROVER_assume( ReceiveContext->references > 0 );
+
+    /* Disconnect callback */
+    __CPROVER_assume(
+        MAYBE_STUBBED_USER_CALLBACK(
+            ReceiveContext->disconnectCallback.function ) );
+
+    /* Network interface methods */
+    __CPROVER_assume(
+        IS_STUBBED_NETWORKIF_RECEIVE(
+            ReceiveContext->pNetworkInterface ) );
+    __CPROVER_assume(
+        MAYBE_STUBBED_NETWORKIF_CREATE(
+            ReceiveContext->pNetworkInterface ) );
+    __CPROVER_assume(
+        MAYBE_STUBBED_NETWORKIF_CLOSE(
+            ReceiveContext->pNetworkInterface ) );
+    __CPROVER_assume(
+        MAYBE_STUBBED_NETWORKIF_SEND(
+            ReceiveContext->pNetworkInterface ) );
+    __CPROVER_assume(
+        MAYBE_STUBBED_NETWORKIF_SETRECEIVECALLBACK(
+            ReceiveContext->pNetworkInterface ) );
+    __CPROVER_assume(
+        MAYBE_STUBBED_NETWORKIF_SETCLOSECALLBACK(
+            ReceiveContext->pNetworkInterface ) );
+    __CPROVER_assume(
+        MAYBE_STUBBED_NETWORKIF_DESTROY(
+            ReceiveContext->pNetworkInterface ) );
+
+
+    IotMqtt_ReceiveCallback( ReceiveContext->pNetworkConnection,
+                             ReceiveContext );
+}
+
+/****************************************************************/

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/Makefile
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/Makefile
@@ -62,8 +62,6 @@ OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_operation.goto
 OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_serialize.goto
 OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_subscription.goto
 
-CBMCFLAGS += --flush
-
 # allow mqtt mallocs to fail for coverage
 DEF += -include mqtt_state.h
 DEF += -DIotMqtt_MallocMessage=malloc_can_fail

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/Makefile
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/Makefile
@@ -1,0 +1,92 @@
+ENTRY?=IotMqtt_ReceiveCallback
+
+################################################################
+# Proof works by case splitting by packet type
+#
+# The value of PACKET should be set on the make command line to one of
+#   CONNACK
+#   PUBLISH
+#   PUBACK
+#   SUBACK
+#   UNSUBACK
+# or should be left undefined to model any other packet type
+#
+# The proof is driving by running make in the six subdirectories.
+
+ifdef PACKET
+DEF += -DCBMC_PACKET=MQTT_PACKET_TYPE_$(PACKET)
+endif
+
+################################################################
+# Proof assumptions
+
+# Bound the number of subscriptions in a list (BOUND = MAX-1)
+SUBSCRIPTION_COUNT_MAX=2
+DEF += -DSUBSCRIPTION_COUNT_MAX=$(SUBSCRIPTION_COUNT_MAX)
+
+# Bound the number of operations in a list (BOUND = MAX-1)
+OPERATION_COUNT_MAX=2
+DEF += -DOPERATION_COUNT_MAX=$(OPERATION_COUNT_MAX)
+
+# Bound the length of subscription topics (BOUND = MAX-1)
+TOPIC_LENGTH_MAX=6
+DEF += -DTOPIC_LENGTH_MAX=$(TOPIC_LENGTH_MAX)
+
+# Bound the remaing length of a packet (BOUND = MAX-1)
+REMAINING_LENGTH_BOUND=15
+DEF += -DREMAINING_LENGTH_BOUND=$(REMAINING_LENGTH_BOUND)
+
+# A constant that should be 2*SUBSCRIPTION_COUNT_MAX-1
+SUBSCRIPTION_LIST_MAX=3
+DEF += -DSUBSCRIPTION_LIST_MAX=$(SUBSCRIPTION_LIST_MAX)
+
+################################################################
+# Abstract the flush packet method
+
+ABSTRACTIONS += --remove-function-body _flushPacket
+
+################################################################
+# Abstract list remove functions
+
+DEF += -DCBMC_STUB_REMOVEALL=1
+DEF += -DCBMC_STUB_REMOVEALLMATCHES=1
+
+################################################################
+
+OBJS += $(MQTT)/cbmc/proofs/$(ENTRY)/$(ENTRY)_harness.goto
+OBJS += $(MQTT)/cbmc/proofs/mqtt_state.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_api.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_helper.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_network.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_operation.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_serialize.goto
+OBJS += $(MQTT)/libraries/standard/mqtt/src/iot_mqtt_subscription.goto
+
+CBMCFLAGS += --flush
+
+# allow mqtt mallocs to fail for coverage
+DEF += -include mqtt_state.h
+DEF += -DIotMqtt_MallocMessage=malloc_can_fail
+DEF += -DIotMqtt_MallocOperation=malloc_can_fail
+
+################################################################
+# Loop unwinding
+
+LOOP += IotListDouble_FindFirstMatch.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += IotListDouble_FindFirstMatch\$$link1.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += IotListDouble_FindFirstMatch\$$link2.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += IotListDouble_FindFirstMatch\$$link3.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += IotListDouble_FindFirstMatch\$$link4.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += IotListDouble_FindFirstMatch\$$link5.0:$(SUBSCRIPTION_COUNT_MAX)
+
+LOOP += _IotMqtt_GetRemainingLength.0:5
+LOOP += _decodeSubackStatus.0:$(REMAINING_LENGTH_BOUND)
+LOOP += valid_IotMqttOperationList.0:$(OPERATION_COUNT_MAX)
+LOOP += valid_IotMqttSubscriptionList.0:$(SUBSCRIPTION_COUNT_MAX)
+
+UNWINDING += --unwind 1
+UNWINDING += --unwindset '$(shell echo $(LOOP) | sed 's/ /,/g')'
+
+################################################################
+
+sinclude ../Makefile.common

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/Makefile.ninja
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/Makefile.ninja
@@ -1,0 +1,33 @@
+# -*- mode: makefile -*-
+
+# This Makefile runs the ReceiveCallback proofs with as much
+# concurrency as possible.  It runs each case in isolation, but runs
+# the two instances of cbmc in parallel.
+#
+# The ninja build file does not run the ReceiveCallback proofs
+# correctly.
+#
+# The problem is that each case of the proof requires a different
+# version of IotMqtt_ReceiveCallback.goto.  One could ask ninja to do
+# a "make clean" before doing a "make goto".  But the result would be
+# that case A would build goto, then case B would build goto, then
+# case A would run cbmc and see the IotMqtt_ReceiveCallback.goto has
+# changed and rebuild goto.  Now the concurrently running cases are
+# stompping on each other's goto binaries.
+
+DIRS = \
+	IotMqtt_ReceiveCallback_CONNACK \
+	IotMqtt_ReceiveCallback_OTHER \
+	IotMqtt_ReceiveCallback_PUBACK \
+	IotMqtt_ReceiveCallback_PUBLISH \
+	IotMqtt_ReceiveCallback_SUBACK \
+	IotMqtt_ReceiveCallback_UNSUBACK
+
+default:
+	ninja veryclean
+	for d in $(DIRS); do \
+		echo -n TIME: STARTING $$d ": "; date; \
+		make -C $$d veryclean2; \
+		ninja $$d; \
+		echo -n TIME: ENDING $$d ": "; date; \
+	done

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/README.md
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/README.md
@@ -3,4 +3,3 @@ This is a memory safety proof for IotMqtt_ReceiveCallback.
 The proof is split into six cases based on the type of the incoming
 packet.  This directory has six subdirectories, one for each case.
 The proof is the result of the proofs in the six subdirectories.
-

--- a/cbmc/proofs/IotMqtt_ReceiveCallback/README.md
+++ b/cbmc/proofs/IotMqtt_ReceiveCallback/README.md
@@ -1,0 +1,6 @@
+This is a memory safety proof for IotMqtt_ReceiveCallback.
+
+The proof is split into six cases based on the type of the incoming
+packet.  This directory has six subdirectories, one for each case.
+The proof is the result of the proofs in the six subdirectories.
+

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -166,7 +166,8 @@ define encode_options
        '=$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')='
 endef
 
-cbmc-batch.yaml: Makefile ../Makefile.common
+# Regenerate cbmc-batch.yaml every time (use PHONY, list no dependencies)
+cbmc-batch.yaml:
 	@echo "Building $@"
 	@$(RM) $@
 	@echo 'build_memory: $(PROOFMEM)' > $@

--- a/cbmc/proofs/make_cbmc_batch_files.py
+++ b/cbmc/proofs/make_cbmc_batch_files.py
@@ -25,29 +25,24 @@
 import os
 import platform
 import subprocess
+import logging
 
-
-def remove_cbmc_yaml_files():
-    for dyr, _, files in os.walk("."):
-        cbmc_batch_files = [os.path.join(os.path.abspath(dyr), file)
-                            for file in files if file == "cbmc-batch.yaml"]
-        for file in cbmc_batch_files:
-            os.remove(file)
-
+MAKEFILE = "Makefile"
+YAML_FILE = "cbmc-batch.yaml"
 
 def create_cbmc_yaml_files():
     # The YAML files are only used by CI and are not needed on Windows.
     if platform.system() == "Windows":
         return
     for dyr, _, files in os.walk("."):
-        harness = [file for file in files if file.endswith("_harness.c")]
-        if harness and "Makefile" in files:
-            subprocess.run(["make", "cbmc-batch.yaml"],
+        if YAML_FILE in files and MAKEFILE in files:
+            logging.info("Building %s in %s", YAML_FILE, dyr)
+            os.remove(os.path.join(os.path.abspath(dyr), YAML_FILE))
+            subprocess.run(["make", YAML_FILE],
                            stdout=subprocess.PIPE,
                            stderr=subprocess.PIPE,
                            cwd=os.path.abspath(dyr),
                            check=True)
 
 if __name__ == '__main__':
-    remove_cbmc_yaml_files()
     create_cbmc_yaml_files()

--- a/cbmc/proofs/mqtt_state.h
+++ b/cbmc/proofs/mqtt_state.h
@@ -253,3 +253,8 @@ IotNetworkError_t IotNetworkInterfaceDestroy( void * pConnection );
 IotMqttCallbackInfo_t *allocate_IotMqttCallbackInfo(IotMqttCallbackInfo_t *pCb);
 void IotUserCallback( void * pCallbackContext,
 		      IotMqttCallbackParam_t * pCallbackParam );
+
+#define IS_STUBBED_USER_CALLBACK(cb) (cb == IotUserCallback)
+#define MAYBE_STUBBED_USER_CALLBACK(cb) (cb == NULL || cb == IotUserCallback)
+
+/****************************************************************/

--- a/cbmc/proofs/ninja.py
+++ b/cbmc/proofs/ninja.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+
+"""
+Write a ninja build file to generate reports for cbmc proofs.
+
+Given a list of folders containing cbmc proofs, write a ninja build
+file the generate reports for these proofs.  The list of folders may
+be given on the command line, in a json file, or found in the file
+system.
+"""
+
+# Add task pool
+
+import sys
+import os
+import platform
+import argparse
+import json
+
+################################################################
+# The command line parser
+
+def argument_parser():
+    """Return the command line parser."""
+
+    parser = argparse.ArgumentParser(
+        description='Generate ninja build file for cbmc proofs.',
+        epilog="""
+            Given a list of folders containing cbmc proofs, write a ninja build
+            file the generate reports for these proofs.  The list of folders may
+            be given on the command line, in a json file, or found in the file
+            system.
+            In the json file, there should be a dict mapping the key "proofs"
+            to a list of folders containing proofs.
+            The file system, all folders folders under the current directory
+            containing a file named 'cbmc-batch.yaml' is considered a
+            proof folder.
+            This script assumes that the proof is driven by a Makefile
+            with targets goto, cbmc, coverage, property, and report.
+            This script does not work with Windows and Visual Studio.
+        """
+    )
+    parser.add_argument('folders', metavar='PROOF', nargs='*',
+                        help='Folder containing a cbmc proof')
+    parser.add_argument('--proofs', metavar='JSON',
+                        help='Json file listing folders containing cbmc proofs')
+    return parser
+
+################################################################
+# The list of folders containing proofs
+#
+# The list of folders will be taken from
+# 1. the list PROOFS defined here or
+# 2. the command line
+# 3. the json file specified on the command line containing a
+#    dict mapping the key JSON_KEY to a list of folders
+# 4. the folders below the current directory containing
+#    a file named FS_KEY
+#
+
+PROOFS = [
+]
+
+JSON_KEY = 'proofs'
+FS_KEY = 'cbmc-batch.yaml'
+
+def find_proofs_in_json_file(filename):
+    """Read the list of folders containing proofs from a json file."""
+
+    if not filename:
+        return []
+    try:
+        with open(filename) as proofs:
+            return json.load(proofs)[JSON_KEY]
+    except (FileNotFoundError, KeyError):
+        raise UserWarning("Can't find key {} in json file {}".format(JSON_KEY, filename))
+    except json.decoder.JSONDecodeError:
+        raise UserWarning("Can't parse json file {}".format(filename))
+
+def find_proofs_in_filesystem():
+    """Locate the folders containing proofs in the filesystem."""
+
+    proofs = []
+    for root, _, files in os.walk('.'):
+        if FS_KEY in files:
+            proofs.append(os.path.normpath(root))
+    return proofs
+
+################################################################
+# The strings used to write sections of the ninja file
+
+NINJA_RULES = """
+################################################################
+# task pool to force sequential builds of goto binaries
+
+pool goto_pool
+  depth = 1
+
+################################################################
+# proof target rules
+
+rule build_json
+  command = cd ${folder} && make sources.json
+  pool = goto_pool
+
+rule build_goto
+  command = cd ${folder} && make goto
+  pool = goto_pool
+
+rule build_cbmc
+  command = cd ${folder} && make cbmc.xml
+
+rule build_coverage
+  command = cd ${folder} && make coverage
+
+rule build_property
+  command = cd ${folder} && make property
+
+rule build_report
+  command = cd ${folder} && make report2
+
+rule clean_folder
+  command = cd ${folder} && make clean2
+
+rule veryclean_folder
+  command = cd ${folder} && make veryclean2
+
+rule open_proof
+  command = open ${folder}/html/index.html
+
+"""
+
+NINJA_BUILDS = """
+################################################################
+# {folder} proof targets
+
+build {folder}/sources.json: build_json
+  folder={folder}
+
+build {folder}/{entry}.goto: build_goto
+  folder={folder}
+
+build {folder}/cbmc.xml: build_cbmc {folder}/{entry}.goto
+  folder={folder}
+
+build {folder}/coverage.xml: build_coverage {folder}/{entry}.goto
+  folder={folder}
+
+build {folder}/property.xml: build_property {folder}/{entry}.goto
+  folder={folder}
+
+build {folder}/html/index.html: build_report {folder}/sources.json {folder}/{entry}.goto {folder}/cbmc.xml {folder}/coverage.xml {folder}/property.xml
+  folder={folder}
+
+build json_{folder}: phony {folder}/sources.json
+
+build goto_{folder}: phony {folder}/{entry}.goto
+
+build cbmc_{folder}: phony {folder}/cbmc.xml
+
+build property_{folder}: phony {folder}/property.xml
+
+build coverage_{folder}: phony {folder}/html/index.html
+
+build report_{folder}: phony {folder}/cbmc.xml
+
+build clean_{folder}: clean_folder
+  folder={folder}
+
+build veryclean_{folder}: veryclean_folder
+  folder={folder}
+
+build open_{folder}: open_proof
+  folder={folder}
+
+build {folder}: phony {folder}/html/index.html
+
+default {folder}
+
+"""
+
+NINJA_GLOBALS = """
+################################################################
+# global targets
+
+build json: phony {json_targets}
+
+build goto: phony {goto_targets}
+
+build cbmc: phony {cbmc_targets}
+
+build property: phony {property_targets}
+
+build coverage: phony {coverage_targets}
+
+build report: phony {report_targets}
+
+build clean: phony {clean_targets}
+
+build veryclean: phony {veryclean_targets}
+
+build open: phony {open_targets}
+
+build fast:  phony {fast_targets}
+
+build slow:  phony {slow_targets}
+
+"""
+
+################################################################
+# The main function
+
+def get_entry(folder):
+    """Find the name of the proof in the proof Makefile."""
+
+    with open('{}/Makefile'.format(folder)) as makefile:
+        for line in makefile:
+            if line.strip().lower().startswith('entry'):
+                return line[line.find('=')+1:].strip()
+            if line.strip().lower().startswith('h_entry'):
+                return line[line.find('=')+1:].strip()
+    raise UserWarning("Can't find ENTRY in {}/Makefile".format(folder))
+
+def write_ninja_build_file():
+    """Write a ninja build file to generate proof results."""
+
+    if platform.system().lower() == 'windows':
+        print("This script does not run on Windows.")
+        sys.exit()
+
+    args = argument_parser().parse_args()
+
+    proofs = (PROOFS or
+              args.folders or
+              find_proofs_in_json_file(args.proofs) or
+              find_proofs_in_filesystem())
+
+    with open('build.ninja', 'w') as ninja:
+        ninja.write(NINJA_RULES)
+        for proof in proofs:
+            entry = get_entry(proof)
+            ninja.write(NINJA_BUILDS.format(folder=proof, entry=entry))
+        targets = lambda kind, folders: ' '.join(
+            ['{}_{}'.format(kind, folder) for folder in folders]
+        )
+        slow = [
+            'IotMqtt_Connect',
+            'IotMqtt_Disconnect',
+            'IotMqtt_ReceiveCallback',
+            'IotMqtt_UnsubscribeSync'
+        ]
+        fast = [proof for proof in proofs if proof not in slow]
+        ninja.write(NINJA_GLOBALS.format(
+            json_targets=targets('json', proofs),
+            goto_targets=targets('goto', proofs),
+            cbmc_targets=targets('cbmc', proofs),
+            property_targets=targets('property', proofs),
+            coverage_targets=targets('coverage', proofs),
+            report_targets=targets('report', proofs),
+            clean_targets=targets('clean', proofs),
+            veryclean_targets=targets('veryclean', proofs),
+            open_targets=targets('open', proofs),
+            fast_targets=' '.join(fast),
+            slow_targets=' '.join(slow)
+        ))
+
+################################################################
+
+if __name__ == "__main__":
+    write_ninja_build_file()


### PR DESCRIPTION
This pull request adds a CBMC memory safety proof for the MQTT method IotMqtt_ReceiveCallback.

This pull request changes a lot of files, but they are all within the CBMC tools directory, and they aren't that scary.

The proof itself is in a single directory along with a .h file that is modified to define two predicates we use in the proof.  The proof is broken into six cases based on the type of the incoming packet.  The proofs of the six cases are driven by six subdirectories, one for each case.  But the main body of the proof consists of the files IotMqtt_ReceiveCallback_harness.c and Makefile in the top-level directory:
* cbmc/proofs/IotMqtt_ReceiveCallback
* cbmc/proofs/mqtt_state.h

Two files add small patches that we use in CI to prepare the source tree for proof:
* cbmc/patches/Stub-network-function-pointers.patch
* cbmc/patches/bound-packet-remaining-length.patch

Three files modify the python infrastructure we use in CI to prepare the source tree for proof:
* cbmc/proofs/Makefile.common
* cbmc/proofs/make_cbmc_batch_files.py
* cbmc/proofs/prepare.py

Two files make it possible to build the CBMC proofs concurrently with ninja:
* cbmc/.gitignore
* cbmc/proofs/ninja.py

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
