### PR TITLE
Build CBMC binaries out of source for concurrent proof checking

### DIFF
--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -229,4 +229,3 @@ veryclean2: veryclean
 	$(RM) viewer-*.json
 
 .PHONY: report2 clean2 veryclean2
-

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -65,12 +65,12 @@ GOTO_DIR=gotos
 GOTOS=$(patsubst %.c,$(GOTO_DIR)/%.goto,$(SRCS))
 
 # Build sources in the source tree with full paths
-$(GOTO_DIR)/%.goto:$(MQTT)/%.c
+$(GOTO_DIR)/%.goto: $(MQTT)/%.c
 	mkdir -p $(dir $@)
 	$(GOTO_CC) -o $@ $(CFLAGS) $<
 
 # build sources in the local directory with relative paths
-$(GOTO_DIR)/%.goto:./%.c
+$(GOTO_DIR)/%.goto: ./%.c
 	mkdir -p $(dir $@)
 	$(GOTO_CC) -o $@ $(CFLAGS) $<
 

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -51,15 +51,35 @@ CFLAGS += $(CFLAGS2) $(INC) $(DEF) -std=gnu99
 
 NONDET += --nondet-static
 
-%.goto : %.c
+# Out of source builds
+#
+# Proof makefiles were originally written using in-source builds, but
+# this inhibits building and running proofs concurrently when
+# different proofs build sources with different configurations.  These
+# definitions assume $(OBJS) is the original list of in-source goto
+# binaries and defines $(GOTOS) to be the list of out-of-source goto
+# binaries written into the local gotos subdirectory.
+
+SRCS=$(patsubst %.goto,%.c,$(patsubst $(MQTT)/%,%,$(OBJS)))
+GOTO_DIR=gotos
+GOTOS=$(patsubst %.c,$(GOTO_DIR)/%.goto,$(SRCS))
+
+# Build sources in the source tree with full paths
+$(GOTO_DIR)/%.goto:$(MQTT)/%.c
+	mkdir -p $(dir $@)
+	$(GOTO_CC) -o $@ $(CFLAGS) $<
+
+# build sources in the local directory with relative paths
+$(GOTO_DIR)/%.goto:./%.c
+	mkdir -p $(dir $@)
 	$(GOTO_CC) -o $@ $(CFLAGS) $<
 
 $(MQTT)/build:
 	(mkdir -p $(MQTT)/build; cd $(MQTT)/build; cmake ..) \
 	       > $(ENTRY)0.txt 2>&1
 
-$(ENTRY)1.goto: $(MQTT)/build $(OBJS)
-	$(GOTO_CC) --function harness -o $@ $(OBJS) \
+$(ENTRY)1.goto: $(MQTT)/build $(GOTOS)
+	$(GOTO_CC) --function harness -o $@ $(GOTOS) \
 		> $(ENTRY)1.txt 2>&1
 
 $(ENTRY)2.goto: $(ENTRY)1.goto
@@ -144,6 +164,7 @@ report: cbmc.txt property.xml coverage.xml
 clean:
 	$(RM) $(OBJS) $(ENTRY).goto
 	$(RM) $(ENTRY)[0-9].goto $(ENTRY)[0-9].txt
+	$(RM) -r $(GOTO_DIR)
 	$(RM) cbmc.txt property.xml coverage.xml TAGS TAGS-*
 	$(RM) *~ \#*
 
@@ -208,3 +229,4 @@ veryclean2: veryclean
 	$(RM) viewer-*.json
 
 .PHONY: report2 clean2 veryclean2
+

--- a/cbmc/proofs/ninja.py
+++ b/cbmc/proofs/ninja.py
@@ -91,21 +91,13 @@ def find_proofs_in_filesystem():
 
 NINJA_RULES = """
 ################################################################
-# task pool to force sequential builds of goto binaries
-
-pool goto_pool
-  depth = 1
-
-################################################################
 # proof target rules
 
 rule build_json
   command = cd ${folder} && make sources.json
-  pool = goto_pool
 
 rule build_goto
-  command = cd ${folder} && make goto
-  pool = goto_pool
+  command = cd ${folder} && make sources.json && make goto
 
 rule build_cbmc
   command = cd ${folder} && make cbmc.xml
@@ -149,7 +141,7 @@ build {folder}/coverage.xml: build_coverage {folder}/{entry}.goto
 build {folder}/property.xml: build_property {folder}/{entry}.goto
   folder={folder}
 
-build {folder}/html/index.html: build_report {folder}/sources.json {folder}/{entry}.goto {folder}/cbmc.xml {folder}/coverage.xml {folder}/property.xml
+build {folder}/html/index.html: build_report {folder}/{entry}.goto {folder}/cbmc.xml {folder}/coverage.xml {folder}/property.xml
   folder={folder}
 
 build json_{folder}: phony {folder}/sources.json


### PR DESCRIPTION
This patch modifies the CBMC Makefile.common to build CBMC goto binaries out-of-source, and modifies the CBMC ninja.py to run CBMC proofs concurrently with better concurrency (no more task pool needed to build CBMC goto binaries sequentially).




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
