### PR TITLE
Update IotMqtt_PublishAsync proof harness

### DIFF
--- a/cbmc/proofs/IotMqtt_PublishAsync/IotMqtt_PublishAsync_harness.c
+++ b/cbmc/proofs/IotMqtt_PublishAsync/IotMqtt_PublishAsync_harness.c
@@ -1,3 +1,30 @@
+/*
+ * IoT MQTT V2.1.0
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file IotMqtt_PublishAsync_harness.c
+ * @brief Implements the proof harness for IotMqtt_PublishAsync function.
+ */
+
 #include "iot_config.h"
 #include "private/iot_mqtt_internal.h"
 
@@ -6,83 +33,115 @@
 
 #include "mqtt_state.h"
 
+typedef bool ( * MatchFunction_t )( const IotLink_t * const pOperationLink,
+                                    void * pCompare );
+
+typedef void ( * FreeElementFunction_t )( void * pData );
+
 /**
- * We abstract all functions related to concurrency and assume they are correct.
- * Thus, we add these stub to increase coverage.
+ * We constrain the return values of these functions because
+ * they are checked by assertions in the MQTT code.
  */
 IotTaskPoolError_t IotTaskPool_CreateJob( IotTaskPoolRoutine_t userCallback,
                                           void * pUserContext,
                                           IotTaskPoolJobStorage_t * const pJobStorage,
                                           IotTaskPoolJob_t * const pJob )
 {
-  if (userCallback == NULL || pJobStorage == NULL || pJob == NULL)
-  {
-    return IOT_TASKPOOL_BAD_PARAMETER;
-  }
-  /* _IotMqtt_ScheduleOperation asserts this */
-  return IOT_TASKPOOL_SUCCESS;
+    assert( userCallback != NULL );
+    assert( pJobStorage != NULL );
+    assert( pJob != NULL );
+
+    /* _IotMqtt_ScheduleOperation asserts this. */
+    return IOT_TASKPOOL_SUCCESS;
 }
 
 IotTaskPoolError_t IotTaskPool_ScheduleDeferred( IotTaskPool_t taskPool,
                                                  IotTaskPoolJob_t job,
                                                  uint32_t timeMs )
 {
-  IotTaskPoolError_t error;
+    IotTaskPoolError_t error;
 
-  /* _IotMqtt_ScheduleOperation asserts this */
-  __CPROVER_assume(error != IOT_TASKPOOL_BAD_PARAMETER &&
-                   error != IOT_TASKPOOL_ILLEGAL_OPERATION);
-  return error;
+    /* _IotMqtt_ScheduleOperation asserts this */
+    __CPROVER_assume( error != IOT_TASKPOOL_BAD_PARAMETER &&
+                      error != IOT_TASKPOOL_ILLEGAL_OPERATION );
+    return error;
 }
 
 /**
  * _IotMqtt_NextPacketIdentifier calls Atomic_Add_u32, which receives
  * a volatile variable as input. Thus, CBMC will always consider that
  * Atomic_Add_u32 will operate over nondetermistic values and raises
- * a unsigned integer overflow failure. However, developers have reported
+ * an unsigned integer overflow failure. However, developers have reported
  * that the use of this overflow is part of the function implementation.
  * In order to mirror _IotMqtt_NextPacketIdentifier behaviour and avoid
  * spurious alarms, we stub out this function to always
  * return a nondetermistic odd value.
  */
-uint16_t _IotMqtt_NextPacketIdentifier( void ) {
-  uint16_t id;
+uint16_t _IotMqtt_NextPacketIdentifier( void )
+{
+    uint16_t id;
 
-  /* Packet identifiers will follow the sequence 1,3,5...65535,1,3,5... */
-  __CPROVER_assume(id & 0x0001 == 1);
+    /* Packet identifiers will follow the sequence 1,3,5...65535,1,3,5... */
+    __CPROVER_assume( id & 0x0001 == 1 );
 
-  return id;
+    return id;
+}
+
+/**
+ * We assume the list remove functions are memory safe.
+ *
+ * We abstract the list remove functions for performance reasons.  Our
+ * abstraction replaces the original list with an unconstrained list.
+ * Our abstraction proves that none of the elements on the original
+ * list are accessed after the remove: We free all elements on the
+ * original list, so that any later access will be caught as a
+ * use-after-free error.
+ */
+void IotListDouble_RemoveAllMatches( const IotListDouble_t * const pList,
+                                     MatchFunction_t isMatch,
+                                     void * pMatch,
+                                     FreeElementFunction_t freeElement,
+                                     size_t linkOffset )
+{
+    free_IotMqttSubscriptionList( pList );
+    allocate_IotMqttSubscriptionList( pList, SUBSCRIPTION_COUNT_MAX - 1 );
 }
 
 void harness()
 {
-  /* assume a valid MQTT connection */
-  IotMqttConnection_t mqttConnection = allocate_IotMqttConnection(NULL);
-  __CPROVER_assume(mqttConnection != NULL);
-  __CPROVER_assume(mqttConnection->pNetworkInterface != NULL);
-  __CPROVER_assume( IS_STUBBED_NETWORKIF_SEND( mqttConnection->pNetworkInterface ) );
-  ensure_IotMqttConnection_has_lists(mqttConnection);
-  __CPROVER_assume(valid_IotMqttConnection(mqttConnection));
- 
-  /* assume a valid publish info */
-  IotMqttPublishInfo_t *pPublishInfo = allocate_IotMqttPublishInfo(NULL);
-  if (pPublishInfo != NULL) __CPROVER_assume(valid_IotMqttPublishInfo(pPublishInfo));
+    /* Assume a valid MQTT connection. */
+    IotMqttConnection_t mqttConnection = allocate_IotMqttConnection( NULL );
 
-  /* assume unconstrained inputs */
-  uint32_t flags;
-  IotMqttCallbackInfo_t *callbackInfo = malloc_can_fail(sizeof (*callbackInfo) );
-
-  /* output */
-  IotMqttOperation_t *publishOperation = malloc_can_fail(sizeof (*publishOperation) );
+    __CPROVER_assume( mqttConnection != NULL );
+    __CPROVER_assume( mqttConnection->pNetworkInterface != NULL );
+    __CPROVER_assume( IS_STUBBED_NETWORKIF_SEND( mqttConnection->pNetworkInterface ) );
+    __CPROVER_assume( IS_STUBBED_NETWORKIF_DESTROY( mqttConnection->pNetworkInterface ) );
+    ensure_IotMqttConnection_has_lists( mqttConnection );
+    __CPROVER_assume( valid_IotMqttConnection( mqttConnection ) );
 
 
-  /* function under verification */
-  IotMqttError_t status = IotMqtt_PublishAsync( mqttConnection, /* always assume a valid connection */
-			                        pPublishInfo,
-			                        flags,
-			                        callbackInfo,
-			                        publishOperation );
-  /* assert post-conditions */
-  assert(IMPLIES(status == IOT_MQTT_STATUS_PENDING, pPublishInfo->qos == IOT_MQTT_QOS_1));
-  assert(IMPLIES(status == IOT_MQTT_SUCCESS, pPublishInfo->qos == IOT_MQTT_QOS_0 || pPublishInfo->qos == IOT_MQTT_QOS_1));
+    /* Assume a valid publish info. */
+    IotMqttPublishInfo_t * pPublishInfo = allocate_IotMqttPublishInfo( NULL );
+    __CPROVER_assume( IMPLIES( pPublishInfo != NULL, valid_IotMqttPublishInfo( pPublishInfo ) ) );
+
+    /* Assume unconstrained inputs. */
+    uint32_t flags;
+    IotMqttCallbackInfo_t * callbackInfo = malloc_can_fail( sizeof( *callbackInfo ) );
+
+    /* Output. */
+    IotMqttOperation_t * publishOperation = malloc_can_fail( sizeof( *publishOperation ) );
+
+
+    /* Function under verification. */
+    IotMqttError_t status = IotMqtt_PublishAsync( mqttConnection,
+                                                  pPublishInfo,
+                                                  flags,
+                                                  callbackInfo,
+                                                  publishOperation );
+    /* Post-conditions. */
+    assert( IMPLIES( status == IOT_MQTT_STATUS_PENDING,
+                     pPublishInfo->qos == IOT_MQTT_QOS_1 ) );
+    assert( IMPLIES( status == IOT_MQTT_SUCCESS,
+                     pPublishInfo->qos == IOT_MQTT_QOS_0 ||
+                     pPublishInfo->qos == IOT_MQTT_QOS_1 ) );
 }

--- a/cbmc/proofs/IotMqtt_PublishAsync/Makefile
+++ b/cbmc/proofs/IotMqtt_PublishAsync/Makefile
@@ -3,8 +3,10 @@ ENTRY=IotMqtt_PublishAsync
 # We abstract all the log and concurrency related functions in this proof
 # and assume their implementation is correct
 ABSTRACTIONS += --remove-function-body IotLog_Generic
-ABSTRACTIONS += --remove-function-body _IotMqtt_ProcessSend
-ABSTRACTIONS += --remove-function-body _destroyMqttConnection
+
+# We also abstract unreachable functions to improve coverage metrics
+ABSTRACTIONS += --remove-function-body IotNetworkInterfaceClose
+ABSTRACTIONS += --remove-function-body IotNetworkInterfaceReceive
 
 OBJS += $(ENTRY)_harness.goto
 OBJS += $(MQTT)/cbmc/proofs/mqtt_state.goto
@@ -22,10 +24,23 @@ DEF += -DSUBSCRIPTION_COUNT_MAX=$(SUBSCRIPTION_COUNT_MAX)
 OPERATION_COUNT_MAX=4
 DEF += -DOPERATION_COUNT_MAX=$(OPERATION_COUNT_MAX)
 
+# Enables CBMC stub for RemoveAllMatches function
+DEF += -DCBMC_STUB_REMOVEALLMATCHES=1
+
+# Allow MQTT allocations to fail for coverage
+DEF += -include mqtt_state.h
+DEF += -DIotMqtt_MallocMessage=malloc_can_fail
+DEF += -DIotMqtt_MallocOperation=malloc_can_fail
+
+# The bound for _encodeRemainingLength is based on the maximum
+# possible value for remainingLength, in this case, 2 * UINT16_MAX + 4
+# (see _IotMqtt_PublishPacketSize). Thus, the bound is the number of
+# times the function must divide the maximum remainingLength
+# value by 128 until hits zero.
+LOOP += _encodeRemainingLength.0:3
 LOOP += IotListDouble_RemoveAllMatches.0:$(SUBSCRIPTION_COUNT_MAX)
-LOOP += valid_IotMqttSubscriptionList.0:$(SUBSCRIPTION_COUNT_MAX)
 LOOP += valid_IotMqttOperationList.0:$(OPERATION_COUNT_MAX)
-LOOP += _encodeRemainingLength.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += valid_IotMqttSubscriptionList.0:$(SUBSCRIPTION_COUNT_MAX)
 
 UNWINDING += --unwind 1
 UNWINDING += --unwindset '$(shell echo $(LOOP) | sed 's/ /,/g')'

--- a/cbmc/proofs/IotMqtt_PublishAsync/README.md
+++ b/cbmc/proofs/IotMqtt_PublishAsync/README.md
@@ -1,0 +1,71 @@
+# Memory safety proof for IotMqtt_PublishAsync
+
+This proof harness attains 94% code coverage.  The following comments explain
+why the uncovered lines of code are unreachable code.
+
+Some functions contain unreachable blocks of code:
+
+* `_IotMqtt_SerializeConnectCommon`
+
+    * `_validatePublish` eliminates that possibility of `QoS == IOT_MQTT_QOS_2`
+
+* `_scheduleNextRetry`
+
+    * `pOperation->u.operation.periodic.retry.count <
+       pOperation->u.operation.periodic.retry.limit`
+
+* `_IotMqtt_DestroyOperation`
+
+    * Notify calls `DestroyOperation` with a linked operation
+
+* `_IotMqtt_RemainingLengthEncodedSize`
+
+    * This function never reaches `length > 2097152U`
+
+* `_IotMqtt_ProcessSend`
+
+    * `pOperation->u.operation.periodic.retry.limit` always 0
+    * `pOperation->u.operation.type != IOT_MQTT_DISCONNECT`
+    * `_completePendingSend` always return `destroyOperation == false`
+
+* `_IotMqtt_PublishPacketSize`
+
+    * This function never reaches `pPublishInfo->payloadLength > payloadLimit`
+
+* `_IotMqtt_SerializePublish`
+
+    * `_IotMqtt_PublishPacketSize` never returns false, because
+       `pPublishInfo->payloadLength` is always smaller than `payloadLimit`
+
+* `_IotMqtt_PublishSetDup`
+
+    * `pPacketIdentifierHigh != NULL`
+
+* `_validatePublishPayload`
+
+    * This function never reaches `payloadLength > maximumPayloadLength`
+
+* `_checkRetryLimit`
+
+    * `pOperation->u.operation.periodic.retry.count <
+       pOperation->u.operation.periodic.retry.limit`
+    *  `pOperation->u.operation.periodic.retry.count != 1U`
+
+* `_IotMqtt_DecrementOperationReferences`
+
+    * `cancelJob == false`
+
+* `_IotMqtt_Notify`
+
+    * `pOperation->u.operation.type != IOT_MQTT_SUBSCRIBE`
+
+* `IotMqtt_OperationType`
+
+    * Always returns `IOT_MQTT_PUBLISH_TO_SERVER`
+
+Some functions are simply unreachable:
+
+* `_IotMqtt_RemoveSubscriptionByPacket`
+
+    * Unreachable: Only function call in from an unreachable block of
+	`_IotMqtt_Notify`

--- a/cbmc/proofs/IotMqtt_PublishAsync/cbmc-viewer.json
+++ b/cbmc/proofs/IotMqtt_PublishAsync/cbmc-viewer.json
@@ -1,21 +1,16 @@
 { "expected-missing-functions":
   [
+    "IotClock_GetTimeMs",
     "IotLog_Generic",
-    "IotMqtt_Wait",
-    "IotMutex_Create",
     "IotMutex_Destroy",
     "IotMutex_Lock",
     "IotMutex_Unlock",
     "IotSemaphore_Create",
     "IotSemaphore_Destroy",
     "IotSemaphore_Post",
-    "IotSemaphore_TimedWait",
-    "IotSemaphore_Wait",
-    "IotTaskPool_CreateJob",
     "IotTaskPool_GetSystemTaskPool",
-    "IotTaskPool_ScheduleDeferred",
     "IotTaskPool_strerror",
-    "IotTaskPool_TryCancel"
+    "_IotMqtt_RemoveSubscriptionByPacket"
   ],
   "proof-name": "IotMqtt_PublishAsync",
   "proof-root": "cbmc/proofs"


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*
 - Improves documentation and format in `IotMqtt_PublishAsync` proof harness;
 - Adds a `README.md` file about coverage results;
 - Removes unnecessary stuff from the proof's Makefile.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
