### PR TITLE
Fix build warnings of logging library

### DIFF
--- a/libraries/standard/utilities/include/iot_logging_levels.h
+++ b/libraries/standard/utilities/include/iot_logging_levels.h
@@ -1,0 +1,112 @@
+/*
+ * Logging Level Macros
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file iot_logging_levels.h
+ * @brief Defines the logging level macros.
+ */
+
+#ifndef IOT_LOGGING_LEVELS_H_
+#define IOT_LOGGING_LEVELS_H_
+
+/* The config header is always included first. */
+#include "config.h"
+
+/**
+ * @constantspage{logging,logging library}
+ *
+ * @section logging_constants_levels Log levels
+ * @brief Log levels for the libraries in this SDK.
+ *
+ * Each library should specify a log level by setting @ref LIBRARY_LOG_LEVEL.
+ * All log messages with a level at or below the specified level will be printed
+ * for that library.
+ *
+ * Currently, there are 4 log levels. In the order of lowest to highest, they are:
+ * - #IOT_LOG_NONE <br>
+ *   @copybrief IOT_LOG_NONE
+ * - #IOT_LOG_ERROR <br>
+ *   @copybrief IOT_LOG_ERROR
+ * - #IOT_LOG_WARN <br>
+ *   @copybrief IOT_LOG_WARN
+ * - #IOT_LOG_INFO <br>
+ *   @copybrief IOT_LOG_INFO
+ * - #IOT_LOG_DEBUG <br>
+ *   @copybrief IOT_LOG_DEBUG
+ */
+
+/**
+ * @brief No log messages.
+ *
+ * When @ref LIBRARY_LOG_LEVEL is #IOT_LOG_NONE, logging is disabled and no
+ * logging messages are printed.
+ */
+#define IOT_LOG_NONE     0
+
+/**
+ * @brief Represents erroneous application state or event.
+ *
+ * These messages describe the situations when a library encounters an error from
+ * which it cannot recover.
+ *
+ * These messages are printed when @ref LIBRARY_LOG_LEVEL is defined as either
+ * of #IOT_LOG_ERROR, #IOT_LOG_WARN, #IOT_LOG_INFO or #IOT_LOG_DEBUG.
+ */
+#define IOT_LOG_ERROR    1
+
+/**
+ * @brief Message about an abnormal event.
+ *
+ * These messages describe the situations when a library encounters
+ * abnormal event that may be indicative of an error. Libraries continue
+ * execution after logging a warning.
+ *
+ * These messages are printed when @ref LIBRARY_LOG_LEVEL is defined as either
+ * of #IOT_LOG_WARN, #IOT_LOG_INFO or #IOT_LOG_DEBUG.
+ */
+#define IOT_LOG_WARN     2
+
+/**
+ * @brief A helpful, informational message.
+ *
+ * These messages describe normal execution of a library. They provide
+ * the progress of the program at a coarse-grained level.
+ *
+ * These messages are printed when @ref LIBRARY_LOG_LEVEL is defined as either
+ * of #IOT_LOG_INFO or #IOT_LOG_DEBUG.
+ */
+#define IOT_LOG_INFO     3
+
+/**
+ * @brief Detailed and excessive debug information.
+ *
+ * Debug log messages are used to provide the
+ * progress of the program at a fine-grained level. These are mostly used
+ * for debugging and may contain excessive information such as internal
+ * variables, buffers, or other specific information.
+ *
+ * These messages are only printed when @ref LIBRARY_LOG_LEVEL is defined as
+ * #IOT_LOG_DEBUG.
+ */
+#define IOT_LOG_DEBUG    4
+
+#endif /* ifndef IOT_LOGGING_LEVELS_H_ */

--- a/libraries/standard/utilities/include/iot_logging_levels.h
+++ b/libraries/standard/utilities/include/iot_logging_levels.h
@@ -28,9 +28,6 @@
 #ifndef IOT_LOGGING_LEVELS_H_
 #define IOT_LOGGING_LEVELS_H_
 
-/* The config header is always included first. */
-#include "config.h"
-
 /**
  * @constantspage{logging,logging library}
  *

--- a/libraries/standard/utilities/include/iot_logging_setup.h
+++ b/libraries/standard/utilities/include/iot_logging_setup.h
@@ -1,5 +1,5 @@
 /*
- * IoT Common V1.1.0
+ * Common Logging Framework
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -22,7 +22,7 @@
 
 /**
  * @file iot_logging_setup.h
- * @brief Defines the logging macro #IotLog.
+ * @brief Defines the common logging framework that calls #IotLog interface.
  */
 
 #ifndef IOT_LOGGING_SETUP_H_
@@ -31,83 +31,9 @@
 /* The config header is always included first. */
 #include "config.h"
 
-/**
- * @constantspage{logging,logging library}
- *
- * @section logging_constants_levels Log levels
- * @brief Log levels for the libraries in this SDK.
- *
- * Each library should specify a log level by setting @ref LIBRARY_LOG_LEVEL.
- * All log messages with a level at or below the specified level will be printed
- * for that library.
- *
- * Currently, there are 4 log levels. In the order of lowest to highest, they are:
- * - #IOT_LOG_NONE <br>
- *   @copybrief IOT_LOG_NONE
- * - #IOT_LOG_ERROR <br>
- *   @copybrief IOT_LOG_ERROR
- * - #IOT_LOG_WARN <br>
- *   @copybrief IOT_LOG_WARN
- * - #IOT_LOG_INFO <br>
- *   @copybrief IOT_LOG_INFO
- * - #IOT_LOG_DEBUG <br>
- *   @copybrief IOT_LOG_DEBUG
- */
+/* Include header for logging level macros. */
+#include "iot_logging_levels.h"
 
-/**
- * @brief No log messages.
- *
- * When @ref LIBRARY_LOG_LEVEL is #IOT_LOG_NONE, logging is disabled and no
- * logging messages are printed.
- */
-#define IOT_LOG_NONE     0
-
-/**
- * @brief Represents erroneous application state or event.
- *
- * These messages describe the situations when a library encounters an error from
- * which it cannot recover.
- *
- * These messages are printed when @ref LIBRARY_LOG_LEVEL is defined as either
- * of #IOT_LOG_ERROR, #IOT_LOG_WARN, #IOT_LOG_INFO or #IOT_LOG_DEBUG.
- */
-#define IOT_LOG_ERROR    1
-
-/**
- * @brief Message about an abnormal event.
- *
- * These messages describe the situations when a library encounters
- * abnormal event that may be indicative of an error. Libraries continue
- * execution after logging a warning.
- *
- * These messages are printed when @ref LIBRARY_LOG_LEVEL is defined as either
- * of #IOT_LOG_WARN, #IOT_LOG_INFO or #IOT_LOG_DEBUG.
- */
-#define IOT_LOG_WARN     2
-
-/**
- * @brief A helpful, informational message.
- *
- * These messages describe normal execution of a library. They provide
- * the progress of the program at a coarse-grained level.
- *
- * These messages are printed when @ref LIBRARY_LOG_LEVEL is defined as either
- * of #IOT_LOG_INFO or #IOT_LOG_DEBUG.
- */
-#define IOT_LOG_INFO     3
-
-/**
- * @brief Detailed and excessive debug information.
- *
- * Debug log messages are used to provide the
- * progress of the program at a fine-grained level. These are mostly used
- * for debugging and may contain excessive information such as internal
- * variables, buffers, or other specific information.
- *
- * These messages are only printed when @ref LIBRARY_LOG_LEVEL is defined as
- * #IOT_LOG_DEBUG.
- */
-#define IOT_LOG_DEBUG    4
 
 /**
  * @functionpage{IotLog,logging,log}

--- a/libraries/standard/utilities/include/iot_logging_setup.h
+++ b/libraries/standard/utilities/include/iot_logging_setup.h
@@ -196,10 +196,14 @@
         #define IotLogDebugWithArgs( pFormat, ... )
 
     #else /* if LIBRARY_LOG_LEVEL == IOT_LOG_ERROR */
-        #define IotLogError( ... )
-        #define IotLogWarn( ... )
-        #define IotLogInfo( ... )
-        #define IotLogDebug( ... )
+        #define IotLogError( message )
+        #define IotLogErrorWithArgs( pFormat, ... )
+        #define IotLogWarn( message )
+        #define IotLogWarnWithArgs( pFormat, ... )
+        #define IotLogInfo( message )
+        #define IotLogInfoWithArgs( pFormat, ... )
+        #define IotLogDebug( message )
+        #define IotLogDebugWithArgs( pFormat, ... )
     #endif /* if LIBRARY_LOG_LEVEL == IOT_LOG_ERROR */
 #endif /* if !defined( LIBRARY_LOG_LEVEL ) || ( ( LIBRARY_LOG_LEVEL != IOT_LOG_NONE ) && ( LIBRARY_LOG_LEVEL != IOT_LOG_ERROR ) && ( LIBRARY_LOG_LEVEL != IOT_LOG_WARN ) && ( LIBRARY_LOG_LEVEL != IOT_LOG_INFO ) && ( LIBRARY_LOG_LEVEL != IOT_LOG_DEBUG ) ) */
 

--- a/platform/include/iot_clock.h
+++ b/platform/include/iot_clock.h
@@ -28,9 +28,6 @@
 #ifndef IOT_CLOCK_H_
 #define IOT_CLOCK_H_
 
-/* The config header is always included first. */
-#include "config.h"
-
 /* Standard includes. */
 #include <stdbool.h>
 #include <stddef.h>

--- a/platform/posix/iot_logging.c
+++ b/platform/posix/iot_logging.c
@@ -28,10 +28,15 @@
 /* Standard includes. */
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 /* Platform clock include. */
-#include "platform/iot_clock.h"
+#include "platform/include/iot_clock.h"
+
+/* Include header for logging level macros. */
+#include "iot_logging_levels.h"
 
 /* Logging includes. */
 #include "iot_logging.h"
@@ -49,6 +54,12 @@
  * @see @ref platform_clock_function_gettimestring
  */
 #define MAX_TIMESTRING_LENGTH    ( 64 )
+
+/**
+ * @brief The longest string in #_pLogLevelStrings (below), plus 3 to accommodate
+ * `[]` and a null-terminator.
+ */
+#define MAX_LOG_LEVEL_LENGTH     ( 8 )
 
 /*-----------------------------------------------------------*/
 
@@ -83,7 +94,7 @@ static bool _reallocLoggingBuffer( void ** pOldBuffer,
         ( void ) memcpy( pNewBuffer, *pOldBuffer, oldSize );
 
         /* Free the old buffer and update the pointer. */
-        IotLogging_Free( *pOldBuffer );
+        free( *pOldBuffer );
         *pOldBuffer = pNewBuffer;
 
         status = true;
@@ -134,7 +145,7 @@ void IotLog_Generic( int32_t messageLevel,
     /* Check for encoding errors. */
     if( requiredMessageSize <= 0 )
     {
-        IotLogging_Free( pLoggingBuffer );
+        free( pLoggingBuffer );
 
         return;
     }
@@ -193,7 +204,7 @@ void IotLog_Generic( int32_t messageLevel,
                                    bufferSize ) == false )
         {
             /* If buffer reallocation failed, return. */
-            IotLogging_Free( pLoggingBuffer );
+            free( pLoggingBuffer );
 
             return;
         }
@@ -214,16 +225,16 @@ void IotLog_Generic( int32_t messageLevel,
     /* Check for encoding errors. */
     if( requiredMessageSize <= 0 )
     {
-        IotLogging_Free( pLoggingBuffer );
+        free( pLoggingBuffer );
 
         return;
     }
 
     /* Print the logging buffer to stdout. */
-    IotLogging_Puts( pLoggingBuffer );
+    puts( pLoggingBuffer );
 
     /* Free the logging buffer. */
-    IotLogging_Free( pLoggingBuffer );
+    free( pLoggingBuffer );
 }
 
 /*-----------------------------------------------------------*/

--- a/platform/posix/iot_logging.c
+++ b/platform/posix/iot_logging.c
@@ -39,7 +39,7 @@
 #include "iot_logging_levels.h"
 
 /* Logging includes. */
-#include "iot_logging.h"
+#include "platform/include/iot_logging.h"
 
 /*-----------------------------------------------------------*/
 

--- a/platform/posix/iot_logging.c
+++ b/platform/posix/iot_logging.c
@@ -69,12 +69,12 @@
  * Converts one of the @ref logging_constants_levels to a string.
  */
 static const char * const _pLogLevelStrings[] =
-{
+    -1 {
     "ERROR", /* IOT_LOG_ERROR */
     "WARN ", /* IOT_LOG_WARN */
     "INFO ", /* IOT_LOG_INFO */
     "DEBUG"  /* IOT_LOG_DEBUG */
-};
+}
 
 /*-----------------------------------------------------------*/
 
@@ -140,7 +140,7 @@ void IotLog_Generic( int32_t messageLevel,
     requiredMessageSize = snprintf( pLoggingBuffer + bufferPosition,
                                     bufferSize - bufferPosition,
                                     "[%s]",
-                                    _pLogLevelStrings[ messageLevel ] );
+                                    _pLogLevelStrings[ messageLevel - 1 ] );
 
     /* Check for encoding errors. */
     if( requiredMessageSize <= 0 )

--- a/platform/posix/iot_logging.c
+++ b/platform/posix/iot_logging.c
@@ -69,12 +69,12 @@
  * Converts one of the @ref logging_constants_levels to a string.
  */
 static const char * const _pLogLevelStrings[] =
-    -1 {
+{
     "ERROR", /* IOT_LOG_ERROR */
     "WARN ", /* IOT_LOG_WARN */
     "INFO ", /* IOT_LOG_INFO */
     "DEBUG"  /* IOT_LOG_DEBUG */
-}
+};
 
 /*-----------------------------------------------------------*/
 

--- a/platform/posix/iot_logging.c
+++ b/platform/posix/iot_logging.c
@@ -64,17 +64,39 @@
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Lookup table for log levels.
+ * @brief Log level code to string conversion utility.
  *
- * Converts one of the @ref logging_constants_levels to a string.
+ * @param[in] messageLevel The log level to convert to string.
+ *
+ * @return The constant string representation of the log level.
  */
-static const char * const _pLogLevelStrings[] =
+static const char * _log_level_strerror( int32_t messageLevel )
 {
-    "ERROR", /* IOT_LOG_ERROR */
-    "WARN ", /* IOT_LOG_WARN */
-    "INFO ", /* IOT_LOG_INFO */
-    "DEBUG"  /* IOT_LOG_DEBUG */
-};
+    assert( ( messageLevel >= IOT_LOG_NONE ) && ( messageLevel <= IOT_LOG_DEBUG ) );
+
+    const char * retVal = NULL;
+
+    switch( messageLevel )
+    {
+        case IOT_LOG_ERROR:
+            retVal = "ERROR";
+            break;
+
+        case IOT_LOG_WARN:
+            retVal = "WARN";
+            break;
+
+        case IOT_LOG_INFO:
+            retVal = "INFO";
+            break;
+
+        case IOT_LOG_DEBUG:
+            retVal = "DEBUG";
+            break;
+    }
+
+    return retVal;
+}
 
 /*-----------------------------------------------------------*/
 
@@ -140,7 +162,7 @@ void IotLog_Generic( int32_t messageLevel,
     requiredMessageSize = snprintf( pLoggingBuffer + bufferPosition,
                                     bufferSize - bufferPosition,
                                     "[%s]",
-                                    _pLogLevelStrings[ messageLevel - 1 ] );
+                                    _log_level_strerror( messageLevel ) );
 
     /* Check for encoding errors. */
     if( requiredMessageSize <= 0 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix build errors for `iot_logging.c` file
Create separate file for storing logging level macros to allow inclusion in `iot_logginc.c`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
