### PR TITLE
Fix issues reported by clang static analysis

### DIFF
--- a/samples/linux/jobs_sample/jobs_sample.c
+++ b/samples/linux/jobs_sample/jobs_sample.c
@@ -353,6 +353,10 @@ int main(int argc, char **argv) {
 	paramsQOS0.payloadLen = strlen(cPayload);
 
 	rc = aws_iot_jobs_send_query(&client, QOS0, AWS_IOT_MY_THING_NAME, NULL, NULL, topicToPublishGetPending, sizeof(topicToPublishGetPending), NULL, 0, JOB_GET_PENDING_TOPIC);
+	if(SUCCESS != rc) {
+		IOT_ERROR("Error calling aws_iot_jobs_send_query: %d ", rc);
+		return rc;
+	}
 
 	AwsIotDescribeJobExecutionRequest describeRequest;
 	describeRequest.executionNumber = 0;

--- a/src/aws_iot_mqtt_client_common_internal.c
+++ b/src/aws_iot_mqtt_client_common_internal.c
@@ -308,7 +308,7 @@ IoT_Error_t aws_iot_mqtt_internal_init_header(MQTTHeader *pHeader, MessageTypes 
 IoT_Error_t aws_iot_mqtt_internal_send_packet(AWS_IoT_Client *pClient, size_t length, Timer *pTimer) {
 
 	size_t sentLen, sent;
-	IoT_Error_t rc;
+	IoT_Error_t rc = FAILURE;
 
 	FUNC_ENTRY;
 

--- a/src/aws_iot_mqtt_client_connect.c
+++ b/src/aws_iot_mqtt_client_connect.c
@@ -564,7 +564,6 @@ IoT_Error_t aws_iot_mqtt_disconnect(AWS_IoT_Client *pClient) {
 
 IoT_Error_t aws_iot_mqtt_attempt_reconnect(AWS_IoT_Client *pClient) {
 	IoT_Error_t rc;
-	ClientState currentState = aws_iot_mqtt_get_client_state(pClient);
 
 	FUNC_ENTRY;
 


### PR DESCRIPTION
The following issues were reported:

1. Uninitialized variable in `aws_iot_mqtt_internal_send_packet` function resulted in garbage return value.
2. `currentState` variable in `aws_iot_mqtt_attempt_reconnect` was not used.
3. Return value from `aws_iot_jobs_send_query` function was not checked in the jobs sample.

This commit addresses the above issues.

These were reported here: https://github.com/aws/aws-iot-device-sdk-embedded-C/issues/882

Signed-off-by: Gaurav Aggarwal <aggarg@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
