### PR TITLE
Log error when re-scheduling of the metrics job fails

### DIFF
--- a/libraries/aws/defender/src/aws_iot_defender_api.c
+++ b/libraries/aws/defender/src/aws_iot_defender_api.c
@@ -504,6 +504,11 @@ static void _metricsPublishRoutine( IotTaskPool_t pTaskPool,
         {
             /* Re-schedule metrics job with period as deferred interval. */
             taskPoolError = IotTaskPool_ScheduleDeferred( IOT_SYSTEM_TASKPOOL, _metricsPublishJob, _periodMilliSecond );
+
+            if( taskPoolError != IOT_TASKPOOL_SUCCESS )
+            {
+                IotLogError( "Failed to re-schedule the metrics job. Error: %s.", IotTaskPool_strerror( taskPoolError ) );
+            }
         }
 
         /* Give Done semaphore so AwsIotDefender_Stop() can proceed */


### PR DESCRIPTION
This was reported as the dead assignment using the clang static analysis tools as mentioned here: https://github.com/aws/aws-iot-device-sdk-embedded-C/issues/883

Signed-off-by: Gaurav Aggarwal <aggarg@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
