### PR TITLE
Incremental HTTPClient_Send(): receive functionality only.

### DIFF
--- a/libraries/standard/http/include/http_client.h
+++ b/libraries/standard/http/include/http_client.h
@@ -84,8 +84,8 @@ typedef struct HTTPNetworkContext HTTPNetworkContext_t;
 /**
  * @brief Transport interface for sending data over the network.
  *
- * If the number of bytes written returned is not equal to bytesToWrite, then
- * #HTTPClient_Send will return HTTP_NETWORK_ERROR. If a negative value is
+ * If the number of bytes written returned is not equal to @p bytesToWrite, then
+ * #HTTPClient_Send will return #HTTP_NETWORK_ERROR. If a negative value is
  * returned then this #HTTPClient_Send will also return #HTTP_NETWORK_ERROR.
  *
  * @param[in] context User defined context.
@@ -101,14 +101,14 @@ typedef int32_t (* HTTPTransportSend_t )( HTTPNetworkContext_t * pContext,
 /**
  * @brief Transport interface for reading data on the network.
  *
- * This function will read up to bytesToRead amount of data from the network.
+ * This function will read up to @p bytesToRead amount of data from the network.
  *
  * If this function returns a value less than zero, then #HTTPClient_Send will
  * return #HTTP_NETWORK_ERROR.
  *
  * If this function returns less than the bytesToRead and greater than zero,
- * then this function will be invoked again if the data in pBuffer contains a
- * partial HTTP response message and there is room left in the pBuffer.
+ * then this function will be invoked again if the data in @p pBuffer contains a
+ * partial HTTP response message and there is room left in the @p pBuffer.
  * Repeated invocations will stop if this function returns zero.
  *
  * @param[in] context User defined context.
@@ -171,9 +171,6 @@ typedef enum HTTPStatus
     /**
      * @brief Part of the HTTP response was received from the network.
      *
-     * This can occur only if #HTTPTransportRecv_t returns zero before the full
-     * response message was received.
-     *
      * Functions that may return this value:
      * - #HTTPClient_Send
      */
@@ -182,8 +179,8 @@ typedef enum HTTPStatus
     /**
      * @brief No HTTP response was received from the network.
      *
-     * This can occur only if #HTTPTransportRecv_t returns zero when first
-     * invoked.
+     * This can occur only if there was no data received from the transport
+     * interface.
      *
      * Functions that may return this value:
      * - #HTTPClient_Send
@@ -484,7 +481,8 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * more information.
  * @param[in] pRequestHeaders Request configuration containing the buffer of
  * headers to send.
- * @param[in] pRequestBodyBuf Request entity body. This can be NULL.
+ * @param[in] pRequestBodyBuf Optional Request entity body. Set to NULL if there
+ * is no request body.
  * @param[in] reqBodyBufLen The length of the request entity in bytes.
  * @param[in] pResponse The response message and some notable response
  * parameters will be returned here on success.

--- a/libraries/standard/http/include/http_client.h
+++ b/libraries/standard/http/include/http_client.h
@@ -108,7 +108,7 @@ typedef int32_t (* HTTPTransportSend_t )( HTTPNetworkContext_t * pContext,
  *
  * If this function returns less than the bytesToRead and greater than zero,
  * then this function will be invoked again if the data in pBuffer contains a
- * partial HTTP response message and there there is room left in the pBuffer.
+ * partial HTTP response message and there is room left in the pBuffer.
  * Repeated invocations will stop if this function returns zero.
  *
  * @param[in] context User defined context.
@@ -191,7 +191,7 @@ typedef enum HTTPStatus
     HTTP_NO_RESPONSE,
 
     /**
-     * @brief The application buffer was not large enough for HTTP request
+     * @brief The application buffer was not large enough for the HTTP request
      * headers or the HTTP response message.
      *
      * Functions that may return this value:

--- a/libraries/standard/http/include/http_client.h
+++ b/libraries/standard/http/include/http_client.h
@@ -471,7 +471,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * parameter pRequestBodyBuf over the transport. The response is received in
  * #HTTPResponse_t.
  *
- * The application should close the connection with the server if any 
+ * The application should close the connection with the server if any
  * HTTP_SECURITY_ALERT_X errors are returned.
  * TODO: List all the security alerts possible after parsing development.
  *

--- a/libraries/standard/http/include/http_client.h
+++ b/libraries/standard/http/include/http_client.h
@@ -471,9 +471,9 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * parameter pRequestBodyBuf over the transport. The response is received in
  * #HTTPResponse_t.
  *
- * The application should close the connection with the server if any
- * HTTP_SECURITY_ALERT_X errors are returned. Any error found in parsing is
- * considered a malformed response and therefore a security alert.
+ * The application should close the connection with the server if any 
+ * HTTP_SECURITY_ALERT_X errors are returned.
+ * TODO: List all the security alerts possible after parsing development.
  *
  * TODO: Expand documentation.
  *

--- a/libraries/standard/http/include/http_client.h
+++ b/libraries/standard/http/include/http_client.h
@@ -488,12 +488,12 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * parameters will be returned here on success.
  *
  * @return One of the following:
- * - #HTTP_SUCCESS
- * - #HTTP_INVALID_PARAMETER
- * - #HTTP_NETWORK_ERROR
- * - #HTTP_PARTIAL_RESPONSE
- * - #HTTP_NO_RESPONSE
- * - #HTTP_INSUFFICIENT_MEMORY
+ * - #HTTP_SUCCESS (If successful.)
+ * - #HTTP_INVALID_PARAMETER (If any provided parameters or their members are invalid.)
+ * - #HTTP_NETWORK_ERROR (Errors in sending or receiving over the transport interface.)
+ * - #HTTP_PARTIAL_RESPONSE (Part of an HTTP response was received in a partially filled response buffer.)
+ * - #HTTP_NO_RESPONSE (No data was received from the transport interface.)
+ * - #HTTP_INSUFFICIENT_MEMORY (The response received could not fit into the response buffer.)
  * TODO: Add more errors for parsing implementation.
  */
 HTTPStatus_t HTTPClient_Send( const HTTPTransportInterface_t * pTransport,

--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -1,18 +1,19 @@
 #include <assert.h>
 #include <string.h>
-#include <stdlib.h>
 #include <stdio.h>
 
 #include "http_client.h"
 #include "private/http_client_internal.h"
+#include "private/http_client_parse.h"
 
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Send the HTTP headers over the transport send interface.
  *
- * @param pTransport Transport interface.
- * @param pRequestHeaders Request headers to send, it includes the buffer and length.
+ * @param[in] pTransport Transport interface.
+ * @param[in] pRequestHeaders Request headers to send, it includes the buffer
+ * and length.
  *
  * @return #HTTP_SUCCESS if successful. If there was a network error or less
  * bytes than what was specified were sent, then #HTTP_NETWORK_ERROR is returned.
@@ -23,9 +24,9 @@ static HTTPStatus_t _sendHttpHeaders( const HTTPTransportInterface_t * pTranspor
 /**
  * @brief Send the HTTP body over the transport send interface.
  *
- * @param pTransport Transport interface.
- * @param pRequestBodyBuf Request body buffer.
- * @param reqBodyLen Length of the request body buffer.
+ * @param[in] pTransport Transport interface.
+ * @param[in] pRequestBodyBuf Request body buffer.
+ * @param[in] reqBodyLen Length of the request body buffer.
  *
  * @return #HTTP_SUCCESS if successful. If there was a network error or less
  * bytes than what was specified were sent, then #HTTP_NETWORK_ERROR is returned.
@@ -53,6 +54,58 @@ static HTTPStatus_t _addHeader( HTTPRequestHeaders_t * pRequestHeaders,
                                 size_t fieldLen,
                                 const char * pValue,
                                 size_t valueLen );
+
+/**
+ * @brief Receive HTTP response from the transport recv interface.
+ *
+ * @param[in] pTransport Transport interface.
+ * @param[in] pResponse Response buffer.
+ * @param[in] bufferLen Length of the response buffer.
+ *
+ * @return Returns #HTTP_SUCCESS if successful. If there was a network error or
+ * more bytes than what was specified were read, then #HTTP_NETWORK_ERROR is
+ * returned.
+ */
+HTTPStatus_t _receiveHttpResponse( const HTTPTransportInterface_t * pTransport,
+                                   uint8_t * pBuffer,
+                                   size_t bufferLen,
+                                   size_t * pBytesReceived );
+
+/**
+ * @brief Get the status of the HTTP response given the parsing state and how
+ * much data is in the response buffer.
+ *
+ * @param[in] parsingState State of the parsing on the HTTP response.
+ * @param[in] totalReceived The amount of network data received in the response
+ * buffer.
+ * @param[in] responseBufferLen The length of the response buffer.
+ *
+ * @return Returns #HTTP_SUCCESS if parsing state denotes it is complete. If the
+ * parsing state denotes it never started, then return #HTTP_NO_RESPONSE. If the
+ * parsing state is incomplete, thenif the response buffer is not full return
+ * #HTTP_PARTIAL_RESPONSE. If the parsing state is incomplete, then if the
+ * response buffer is full return #HTTP_INSUFFICIENT_MEMORY.
+ */
+static HTTPStatus_t _getFinalResponseStatus( HTTPParsingState_t parsingState,
+                                             size_t totalReceived,
+                                             size_t responseBufferLen );
+
+/**
+ * @brief Receive the HTTP response from the network and parse it.
+ *
+ * @param[in] pTransport Transport interface.
+ * @param[in] pResponse Response message to receive data from the network.
+ *
+ * @return Returns #HTTP_SUCCESS if successful. If there was an issue with receiving
+ * the response over the network interface, then #HTTP_NETWORK_ERROR is returned,
+ * please see #_receiveHttpResponse. If there was an issue with parsing, then the
+ * parsing error that occurred will be returned, please see
+ * #_HTTPClient_InitializeParsingContext and #_HTTPClient_ParseResponse. Please
+ * see #_getFinalResponseStatus for the status returned when there were no
+ * network or parsing errors.
+ */
+static HTTPStatus_t _receiveAndParseHttpResponse( const HTTPTransportInterface_t * pTransport,
+                                                  HTTPResponse_t * pResponse );
 
 /*-----------------------------------------------------------*/
 
@@ -210,6 +263,10 @@ static HTTPStatus_t _sendHttpHeaders( const HTTPTransportInterface_t * pTranspor
     HTTPStatus_t returnStatus = HTTP_SUCCESS;
     int32_t transportStatus = 0;
 
+    assert( pTransport != NULL );
+    assert( pTransport->send != NULL );
+    assert( pRequestHeaders != NULL );
+
     /* Send the HTTP headers over the network. */
     transportStatus = pTransport->send( pTransport->pContext,
                                         pRequestHeaders->pBuffer,
@@ -217,22 +274,25 @@ static HTTPStatus_t _sendHttpHeaders( const HTTPTransportInterface_t * pTranspor
 
     if( transportStatus < 0 )
     {
-        IotLogErrorWithArgs( "Error in sending the HTTP headers over the transport "
-                             "interface: Transport status %d.",
+        IotLogErrorWithArgs( "Failed to send HTTP headers: Transport send()"
+                             " returned error: Transport Status = %d",
                              transportStatus );
         returnStatus = HTTP_NETWORK_ERROR;
     }
     else if( transportStatus != pRequestHeaders->headersLen )
     {
-        IotLogErrorWithArgs( "Failure in sending HTTP headers: Transport layer "
-                             "did not send the required bytes: Required Bytes=%d"
-                             ", Sent Bytes=%d.",
+        IotLogErrorWithArgs( "Failed to send HTTP headers: Transport layer "
+                             "did not send the required bytes: Required bytes = %d"
+                             ", Sent bytes=%d.",
+                             pRequestHeaders->headersLen,
                              transportStatus );
         returnStatus = HTTP_NETWORK_ERROR;
     }
     else
     {
-        /* Empty else MISRA 15.7 */
+        IotLogDebugWithArgs( "Sent HTTP headers over the transport: Bytes sent "
+                             "= %d.",
+                             transportStatus );
     }
 
     return returnStatus;
@@ -247,28 +307,34 @@ static HTTPStatus_t _sendHttpBody( const HTTPTransportInterface_t * pTransport,
     HTTPStatus_t returnStatus = HTTP_SUCCESS;
     int32_t transportStatus = 0;
 
-    /* Send the HTTP body over the network. */
-    if( pRequestBodyBuf != NULL )
-    {
-        transportStatus = pTransport->send( pTransport->pContext,
-                                            pRequestBodyBuf,
-                                            reqBodyBufLen );
+    assert( pTransport != NULL );
+    assert( pTransport->send != NULL );
+    assert( pRequestBodyBuf != NULL );
 
-        if( transportStatus < 0 )
-        {
-            IotLogErrorWithArgs( "Error in sending the HTTP body over the "
-                                 "transport interface. Transport status %d.",
-                                 transportStatus );
-            returnStatus = HTTP_NETWORK_ERROR;
-        }
-        else if( transportStatus != reqBodyBufLen )
-        {
-            IotLogErrorWithArgs( "Failure in sending HTTP headers: Transport layer "
-                                 "did not send the required bytes: Required Bytes=%d"
-                                 ", Sent Bytes=%d.",
-                                 transportStatus );
-            returnStatus = HTTP_NETWORK_ERROR;
-        }
+    transportStatus = pTransport->send( pTransport->pContext,
+                                        pRequestBodyBuf,
+                                        reqBodyBufLen );
+
+    if( transportStatus < 0 )
+    {
+        IotLogErrorWithArgs( "Failed to send HTTP body: Transport send()"
+                             " returned error: Transport Status = %d",
+                             transportStatus );
+        returnStatus = HTTP_NETWORK_ERROR;
+    }
+    else if( transportStatus != reqBodyBufLen )
+    {
+        IotLogErrorWithArgs( "Failed to send HTTP body: Transport layer "
+                             "did not send the required bytes: Required bytes = %d"
+                             ", Sent bytes=%d.",
+                             reqBodyBufLen,
+                             transportStatus );
+        returnStatus = HTTP_NETWORK_ERROR;
+    }
+    else
+    {
+        IotLogDebugWithArgs( "Sent HTTP body over the transport: Bytes sent = %d.",
+                             transportStatus );
     }
 
     return returnStatus;
@@ -276,11 +342,168 @@ static HTTPStatus_t _sendHttpBody( const HTTPTransportInterface_t * pTransport,
 
 /*-----------------------------------------------------------*/
 
-static HTTPStatus_t _receiveHttpResponse( const HTTPTransportInterface_t * pTransport,
-                                          HTTPResponse_t * pResponse )
+HTTPStatus_t _receiveHttpResponse( const HTTPTransportInterface_t * pTransport,
+                                   uint8_t * pBuffer,
+                                   size_t bufferLen,
+                                   size_t * pBytesReceived )
 {
-    /* TODO: Receive the HTTP response with parsing. */
-    return HTTP_SUCCESS;
+    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+
+    assert( pTransport != NULL );
+    assert( pTransport->recv != NULL );
+    assert( pBuffer != NULL );
+    assert( pBytesReceived != NULL );
+
+    int32_t transportStatus = pTransport->recv( pTransport->pContext,
+                                                pBuffer,
+                                                bufferLen );
+
+    /* A transport status of less than zero is an error. */
+    if( transportStatus < 0 )
+    {
+        IotLogErrorWithArgs( "Failed to receive HTTP response: Transport recv() "
+                             "returned error: Transport status = %d.",
+                             transportStatus );
+        returnStatus = HTTP_NETWORK_ERROR;
+    }
+    else if( transportStatus > bufferLen )
+    {
+        /* There is a bug in the transport recv if more bytes are reported
+         * to have been read than the bytes asked for. */
+        IotLogErrorWithArgs( "Failed to receive HTTP response: Transport recv() "
+                             " read more bytes than expected: Bytes read = %d",
+                             transportStatus );
+        returnStatus = HTTP_NETWORK_ERROR;
+    }
+    else if( transportStatus > 0 )
+    {
+        /* Some or all of the specified data was received. */
+        *pBytesReceived = ( size_t ) ( transportStatus );
+        IotLogDebugWithArgs( "Received data from the transport: Bytes "
+                             "received = %d.",
+                             transportStatus );
+    }
+    else
+    {
+        /* When a zero is returned from the transport recv it will not be
+         * invoked again. */
+        IotLogDebug( "Transport recv returned 0. Receiving transport data"
+                     "is complete." );
+    }
+
+    return returnStatus;
+}
+
+/*-----------------------------------------------------------*/
+
+static HTTPStatus_t _getFinalResponseStatus( HTTPParsingState_t parsingState,
+                                             size_t totalReceived,
+                                             size_t responseBufferLen )
+{
+    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+
+    assert( parsingState >= HTTP_PARSING_NONE &&
+            parsingState <= HTTP_PARSING_COMPLETE );
+    assert( totalReceived <= responseBufferLen );
+
+    /* If no parsing occurred, that means network data was never received. */
+    if( parsingState == HTTP_PARSING_NONE )
+    {
+        IotLogErrorWithArgs( "Response not received: Zero returned from "
+                             "transport recv: Total received = % d",
+                             totalReceived );
+        returnStatus = HTTP_NO_RESPONSE;
+    }
+    else if( parsingState == HTTP_PARSING_INCOMPLETE )
+    {
+        if( totalReceived == responseBufferLen )
+        {
+            IotLogErrorWithArgs( "Response is too large for the response buffer"
+                                 ": Response buffer size in bytes = %d",
+                                 responseBufferLen );
+            returnStatus = HTTP_INSUFFICIENT_MEMORY;
+        }
+        else
+        {
+            IotLogErrorWithArgs( "Partial response received: Transport recv "
+                                 "returned zero before the complete response: "
+                                 "Partial size = %d, Response buffer space "
+                                 "left = %d",
+                                 totalReceived,
+                                 responseBufferLen - totalReceived );
+            returnStatus = HTTP_PARTIAL_RESPONSE;
+        }
+    }
+    else
+    {
+        /* Empty else for MISRA 15.7 compliance. */
+    }
+
+    return returnStatus;
+}
+
+static HTTPStatus_t _receiveAndParseHttpResponse( const HTTPTransportInterface_t * pTransport,
+                                                  HTTPResponse_t * pResponse )
+{
+    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+    size_t totalReceived = 0;
+    size_t currentReceived = 0;
+    HTTPParsingContext_t parsingContext = { 0 };
+
+    if( pResponse->pBuffer == NULL )
+    {
+        IotLogError( "Parameter check failed: pResponse->pBuffer is NULL." );
+        returnStatus = HTTP_INVALID_PARAMETER;
+    }
+
+    if( returnStatus == HTTP_SUCCESS )
+    {
+        /* Initialize the parsing context. */
+        returnStatus = _HTTPClient_InitializeParsingContext( &parsingContext );
+    }
+
+    /* While there are no errors in the transport recv or parsing, the response
+     * message is not finished, and there is room in the response buffer. */
+    while( ( returnStatus == HTTP_SUCCESS ) &&
+           ( parsingContext.state != HTTP_PARSING_COMPLETE ) &&
+           ( totalReceived < pResponse->bufferLen ) )
+    {
+        /* Receive the HTTP response data into the pResponse->pBuffer. */
+        returnStatus = _receiveHttpResponse( pTransport,
+                                             pResponse->pBuffer + totalReceived,
+                                             pResponse->bufferLen - totalReceived,
+                                             &currentReceived );
+
+        if( returnStatus == HTTP_SUCCESS )
+        {
+            if( currentReceived > 0 )
+            {
+                totalReceived += currentReceived;
+                /* Data is received into the buffer and must be parsed. */
+                returnStatus = _HTTPClient_ParseResponse( &parsingContext,
+                                                          pResponse->pBuffer + totalReceived,
+                                                          currentReceived );
+            }
+            else
+            {
+                /* If there was no data received, then end receiving and parsing
+                 * the response. */
+                break;
+            }
+        }
+    }
+
+    if( returnStatus == HTTP_SUCCESS )
+    {
+        /* For no network or parsing errors, the final status of the response
+         * message is derived from the state of the parsing and how much data
+         * is in the buffer. */
+        returnStatus = _getFinalResponseStatus( parsingContext.state,
+                                                totalReceived,
+                                                pResponse->bufferLen );
+    }
+
+    return returnStatus;
 }
 
 /*-----------------------------------------------------------*/
@@ -320,7 +543,7 @@ HTTPStatus_t HTTPClient_Send( const HTTPTransportInterface_t * pTransport,
     }
     else
     {
-        /* Empty else MISRA 15.7 */
+        /* Empty else for MISRA 15.7 compliance. */
     }
 
     /* Send the headers, which are at one location in memory. */
@@ -333,15 +556,31 @@ HTTPStatus_t HTTPClient_Send( const HTTPTransportInterface_t * pTransport,
     /* Send the body, which is at another location in memory. */
     if( returnStatus == HTTP_SUCCESS )
     {
-        returnStatus = _sendHttpBody( pTransport,
-                                      pRequestBodyBuf,
-                                      reqBodyBufLen );
+        if( pRequestBodyBuf != NULL )
+        {
+            returnStatus = _sendHttpBody( pTransport,
+                                          pRequestBodyBuf,
+                                          reqBodyBufLen );
+        }
+        else
+        {
+            IotLogDebug( "A request body was not sent: pRequestBodyBuf is NULL." );
+        }
     }
 
     if( returnStatus == HTTP_SUCCESS )
     {
-        returnStatus = _receiveHttpResponse( pTransport,
-                                             pResponse );
+        /* If the application chooses to receive a response, then pResponse
+         * will not be NULL. */
+        if( pResponse != NULL )
+        {
+            returnStatus = _receiveAndParseHttpResponse( pTransport,
+                                                         pResponse );
+        }
+        else
+        {
+            IotLogWarn( "A response was not received: pResponse is NULL. " );
+        }
     }
 
     return returnStatus;

--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -459,7 +459,8 @@ static HTTPStatus_t _receiveAndParseHttpResponse( const HTTPTransportInterface_t
     if( returnStatus == HTTP_SUCCESS )
     {
         /* Initialize the parsing context. */
-        returnStatus = _HTTPClient_InitializeParsingContext( &parsingContext );
+        returnStatus = _HTTPClient_InitializeParsingContext( &parsingContext,
+                                                             pResponse->pHeaderParsingCallback );
     }
 
     /* While there are no errors in the transport recv or parsing, the response

--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -292,7 +292,7 @@ static HTTPStatus_t _sendHttpHeaders( const HTTPTransportInterface_t * pTranspor
     else
     {
         IotLogDebugWithArgs( "Sent HTTP headers over the transport: BytesSent "
-                             "= %d.",
+                             "=%d.",
                              transportStatus );
     }
 
@@ -542,7 +542,7 @@ HTTPStatus_t HTTPClient_Send( const HTTPTransportInterface_t * pTransport,
         IotLogError( "Parameter check failed: pRequestHeaders->pBuffer is NULL." );
         returnStatus = HTTP_INVALID_PARAMETER;
     }
-    else if( pResponse && ( pResponse->pBuffer == NULL ) )
+    else if( ( pResponse != NULL ) && ( pResponse->pBuffer == NULL ) )
     {
         IotLogError( "Parameter check failed: pResponse->pBuffer is NULL." );
         returnStatus = HTTP_INVALID_PARAMETER;

--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -275,14 +275,14 @@ static HTTPStatus_t _sendHttpHeaders( const HTTPTransportInterface_t * pTranspor
     if( transportStatus < 0 )
     {
         IotLogErrorWithArgs( "Failed to send HTTP headers: Transport send()"
-                             " returned error: Transport Status = %d",
+                             " returned error: Transport Status=%d",
                              transportStatus );
         returnStatus = HTTP_NETWORK_ERROR;
     }
-    else if( transportStatus != pRequestHeaders->headersLen )
+    else if( (size_t)transportStatus != pRequestHeaders->headersLen )
     {
         IotLogErrorWithArgs( "Failed to send HTTP headers: Transport layer "
-                             "did not send the required bytes: Required bytes = %d"
+                             "did not send the required bytes: Required bytes=%d"
                              ", Sent bytes=%d.",
                              pRequestHeaders->headersLen,
                              transportStatus );
@@ -318,14 +318,14 @@ static HTTPStatus_t _sendHttpBody( const HTTPTransportInterface_t * pTransport,
     if( transportStatus < 0 )
     {
         IotLogErrorWithArgs( "Failed to send HTTP body: Transport send() "
-                             " returned error: Transport Status = %d",
+                             " returned error: Transport Status=%d",
                              transportStatus );
         returnStatus = HTTP_NETWORK_ERROR;
     }
-    else if( transportStatus != reqBodyBufLen )
+    else if( ( size_t )transportStatus != reqBodyBufLen )
     {
         IotLogErrorWithArgs( "Failed to send HTTP body: Transport send() "
-                             "did not send the required bytes: Required bytes = %d"
+                             "did not send the required bytes: Required bytes=%d"
                              ", Sent bytes=%d.",
                              reqBodyBufLen,
                              transportStatus );
@@ -333,7 +333,7 @@ static HTTPStatus_t _sendHttpBody( const HTTPTransportInterface_t * pTransport,
     }
     else
     {
-        IotLogDebugWithArgs( "Sent HTTP body over the transport: Bytes sent = %d.",
+        IotLogDebugWithArgs( "Sent HTTP body over the transport: Bytes sent=%d.",
                              transportStatus );
     }
 
@@ -362,16 +362,16 @@ HTTPStatus_t _receiveHttpResponse( const HTTPTransportInterface_t * pTransport,
     if( transportStatus < 0 )
     {
         IotLogErrorWithArgs( "Failed to receive HTTP response: Transport recv() "
-                             "returned error: Transport status = %d.",
+                             "returned error: Transport status=%d.",
                              transportStatus );
         returnStatus = HTTP_NETWORK_ERROR;
     }
-    else if( transportStatus > bufferLen )
+    else if( (size_t)transportStatus > bufferLen )
     {
         /* There is a bug in the transport recv if more bytes are reported
          * to have been read than the bytes asked for. */
         IotLogErrorWithArgs( "Failed to receive HTTP response: Transport recv() "
-                             " read more bytes than expected: Bytes read = %d",
+                             " read more bytes than expected: Bytes read=%d",
                              transportStatus );
         returnStatus = HTTP_NETWORK_ERROR;
     }
@@ -380,7 +380,7 @@ HTTPStatus_t _receiveHttpResponse( const HTTPTransportInterface_t * pTransport,
         /* Some or all of the specified data was received. */
         *pBytesReceived = ( size_t ) ( transportStatus );
         IotLogDebugWithArgs( "Received data from the transport: Bytes "
-                             "received = %d.",
+                             "received=%d.",
                              transportStatus );
     }
     else
@@ -410,7 +410,7 @@ static HTTPStatus_t _getFinalResponseStatus( HTTPParsingState_t parsingState,
     if( parsingState == HTTP_PARSING_NONE )
     {
         IotLogErrorWithArgs( "Response not received: Zero returned from "
-                             "transport recv: Total received = % d",
+                             "transport recv: Total received=%d",
                              totalReceived );
         returnStatus = HTTP_NO_RESPONSE;
     }
@@ -419,7 +419,7 @@ static HTTPStatus_t _getFinalResponseStatus( HTTPParsingState_t parsingState,
         if( totalReceived == responseBufferLen )
         {
             IotLogErrorWithArgs( "Response is too large for the response buffer"
-                                 ": Response buffer size in bytes = %d",
+                                 ": Response buffer size in bytes=%d",
                                  responseBufferLen );
             returnStatus = HTTP_INSUFFICIENT_MEMORY;
         }
@@ -427,8 +427,8 @@ static HTTPStatus_t _getFinalResponseStatus( HTTPParsingState_t parsingState,
         {
             IotLogErrorWithArgs( "Partial response received: Transport recv "
                                  "returned zero before the complete response: "
-                                 "Partial size = %d, Response buffer space "
-                                 "left = %d",
+                                 "Partial size=%d, Response buffer space "
+                                 "left=%d",
                                  totalReceived,
                                  responseBufferLen - totalReceived );
             returnStatus = HTTP_PARTIAL_RESPONSE;

--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -80,11 +80,11 @@ HTTPStatus_t _receiveHttpResponse( const HTTPTransportInterface_t * pTransport,
  * buffer.
  * @param[in] responseBufferLen The length of the response buffer.
  *
- * @return Returns #HTTP_SUCCESS if parsing state denotes it is complete. If the
- * parsing state denotes it never started, then return #HTTP_NO_RESPONSE. If the
- * parsing state is incomplete, thenif the response buffer is not full return
- * #HTTP_PARTIAL_RESPONSE. If the parsing state is incomplete, then if the
- * response buffer is full return #HTTP_INSUFFICIENT_MEMORY.
+ * @return Returns #HTTP_SUCCESS if the parsing state is complete. If
+ * the parsing state denotes it never started, then return #HTTP_NO_RESPONSE. If
+ * the parsing state is incomplete, then if the response buffer is not full
+ * #HTTP_PARTIAL_RESPONSE is returned. If the parsing state is incomplete, then
+ * if the response buffer is full #HTTP_INSUFFICIENT_MEMORY is returned.
  */
 static HTTPStatus_t _getFinalResponseStatus( HTTPParsingState_t parsingState,
                                              size_t totalReceived,
@@ -317,14 +317,14 @@ static HTTPStatus_t _sendHttpBody( const HTTPTransportInterface_t * pTransport,
 
     if( transportStatus < 0 )
     {
-        IotLogErrorWithArgs( "Failed to send HTTP body: Transport send()"
+        IotLogErrorWithArgs( "Failed to send HTTP body: Transport send() "
                              " returned error: Transport Status = %d",
                              transportStatus );
         returnStatus = HTTP_NETWORK_ERROR;
     }
     else if( transportStatus != reqBodyBufLen )
     {
-        IotLogErrorWithArgs( "Failed to send HTTP body: Transport layer "
+        IotLogErrorWithArgs( "Failed to send HTTP body: Transport send() "
                              "did not send the required bytes: Required bytes = %d"
                              ", Sent bytes=%d.",
                              reqBodyBufLen,
@@ -387,7 +387,7 @@ HTTPStatus_t _receiveHttpResponse( const HTTPTransportInterface_t * pTransport,
     {
         /* When a zero is returned from the transport recv it will not be
          * invoked again. */
-        IotLogDebug( "Transport recv returned 0. Receiving transport data"
+        IotLogDebug( "Transport recv() returned 0. Receiving transport data"
                      "is complete." );
     }
 

--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -157,7 +157,7 @@ static HTTPStatus_t _addHeader( HTTPRequestHeaders_t * pRequestHeaders,
         if( ( bytesWritten + HTTP_HEADER_LINE_SEPARATOR_LEN ) != toAddLen )
         {
             IotLogErrorWithArgs( "Internal error in snprintf() in _addHeader(). "
-                                 "Bytes written: %d.", bytesWritten );
+                                 "BytesWritten: %d.", bytesWritten );
         }
         else
         {
@@ -275,22 +275,22 @@ static HTTPStatus_t _sendHttpHeaders( const HTTPTransportInterface_t * pTranspor
     if( transportStatus < 0 )
     {
         IotLogErrorWithArgs( "Failed to send HTTP headers: Transport send()"
-                             " returned error: Transport Status=%d",
+                             " returned error: TransportStatus=%d",
                              transportStatus );
         returnStatus = HTTP_NETWORK_ERROR;
     }
     else if( (size_t)transportStatus != pRequestHeaders->headersLen )
     {
         IotLogErrorWithArgs( "Failed to send HTTP headers: Transport layer "
-                             "did not send the required bytes: Required bytes=%d"
-                             ", Sent bytes=%d.",
+                             "did not send the required bytes: RequiredBytes=%d"
+                             ", SentBytes=%d.",
                              pRequestHeaders->headersLen,
                              transportStatus );
         returnStatus = HTTP_NETWORK_ERROR;
     }
     else
     {
-        IotLogDebugWithArgs( "Sent HTTP headers over the transport: Bytes sent "
+        IotLogDebugWithArgs( "Sent HTTP headers over the transport: BytesSent "
                              "= %d.",
                              transportStatus );
     }
@@ -318,14 +318,14 @@ static HTTPStatus_t _sendHttpBody( const HTTPTransportInterface_t * pTransport,
     if( transportStatus < 0 )
     {
         IotLogErrorWithArgs( "Failed to send HTTP body: Transport send() "
-                             " returned error: Transport Status=%d",
+                             " returned error: TransportStatus=%d",
                              transportStatus );
         returnStatus = HTTP_NETWORK_ERROR;
     }
     else if( ( size_t )transportStatus != reqBodyBufLen )
     {
         IotLogErrorWithArgs( "Failed to send HTTP body: Transport send() "
-                             "did not send the required bytes: Required bytes=%d"
+                             "did not send the required bytes: RequiredBytes=%d"
                              ", Sent bytes=%d.",
                              reqBodyBufLen,
                              transportStatus );
@@ -333,7 +333,7 @@ static HTTPStatus_t _sendHttpBody( const HTTPTransportInterface_t * pTransport,
     }
     else
     {
-        IotLogDebugWithArgs( "Sent HTTP body over the transport: Bytes sent=%d.",
+        IotLogDebugWithArgs( "Sent HTTP body over the transport: BytesSent=%d.",
                              transportStatus );
     }
 
@@ -362,7 +362,7 @@ HTTPStatus_t _receiveHttpResponse( const HTTPTransportInterface_t * pTransport,
     if( transportStatus < 0 )
     {
         IotLogErrorWithArgs( "Failed to receive HTTP response: Transport recv() "
-                             "returned error: Transport status=%d.",
+                             "returned error: TransportStatus=%d.",
                              transportStatus );
         returnStatus = HTTP_NETWORK_ERROR;
     }
@@ -371,7 +371,7 @@ HTTPStatus_t _receiveHttpResponse( const HTTPTransportInterface_t * pTransport,
         /* There is a bug in the transport recv if more bytes are reported
          * to have been read than the bytes asked for. */
         IotLogErrorWithArgs( "Failed to receive HTTP response: Transport recv() "
-                             " read more bytes than expected: Bytes read=%d",
+                             " read more bytes than expected: BytesRead=%d",
                              transportStatus );
         returnStatus = HTTP_NETWORK_ERROR;
     }
@@ -379,8 +379,7 @@ HTTPStatus_t _receiveHttpResponse( const HTTPTransportInterface_t * pTransport,
     {
         /* Some or all of the specified data was received. */
         *pBytesReceived = ( size_t ) ( transportStatus );
-        IotLogDebugWithArgs( "Received data from the transport: Bytes "
-                             "received=%d.",
+        IotLogDebugWithArgs( "Received data from the transport: BytesReceived=%d.",
                              transportStatus );
     }
     else
@@ -410,7 +409,7 @@ static HTTPStatus_t _getFinalResponseStatus( HTTPParsingState_t parsingState,
     if( parsingState == HTTP_PARSING_NONE )
     {
         IotLogErrorWithArgs( "Response not received: Zero returned from "
-                             "transport recv: Total received=%d",
+                             "transport recv: totalReceived=%d",
                              totalReceived );
         returnStatus = HTTP_NO_RESPONSE;
     }
@@ -419,7 +418,7 @@ static HTTPStatus_t _getFinalResponseStatus( HTTPParsingState_t parsingState,
         if( totalReceived == responseBufferLen )
         {
             IotLogErrorWithArgs( "Response is too large for the response buffer"
-                                 ": Response buffer size in bytes=%d",
+                                 ": responseBufferLen=%d",
                                  responseBufferLen );
             returnStatus = HTTP_INSUFFICIENT_MEMORY;
         }

--- a/libraries/standard/http/src/http_client_parse.c
+++ b/libraries/standard/http/src/http_client_parse.c
@@ -8,7 +8,7 @@ HTTPStatus_t _HTTPClient_InitializeParsingContext( HTTPParsingContext_t * pParsi
 }
 
 HTTPStatus_t _HTTPClient_ParseResponse( HTTPParsingContext_t * pParsingContext,
-                                        uint8_t * pBuffer,
+                                        const uint8_t * pBuffer,
                                         size_t bufferLen )
 {
     /* This function is to be implemented. For now we return success. */

--- a/libraries/standard/http/src/http_client_parse.c
+++ b/libraries/standard/http/src/http_client_parse.c
@@ -1,6 +1,7 @@
 #include "private/http_client_parse.h"
 
-HTTPStatus_t _HTTPClient_InitializeParsingContext( HTTPParsingContext_t * pParsingContext )
+HTTPStatus_t _HTTPClient_InitializeParsingContext( HTTPParsingContext_t * pParsingContext,
+                                                   HTTPClient_HeaderParsingCallback_t * pHeaderParsingCallback )
 {
     /* This function is to be implenmented. */
     return HTTP_SUCCESS;

--- a/libraries/standard/http/src/http_client_parse.c
+++ b/libraries/standard/http/src/http_client_parse.c
@@ -1,0 +1,16 @@
+#include "private/http_client_parse.h"
+
+HTTPStatus_t _HTTPClient_InitializeParsingContext( HTTPParsingContext_t * pParsingContext )
+{
+    /* This function is to be implenmented. */
+    return HTTP_SUCCESS;
+}
+
+HTTPStatus_t _HTTPClient_ParseResponse( HTTPParsingContext_t * pParsingContext,
+                                        uint8_t * pBuffer,
+                                        size_t bufferLen )
+{
+    /* This function is to be implemented. For now we return success. */
+    pParsingContext->state = HTTP_PARSING_COMPLETE;
+    return HTTP_SUCCESS;
+}

--- a/libraries/standard/http/src/private/http_client_parse.h
+++ b/libraries/standard/http/src/private/http_client_parse.h
@@ -26,19 +26,23 @@ typedef struct HTTPParsingContext
         http_parser httpParser; /**< Third-party http-parser context. */
     #endif
     HTTPParsingState_t state;   /**< The current state of the HTTP response parsed. */
+    HTTPClient_HeaderParsingCallback_t * pHeaderParsingCallback;
 } HTTPParsingContext_t;
 
 /**
  * Initialize the HTTP Client response parsing context.
  *
  * @param[in] pParsingContext The state of response parsing to initialize.
+ * @param[in] pHeaderParsingCallback Callback to invoked for each complete
+ * header and value found.
  *
  * @return One of the following:
  * - #HTTP_SUCCESS
  * - #HTTP_INVALID_PARAMETER
  * TODO: Other return values will be added during implementation of the parsing.
  */
-HTTPStatus_t _HTTPClient_InitializeParsingContext( HTTPParsingContext_t * pParsingContext );
+HTTPStatus_t _HTTPClient_InitializeParsingContext( HTTPParsingContext_t * pParsingContext,
+                                                   HTTPClient_HeaderParsingCallback_t * pHeaderParsingCallback );
 
 /**
  * Parse the input HTTP response buffer.

--- a/libraries/standard/http/src/private/http_client_parse.h
+++ b/libraries/standard/http/src/private/http_client_parse.h
@@ -23,9 +23,9 @@ typedef struct HTTPParsingContext
     /* http-parser dependencies will be added in the next incremental change. */
     /* Below will be un-commented when parsing is implemented. */
     #if 0
-        http_parser httpParser; /**< Third-party http-parser context. */
+        http_parser httpParser;                                  /**< Third-party http-parser context. */
     #endif
-    HTTPParsingState_t state;   /**< The current state of the HTTP response parsed. */
+    HTTPParsingState_t state;                                    /**< The current state of the HTTP response parsed. */
     HTTPClient_HeaderParsingCallback_t * pHeaderParsingCallback; /**< Callback to invoke with each header found. */
 } HTTPParsingContext_t;
 
@@ -51,8 +51,8 @@ HTTPStatus_t _HTTPClient_InitializeParsingContext( HTTPParsingContext_t * pParsi
  * HTTP response. The state of what was last parsed in the response is kept in
  * #HTTPParsingContext_t.
  *
- * The application should close the connection with the server if any 
- * HTTP_SECURITY_ALERT_X errors are returned. 
+ * The application should close the connection with the server if any
+ * HTTP_SECURITY_ALERT_X errors are returned.
  * TODO: List all the security alerts possible after parsing development.
  *
  * @param[in] pParsingState The state of the response parsing.

--- a/libraries/standard/http/src/private/http_client_parse.h
+++ b/libraries/standard/http/src/private/http_client_parse.h
@@ -10,13 +10,13 @@
  */
 typedef enum HTTPParsingState_t
 {
-    HTTP_PARSING_NONE = 0,   /**< The parser is initialized and has not started reading any message. */
+    HTTP_PARSING_NONE = 0,   /**< The parser has not started reading any response. */
     HTTP_PARSING_INCOMPLETE, /**< The parse found a partial reponse. */
     HTTP_PARSING_COMPLETE    /**< The parser found the entire response. */
 } HTTPParsingState_t;
 
 /**
- * The HTTP parsing context.
+ * The HTTP response parsing context.
  */
 typedef struct HTTPParsingContext
 {
@@ -26,7 +26,7 @@ typedef struct HTTPParsingContext
         http_parser httpParser; /**< Third-party http-parser context. */
     #endif
     HTTPParsingState_t state;   /**< The current state of the HTTP response parsed. */
-    HTTPClient_HeaderParsingCallback_t * pHeaderParsingCallback;
+    HTTPClient_HeaderParsingCallback_t * pHeaderParsingCallback; /**< Callback to invoke with each header found. */
 } HTTPParsingContext_t;
 
 /**

--- a/libraries/standard/http/src/private/http_client_parse.h
+++ b/libraries/standard/http/src/private/http_client_parse.h
@@ -51,9 +51,9 @@ HTTPStatus_t _HTTPClient_InitializeParsingContext( HTTPParsingContext_t * pParsi
  * HTTP response. The state of what was last parsed in the response is kept in
  * #HTTPParsingContext_t.
  *
- * Any error found in parsing is considered a malformed response and therefore
- * a security alert. The application should close the connection with the server
- * if any HTTP_SECURITY_ALERT_X errors are returned.
+ * The application should close the connection with the server if any 
+ * HTTP_SECURITY_ALERT_X errors are returned. 
+ * TODO: List all the security alerts possible after parsing development.
  *
  * @param[in] pParsingState The state of the response parsing.
  * @param[in] pBuffer The buffer containing response message to parse.

--- a/libraries/standard/http/src/private/http_client_parse.h
+++ b/libraries/standard/http/src/private/http_client_parse.h
@@ -23,9 +23,9 @@ typedef struct HTTPParsingContext
     /* http-parser dependencies will be added in the next incremental change. */
     /* Below will be un-commented when parsing is implemented. */
     #if 0
-        http_parser httpParser;                                  /**< Third-party http-parser context. */
+        http_parser httpParser; /**< Third-party http-parser context. */
     #endif
-    HTTPParsingState_t state;                                    /**< The current state of the HTTP response parsed. */
+    HTTPParsingState_t state;   /**< The current state of the HTTP response parsed. */
     HTTPClient_HeaderParsingCallback_t * pHeaderParsingCallback; /**< Callback to invoke with each header found. */
 } HTTPParsingContext_t;
 

--- a/libraries/standard/http/src/private/http_client_parse.h
+++ b/libraries/standard/http/src/private/http_client_parse.h
@@ -1,0 +1,68 @@
+#ifndef HTTP_CLIENT_PARSE_H_
+#define HTTP_CLIENT_PARSE_H_
+
+#include "http_client.h"
+/* #include "http_parser.h" */
+
+/**
+ * @brief The state of the response message parsed after
+ * #HTTPClient_ParseResponse returns.
+ */
+typedef enum HTTPParsingState_t
+{
+    HTTP_PARSING_NONE = 0,   /**< The parser is initialized and has not started reading any message. */
+    HTTP_PARSING_INCOMPLETE, /**< The parse found a partial reponse. */
+    HTTP_PARSING_COMPLETE    /**< The parser found the entire response. */
+} HTTPParsingState_t;
+
+/**
+ * The HTTP parsing context.
+ */
+typedef struct HTTPParsingContext
+{
+    /* http-parser dependencies will be added in the next incremental change. */
+    /* Below will be un-commented when parsing is implemented. */
+    #if 0
+        http_parser httpParser; /**< Third-party http-parser context. */
+    #endif
+    HTTPParsingState_t state;   /**< The current state of the HTTP response parsed. */
+} HTTPParsingContext_t;
+
+/**
+ * Initialize the HTTP Client response parsing context.
+ *
+ * @param[in] pParsingContext The state of response parsing to initialize.
+ *
+ * @return One of the following:
+ * - #HTTP_SUCCESS
+ * - #HTTP_INVALID_PARAMETER
+ * TODO: Other return values will be added during implementation of the parsing.
+ */
+HTTPStatus_t _HTTPClient_InitializeParsingContext( HTTPParsingContext_t * pParsingContext );
+
+/**
+ * Parse the input HTTP response buffer.
+ *
+ * This function may be invoked multiple times for different parts of the the
+ * HTTP response. The state of what was last parsed in the response is kept in
+ * #HTTPParsingContext_t.
+ *
+ * Any error found in parsing is considered a malformed response and therefore
+ * a security alert. The application should close the connection with the server
+ * if any HTTP_SECURITY_ALERT_X errors are returned.
+ *
+ * @param[in] pParsingState The state of the response parsing.
+ * @param[in] pBuffer The buffer containing response message to parse.
+ * @param[in] bufferLen The length in the buffer to parse.
+ *
+ * @return One of the following:
+ * - #HTTP_SUCCESS
+ * - #HTTP_INVALID_PARAMETER
+ * - #HTTP_SECURITY_ALERT_PARSER_INVALID_CHARACTER
+ * TODO: Other return values are to be added during implementation of parsing.
+ */
+HTTPStatus_t _HTTPClient_ParseResponse( HTTPParsingContext_t * pParsingContext,
+                                        uint8_t * pBuffer,
+                                        size_t bufferLen );
+
+#endif /* ifndef HTTP_CLIENT_PARSE_H_ */

--- a/libraries/standard/http/src/private/http_client_parse.h
+++ b/libraries/standard/http/src/private/http_client_parse.h
@@ -11,30 +11,30 @@
 typedef enum HTTPParsingState_t
 {
     HTTP_PARSING_NONE = 0,   /**< The parser has not started reading any response. */
-    HTTP_PARSING_INCOMPLETE, /**< The parse found a partial reponse. */
+    HTTP_PARSING_INCOMPLETE, /**< The parser found a partial reponse. */
     HTTP_PARSING_COMPLETE    /**< The parser found the entire response. */
 } HTTPParsingState_t;
 
 /**
- * The HTTP response parsing context.
+ * @brief The HTTP response parsing context.
  */
 typedef struct HTTPParsingContext
 {
     /* http-parser dependencies will be added in the next incremental change. */
     /* Below will be un-commented when parsing is implemented. */
     #if 0
-        http_parser httpParser; /**< Third-party http-parser context. */
+        http_parser httpParser;                                  /**< Third-party http-parser context. */
     #endif
-    HTTPParsingState_t state;   /**< The current state of the HTTP response parsed. */
+    HTTPParsingState_t state;                                    /**< The current state of the HTTP response parsed. */
     HTTPClient_HeaderParsingCallback_t * pHeaderParsingCallback; /**< Callback to invoke with each header found. */
 } HTTPParsingContext_t;
 
 /**
- * Initialize the HTTP Client response parsing context.
+ * @brief Initialize the HTTP Client response parsing context.
  *
- * @param[in] pParsingContext The state of response parsing to initialize.
- * @param[in] pHeaderParsingCallback Callback to invoked for each complete
- * header and value found.
+ * @param[in,out] pParsingContext The parsing context to initialize.
+ * @param[in] pHeaderParsingCallback Callback that will be invoked for each
+ * header and value pair found.
  *
  * @return One of the following:
  * - #HTTP_SUCCESS
@@ -55,7 +55,7 @@ HTTPStatus_t _HTTPClient_InitializeParsingContext( HTTPParsingContext_t * pParsi
  * HTTP_SECURITY_ALERT_X errors are returned.
  * TODO: List all the security alerts possible after parsing development.
  *
- * @param[in] pParsingState The state of the response parsing.
+ * @param[in,out] pParsingState The state of the response parsing.
  * @param[in] pBuffer The buffer containing response message to parse.
  * @param[in] bufferLen The length in the buffer to parse.
  *
@@ -66,7 +66,7 @@ HTTPStatus_t _HTTPClient_InitializeParsingContext( HTTPParsingContext_t * pParsi
  * TODO: Other return values are to be added during implementation of parsing.
  */
 HTTPStatus_t _HTTPClient_ParseResponse( HTTPParsingContext_t * pParsingContext,
-                                        uint8_t * pBuffer,
+                                        const uint8_t * pBuffer,
                                         size_t bufferLen );
 
 #endif /* ifndef HTTP_CLIENT_PARSE_H_ */

--- a/libraries/standard/http/test/Makefile
+++ b/libraries/standard/http/test/Makefile
@@ -29,7 +29,6 @@ FUNCTIONS = _addHeader \
 			_sendHttpBody \
 			_receiveHttpResponse \
 			_receiveAndParseHttpResponse \
-			_receiveHttpResponse \
 			_HTTPClient_InitializeParsingContext \
 			_HTTPClient_ParseResponse \
 			_getFinalResponseStatus
@@ -46,7 +45,6 @@ HTTPClient_Send.c: _sendHttpHeaders.c \
 				   _sendHttpBody.c \
 				   _receiveHttpResponse.c \
 				   _receiveAndParseHttpResponse.c \
-				   _receiveHttpResponse.c \
 				   _HTTPClient_InitializeParsingContext.c \
 				   _HTTPClient_ParseResponse.c \
 				   _getFinalResponseStatus.c \

--- a/libraries/standard/http/test/Makefile
+++ b/libraries/standard/http/test/Makefile
@@ -4,6 +4,9 @@ CSDK_ROOT = ../../../..
 # Directory indexing includes subdirectories.
 SOURCE = ../src
 
+# Show extra warnings.
+CFLAGS += -Wextra
+
 # arguments given to the compiler (default: see the included file)
 #CFLAGS = std=c99 -Wall -fprofile-arcs -ftest-coverage -O0 -ggdb
 

--- a/libraries/standard/http/test/Makefile
+++ b/libraries/standard/http/test/Makefile
@@ -8,7 +8,11 @@ SOURCE = ../src
 #CFLAGS = std=c99 -Wall -fprofile-arcs -ftest-coverage -O0 -ggdb
 
 # include directories given to the compiler (default: none)
-INCLUDE = . ../include $(CSDK_ROOT)/platform/include ../../utilities/include ../src
+INCLUDE = . \
+		  ../include \
+		  ../src \
+		  $(CSDK_ROOT)/platform/include \
+		  ../../utilities/include
 
 # the default goal (default: help)
 # Set to build or test as desired.
@@ -20,7 +24,15 @@ INCLUDE = . ../include $(CSDK_ROOT)/platform/include ../../utilities/include ../
 
 # functions to dump into separate source files
 # Values based on test source file names will be dynamically added.
-FUNCTIONS = _sendHttpHeaders _sendHttpBody _receiveHttpResponse _addHeader
+FUNCTIONS = _addHeader \
+            _sendHttpHeaders \
+			_sendHttpBody \
+			_receiveHttpResponse \
+			_receiveAndParseHttpResponse \
+			_receiveHttpResponse \
+			_HTTPClient_InitializeParsingContext \
+			_HTTPClient_ParseResponse \
+			_getFinalResponseStatus
 
 # Changes to the above variables should remain above this include.
 include Mock4thewin.mk
@@ -29,8 +41,15 @@ include Mock4thewin.mk
 $(TESTS): $(CSDK_ROOT)/platform/posix/iot_clock_posix.o $(CSDK_ROOT)/platform/posix/iot_logging.o
 
 # additional dependency for a specific test
-HTTPClient_Send.c: _sendHttpHeaders.c _sendHttpBody.c _receiveHttpResponse.c
 HTTPClient_AddHeader.c: _addHeader.c
+HTTPClient_Send.c: _sendHttpHeaders.c \
+				   _sendHttpBody.c \
+				   _receiveHttpResponse.c \
+				   _receiveAndParseHttpResponse.c \
+				   _receiveHttpResponse.c \
+				   _HTTPClient_InitializeParsingContext.c \
+				   _HTTPClient_ParseResponse.c \
+				   _getFinalResponseStatus.c \
 
 # additional header dependencies for all tests
 COMMON = common.h

--- a/libraries/standard/http/test/common.h
+++ b/libraries/standard/http/test/common.h
@@ -5,5 +5,6 @@
 
 /* Private includes for internal macros. */
 #include "private/http_client_internal.h"
+#include "private/http_client_parse.h"
 
 #define assert( x )

--- a/libraries/standard/http/test/test-HTTPClient_AddHeader.c
+++ b/libraries/standard/http/test/test-HTTPClient_AddHeader.c
@@ -151,7 +151,7 @@ int main()
                   HTTP_TEST_HEADER_REQUEST_LINE,
                   HTTP_TEST_HEADER_FIELD, HTTP_TEST_HEADER_VALUE,
                   HTTP_TEST_HEADER_FIELD, HTTP_TEST_HEADER_VALUE )
-        == expectedHeaderLen );
+        == ( int )expectedHeaderLen );
     /* Prefill the buffer with a request line and header. */
     ok( snprintf( ( char * ) reqHeaders.pBuffer,
                   HTTP_TEST_TEMPLATE_HEADER_LEN + 1,

--- a/libraries/standard/http/test/test-HTTPClient_Send.c
+++ b/libraries/standard/http/test/test-HTTPClient_Send.c
@@ -2,13 +2,23 @@
 #include <stdio.h>
 #include "common.h"
 
+/* THESE TESTS WILL MOVE TO THE UNITY FRAMEWORK.
+ * ok()'s will be replaced with proper unity macros. */
+
 
 /* Functions are pulled out into their own C files to be tested as a unit. */
 #include "_sendHttpHeaders.c"
 #include "_sendHttpBody.c"
 #include "_receiveHttpResponse.c"
+#include "_HTTPClient_InitializeParsingContext.c"
+#include "_HTTPClient_ParseResponse.c"
+#include "_getFinalResponseStatus.c"
+#include "_receiveAndParseHttpResponse.c"
 #include "HTTPClient_Send.c"
 
+/* HTTP OK Status-Line. */
+#define HTTP_STATUS_LINE_OK    "HTTP/1.1 200 OK\r\n"
+#define HTTP_STATUS_CODE_OK    200
 
 /* Template HTTP successful response with no body. */
 #define HTTP_TEST_RESPONSE_HEADER_LINES_NO_BODY \
@@ -19,10 +29,12 @@
     "Vary: *\r\n"                               \
     "P3P: CP=\"This is not a P3P policy\"\r\n"  \
     "xserver: www1021\r\n\r\n"
-#define HTTP_TEST_RESPONSE_HEADER_LINES_NO_BODY_LENGTH    sizeof( HTTP_TEST_RESPONSE_HEADER_LINES_NO_BODY ) - 1
+#define HTTP_TEST_RESPONSE_HEADER_LINES_NO_BODY_LENGTH          sizeof( HTTP_TEST_RESPONSE_HEADER_LINES_NO_BODY ) - 1U
+#define HTTP_TEST_RESPONSE_HEADER_LINES_NO_BODY_HEADER_COUNT    6
 
-/* Template HTTP request for a head request. */
-#define HTTP_TEST_REQUEST_HEAD                 \
+
+/* Template HTTP request for a HEAD request. */
+#define HTTP_TEST_REQUEST_HEAD_HEADERS         \
     "HEAD /somedir/somepage.html HTTP/1.1\r\n" \
     "test-header0: test-value0\r\n"            \
     "test-header1: test-value1\r\n"            \
@@ -31,10 +43,27 @@
     "test-header4: test-value1\r\n"            \
     "test-header5: test-value2\r\n"            \
     "\r\n"
-#define HTTP_TEST_REQUEST_HEAD_LENGTH    sizeof( HTTP_TEST_REQUEST_HEAD ) - 1
+#define HTTP_TEST_REQUEST_HEAD_HEADERS_LENGTH    sizeof( HTTP_TEST_REQUEST_HEAD_HEADERS ) - 1
+
+/* Template HTTP request for a PUT request. */
+#define HTTP_TEST_REQUEST_PUT_HEADERS         \
+    "PUT /somedir/somepage.html HTTP/1.1\r\n" \
+    "Content-Length: 26\r\n"                  \
+    "test-header1: test-value1\r\n"           \
+    "test-header2: test-value2\r\n"           \
+    "test-header3: test-value0\r\n"           \
+    "test-header4: test-value1\r\n"           \
+    "test-header5: test-value2\r\n"           \
+    "\r\n"
+#define HTTP_TEST_REQUEST_PUT_HEADERS_LENGTH    sizeof( HTTP_TEST_REQUEST_PUT_HEADERS ) - 1
+#define HTTP_TEST_REQUEST_PUT_BODY              "abcdefghijklmnopqrstuvwxyz"
+#define HTTP_TEST_REQUEST_PUT_BODY_LENGTH       sizeof( HTTP_TEST_REQUEST_PUT_BODY ) - 1
 
 /* Test buffer to share among the test. */
-static uint8_t httpBuffer[ 1024 ] = { 0 };
+#define HTTP_TEST_BUFFER_LENGTH                 1024
+static uint8_t httpBuffer[ HTTP_TEST_BUFFER_LENGTH ] = { 0 };
+
+/* -----------------------------------------------------------------------*/
 
 /* Mocked successful transport send. */
 static int32_t transportSendSuccess( HTTPNetworkContext_t * pContext,
@@ -46,13 +75,65 @@ static int32_t transportSendSuccess( HTTPNetworkContext_t * pContext,
     return bytesToWrite;
 }
 
+/* -----------------------------------------------------------------------*/
+
+/* This section  contains all the support needed to mock the two different
+ * transport interface send cases. The three transport send error cases are:
+ * 1. A negative value returned.
+ * 2. Less than bytesToWrite returned. */
+
+/* Transport send is called separately for the headers and the body, this counts
+ * the number of calls so far. */
+uint8_t sendCurrentCall;
+uint8_t sendErrorCall;
+static int32_t transportSendNetworkError( HTTPNetworkContext_t * pContext,
+                                          const void * pBuffer,
+                                          size_t bytesToWrite )
+{
+    ( void ) pContext;
+    ( void ) pBuffer;
+    int32_t retVal = bytesToWrite;
+
+    if( sendErrorCall == sendCurrentCall )
+    {
+        retVal = -1;
+    }
+
+    sendCurrentCall++;
+    return retVal;
+}
+
+static int32_t transportSendLessThanBytesToWrite( HTTPNetworkContext_t * pContext,
+                                                  const void * pBuffer,
+                                                  size_t bytesToWrite )
+{
+    ( void ) pContext;
+    ( void ) pBuffer;
+    int32_t retVal = bytesToWrite;
+
+    if( sendErrorCall == sendCurrentCall )
+    {
+        retVal -= 1;
+    }
+
+    sendCurrentCall++;
+    return retVal;
+}
+
+#define transportSendErrorReset() \
+    do {                          \
+        sendCurrentCall = 0;      \
+        sendErrorCall = 0;        \
+    } while( 0 );
+
+/* -----------------------------------------------------------------------*/
+
 /* Mocked successful transport read. */
 static int32_t transportRecvSuccess( HTTPNetworkContext_t * pContext,
                                      void * pBuffer,
                                      size_t bytesToRead )
 {
     ( void ) pContext;
-    ( void ) pBuffer;
 
     memcpy( pBuffer,
             HTTP_TEST_RESPONSE_HEADER_LINES_NO_BODY,
@@ -61,62 +142,114 @@ static int32_t transportRecvSuccess( HTTPNetworkContext_t * pContext,
     return sizeof( HTTP_TEST_RESPONSE_HEADER_LINES_NO_BODY ) - 1;
 }
 
-/* Mocked network error returning transport send. */
-static int32_t transportSendNetworkError( HTTPNetworkContext_t * pContext,
-                                          const void * pBuffer,
-                                          size_t bytesToWrite )
+/* -----------------------------------------------------------------------*/
+
+/* This section contains all the support needed to mock an incremental transport
+ * read. The mocked transport receive will read 128 bytes at time from the
+ * response. */
+
+/* Default increment read bytes transportRecvIncremental. */
+#define INCREMENT_BYTES_DEFAULT    0x80U
+
+uint32_t bytesRead;        /* Total bytes read over multple calls. */
+uint8_t * pNetworkData;    /* The network data to read. */
+size_t networkDataLen;     /* The network data to read's length. */
+size_t incrementReadBytes; /* How many bytes of network data to read each call. */
+size_t stopReadBytes;      /* Stop reading at >= this many bytes. */
+static int32_t transportRecvIncremental( HTTPNetworkContext_t * pContext,
+                                         void * pBuffer,
+                                         size_t bytesToRead )
+{
+    ( void ) pContext;
+
+    if( bytesRead >= stopReadBytes )
+    {
+        return 0;
+    }
+
+    uint8_t * pCopyLoc = pNetworkData + bytesRead;
+    size_t messageLenLeft = networkDataLen - bytesRead;
+    size_t copyLen = incrementReadBytes;
+
+    /* If the amount requested to read is smaller than the increment, then
+     * copy that amount. */
+    if( bytesToRead < copyLen )
+    {
+        copyLen = bytesToRead;
+    }
+
+    /* If there is less message left than the amount to read, then copy the
+     * rest. */
+    if( messageLenLeft < copyLen )
+    {
+        copyLen = messageLenLeft;
+    }
+
+    memcpy( pBuffer, pCopyLoc, copyLen );
+    bytesRead += copyLen;
+    return copyLen;
+}
+#define transportRecvIncrementalReset()                                       \
+    do {                                                                      \
+        bytesRead = 0;                                                        \
+        pNetworkData = ( uint8_t * ) HTTP_TEST_RESPONSE_HEADER_LINES_NO_BODY; \
+        networkDataLen = HTTP_TEST_RESPONSE_HEADER_LINES_NO_BODY_LENGTH;      \
+        incrementReadBytes = INCREMENT_BYTES_DEFAULT;                         \
+        stopReadBytes = 0;                                                    \
+    } while( 0 );
+
+
+/* -----------------------------------------------------------------------*/
+
+/* Mocked network error returning transport recv. */
+static int32_t transportRecvNetworkError( HTTPNetworkContext_t * pContext,
+                                          void * pBuffer,
+                                          size_t bytesToRead )
 {
     ( void ) pContext;
     ( void ) pBuffer;
-    ( void ) bytesToWrite;
+    ( void ) bytesToRead;
 
     return -1;
 }
 
-/* Mocked transport send that returns less bytes than expected. */
-static int32_t transportSendLessThanBytesToWrite( HTTPNetworkContext_t * pContext,
-                                                  const void * pBuffer,
-                                                  size_t bytesToWrite )
+/* -----------------------------------------------------------------------*/
+
+/* Mocked transport recv function that returns more bytes than expected. */
+static int32_t transportRecvMoreThanBytesToRead( HTTPNetworkContext_t * pContext,
+                                                 void * pBuffer,
+                                                 size_t bytesToRead )
 {
     ( void ) pContext;
     ( void ) pBuffer;
-    ( void ) bytesToWrite;
 
-    return bytesToWrite - 1;
+    return( bytesToRead + 1 );
 }
 
+/* -----------------------------------------------------------------------*/
 
 int main()
 {
     HTTPStatus_t returnStatus = HTTP_SUCCESS;
     HTTPResponse_t response = { 0 };
+    HTTPTransportInterface_t transportInterface = { 0 };
+    HTTPRequestHeaders_t requestHeaders = { 0 };
 
-    response.pBuffer = httpBuffer;
-    response.bufferLen = sizeof( httpBuffer );
-
-    HTTPTransportInterface_t transportInterface =
-    {
-        .recv     = transportRecvSuccess,
-        .send     = transportSendSuccess,
-        .pContext = NULL
-    };
-
-    HTTPRequestHeaders_t requestHeadersHead =
-    {
-        .pBuffer    = ( uint8_t * ) ( HTTP_TEST_REQUEST_HEAD ),
-        .bufferLen  = sizeof( HTTP_TEST_REQUEST_HEAD ) - 1,
-        .headersLen = sizeof( HTTP_TEST_REQUEST_HEAD ) - 1
-    };
-
-#define reset()                                                                \
-    do {                                                                       \
-        transportInterface.recv = transportRecvSuccess;                        \
-        transportInterface.send = transportSendSuccess;                        \
-        transportInterface.pContext = NULL;                                    \
-        requestHeadersHead.pBuffer = ( uint8_t * ) ( HTTP_TEST_REQUEST_HEAD ); \
-        requestHeadersHead.bufferLen = sizeof( HTTP_TEST_REQUEST_HEAD ) - 1;   \
-        requestHeadersHead.headersLen = sizeof( HTTP_TEST_REQUEST_HEAD ) - 1;  \
-    } while( 0 )
+/* Resets each test back to the original happy path state. */
+#define reset()                                                                    \
+    do {                                                                           \
+        transportInterface.recv = transportRecvSuccess;                            \
+        transportInterface.send = transportSendSuccess;                            \
+        transportInterface.pContext = NULL;                                        \
+        requestHeaders.pBuffer = ( uint8_t * ) ( HTTP_TEST_REQUEST_HEAD_HEADERS ); \
+        requestHeaders.bufferLen = HTTP_TEST_REQUEST_HEAD_HEADERS_LENGTH;          \
+        requestHeaders.headersLen = HTTP_TEST_REQUEST_HEAD_HEADERS_LENGTH;         \
+        memset( &response, 0, sizeof( HTTPResponse_t ) );                          \
+        response.pBuffer = httpBuffer;                                             \
+        response.bufferLen = sizeof( httpBuffer );                                 \
+        transportRecvIncrementalReset();                                           \
+        transportSendErrorReset();                                                 \
+    } while( 0 );
     reset();
 
     /* -----------------------------------------------------------------------*/
@@ -124,22 +257,92 @@ int main()
     /* Happy Path testing. Test sending a request and successfully receiving a
      * response that is within the bounds of the response buffer. */
     returnStatus = HTTPClient_Send( &transportInterface,
-                                    &requestHeadersHead,
+                                    &requestHeaders,
                                     NULL,
                                     0,
                                     &response );
 
     ok( returnStatus == HTTP_SUCCESS );
-    /* TODO: Check the response is parsed successfully. */
+    /* Uncomment after parsing is implemented. */
+    /* ok( response.body == NULL ); */
+    /* ok( response.bodyLen == 0 ); */
+    /* ok( response.headers == response.pBuffer + ( sizeof( HTTP_STATUS_LINE_OK ) - 1 ) ); */
+    /* ok( response.headersLen == HTTP_TEST_RESPONSE_HEADER_LINES_NO_BODY_LENGTH ); */
+    /* ok( response.statusCode == HTTP_STATUS_CODE_OK ); */
+    /* ok( response.contentLength == 0 ); */
+    /* ok( response.headerCount == HTTP_TEST_RESPONSE_HEADER_LINES_NO_BODY_HEADER_COUNT ); */
     reset();
 
     /* -----------------------------------------------------------------------*/
 
-    /* Test an error returned from a unsuccessful transport send. */
+    /* Happy path testing. Test sending a non-null body buffer and received a full
+     * response. */
+    requestHeaders.pBuffer = ( uint8_t * ) ( HTTP_TEST_REQUEST_PUT_HEADERS );
+    requestHeaders.bufferLen = HTTP_TEST_REQUEST_PUT_HEADERS_LENGTH;
+    requestHeaders.headersLen = HTTP_TEST_REQUEST_PUT_HEADERS_LENGTH;
+    returnStatus = HTTPClient_Send( &transportInterface,
+                                    &requestHeaders,
+                                    ( uint8_t * ) HTTP_TEST_REQUEST_PUT_BODY,
+                                    HTTP_TEST_REQUEST_PUT_BODY_LENGTH,
+                                    &response );
+
+    ok( returnStatus == HTTP_SUCCESS );
+    /* Uncomment after parsing is implemented. */
+    /* ok( response.body == NULL ); */
+    /* ok( response.bodyLen == 0 ); */
+    /* ok( response.headers == response.pBuffer + ( sizeof( HTTP_STATUS_LINE_OK ) - 1 ) ); */
+    /* ok( response.headersLen == HTTP_TEST_RESPONSE_HEADER_LINES_NO_BODY_LENGTH ); */
+    /* ok( response.statusCode == HTTP_STATUS_CODE_OK ); */
+    /* ok( response.contentLength == 0 ); */
+    /* ok( response.headerCount == HTTP_TEST_RESPONSE_HEADER_LINES_NO_BODY_HEADER_COUNT ); */
+    reset();
+
+    /* -----------------------------------------------------------------------*/
+
+    /* Test receiving the response message with multiple calls to transport
+     * recv. */
+    transportInterface.recv = transportRecvIncremental;
+    stopReadBytes = networkDataLen; /* Read the whole network data. */
+    returnStatus = HTTPClient_Send( &transportInterface,
+                                    &requestHeaders,
+                                    NULL,
+                                    0,
+                                    &response );
+
+    ok( returnStatus == HTTP_SUCCESS );
+    /* Uncomment after parsing is implemented. */
+    /* ok( response.body == NULL ); */
+    /* ok( response.bodyLen == 0 ); */
+    /* ok( response.headers == response.pBuffer + ( sizeof( HTTP_STATUS_LINE_OK ) - 1 ) ); */
+    /* ok( response.headersLen == HTTP_TEST_RESPONSE_HEADER_LINES_NO_BODY_LENGTH ); */
+    /* ok( response.statusCode == HTTP_STATUS_CODE_OK ); */
+    /* ok( response.contentLength == 0 ); */
+    /* ok( response.headerCount == HTTP_TEST_RESPONSE_HEADER_LINES_NO_BODY_HEADER_COUNT ); */
+    reset();
+
+    /* -----------------------------------------------------------------------*/
+
+    /* Test receiving with a NULL response. */
+    requestHeaders.pBuffer = ( uint8_t * ) ( HTTP_TEST_REQUEST_PUT_HEADERS );
+    requestHeaders.bufferLen = HTTP_TEST_REQUEST_PUT_HEADERS_LENGTH;
+    requestHeaders.headersLen = HTTP_TEST_REQUEST_PUT_HEADERS_LENGTH;
+    returnStatus = HTTPClient_Send( &transportInterface,
+                                    &requestHeaders,
+                                    ( uint8_t * ) HTTP_TEST_REQUEST_PUT_BODY,
+                                    HTTP_TEST_REQUEST_PUT_BODY_LENGTH,
+                                    NULL );
+
+    ok( returnStatus == HTTP_SUCCESS );
+    reset();
+
+    /* -----------------------------------------------------------------------*/
+
+    /* Test a network error returned from a transport send of the request
+     * headers. */
+    sendErrorCall = 0;
     transportInterface.send = transportSendNetworkError;
-
     returnStatus = HTTPClient_Send( &transportInterface,
-                                    &requestHeadersHead,
+                                    &requestHeaders,
                                     NULL,
                                     0,
                                     &response );
@@ -149,23 +352,114 @@ int main()
 
     /* -----------------------------------------------------------------------*/
 
-    /* Test less bytes than expected returned from transport send. */
-    transportInterface.send = transportSendLessThanBytesToWrite;
-
+    /* Test a network error returned from a transport send of the request
+     * body. */
+    transportInterface.send = transportSendNetworkError;
+    sendErrorCall = 1;
+    requestHeaders.pBuffer = ( uint8_t * ) ( HTTP_TEST_REQUEST_PUT_HEADERS );
+    requestHeaders.bufferLen = HTTP_TEST_REQUEST_PUT_HEADERS_LENGTH;
+    requestHeaders.headersLen = HTTP_TEST_REQUEST_PUT_HEADERS_LENGTH;
     returnStatus = HTTPClient_Send( &transportInterface,
-                                    &requestHeadersHead,
+                                    &requestHeaders,
+                                    ( uint8_t * ) HTTP_TEST_REQUEST_PUT_BODY,
+                                    HTTP_TEST_REQUEST_PUT_BODY_LENGTH,
+                                    &response );
+
+    ok( returnStatus == HTTP_NETWORK_ERROR );
+    reset();
+
+    /* -----------------------------------------------------------------------*/
+
+    /* Test less bytes than expected returned from a transport send of the
+     * request headers. */
+    transportInterface.send = transportSendLessThanBytesToWrite;
+    sendErrorCall = 0U;
+    returnStatus = HTTPClient_Send( &transportInterface,
+                                    &requestHeaders,
                                     NULL,
                                     0,
                                     &response );
 
     ok( returnStatus == HTTP_NETWORK_ERROR );
     reset();
+
+    /* -----------------------------------------------------------------------*/
+
+    /* Test less bytes than expected returned from a transport send of the
+     * request body. */
+    transportInterface.send = transportSendLessThanBytesToWrite;
+    sendErrorCall = 1;
+    requestHeaders.pBuffer = ( uint8_t * ) ( HTTP_TEST_REQUEST_PUT_HEADERS );
+    requestHeaders.bufferLen = HTTP_TEST_REQUEST_PUT_HEADERS_LENGTH;
+    requestHeaders.headersLen = HTTP_TEST_REQUEST_PUT_HEADERS_LENGTH;
+    returnStatus = HTTPClient_Send( &transportInterface,
+                                    &requestHeaders,
+                                    ( uint8_t * ) HTTP_TEST_REQUEST_PUT_BODY,
+                                    HTTP_TEST_REQUEST_PUT_BODY_LENGTH,
+                                    &response );
+
+    ok( returnStatus == HTTP_NETWORK_ERROR );
+    reset();
+
+    /* -----------------------------------------------------------------------*/
+
+    /* Test a network error returned from a transport recv of the response. */
+    transportInterface.recv = transportRecvNetworkError;
+    returnStatus = HTTPClient_Send( &transportInterface,
+                                    &requestHeaders,
+                                    NULL,
+                                    0,
+                                    &response );
+    ok( returnStatus = HTTP_NETWORK_ERROR );
+    reset();
+
+    /* -----------------------------------------------------------------------*/
+
+    /* Test more bytes than expected returned from a transport recv of the
+     * response. */
+    transportInterface.recv = transportRecvMoreThanBytesToRead;
+    returnStatus = HTTPClient_Send( &transportInterface,
+                                    &requestHeaders,
+                                    NULL,
+                                    0,
+                                    &response );
+    ok( returnStatus = HTTP_NETWORK_ERROR );
+    reset();
+
+    /* -----------------------------------------------------------------------*/
+
+    /* Test transport recv returning zero when first invoked. */
+    transportInterface.recv = transportRecvIncremental;
+    stopReadBytes = 0; /* Stop immediately. */
+    returnStatus = HTTPClient_Send( &transportInterface,
+                                    &requestHeaders,
+                                    NULL,
+                                    0,
+                                    &response );
+    ok( returnStatus = HTTP_NO_RESPONSE );
+    reset();
+
+    /* -----------------------------------------------------------------------*/
+
+    /* Test transport recv returning zero in the middle of a response message. */
+    /* This test will be invoked upon parsing implementation completion. */
+    #if 0
+        transportInterface.recv = transportRecvMoreThanBytesToRead;
+        stopReadBytes = incrementReadBytes; /* Stop after the first increment. */
+        returnStatus = HTTPClient_Send( &transportInterface,
+                                        &requestHeaders,
+                                        NULL,
+                                        0,
+                                        &response );
+        ok( returnStatus = HTTP_PARTIAL_RESPONSE );
+        reset();
+    #endif
 
     /* -----------------------------------------------------------------------*/
 
     /* Test a NULL transport interface. */
     returnStatus = HTTPClient_Send( NULL,
-                                    &requestHeadersHead,
+                                    &requestHeaders,
                                     NULL,
                                     0,
                                     &response );
@@ -178,7 +472,7 @@ int main()
     /* Test a NULL transport interface send. */
     transportInterface.send = NULL;
     returnStatus = HTTPClient_Send( &transportInterface,
-                                    &requestHeadersHead,
+                                    &requestHeaders,
                                     NULL,
                                     0,
                                     &response );
@@ -191,7 +485,7 @@ int main()
     /* Test a NULL transport interface recv. */
     transportInterface.recv = NULL;
     returnStatus = HTTPClient_Send( &transportInterface,
-                                    &requestHeadersHead,
+                                    &requestHeaders,
                                     NULL,
                                     0,
                                     &response );
@@ -214,15 +508,30 @@ int main()
     /* -----------------------------------------------------------------------*/
 
     /* Test NULL request header buffer. */
-    requestHeadersHead.pBuffer = NULL;
+    requestHeaders.pBuffer = NULL;
     returnStatus = HTTPClient_Send( &transportInterface,
-                                    &requestHeadersHead,
+                                    &requestHeaders,
                                     NULL,
                                     0,
                                     &response );
 
     ok( returnStatus == HTTP_INVALID_PARAMETER );
     reset();
+
+    /* -----------------------------------------------------------------------*/
+
+    /* Test a NULL response buffer. */
+    response.pBuffer = NULL;
+    returnStatus = HTTPClient_Send( &transportInterface,
+                                    &requestHeaders,
+                                    NULL,
+                                    0,
+                                    &response );
+
+    ok( returnStatus == HTTP_INVALID_PARAMETER );
+    reset();
+
+    /* -----------------------------------------------------------------------*/
 
     return grade();
 }


### PR DESCRIPTION
Implemented temporary unit tests. These unit tests will be moved to the unity framework when it is setup. These are used to verify logic in the current PR.

Parsing of the response is not implemented yet. This PR implements only receiving the response from the network and handling when the parser finds no response, an incomplete response, and a complete response.

![image](https://user-images.githubusercontent.com/6563840/80434006-6dbc5400-88ad-11ea-8c0c-748b45186f79.png)

The last PR brought in the **send over transport** functionality only, but there have been fixes to logging and parameter checking.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
