### PR TITLE
Add missing const to pResponse parameter in HTTPClient_ReadHeader

### DIFF
--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -594,7 +594,7 @@ HTTPStatus_t HTTPClient_Send( const HTTPTransportInterface_t * pTransport,
 
 /*-----------------------------------------------------------*/
 
-HTTPStatus_t HTTPClient_ReadHeader( HTTPResponse_t * pResponse,
+HTTPStatus_t HTTPClient_ReadHeader( const HTTPResponse_t * pResponse,
                                     const char * pName,
                                     size_t nameLen,
                                     char ** pValue,


### PR DESCRIPTION
*Description of changes:*
We change the original .c:
```
HTTPStatus_t HTTPClient_ReadHeader( HTTPResponse_t * pResponse,
                                    const char * pName,
                                    size_t nameLen,
                                    char ** pValue,
                                    size_t * valueLen )
```
to follow the .h:
```
HTTPStatus_t HTTPClient_ReadHeader( const HTTPResponse_t * pResponse,
                                    const char * pName,
                                    size_t nameLen,
                                    char ** pValue,
                                    size_t * valueLen );
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
