### PR TITLE
Update macro name causing build failure

### DIFF
--- a/libraries/standard/http/src/private/http_client_internal.h
+++ b/libraries/standard/http/src/private/http_client_internal.h
@@ -102,7 +102,7 @@
  * Largest size is of the form "bytes=<Max-Integer-Value>-<<Max-Integer-Value>" */
 #define MAX_RANGE_REQUEST_VALUE_LEN                                            \
     ( RANGE_REQUEST_HEADER_VALUE_PREFIX_LEN + MAX_INT32_NO_OF_DECIMAL_DIGITS + \
-      1u /* Dash character '-' */ + MAX_INT32_NO_OF_DIGITS )
+      1u /* Dash character '-' */ + MAX_INT32_NO_OF_DECIMAL_DIGITS )
 
 
 #endif /* ifndef HTTP_CLIENT_INTERNAL_H_ */


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix build failure in http from stale macro name that missed re-name update in PR https://github.com/aws/aws-iot-device-sdk-embedded-C/pull/909
Verified that `make test` builds
![image](https://user-images.githubusercontent.com/5158611/80832066-d4d55380-8ba0-11ea-8780-c04d396d45fe.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
