### PR TITLE
Add third-party http-parser as a Git Submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libraries/standard/http/third_party/http_parser"]
+	path = libraries/standard/http/third_party/http_parser
+	url = git@github.com:nodejs/http-parser.git


### PR DESCRIPTION
This brings in https://github.com/nodejs/http-parser as a submodule under **libraries/standard/http/third_party/http_parser**

This is needed for the HTTP Client library to parse the incoming response and to find a header in a completed response.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
