### PR TITLE
Rename Log() -> SdkLog() to avoid naming collision

### DIFF
--- a/libraries/standard/http/src/private/http_client_internal.h
+++ b/libraries/standard/http/src/private/http_client_internal.h
@@ -7,13 +7,13 @@
  * AWS IoT Embedded C SDK optional specific logging setup.
  */
 #ifdef USE_AWS_IOT_CSDK_LOGGING
-    #ifdef IOT_LOG_LEVEL_HTTP
-        #define LIBRARY_LOG_LEVEL        IOT_LOG_LEVEL_HTTP
+    #ifdef LOG_LEVEL_HTTP
+        #define LIBRARY_LOG_LEVEL        LOG_LEVEL_HTTP
     #else
-        #ifdef IOT_LOG_LEVEL_GLOBAL
-            #define LIBRARY_LOG_LEVEL    IOT_LOG_LEVEL_GLOBAL
+        #ifdef LOG_LEVEL_GLOBAL
+            #define LIBRARY_LOG_LEVEL    LOG_LEVEL_GLOBAL
         #else
-            #define LIBRARY_LOG_LEVEL    IOT_LOG_NONE
+            #define LIBRARY_LOG_LEVEL    LOG_NONE
         #endif
     #endif
     #define LIBRARY_LOG_NAME             ( "HTTP" )

--- a/libraries/standard/http/src/private/http_client_internal.h
+++ b/libraries/standard/http/src/private/http_client_internal.h
@@ -6,7 +6,7 @@
 /**
  * AWS IoT Embedded C SDK optional specific logging setup.
  */
-#ifdef USE_AWS_IOT_CSDK_LOGGING
+#ifdef USE_CSDK_LOGGING
     #ifdef LOG_LEVEL_HTTP
         #define LIBRARY_LOG_LEVEL        LOG_LEVEL_HTTP
     #else
@@ -18,7 +18,7 @@
     #endif
     #define LIBRARY_LOG_NAME             ( "HTTP" )
     #include "logging_setup.h"
-#else /* ifdef USE_AWS_IOT_CSDK_LOGGING */
+#else /* ifdef USE_CSDK_LOGGING */
 /* Otherwise please define logging macros in config.h. */
     #define LogError( message )
     #define LogErrorWithArgs( format, ... )
@@ -28,7 +28,7 @@
     #define LogInfoWithArgs( format, ... )
     #define LogDebug( message )
     #define LogDebugWithArgs( format, ... )
-#endif /* ifdef USE_AWS_IOT_CSDK_LOGGING */
+#endif /* ifdef USE_CSDK_LOGGING */
 
 /**
  * @brief The HTTP protocol version of this library is HTTP/1.1.

--- a/libraries/standard/http/test/config.h
+++ b/libraries/standard/http/test/config.h
@@ -6,19 +6,19 @@
 #ifdef USE_AWS_IOT_CSDK_LOGGING
 
 /* Include file for POSIX reference implementation. */
-    #include "iot_logging.h"
+    #include "logging.h"
 
 /* Define the IotLog logging interface to enable logging.
  * This demo maps the macro to the reference POSIX implementation for logging.
  * Note: @ref LIBRARY_LOG_NAME adds the name of the library, that produces the
  * log, as metadata in each log message. */
-    #define IotLog( messageLevel, pFormat, ... ) \
-    IotLog_Generic( messageLevel,                \
-                    "[%s:%d] [%s] "pFormat,      \
-                    __FILE__,                    \
-                    __LINE__,                    \
-                    LIBRARY_LOG_NAME,            \
-                    __VA_ARGS__ )
+    #define SdkLog( messageLevel, pFormat, ... ) \
+    Log_Generic( messageLevel,                   \
+                 "[%s:%d] [%s] "pFormat,         \
+                 __FILE__,                       \
+                 __LINE__,                       \
+                 LIBRARY_LOG_NAME,               \
+                 __VA_ARGS__ )
 
 #endif /* ifdef USE_AWS_IOT_CSDK_LOGGING */
 

--- a/libraries/standard/http/test/config.h
+++ b/libraries/standard/http/test/config.h
@@ -3,7 +3,7 @@
 
 #define LOG_LEVEL_HTTP    LOG_DEBUG
 
-#ifdef USE_AWS_IOT_CSDK_LOGGING
+#ifdef USE_CSDK_LOGGING
 
 /* Include file for POSIX reference implementation. */
     #include "logging.h"
@@ -20,6 +20,6 @@
                  LIBRARY_LOG_NAME,               \
                  __VA_ARGS__ )
 
-#endif /* ifdef USE_AWS_IOT_CSDK_LOGGING */
+#endif /* ifdef USE_CSDK_LOGGING */
 
 #endif /* ifndef CONFIG_H */

--- a/libraries/standard/http/test/config.h
+++ b/libraries/standard/http/test/config.h
@@ -1,7 +1,7 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-#define IOT_LOG_LEVEL_HTTP    IOT_LOG_DEBUG
+#define LOG_LEVEL_HTTP    LOG_DEBUG
 
 #ifdef USE_AWS_IOT_CSDK_LOGGING
 

--- a/libraries/standard/http/utest/config.h
+++ b/libraries/standard/http/utest/config.h
@@ -8,19 +8,19 @@
 #ifdef USE_AWS_IOT_CSDK_LOGGING
 
 /* Include file for POSIX reference implementation. */
-    #include "iot_logging.h"
+    #include "logging.h"
 
 /* Define the IotLog logging interface to enable logging.
  * This demo maps the macro to the reference POSIX implementation for logging.
  * Note: @ref LIBRARY_LOG_NAME adds the name of the library, that produces the
  * log, as metadata in each log message. */
-    #define IotLog( messageLevel, pFormat, ... ) \
-    IotLog_Generic( messageLevel,                \
-                    "[%s:%d] [%s] "pFormat,      \
-                    __FILE__,                    \
-                    __LINE__,                    \
-                    LIBRARY_LOG_NAME,            \
-                    __VA_ARGS__ )
+    #define SdkLog( messageLevel, pFormat, ... ) \
+    Log_Generic( messageLevel,                   \
+                 "[%s:%d] [%s] "pFormat,         \
+                 __FILE__,                       \
+                 __LINE__,                       \
+                 LIBRARY_LOG_NAME,               \
+                 __VA_ARGS__ )
 
 #endif /* ifdef USE_AWS_IOT_CSDK_LOGGING */
 

--- a/libraries/standard/http/utest/config.h
+++ b/libraries/standard/http/utest/config.h
@@ -1,11 +1,11 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-#define LOG_LEVEL_HTTP              LOG_DEBUG
+#define LOG_LEVEL_HTTP      LOG_DEBUG
 
-#define USE_AWS_IOT_CSDK_LOGGING    1
+#define USE_CSDK_LOGGING    1
 
-#ifdef USE_AWS_IOT_CSDK_LOGGING
+#ifdef USE_CSDK_LOGGING
 
 /* Include file for POSIX reference implementation. */
     #include "logging.h"
@@ -22,6 +22,6 @@
                  LIBRARY_LOG_NAME,               \
                  __VA_ARGS__ )
 
-#endif /* ifdef USE_AWS_IOT_CSDK_LOGGING */
+#endif /* ifdef USE_CSDK_LOGGING */
 
 #endif /* ifndef CONFIG_H */

--- a/libraries/standard/http/utest/config.h
+++ b/libraries/standard/http/utest/config.h
@@ -1,7 +1,7 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-#define IOT_LOG_LEVEL_HTTP          IOT_LOG_DEBUG
+#define LOG_LEVEL_HTTP              LOG_DEBUG
 
 #define USE_AWS_IOT_CSDK_LOGGING    1
 

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -738,7 +738,7 @@ static void logConnackResponse( uint8_t responseCode )
     /* Declare the CONNACK response code strings. The fourth byte of CONNACK
      * indexes into this array for the corresponding response. This array
      * does not need to be allocated if logs are not enabled. */
-    #if LIBRARY_LOG_LEVEL > IOT_LOG_NONE
+    #if LIBRARY_LOG_LEVEL > LOG_NONE
         static const char * const pConnackResponses[ 6 ] =
         {
             "Connection accepted.",                               /* 0 */
@@ -749,7 +749,7 @@ static void logConnackResponse( uint8_t responseCode )
             "Connection refused: not authorized."                 /* 5 */
         };
         LogErrorWithArgs( "%s", pConnackResponses[ responseCode ] );
-    #endif /* if LIBRARY_LOG_LEVEL > IOT_LOG_NONE */
+    #endif /* if LIBRARY_LOG_LEVEL > LOG_NONE */
 }
 
 /*-----------------------------------------------------------*/

--- a/libraries/standard/mqtt/src/private/mqtt_internal.h
+++ b/libraries/standard/mqtt/src/private/mqtt_internal.h
@@ -5,13 +5,13 @@
  * AWS IoT Embedded C SDK optional specific logging setup.
  */
 #ifdef USE_AWS_IOT_CSDK_LOGGING
-    #ifdef IOT_LOG_LEVEL_MQTT
-        #define LIBRARY_LOG_LEVEL        IOT_LOG_LEVEL_MQTT
+    #ifdef LOG_LEVEL_MQTT
+        #define LIBRARY_LOG_LEVEL        LOG_LEVEL_MQTT
     #else
-        #ifdef IOT_LOG_LEVEL_GLOBAL
-            #define LIBRARY_LOG_LEVEL    IOT_LOG_LEVEL_GLOBAL
+        #ifdef LOG_LEVEL_GLOBAL
+            #define LIBRARY_LOG_LEVEL    LOG_LEVEL_GLOBAL
         #else
-            #define LIBRARY_LOG_LEVEL    IOT_LOG_NONE
+            #define LIBRARY_LOG_LEVEL    LOG_NONE
         #endif
     #endif
     #define LIBRARY_LOG_NAME             ( "MQTT" )

--- a/libraries/standard/mqtt/utest/config.h
+++ b/libraries/standard/mqtt/utest/config.h
@@ -1,11 +1,11 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-#define LOG_LEVEL_HTTP              LOG_DEBUG
+#define LOG_LEVEL_HTTP      LOG_DEBUG
 
-#define USE_AWS_IOT_CSDK_LOGGING    1
+#define USE_CSDK_LOGGING    1
 
-#ifdef USE_AWS_IOT_CSDK_LOGGING
+#ifdef USE_CSDK_LOGGING
 
 /* Include file for POSIX reference implementation. */
     #include "logging.h"
@@ -22,7 +22,7 @@
                  LIBRARY_LOG_NAME,               \
                  __VA_ARGS__ )
 
-#endif /* ifdef USE_AWS_IOT_CSDK_LOGGING */
+#endif /* ifdef USE_CSDK_LOGGING */
 
 
 /* Set network context to socket (int). */

--- a/libraries/standard/mqtt/utest/config.h
+++ b/libraries/standard/mqtt/utest/config.h
@@ -8,19 +8,19 @@
 #ifdef USE_AWS_IOT_CSDK_LOGGING
 
 /* Include file for POSIX reference implementation. */
-    #include "iot_logging.h"
+    #include "logging.h"
 
 /* Define the IotLog logging interface to enable logging.
  * This demo maps the macro to the reference POSIX implementation for logging.
  * Note: @ref LIBRARY_LOG_NAME adds the name of the library, that produces the
  * log, as metadata in each log message. */
-    #define IotLog( messageLevel, pFormat, ... ) \
-    IotLog_Generic( messageLevel,                \
-                    "[%s:%d] [%s] "pFormat,      \
-                    __FILE__,                    \
-                    __LINE__,                    \
-                    LIBRARY_LOG_NAME,            \
-                    __VA_ARGS__ )
+    #define SdkLog( messageLevel, pFormat, ... ) \
+    Log_Generic( messageLevel,                   \
+                 "[%s:%d] [%s] "pFormat,         \
+                 __FILE__,                       \
+                 __LINE__,                       \
+                 LIBRARY_LOG_NAME,               \
+                 __VA_ARGS__ )
 
 #endif /* ifdef USE_AWS_IOT_CSDK_LOGGING */
 

--- a/libraries/standard/mqtt/utest/config.h
+++ b/libraries/standard/mqtt/utest/config.h
@@ -1,7 +1,7 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-#define IOT_LOG_LEVEL_HTTP          IOT_LOG_DEBUG
+#define LOG_LEVEL_HTTP              LOG_DEBUG
 
 #define USE_AWS_IOT_CSDK_LOGGING    1
 

--- a/libraries/standard/utilities/include/logging_levels.h
+++ b/libraries/standard/utilities/include/logging_levels.h
@@ -39,25 +39,25 @@
  * for that library.
  *
  * Currently, there are 4 log levels. In the order of lowest to highest, they are:
- * - #IOT_LOG_NONE <br>
- *   @copybrief IOT_LOG_NONE
- * - #IOT_LOG_ERROR <br>
- *   @copybrief IOT_LOG_ERROR
- * - #IOT_LOG_WARN <br>
- *   @copybrief IOT_LOG_WARN
- * - #IOT_LOG_INFO <br>
- *   @copybrief IOT_LOG_INFO
- * - #IOT_LOG_DEBUG <br>
- *   @copybrief IOT_LOG_DEBUG
+ * - #LOG_NONE <br>
+ *   @copybrief LOG_NONE
+ * - #LOG_ERROR <br>
+ *   @copybrief LOG_ERROR
+ * - #LOG_WARN <br>
+ *   @copybrief LOG_WARN
+ * - #LOG_INFO <br>
+ *   @copybrief LOG_INFO
+ * - #LOG_DEBUG <br>
+ *   @copybrief LOG_DEBUG
  */
 
 /**
  * @brief No log messages.
  *
- * When @ref LIBRARY_LOG_LEVEL is #IOT_LOG_NONE, logging is disabled and no
+ * When @ref LIBRARY_LOG_LEVEL is #LOG_NONE, logging is disabled and no
  * logging messages are printed.
  */
-#define IOT_LOG_NONE     0
+#define LOG_NONE     0
 
 /**
  * @brief Represents erroneous application state or event.
@@ -66,9 +66,9 @@
  * which it cannot recover.
  *
  * These messages are printed when @ref LIBRARY_LOG_LEVEL is defined as either
- * of #IOT_LOG_ERROR, #IOT_LOG_WARN, #IOT_LOG_INFO or #IOT_LOG_DEBUG.
+ * of #LOG_ERROR, #LOG_WARN, #LOG_INFO or #LOG_DEBUG.
  */
-#define IOT_LOG_ERROR    1
+#define LOG_ERROR    1
 
 /**
  * @brief Message about an abnormal event.
@@ -78,9 +78,9 @@
  * execution after logging a warning.
  *
  * These messages are printed when @ref LIBRARY_LOG_LEVEL is defined as either
- * of #IOT_LOG_WARN, #IOT_LOG_INFO or #IOT_LOG_DEBUG.
+ * of #LOG_WARN, #LOG_INFO or #LOG_DEBUG.
  */
-#define IOT_LOG_WARN     2
+#define LOG_WARN     2
 
 /**
  * @brief A helpful, informational message.
@@ -89,9 +89,9 @@
  * the progress of the program at a coarse-grained level.
  *
  * These messages are printed when @ref LIBRARY_LOG_LEVEL is defined as either
- * of #IOT_LOG_INFO or #IOT_LOG_DEBUG.
+ * of #LOG_INFO or #LOG_DEBUG.
  */
-#define IOT_LOG_INFO     3
+#define LOG_INFO     3
 
 /**
  * @brief Detailed and excessive debug information.
@@ -102,8 +102,8 @@
  * variables, buffers, or other specific information.
  *
  * These messages are only printed when @ref LIBRARY_LOG_LEVEL is defined as
- * #IOT_LOG_DEBUG.
+ * #LOG_DEBUG.
  */
-#define IOT_LOG_DEBUG    4
+#define LOG_DEBUG    4
 
 #endif /* ifndef IOT_LOGGING_LEVELS_H_ */

--- a/libraries/standard/utilities/include/logging_setup.h
+++ b/libraries/standard/utilities/include/logging_setup.h
@@ -21,12 +21,12 @@
  */
 
 /**
- * @file iot_logging_setup.h
+ * @file logging_setup.h
  * @brief Defines the common logging framework that calls #Log interface.
  */
 
-#ifndef IOT_LOGGING_SETUP_H_
-#define IOT_LOGGING_SETUP_H_
+#ifndef LOGGING_SETUP_H_
+#define LOGGING_SETUP_H_
 
 /* The config header is always included first. */
 #include "config.h"
@@ -48,8 +48,8 @@
  * This macro should be mapped to the platform's logging library.
  *
  * @param[in] messageLevel The integer code for the log level of the message.
- * Must be one of #IOT_LOG_ERROR, #IOT_LOG_WARN, #IOT_LOG_INFO or #IOT_LOG_DEBUG.
- * Must not be #IOT_LOG_NONE.
+ * Must be one of #LOG_ERROR, #LOG_WARN, #LOG_INFO or #LOG_DEBUG.
+ * Must not be #LOG_NONE.
  * @param[in] pFormat The format string for the log message.
  * @param[in] ... The variadic argument list for the format string.
  *
@@ -58,136 +58,136 @@
 
 /**
  * @def LogError( message  )
- * @brief Abbreviated logging macro for stand-alone message strings at level #IOT_LOG_ERROR.
+ * @brief Abbreviated logging macro for stand-alone message strings at level #LOG_ERROR.
  *
  * Equivalent to:
  * @code{c}
- * Log( IOT_LOG_ERROR, "%s" , message )
+ * SdkLog( LOG_ERROR, "%s" , message )
  * @endcode
  */
 
 /**
  * @def LogErrorWithArgs( pFormat, ...  )
- * @brief Abbreviated logging macro for messages with arguments at level #IOT_LOG_ERROR.
+ * @brief Abbreviated logging macro for messages with arguments at level #LOG_ERROR.
  *
  * Equivalent to:
  * @code{c}
- * Log( IOT_LOG_ERROR, pFormat, ... )
+ * SdkLog( LOG_ERROR, pFormat, ... )
  * @endcode
  */
 
 /**
  * @def LogWarn( message  )
- * @brief Abbreviated logging macro for stand-alone message strings at level #IOT_LOG_WARN.
+ * @brief Abbreviated logging macro for stand-alone message strings at level #LOG_WARN.
  *
  * Equivalent to:
  * @code{c}
- * Log( IOT_LOG_WARN, "%s" , message )
+ * SdkLog( LOG_WARN, "%s" , message )
  * @endcode
  */
 
 /**
  * @def LogWarnWithArgs( pFormat, ...  )
- * @brief Abbreviated logging macro for messages with arguments at level #IOT_LOG_WARN.
+ * @brief Abbreviated logging macro for messages with arguments at level #LOG_WARN.
  *
  * Equivalent to:
  * @code{c}
- * Log( IOT_LOG_WARN, pFormat, ... )
+ * SdkLog( LOG_WARN, pFormat, ... )
  * @endcode
  */
 
 /**
  * @def LogInfo( message  )
- * @brief Abbreviated logging macro for stand-alone message strings at level #IOT_LOG_INFO.
+ * @brief Abbreviated logging macro for stand-alone message strings at level #LOG_INFO.
  *
  * Equivalent to:
  * @code{c}
- * Log( IOT_LOG_INFO, "%s" , message )
+ * SdkLog( LOG_INFO, "%s" , message )
  * @endcode
  */
 
 /**
  * @def LogInfoWithArgs( pFormat, ...  )
- * @brief Abbreviated logging macro for messages with arguments at level #IOT_LOG_INFO.
+ * @brief Abbreviated logging macro for messages with arguments at level #LOG_INFO.
  *
  * Equivalent to:
  * @code{c}
- * Log( IOT_LOG_INFO, pFormat, ... )
+ * SdkLog( LOG_INFO, pFormat, ... )
  * @endcode
  */
 
 /**
  * @def LogDebug( message  )
- * @brief Abbreviated logging macro for stand-alone message strings at level #IOT_LOG_DEBUG.
+ * @brief Abbreviated logging macro for stand-alone message strings at level #LOG_DEBUG.
  *
  * Equivalent to:
  * @code{c}
- * Log( IOT_LOG_DEBUG, "%s" , message )
+ * SdkLog( LOG_DEBUG, "%s" , message )
  * @endcode
  */
 
 /**
  * @def LogDebugWithArgs( pFormat, ...  )
- * @brief Abbreviated logging macro for messages with arguments at level #IOT_LOG_DEBUG.
+ * @brief Abbreviated logging macro for messages with arguments at level #LOG_DEBUG.
  *
  * Equivalent to:
  * @code{c}
- * Log( IOT_LOG_DEBUG, pFormat, ... )
+ * SdkLog( LOG_DEBUG, pFormat, ... )
  * @endcode
  */
 
 /* Check that LIBRARY_LOG_LEVEL is defined and has a valid value. */
-#if !defined( LIBRARY_LOG_LEVEL ) ||           \
-    ( ( LIBRARY_LOG_LEVEL != IOT_LOG_NONE ) && \
-    ( LIBRARY_LOG_LEVEL != IOT_LOG_ERROR ) &&  \
-    ( LIBRARY_LOG_LEVEL != IOT_LOG_WARN ) &&   \
-    ( LIBRARY_LOG_LEVEL != IOT_LOG_INFO ) &&   \
-    ( LIBRARY_LOG_LEVEL != IOT_LOG_DEBUG ) )
-    #error "Please define LIBRARY_LOG_LEVEL as either IOT_LOG_NONE, IOT_LOG_ERROR, IOT_LOG_WARN, IOT_LOG_INFO, or IOT_LOG_DEBUG."
+#if !defined( LIBRARY_LOG_LEVEL ) ||       \
+    ( ( LIBRARY_LOG_LEVEL != LOG_NONE ) && \
+    ( LIBRARY_LOG_LEVEL != LOG_ERROR ) &&  \
+    ( LIBRARY_LOG_LEVEL != LOG_WARN ) &&   \
+    ( LIBRARY_LOG_LEVEL != LOG_INFO ) &&   \
+    ( LIBRARY_LOG_LEVEL != LOG_DEBUG ) )
+    #error "Please define LIBRARY_LOG_LEVEL as either LOG_NONE, LOG_ERROR, LOG_WARN, LOG_INFO, or LOG_DEBUG."
 #else
-    #if LIBRARY_LOG_LEVEL != IOT_LOG_NONE
-        #if !defined( Log )
-            #error "Please define the common logging interface macro, Log(messageLevel, pFormat, ...)."
+    #if LIBRARY_LOG_LEVEL != LOG_NONE
+        #if !defined( SdkLog )
+            #error "Please define the common logging interface macro, sdkLog(messageLevel, pFormat, ...)."
         #endif
     #endif
 
-    #if LIBRARY_LOG_LEVEL == IOT_LOG_DEBUG
+    #if LIBRARY_LOG_LEVEL == LOG_DEBUG
         /* All log level messages will logged. */
-        #define LogError( message )                 Log( IOT_LOG_ERROR, "%s", message )
-        #define LogErrorWithArgs( pFormat, ... )    Log( IOT_LOG_ERROR, pFormat, __VA_ARGS__ )
-        #define LogWarn( message )                  Log( IOT_LOG_WARN, "%s", message )
-        #define LogWarnWithArgs( pFormat, ... )     Log( IOT_LOG_WARN, pFormat, __VA_ARGS__ )
-        #define LogInfo( message )                  Log( IOT_LOG_INFO, "%s", message )
-        #define LogInfoWithArgs( pFormat, ... )     Log( IOT_LOG_INFO, pFormat, __VA_ARGS__ )
-        #define LogDebug( message )                 Log( IOT_LOG_DEBUG, "%s", message )
-        #define LogDebugWithArgs( pFormat, ... )    Log( IOT_LOG_DEBUG, pFormat, __VA_ARGS__ )
+        #define LogError( message )                 SdkLog( LOG_ERROR, "%s", message )
+        #define LogErrorWithArgs( pFormat, ... )    SdkLog( LOG_ERROR, pFormat, __VA_ARGS__ )
+        #define LogWarn( message )                  SdkLog( LOG_WARN, "%s", message )
+        #define LogWarnWithArgs( pFormat, ... )     SdkLog( LOG_WARN, pFormat, __VA_ARGS__ )
+        #define LogInfo( message )                  SdkLog( LOG_INFO, "%s", message )
+        #define LogInfoWithArgs( pFormat, ... )     SdkLog( LOG_INFO, pFormat, __VA_ARGS__ )
+        #define LogDebug( message )                 SdkLog( LOG_DEBUG, "%s", message )
+        #define LogDebugWithArgs( pFormat, ... )    SdkLog( LOG_DEBUG, pFormat, __VA_ARGS__ )
 
-    #elif LIBRARY_LOG_LEVEL == IOT_LOG_INFO
+    #elif LIBRARY_LOG_LEVEL == LOG_INFO
         /* Only INFO, WARNING and ERROR messages will be logged. */
-        #define LogError( message )                 Log( IOT_LOG_ERROR, "%s", message )
-        #define LogErrorWithArgs( pFormat, ... )    Log( IOT_LOG_ERROR, pFormat, __VA_ARGS__ )
-        #define LogWarn( message )                  Log( IOT_LOG_WARN, "%s", message )
-        #define LogWarnWithArgs( pFormat, ... )     Log( IOT_LOG_WARN, pFormat, __VA_ARGS__ )
-        #define LogInfo( message )                  Log( IOT_LOG_INFO, "%s", message )
-        #define LogInfoWithArgs( pFormat, ... )     Log( IOT_LOG_INFO, pFormat, __VA_ARGS__ )
+        #define LogError( message )                 SdkLog( LOG_ERROR, "%s", message )
+        #define LogErrorWithArgs( pFormat, ... )    SdkLog( LOG_ERROR, pFormat, __VA_ARGS__ )
+        #define LogWarn( message )                  SdkLog( LOG_WARN, "%s", message )
+        #define LogWarnWithArgs( pFormat, ... )     SdkLog( LOG_WARN, pFormat, __VA_ARGS__ )
+        #define LogInfo( message )                  SdkLog( LOG_INFO, "%s", message )
+        #define LogInfoWithArgs( pFormat, ... )     SdkLog( LOG_INFO, pFormat, __VA_ARGS__ )
         #define LogDebug( message )
         #define LogDebugWithArgs( pFormat, ... )
 
-    #elif LIBRARY_LOG_LEVEL == IOT_LOG_WARN
+    #elif LIBRARY_LOG_LEVEL == LOG_WARN
         /* Only WARNING and ERROR messages will be logged.*/
-        #define LogError( message )                 Log( IOT_LOG_ERROR, "%s", message )
-        #define LogErrorWithArgs( pFormat, ... )    Log( IOT_LOG_ERROR, pFormat, __VA_ARGS__ )
-        #define LogWarn( message )                  Log( IOT_LOG_WARN, "%s", message )
-        #define LogWarnWithArgs( pFormat, ... )     Log( IOT_LOG_WARN, pFormat, __VA_ARGS__ )
+        #define LogError( message )                 SdkLog( LOG_ERROR, "%s", message )
+        #define LogErrorWithArgs( pFormat, ... )    SdkLog( LOG_ERROR, pFormat, __VA_ARGS__ )
+        #define LogWarn( message )                  SdkLog( LOG_WARN, "%s", message )
+        #define LogWarnWithArgs( pFormat, ... )     SdkLog( LOG_WARN, pFormat, __VA_ARGS__ )
         #define LogInfo( message )
         #define LogInfoWithArgs( pFormat, ... )
         #define LogDebug( message )
         #define LogDebugWithArgs( pFormat, ... )
 
-    #elif LIBRARY_LOG_LEVEL == IOT_LOG_ERROR
+    #elif LIBRARY_LOG_LEVEL == LOG_ERROR
         /* Only ERROR messages will be logged. */
-        #define LogError( message )                 Log( IOT_LOG_ERROR, "%s", message )
-        #define LogErrorWithArgs( pFormat, ... )    Log( IOT_LOG_ERROR, pFormat, __VA_ARGS__ )
+        #define LogError( message )                 SdkLog( LOG_ERROR, "%s", message )
+        #define LogErrorWithArgs( pFormat, ... )    SdkLog( LOG_ERROR, pFormat, __VA_ARGS__ )
         #define LogWarn( message )
         #define LogWarnWithArgs( pFormat, ... )
         #define LogInfo( message )
@@ -195,7 +195,7 @@
         #define LogDebug( message )
         #define LogDebugWithArgs( pFormat, ... )
 
-    #else /* if LIBRARY_LOG_LEVEL == IOT_LOG_ERROR */
+    #else /* if LIBRARY_LOG_LEVEL == LOG_ERROR */
         #define LogError( message )
         #define LogErrorWithArgs( pFormat, ... )
         #define LogWarn( message )
@@ -204,7 +204,7 @@
         #define LogInfoWithArgs( pFormat, ... )
         #define LogDebug( message )
         #define LogDebugWithArgs( pFormat, ... )
-    #endif /* if LIBRARY_LOG_LEVEL == IOT_LOG_ERROR */
-#endif /* if !defined( LIBRARY_LOG_LEVEL ) || ( ( LIBRARY_LOG_LEVEL != IOT_LOG_NONE ) && ( LIBRARY_LOG_LEVEL != IOT_LOG_ERROR ) && ( LIBRARY_LOG_LEVEL != IOT_LOG_WARN ) && ( LIBRARY_LOG_LEVEL != IOT_LOG_INFO ) && ( LIBRARY_LOG_LEVEL != IOT_LOG_DEBUG ) ) */
+    #endif /* if LIBRARY_LOG_LEVEL == LOG_ERROR */
+#endif /* if !defined( LIBRARY_LOG_LEVEL ) || ( ( LIBRARY_LOG_LEVEL != LOG_NONE ) && ( LIBRARY_LOG_LEVEL != LOG_ERROR ) && ( LIBRARY_LOG_LEVEL != LOG_WARN ) && ( LIBRARY_LOG_LEVEL != LOG_INFO ) && ( LIBRARY_LOG_LEVEL != LOG_DEBUG ) ) */
 
-#endif /* ifndef IOT_LOGGING_SETUP_H_ */
+#endif /* ifndef LOGGING_SETUP_H_ */

--- a/platform/posix/clock_posix.c
+++ b/platform/posix/clock_posix.c
@@ -41,13 +41,13 @@
 #include "clock.h"
 
 /* Configure logs for the functions in this file. */
-#ifdef IOT_LOG_LEVEL_PLATFORM
-    #define LIBRARY_LOG_LEVEL        IOT_LOG_LEVEL_PLATFORM
+#ifdef LOG_LEVEL_PLATFORM
+    #define LIBRARY_LOG_LEVEL        LOG_LEVEL_PLATFORM
 #else
-    #ifdef IOT_LOG_LEVEL_GLOBAL
-        #define LIBRARY_LOG_LEVEL    IOT_LOG_LEVEL_GLOBAL
+    #ifdef LOG_LEVEL_GLOBAL
+        #define LIBRARY_LOG_LEVEL    LOG_LEVEL_GLOBAL
     #else
-        #define LIBRARY_LOG_LEVEL    IOT_LOG_NONE
+        #define LIBRARY_LOG_LEVEL    LOG_NONE
     #endif
 #endif
 

--- a/platform/posix/logging.c
+++ b/platform/posix/logging.c
@@ -72,25 +72,25 @@
  */
 static const char * _log_level_strerror( int32_t messageLevel )
 {
-    assert( ( messageLevel >= IOT_LOG_NONE ) && ( messageLevel <= IOT_LOG_DEBUG ) );
+    assert( ( messageLevel >= LOG_NONE ) && ( messageLevel <= LOG_DEBUG ) );
 
     const char * retVal = NULL;
 
     switch( messageLevel )
     {
-        case IOT_LOG_ERROR:
+        case LOG_ERROR:
             retVal = "ERROR";
             break;
 
-        case IOT_LOG_WARN:
+        case LOG_WARN:
             retVal = "WARN";
             break;
 
-        case IOT_LOG_INFO:
+        case LOG_INFO:
             retVal = "INFO";
             break;
 
-        case IOT_LOG_DEBUG:
+        case LOG_DEBUG:
             retVal = "DEBUG";
             break;
     }
@@ -131,7 +131,7 @@ void Log_Generic( int32_t messageLevel,
                   const char * const pFormat,
                   ... )
 {
-    assert( ( messageLevel >= IOT_LOG_NONE ) && ( messageLevel <= IOT_LOG_DEBUG ) );
+    assert( ( messageLevel >= LOG_NONE ) && ( messageLevel <= LOG_DEBUG ) );
 
     int requiredMessageSize = 0;
     size_t bufferSize = 0,


### PR DESCRIPTION
*Description of changes:*
* Avoid potential naming collisions with the `Log` macro interface by renaming it to `SdkLog`
* Remove `IOT_` prefix from logging level macros

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
