### PR TITLE
Minor re-arrangement of Cmake logic across CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ include("tools/cmake/filePaths.cmake")
 # Configure options to always show in CMake GUI.
 option( BUILD_TESTS
         "Set this to ON to build both demo and test executables. When OFF, only demo executables are built."
-        ON )
+        OFF )
 option( BUILD_CLONE_SUBMODULES
         "Set this to ON to automatically clone any required Git submodules. When OFF, submodules must be manually cloned."
         ON )

--- a/libraries/3rdparty/CMakeLists.txt
+++ b/libraries/3rdparty/CMakeLists.txt
@@ -1,0 +1,63 @@
+# Configuration for CMock if testing is enabled.
+if( ${BUILD_TESTS} )
+    # Check if the CMock source directory exists.
+    if( NOT EXISTS ${3RDPARTY_DIR}/CMock/src )
+        # Attempt to clone CMock.
+        if( ${BUILD_CLONE_SUBMODULES} )
+            find_package( Git REQUIRED )
+
+            message( "Cloning submodule CMock." )
+            execute_process( COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive libraries/3rdparty/CMock
+                             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+                             RESULT_VARIABLE CMOCK_CLONE_RESULT )
+
+            if( NOT ${CMOCK_CLONE_RESULT} STREQUAL "0" )
+                message( FATAL_ERROR "Failed to clone CMock submodule." )
+            endif()
+        else()
+            message( FATAL_ERROR "The required submodule CMock does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
+        endif()
+    endif()
+
+    # Build Configuration for CMock and Unity libraries.
+    include_directories("${3RDPARTY_DIR}/CMock/vendor/unity/src/"
+                        "${3RDPARTY_DIR}/CMock/vendor/unity/extras/fixture/src"
+                        "${3RDPARTY_DIR}/CMock/vendor/unity/extras/memory/src"
+                        "${3RDPARTY_DIR}/CMock/src"
+            )
+    link_directories("${CMAKE_BINARY_DIR}/lib"
+            )
+
+    add_library(cmock STATIC
+            "${ROOT_DIR}/libraries/3rdparty/CMock/src/cmock.c"
+            )
+
+    set_target_properties(cmock PROPERTIES
+            ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+            POSITION_INDEPENDENT_CODE ON
+            COMPILE_FLAGS "-Og"
+            )
+
+    add_library(unity STATIC
+            "${3RDPARTY_DIR}/CMock/vendor/unity/src/unity.c"
+            "${3RDPARTY_DIR}/CMock/vendor/unity/extras/fixture/src/unity_fixture.c"
+            "${3RDPARTY_DIR}/CMock/vendor/unity/extras/memory/src/unity_memory.c"
+            )
+    set_target_properties(unity PROPERTIES
+            ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+            POSITION_INDEPENDENT_CODE ON
+            )
+
+    target_include_directories(cmock PUBLIC
+            ${ROOT_DIR}/libraries/3rdparty/CMock/src
+            ${ROOT_DIR}/libraries/3rdparty/CMock/vendor/unity/src/
+            ${ROOT_DIR}/libraries/3rdparty/CMock/examples
+            )
+    target_link_libraries(cmock unity)
+
+    add_custom_target(coverage
+            COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/tools/cmock/coverage.cmake
+            DEPENDS cmock unity http_utest mqtt_utest
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+            )
+endif()

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -1,71 +1,9 @@
+include("${ROOT_DIR}/tools/cmock/create_test.cmake")
 
-if( ${BUILD_TESTS} )
-    # Check if the CMock source directory exists.
-    if( NOT EXISTS ${3RDPARTY_DIR}/CMock/src )
-        # Attempt to clone CMock.
-        if( ${BUILD_CLONE_SUBMODULES} )
-            find_package( Git REQUIRED )
-
-            message( "Cloning submodule CMock." )
-            execute_process( COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive libraries/3rdparty/CMock
-                             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-                             RESULT_VARIABLE CMOCK_CLONE_RESULT )
-
-            if( NOT ${CMOCK_CLONE_RESULT} STREQUAL "0" )
-                message( FATAL_ERROR "Failed to clone CMock submodule." )
-            endif()
-        else()
-            message( FATAL_ERROR "The required submodule CMock does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
-        endif()
-    endif()
-
-    include("${ROOT_DIR}/tools/cmock/create_test.cmake")
-
-    include_directories("${3RDPARTY_DIR}/CMock/vendor/unity/src/"
-                        "${3RDPARTY_DIR}/CMock/vendor/unity/extras/fixture/src"
-                        "${3RDPARTY_DIR}/CMock/vendor/unity/extras/memory/src"
-                        "${3RDPARTY_DIR}/CMock/src"
-            )
-    link_directories("${CMAKE_BINARY_DIR}/lib"
-            )
-
-    add_library(cmock STATIC
-            "${ROOT_DIR}/libraries/3rdparty/CMock/src/cmock.c"
-            )
-
-    set_target_properties(cmock PROPERTIES
-            ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
-            POSITION_INDEPENDENT_CODE ON
-            COMPILE_FLAGS "-Og"
-            )
-
-    add_library(unity STATIC
-            "${3RDPARTY_DIR}/CMock/vendor/unity/src/unity.c"
-            "${3RDPARTY_DIR}/CMock/vendor/unity/extras/fixture/src/unity_fixture.c"
-            "${3RDPARTY_DIR}/CMock/vendor/unity/extras/memory/src/unity_memory.c"
-            )
-    set_target_properties(unity PROPERTIES
-            ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
-            POSITION_INDEPENDENT_CODE ON
-            )
-
-    target_include_directories(cmock PUBLIC
-            ${ROOT_DIR}/libraries/3rdparty/CMock/src
-            ${ROOT_DIR}/libraries/3rdparty/CMock/vendor/unity/src/
-            ${ROOT_DIR}/libraries/3rdparty/CMock/examples
-            )
-    target_link_libraries(cmock unity)
-
-    add_custom_target(coverage
-            COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/tools/cmock/coverage.cmake
-            DEPENDS cmock unity http_utest mqtt_utest
-            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-            )
-endif()
-
-# Add standard modules
+# Add all CMakeLists.txt in 3rdparty and standard folders.
 file(GLOB standard_modules "${MODULES_DIR}/standard/*")
-foreach(module IN LISTS standard_modules)
+file(GLOB 3rdparty_modules "${3RDPARTY_DIR}/*")
+foreach(module IN LISTS standard_modules 3rdparty_modules)
     if(IS_DIRECTORY "${module}" AND EXISTS "${module}/CMakeLists.txt")
         add_subdirectory(${module})
     endif()


### PR DESCRIPTION
*Description of changes:*
* Move 3rdparty specific CMake logic to `3rdpaty/CMakeLists.txt`
* Make default value of `BUILD_TESTS` to `OFF` (to prevent build failures due to CMock and Ruby dependencies during initial adoption/testing by new customers)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
