### PR TITLE
Add MQTT_Init unit tests using Unity Framework

### DIFF
--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -5,6 +5,11 @@
 /* Include paths for public enums, structures, and macros. */
 #include "mqtt.h"
 
+/**
+ * @brief A valid starting packet ID per MQTT spec. Start from 1.
+ */
+#define MQTT_NEXT_PACKET_ID_START    ( 1 )
+
 /* ============================   UNITY FIXTURES ============================ */
 
 /* Called before each test method. */
@@ -28,7 +33,7 @@ int suiteTearDown( int numFailures )
 }
 
 /* ============================   Testing MQTT_Init ========================= */
-void test_Mqtt_init_complete( void )
+void test_MQTT_Init_complete( void )
 {
     MQTTContext_t context;
     MQTTTransportInterface_t transport;
@@ -41,4 +46,5 @@ void test_Mqtt_init_complete( void )
     TEST_ASSERT_EQUAL_MEMORY( &transport, &context.transportInterface, sizeof( transport ) );
     TEST_ASSERT_EQUAL_MEMORY( &callbacks, &context.callbacks, sizeof( callbacks ) );
     TEST_ASSERT_EQUAL_MEMORY( &networkBuffer, &context.networkBuffer, sizeof( networkBuffer ) );
+    TEST_ASSERT_EQUAL( MQTT_NEXT_PACKET_ID_START, context.nextPacketId );
 }

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -31,7 +31,7 @@ void suiteSetUp()
 int suiteTearDown( int numFailures )
 {
     /* Disable unused variable warning. */
-    ( void ) numFailures;
+    return numFailures;
 }
 
 /* ============================   Testing MQTT_Init ========================= */

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -42,7 +42,7 @@ void test_MQTT_Init_happy_path( void )
     MQTTApplicationCallbacks_t callbacks;
 
     mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
-    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus )
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     TEST_ASSERT_EQUAL( MQTTNotConnected, context.connectStatus );
     TEST_ASSERT_EQUAL( MQTT_NEXT_PACKET_ID_START, context.nextPacketId );
     /* These Unity assertions take pointers and compare their contents. */

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -6,21 +6,23 @@
 #include "mqtt.h"
 
 /* ============================   UNITY FIXTURES ============================ */
+
+/* Called before each test method. */
 void setUp( void )
 {
 }
 
-/* called before each testcase */
+/* Called after each test method. */
 void tearDown( void )
 {
 }
 
-/* called at the beginning of the whole suite */
+/* Called at the beginning of the whole suite. */
 void suiteSetUp()
 {
 }
 
-/* called at the end of the whole suite */
+/* Called at the end of the whole suite. */
 int suiteTearDown( int numFailures )
 {
 }

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -30,7 +30,6 @@ void suiteSetUp()
 /* Called at the end of the whole suite. */
 int suiteTearDown( int numFailures )
 {
-    /* Disable unused variable warning. */
     return numFailures;
 }
 

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -27,11 +27,18 @@ int suiteTearDown( int numFailures )
 {
 }
 
-/* ============================   Testing MQTT_Connect ====================== */
-void test_Mqtt_connect_packet_size_gt_max( void )
+/* ============================   Testing MQTT_Init ========================= */
+void test_Mqtt_init_complete( void )
 {
-    /* This mocked method will be called inside MQTT_Connect(...). */
-    MQTT_GetConnectPacketSize_ExpectAnyArgsAndReturn( MQTTBadParameter );
+    MQTTContext_t context;
+    MQTTTransportInterface_t transport;
+    MQTTFixedBuffer_t networkBuffer;
+    MQTTApplicationCallbacks_t callbacks;
 
-    TEST_ASSERT_EQUAL( MQTT_Connect( NULL, NULL, NULL, 0U, NULL ), MQTTBadParameter );
+    MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    TEST_ASSERT_EQUAL( context.connectStatus, MQTTNotConnected );
+    /* These Unity assertions take pointers and compare their contents. */
+    TEST_ASSERT_EQUAL_MEMORY( &context.transportInterface, &transport, sizeof( transport ) );
+    TEST_ASSERT_EQUAL_MEMORY( &context.callbacks, &callbacks, sizeof( callbacks ) );
+    TEST_ASSERT_EQUAL_MEMORY( &context.networkBuffer, &networkBuffer, sizeof( networkBuffer ) );
 }

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -34,7 +34,11 @@ int suiteTearDown( int numFailures )
 }
 
 /* ============================   Testing MQTT_Init ========================= */
-void test_MQTT_Init_happy_path( void )
+
+/**
+ * @brief Test that MQTT_Init is able to update the context object correctly.
+ */
+void test_MQTT_Init_Happy_path( void )
 {
     MQTTStatus_t mqttStatus;
     MQTTContext_t context;
@@ -52,7 +56,10 @@ void test_MQTT_Init_happy_path( void )
     TEST_ASSERT_EQUAL_MEMORY( &networkBuffer, &context.networkBuffer, sizeof( networkBuffer ) );
 }
 
-void test_MQTT_Init_invalid_params( void )
+/**
+ * @brief Test that any NULL parameter causes MQTT_Init to return MQTTBadParameter.
+ */
+void test_MQTT_Init_Invalid_params( void )
 {
     MQTTStatus_t mqttStatus;
     MQTTContext_t context;

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -33,18 +33,42 @@ int suiteTearDown( int numFailures )
 }
 
 /* ============================   Testing MQTT_Init ========================= */
-void test_MQTT_Init_complete( void )
+void test_MQTT_Init_happy_path( void )
 {
+    MQTTStatus_t mqttStatus;
     MQTTContext_t context;
     MQTTTransportInterface_t transport;
     MQTTFixedBuffer_t networkBuffer;
     MQTTApplicationCallbacks_t callbacks;
 
-    MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus )
     TEST_ASSERT_EQUAL( MQTTNotConnected, context.connectStatus );
+    TEST_ASSERT_EQUAL( MQTT_NEXT_PACKET_ID_START, context.nextPacketId );
     /* These Unity assertions take pointers and compare their contents. */
     TEST_ASSERT_EQUAL_MEMORY( &transport, &context.transportInterface, sizeof( transport ) );
     TEST_ASSERT_EQUAL_MEMORY( &callbacks, &context.callbacks, sizeof( callbacks ) );
     TEST_ASSERT_EQUAL_MEMORY( &networkBuffer, &context.networkBuffer, sizeof( networkBuffer ) );
-    TEST_ASSERT_EQUAL( MQTT_NEXT_PACKET_ID_START, context.nextPacketId );
+}
+
+void test_MQTT_Init_invalid_params( void )
+{
+    MQTTStatus_t mqttStatus;
+    MQTTContext_t context;
+    MQTTTransportInterface_t transport;
+    MQTTFixedBuffer_t networkBuffer;
+    MQTTApplicationCallbacks_t callbacks;
+
+    /* Check that MQTTBadParameter is returned if any NULL parameters are passed. */
+    mqttStatus = MQTT_Init( NULL, &transport, &callbacks, &networkBuffer );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
+
+    mqttStatus = MQTT_Init( &context, NULL, &callbacks, &networkBuffer );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
+
+    mqttStatus = MQTT_Init( &context, &transport, NULL, &networkBuffer );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
+
+    mqttStatus = MQTT_Init( &context, &transport, &callbacks, NULL );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
 }

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -2,8 +2,6 @@
 
 #include "unity.h"
 
-#include "mock_mqtt_lightweight.h"
-
 /* Include paths for public enums, structures, and macros. */
 #include "mqtt.h"
 

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -31,7 +31,7 @@ void suiteSetUp()
 int suiteTearDown( int numFailures )
 {
     /* Disable unused variable warning. */
-    return numFailures;
+    ( void ) numFailures;
 }
 
 /* ============================   Testing MQTT_Init ========================= */

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -30,6 +30,8 @@ void suiteSetUp()
 /* Called at the end of the whole suite. */
 int suiteTearDown( int numFailures )
 {
+    /* Disable unused variable warning. */
+    return numFailures;
 }
 
 /* ============================   Testing MQTT_Init ========================= */

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -34,9 +34,9 @@ void test_Mqtt_init_complete( void )
     MQTTApplicationCallbacks_t callbacks;
 
     MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
-    TEST_ASSERT_EQUAL( context.connectStatus, MQTTNotConnected );
+    TEST_ASSERT_EQUAL( MQTTNotConnected, context.connectStatus );
     /* These Unity assertions take pointers and compare their contents. */
-    TEST_ASSERT_EQUAL_MEMORY( &context.transportInterface, &transport, sizeof( transport ) );
-    TEST_ASSERT_EQUAL_MEMORY( &context.callbacks, &callbacks, sizeof( callbacks ) );
-    TEST_ASSERT_EQUAL_MEMORY( &context.networkBuffer, &networkBuffer, sizeof( networkBuffer ) );
+    TEST_ASSERT_EQUAL_MEMORY( &transport, &context.transportInterface, sizeof( transport ) );
+    TEST_ASSERT_EQUAL_MEMORY( &callbacks, &context.callbacks, sizeof( callbacks ) );
+    TEST_ASSERT_EQUAL_MEMORY( &networkBuffer, &context.networkBuffer, sizeof( networkBuffer ) );
 }


### PR DESCRIPTION
Create two methods that achieve 100% branch coverage on MQTT_Init:
- `test_MQTT_Init_Happy_path` tests that MQTT_Init is able to update the context object correctly
- `test_MQTT_Init_Invalid_params` tests that any NULL parameter causes MQTT_Init to return MQTTBadParameter.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
