### PR TITLE
test: MQTT_SerializeConnect unit tests using Unity Framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,13 @@ if( ${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR} )
     message( FATAL_ERROR "In-source build is not allowed. Please build in a separate directory, such as ${PROJECT_SOURCE_DIR}/build." )
 endif()
 
-# Import global configurations.
-include( "tools/cmake/filePaths.cmake" )
+# Set global path variables.
+get_filename_component(__root_dir "${CMAKE_CURRENT_LIST_DIR}" ABSOLUTE)
+set(ROOT_DIR ${__root_dir} CACHE INTERNAL "C SDK source root.")
+set(DEMOS_DIR "${ROOT_DIR}/demos" CACHE INTERNAL "C SDK demos root.")
+set(MODULES_DIR "${ROOT_DIR}/libraries" CACHE INTERNAL "C SDK modules root.")
+set(3RDPARTY_DIR "${MODULES_DIR}/3rdparty" CACHE INTERNAL "3rdparty libraries root.")
+
 include( "demos/logging-stack/logging.cmake" )
 
 # Configure options to always show in CMake GUI.

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -35,7 +35,7 @@ if( ${BUILD_TESTS} )
     # Add a target for running coverage on tests.
     add_custom_target(coverage
         COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/tools/cmock/coverage.cmake
-        DEPENDS cmock unity http_utest mqtt_utest mqtt_state_utest
+        DEPENDS cmock unity http_utest mqtt_utest mqtt_state_utest mqtt_lightweight_utest
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )
 endif()

--- a/libraries/standard/mqtt/utest/CMakeLists.txt
+++ b/libraries/standard/mqtt/utest/CMakeLists.txt
@@ -48,6 +48,7 @@ list(APPEND test_include_directories
 
 # =============================  (end edit)  ===================================
 
+# define targets for testing mqtt.c
 set(mock_name "${project_name}_mock")
 set(real_name "${project_name}_real")
 
@@ -88,7 +89,22 @@ set(utest_source "${project_name}_state_utest.c")
 
 set(utest_link_list "")
 list(APPEND utest_link_list
-            -lunity
+            lib${real_name}.a
+        )
+
+create_test(${utest_name}
+            ${utest_source}
+            "${utest_link_list}"
+            "${utest_dep_list}"
+            "${test_include_directories}"
+        )
+
+# define targets for testing mqtt_lightweight.c
+set(utest_name "${project_name}_lightweight_utest")
+set(utest_source "${project_name}_lightweight_utest.c")
+
+set(utest_link_list "")
+list(APPEND utest_link_list
             lib${real_name}.a
         )
 

--- a/libraries/standard/mqtt/utest/CMakeLists.txt
+++ b/libraries/standard/mqtt/utest/CMakeLists.txt
@@ -48,7 +48,6 @@ list(APPEND test_include_directories
 
 # =============================  (end edit)  ===================================
 
-# define targets for testing mqtt.c
 set(mock_name "${project_name}_mock")
 set(real_name "${project_name}_real")
 
@@ -74,6 +73,7 @@ list(APPEND utest_dep_list
             ${real_name}
         )
 
+# create targets for testing mqtt.c
 set(utest_name "${project_name}_utest")
 set(utest_source "${project_name}_utest.c")
 create_test(${utest_name}
@@ -99,7 +99,7 @@ create_test(${utest_name}
             "${test_include_directories}"
         )
 
-# define targets for testing mqtt_lightweight.c
+# create targets for testing mqtt_lightweight.c
 set(utest_name "${project_name}_lightweight_utest")
 set(utest_source "${project_name}_lightweight_utest.c")
 

--- a/libraries/standard/mqtt/utest/CMakeLists.txt
+++ b/libraries/standard/mqtt/utest/CMakeLists.txt
@@ -73,7 +73,6 @@ list(APPEND utest_dep_list
             ${real_name}
         )
 
-# create targets for testing mqtt.c
 set(utest_name "${project_name}_utest")
 set(utest_source "${project_name}_utest.c")
 create_test(${utest_name}
@@ -83,14 +82,15 @@ create_test(${utest_name}
             "${test_include_directories}"
         )
 
-# create targets for testing mqtt_lightweight.c
-set(utest_name "${project_name}_state_utest")
-set(utest_source "${project_name}_state_utest.c")
-
+# need to redefine because the tests below don't use any mocks
 set(utest_link_list "")
 list(APPEND utest_link_list
-            lib${real_name}.a
+                lib${real_name}.a
         )
+
+# mqtt_state_utest
+set(utest_name "${project_name}_state_utest")
+set(utest_source "${project_name}_state_utest.c")
 
 create_test(${utest_name}
             ${utest_source}
@@ -99,7 +99,7 @@ create_test(${utest_name}
             "${test_include_directories}"
         )
 
-# create targets for testing mqtt_lightweight.c
+# mqtt_lightweight_utest
 set(utest_name "${project_name}_lightweight_utest")
 set(utest_source "${project_name}_lightweight_utest.c")
 

--- a/libraries/standard/mqtt/utest/mqtt_config.h
+++ b/libraries/standard/mqtt/utest/mqtt_config.h
@@ -54,7 +54,7 @@ typedef int MQTTNetworkContext_t;
  *
  * No two clients may use the same client identifier simultaneously.
  */
-#define CLIENT_IDENTIFIER                   "testclient"
+#define MQTT_CLIENT_IDENTIFIER              "testclient"
 
 
 #endif /* ifndef MQTT_CONFIG_H_ */

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -14,24 +14,30 @@
  * @brief Test-defined macro for MQTT username.
  */
 #define MQTT_TEST_USERNAME               "username"
-#define MQTT_TEST_USERNAME_LEN           sizeof( MQTT_TEST_USERNAME ) - 1
+#define MQTT_TEST_USERNAME_LEN           ( sizeof( MQTT_TEST_USERNAME ) - 1 )
 
 /**
  * @brief Test-defined macro for MQTT password.
  */
 #define MQTT_TEST_PASSWORD               "password"
-#define MQTT_TEST_PASSWORD_LEN           sizeof( MQTT_TEST_PASSWORD ) - 1
+#define MQTT_TEST_PASSWORD_LEN           ( sizeof( MQTT_TEST_PASSWORD ) - 1 )
 
 /**
  * @brief Test-defined macro for MQTT topic.
  */
 #define MQTT_TEST_TOPIC                  "topic"
-#define MQTT_TEST_TOPIC_LEN              sizeof( MQTT_TEST_TOPIC ) - 1
+#define MQTT_TEST_TOPIC_LEN              ( sizeof( MQTT_TEST_TOPIC ) - 1 )
 
 /**
  * @brief Length of the client identifier.
  */
-#define CLIENT_IDENTIFIER_LEN            sizeof( CLIENT_IDENTIFIER ) - 1
+#define MQTT_CLIENT_IDENTIFIER_LEN       ( sizeof( MQTT_CLIENT_IDENTIFIER ) - 1 )
+
+/**
+ * @brief Payload for will info.
+ */
+#define MQTT_SAMPLE_PAYLOAD              "payload"
+#define MQTT_SAMPLE_PAYLOAD_LEN          ( sizeof( MQTT_SAMPLE_PAYLOAD ) - 1 )
 
 /* MQTT CONNECT flags. */
 #define MQTT_CONNECT_FLAG_CLEAN          ( 1 )            /**< @brief Clean session. */
@@ -126,8 +132,8 @@ static void setupNetworkBuffer( MQTTFixedBuffer_t * const pNetworkBuffer )
 static void setupConnectInfo( MQTTConnectInfo_t * const pConnectInfo )
 {
     pConnectInfo->cleanSession = true;
-    pConnectInfo->pClientIdentifier = CLIENT_IDENTIFIER;
-    pConnectInfo->clientIdentifierLength = CLIENT_IDENTIFIER_LEN;
+    pConnectInfo->pClientIdentifier = MQTT_CLIENT_IDENTIFIER;
+    pConnectInfo->clientIdentifierLength = MQTT_CLIENT_IDENTIFIER_LEN;
     pConnectInfo->keepAliveSeconds = 0;
     pConnectInfo->pUserName = MQTT_TEST_USERNAME;
     pConnectInfo->userNameLength = MQTT_TEST_USERNAME_LEN;
@@ -142,32 +148,32 @@ static void setupConnectInfo( MQTTConnectInfo_t * const pConnectInfo )
  */
 static void setupWillInfo( MQTTPublishInfo_t * const pWillInfo )
 {
-    pWillInfo->pPayload = NULL;
-    pWillInfo->payloadLength = 0;
-    pWillInfo->pTopicName = CLIENT_IDENTIFIER;
-    pWillInfo->topicNameLength = CLIENT_IDENTIFIER_LEN;
+    pWillInfo->pPayload = MQTT_SAMPLE_PAYLOAD;
+    pWillInfo->payloadLength = MQTT_SAMPLE_PAYLOAD_LEN;
+    pWillInfo->pTopicName = MQTT_CLIENT_IDENTIFIER;
+    pWillInfo->topicNameLength = MQTT_CLIENT_IDENTIFIER_LEN;
     pWillInfo->dup = true;
     pWillInfo->qos = MQTTQoS0;
     pWillInfo->retain = true;
 }
 
 /**
- * @brief Encode remaining length into pBuffer for packet serialization
+ * @brief Encode remaining length into pDestination for packet serialization
  * using MQTT v3.1.1 spec.
  *
- * @param[in] pBuffer Buffer to write encoded remaining length.
- * @param[in] length Actual Remaining length.
+ * @param[in] pDestination Buffer to write encoded remaining length.
+ * @param[in] length Actual remaining length.
  */
-static size_t encodeRemainingLength( uint8_t * pBuffer,
+static size_t encodeRemainingLength( uint8_t * pDestination,
                                      size_t length )
 {
     uint8_t lengthByte;
     uint8_t * pLengthEnd = NULL;
     size_t remainingLength = length;
 
-    TEST_ASSERT_NOT_NULL( pBuffer );
+    TEST_ASSERT_NOT_NULL( pDestination );
 
-    pLengthEnd = pBuffer;
+    pLengthEnd = pDestination;
 
     /* This algorithm is copied from the MQTT v3.1.1 spec. */
     do
@@ -186,15 +192,16 @@ static size_t encodeRemainingLength( uint8_t * pBuffer,
         pLengthEnd++;
     } while( remainingLength > 0U );
 
-    return ( size_t ) ( pLengthEnd - pBuffer );
+    return ( size_t ) ( pLengthEnd - pDestination );
 }
 
 /**
  * @brief Encode UTF-8 string and its length into pDestination for
  * packet serialization.
  *
- * @param[in] pDestination Buffer to write encoded remaining length.
- * @param[in] length Actual Remaining length.
+ * @param[in] pDestination Buffer to write encoded string.
+ * @param[in] source String to encode.
+ * @param[in] sourceLength Length of the string to encode.
  */
 static size_t encodeString( uint8_t * pDestination,
                             const char * source,
@@ -206,6 +213,7 @@ static size_t encodeString( uint8_t * pDestination,
      * This is to use same type buffers in memcpy. */
     const uint8_t * pSourceBuffer = ( const uint8_t * ) source;
 
+    TEST_ASSERT_NOT_NULL( pSourceBuffer );
     TEST_ASSERT_NOT_NULL( pDestination );
 
     pBuffer = pDestination;
@@ -449,16 +457,16 @@ void test_MQTT_SerializeConnect_happy_paths()
 
 
     /* Re-initialize objects for branch coverage. */
-    willInfo.pPayload = NULL;
-    willInfo.payloadLength = 0;
-    willInfo.pTopicName = CLIENT_IDENTIFIER;
-    willInfo.topicNameLength = CLIENT_IDENTIFIER_LEN;
+    willInfo.pPayload = MQTT_SAMPLE_PAYLOAD;
+    willInfo.payloadLength = MQTT_SAMPLE_PAYLOAD_LEN;
+    willInfo.pTopicName = MQTT_CLIENT_IDENTIFIER;
+    willInfo.topicNameLength = MQTT_CLIENT_IDENTIFIER_LEN;
     willInfo.dup = true;
     willInfo.qos = MQTTQoS2;
     willInfo.retain = false;
     connectInfo.cleanSession = false;
-    connectInfo.pClientIdentifier = CLIENT_IDENTIFIER;
-    connectInfo.clientIdentifierLength = CLIENT_IDENTIFIER_LEN;
+    connectInfo.pClientIdentifier = MQTT_CLIENT_IDENTIFIER;
+    connectInfo.clientIdentifierLength = MQTT_CLIENT_IDENTIFIER_LEN;
     connectInfo.pUserName = NULL;
     connectInfo.userNameLength = 0;
     connectInfo.pPassword = NULL;

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -340,8 +340,8 @@ static void verifySerializedConnectPacket( const MQTTConnectInfo_t * const pConn
 }
 
 /**
- * @brief Successfully call Mqtt_SerializeConnect using different parameters
- * until we have full coverage on the private method, serializeConnectPacket(...).
+ * @brief Call Mqtt_SerializeConnect using NULL parameters and insufficient buffer
+ * size until we receive all possible MQTTBadParameter and MQTTNoMemory errors.
  */
 void test_MQTT_SerializeConnect_invalid_params()
 {

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -102,7 +102,7 @@ void suiteSetUp()
 /* Called at the end of the whole suite. */
 int suiteTearDown( int numFailures )
 {
-    ( void ) numFailures;
+    return numFailures;
 }
 
 /* =====================  Testing MQTT_SerializeConnect ===================== */
@@ -151,6 +151,13 @@ static void setupWillInfo( MQTTPublishInfo_t * const pWillInfo )
     pWillInfo->retain = true;
 }
 
+/**
+ * @brief Encode remaining length into pDestination for packet serialization
+ * using MQTT v3.1.1 spec.
+ *
+ * @param[in] pDestination Buffer to write encoded remaining length.
+ * @param[in] length Actual Remaining length.
+ */
 static size_t encodeRemainingLength( uint8_t * pDestination,
                                      size_t length )
 {
@@ -182,6 +189,13 @@ static size_t encodeRemainingLength( uint8_t * pDestination,
     return ( size_t ) ( pLengthEnd - pDestination );
 }
 
+/**
+ * @brief Encode UTF-8 string and its length into pDestination for
+ * packet serialization.
+ *
+ * @param[in] pDestination Buffer to write encoded remaining length.
+ * @param[in] length Actual Remaining length.
+ */
 static size_t encodeString( uint8_t * pDestination,
                             const char * source,
                             uint16_t sourceLength )
@@ -213,6 +227,16 @@ static size_t encodeString( uint8_t * pDestination,
     return ( size_t ) ( pBuffer - pDestination );
 }
 
+/**
+ * @brief Check the serialization of an MQTT CONNECT packet in the given buffer,
+ * following the same order in serializeConnectPacket.
+ *
+ * @param[in] pConnectInfo MQTT CONNECT packet parameters.
+ * @param[in] pWillInfo Last Will and Testament. Pass NULL if not used.
+ * @param[in] remainingLength Remaining Length of MQTT CONNECT packet.
+ * @param[in] pBuffer Buffer to check packet serialization.
+ *
+ */
 static void verifySerializedConnectPacket( const MQTTConnectInfo_t * const pConnectInfo,
                                            const MQTTPublishInfo_t * const pWillInfo,
                                            size_t remainingLength,

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -449,12 +449,21 @@ void test_MQTT_SerializeConnect_happy_paths()
 
 
     /* Re-initialize objects for branch coverage. */
+    willInfo.pPayload = NULL;
+    willInfo.payloadLength = 0;
+    willInfo.pTopicName = CLIENT_IDENTIFIER;
+    willInfo.topicNameLength = CLIENT_IDENTIFIER_LEN;
+    willInfo.dup = true;
     willInfo.qos = MQTTQoS2;
+    willInfo.retain = false;
     connectInfo.cleanSession = false;
+    connectInfo.pClientIdentifier = CLIENT_IDENTIFIER;
+    connectInfo.clientIdentifierLength = CLIENT_IDENTIFIER_LEN;
     connectInfo.pUserName = NULL;
     connectInfo.userNameLength = 0;
     connectInfo.pPassword = NULL;
-    willInfo.retain = false;
+    connectInfo.passwordLength = 0;
+
     mqttStatus = MQTT_GetConnectPacketSize( &connectInfo,
                                             NULL,
                                             &remainingLength,

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -114,12 +114,12 @@ void test_Mqtt_SerializeConnect_invalid_params()
     /* Test NULL pConnectInfo. */
     mqttStatus = MQTT_SerializeConnect( NULL, NULL,
                                         remainingLength, &networkBuffer );
-    TEST_ASSERT_EQUAL( mqttStatus, MQTTBadParameter );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
 
     /* Test NULL pBuffer. */
     mqttStatus = MQTT_SerializeConnect( &connectInfo, NULL,
                                         remainingLength, NULL );
-    TEST_ASSERT_EQUAL( mqttStatus, MQTTBadParameter );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
 
     /* Test connectPacketSize > pBuffer->size. */
     /* Get MQTT connect packet size and remaining length. */
@@ -127,12 +127,12 @@ void test_Mqtt_SerializeConnect_invalid_params()
                                             NULL,
                                             &remainingLength,
                                             &packetSize );
-    TEST_ASSERT_EQUAL( mqttStatus, MQTTSuccess );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     networkBuffer.pBuffer = mqttBuffer;
     networkBuffer.size = remainingLength - 1;
     mqttStatus = MQTT_SerializeConnect( &connectInfo, NULL,
                                         remainingLength, &networkBuffer );
-    TEST_ASSERT_EQUAL( mqttStatus, MQTTNoMemory );
+    TEST_ASSERT_EQUAL( MQTTNoMemory, mqttStatus );
 }
 
 /**
@@ -157,10 +157,10 @@ void test_Mqtt_SerializeConnect_happy_path()
                                             &willInfo,
                                             &remainingLength,
                                             &packetSize );
-    TEST_ASSERT_EQUAL( mqttStatus, MQTTSuccess );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     mqttStatus = MQTT_SerializeConnect( &connectInfo, &willInfo,
                                         remainingLength, &networkBuffer );
-    TEST_ASSERT_EQUAL( mqttStatus, MQTTSuccess );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
 
     /* Repeat with QoS2. */
     willInfo.qos = MQTTQoS2;
@@ -168,10 +168,10 @@ void test_Mqtt_SerializeConnect_happy_path()
                                             &willInfo,
                                             &remainingLength,
                                             &packetSize );
-    TEST_ASSERT_EQUAL( mqttStatus, MQTTSuccess );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     mqttStatus = MQTT_SerializeConnect( &connectInfo, &willInfo,
                                         remainingLength, &networkBuffer );
-    TEST_ASSERT_EQUAL( mqttStatus, MQTTSuccess );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
 }
 
 /* ========================================================================== */

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -1,0 +1,128 @@
+#include <stdbool.h>
+
+#include "unity.h"
+
+/* Include paths for public enums, structures, and macros. */
+#include "mqtt.h"
+#include "mqtt_lightweight.h"
+
+/**
+ * @brief Size of the fixed and variable header of a CONNECT packet.
+ */
+#define MQTT_PACKET_CONNECT_HEADER_SIZE    ( 10UL )
+
+/**
+ * @brief Test-defined macros for MQTT.
+ */
+#define MQTT_TEST_USERNAME                 "username"
+#define MQTT_TEST_USERNAME_LEN             sizeof( MQTT_TEST_USERNAME ) - 1
+
+#define MQTT_TEST_PASSWORD                 "password"
+#define MQTT_TEST_PASSWORD_LEN             sizeof( MQTT_TEST_PASSWORD ) - 1
+
+#define MQTT_TEST_TOPIC                    "topic"
+#define MQTT_TEST_TOPIC_LEN                sizeof( MQTT_TEST_TOPIC ) - 1
+
+#define CLIENT_IDENTIFIER_LEN              sizeof( CLIENT_IDENTIFIER ) - 1
+
+#define MQTT_TEST_BUFFER_LENGTH            ( 1024 )
+
+static uint8_t mqttBuffer[ MQTT_TEST_BUFFER_LENGTH ] = { 0 };
+
+/* ============================   UNITY FIXTURES ============================ */
+void setUp( void )
+{
+}
+
+/* called before each testcase */
+void tearDown( void )
+{
+}
+
+/* called at the beginning of the whole suite */
+void suiteSetUp()
+{
+}
+
+/* called at the end of the whole suite */
+int suiteTearDown( int numFailures )
+{
+}
+
+/* =====================  Testing MQTT_SerializeConnect ===================== */
+
+void test_Mqtt_SerializeConnect_invalid_params()
+{
+    MQTTStatus_t mqttStatus = MQTTSuccess;
+    size_t remainingLength, packetSize;
+    MQTTFixedBuffer_t networkBuffer;
+    MQTTConnectInfo_t connectInfo;
+
+    /* Test NULL pConnectInfo. */
+    mqttStatus = MQTT_SerializeConnect( NULL, NULL, remainingLength, &networkBuffer );
+    TEST_ASSERT_EQUAL( mqttStatus, MQTTBadParameter );
+
+    /* Test NULL pBuffer. */
+    mqttStatus = MQTT_SerializeConnect( &connectInfo, NULL, remainingLength, NULL );
+    TEST_ASSERT_EQUAL( mqttStatus, MQTTBadParameter );
+
+    /* Test connectPacketSize > pBuffer->size. */
+    networkBuffer.pBuffer = mqttBuffer;
+    networkBuffer.size = MQTT_PACKET_CONNECT_HEADER_SIZE - 1;
+    mqttStatus = MQTT_SerializeConnect( &connectInfo, NULL,
+                                        remainingLength, &networkBuffer );
+    TEST_ASSERT_EQUAL( mqttStatus, MQTTNoMemory );
+}
+
+void test_Mqtt_SerializeConnect_happy_path()
+{
+    MQTTStatus_t mqttStatus = MQTTSuccess;
+    size_t remainingLength, packetSize;
+    MQTTFixedBuffer_t networkBuffer;
+    MQTTConnectInfo_t connectInfo;
+    MQTTPublishInfo_t willInfo;
+
+    networkBuffer.pBuffer = mqttBuffer;
+    networkBuffer.size = MQTT_TEST_BUFFER_LENGTH;
+
+    connectInfo.cleanSession = true;
+    connectInfo.pClientIdentifier = CLIENT_IDENTIFIER;
+    connectInfo.clientIdentifierLength = CLIENT_IDENTIFIER_LEN;
+    connectInfo.keepAliveSeconds = 0;
+    connectInfo.pUserName = MQTT_TEST_USERNAME;
+    connectInfo.userNameLength = MQTT_TEST_USERNAME_LEN;
+    connectInfo.pPassword = MQTT_TEST_PASSWORD;
+    connectInfo.passwordLength = MQTT_TEST_PASSWORD_LEN;
+
+    willInfo.pPayload = NULL;
+    willInfo.payloadLength = 0;
+    willInfo.pTopicName = CLIENT_IDENTIFIER;
+    willInfo.topicNameLength = CLIENT_IDENTIFIER_LEN;
+    willInfo.dup = true;
+    willInfo.qos = MQTTQoS1;
+    willInfo.retain = true;
+
+    /* We successfully call Mqtt_SerializeConnect until we have full coverage
+     * on the private method, serializeConnectPacket(...). */
+
+    /* Get MQTT connect packet size and remaining length. */
+    mqttStatus = MQTT_GetConnectPacketSize( &connectInfo,
+                                            &willInfo,
+                                            &remainingLength,
+                                            &packetSize );
+    TEST_ASSERT_EQUAL( mqttStatus, MQTTSuccess );
+    mqttStatus = MQTT_SerializeConnect( &connectInfo, &willInfo, remainingLength, &networkBuffer );
+    TEST_ASSERT_EQUAL( mqttStatus, MQTTSuccess );
+
+    /* Repeat with QoS2. */
+    willInfo.qos = MQTTQoS2;
+    mqttStatus = MQTT_GetConnectPacketSize( &connectInfo,
+                                            &willInfo,
+                                            &remainingLength,
+                                            &packetSize );
+    TEST_ASSERT_EQUAL( mqttStatus, MQTTSuccess );
+    mqttStatus = MQTT_SerializeConnect( &connectInfo, &willInfo, remainingLength, &networkBuffer );
+    TEST_ASSERT_EQUAL( mqttStatus, MQTTSuccess );
+}
+
+/* ========================================================================== */

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -152,22 +152,22 @@ static void setupWillInfo( MQTTPublishInfo_t * const pWillInfo )
 }
 
 /**
- * @brief Encode remaining length into pDestination for packet serialization
+ * @brief Encode remaining length into pBuffer for packet serialization
  * using MQTT v3.1.1 spec.
  *
- * @param[in] pDestination Buffer to write encoded remaining length.
+ * @param[in] pBuffer Buffer to write encoded remaining length.
  * @param[in] length Actual Remaining length.
  */
-static size_t encodeRemainingLength( uint8_t * pDestination,
+static size_t encodeRemainingLength( uint8_t * pBuffer,
                                      size_t length )
 {
     uint8_t lengthByte;
     uint8_t * pLengthEnd = NULL;
     size_t remainingLength = length;
 
-    TEST_ASSERT_NOT_NULL( pDestination );
+    TEST_ASSERT_NOT_NULL( pBuffer );
 
-    pLengthEnd = pDestination;
+    pLengthEnd = pBuffer;
 
     /* This algorithm is copied from the MQTT v3.1.1 spec. */
     do
@@ -186,7 +186,7 @@ static size_t encodeRemainingLength( uint8_t * pDestination,
         pLengthEnd++;
     } while( remainingLength > 0U );
 
-    return ( size_t ) ( pLengthEnd - pDestination );
+    return ( size_t ) ( pLengthEnd - pBuffer );
 }
 
 /**

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -3,7 +3,6 @@
 #include "unity.h"
 
 /* Include paths for public enums, structures, and macros. */
-#include "mqtt.h"
 #include "mqtt_lightweight.h"
 
 /**

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -102,6 +102,7 @@ void suiteSetUp()
 /* Called at the end of the whole suite. */
 int suiteTearDown( int numFailures )
 {
+    ( void ) numFailures;
 }
 
 /* =====================  Testing MQTT_SerializeConnect ===================== */

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -1,4 +1,4 @@
-#include <stdbool.h>
+#include <string.h>
 
 #include "unity.h"
 
@@ -6,29 +6,79 @@
 #include "mqtt_lightweight.h"
 
 /**
+ * @brief MQTT protocol version 3.1.1.
+ */
+#define MQTT_VERSION_3_1_1               ( ( uint8_t ) 4U )
+
+/**
  * @brief Test-defined macro for MQTT username.
  */
-#define MQTT_TEST_USERNAME         "username"
-#define MQTT_TEST_USERNAME_LEN     sizeof( MQTT_TEST_USERNAME ) - 1
+#define MQTT_TEST_USERNAME               "username"
+#define MQTT_TEST_USERNAME_LEN           sizeof( MQTT_TEST_USERNAME ) - 1
 
 /**
  * @brief Test-defined macro for MQTT password.
  */
-#define MQTT_TEST_PASSWORD         "password"
-#define MQTT_TEST_PASSWORD_LEN     sizeof( MQTT_TEST_PASSWORD ) - 1
+#define MQTT_TEST_PASSWORD               "password"
+#define MQTT_TEST_PASSWORD_LEN           sizeof( MQTT_TEST_PASSWORD ) - 1
 
 /**
  * @brief Test-defined macro for MQTT topic.
  */
-#define MQTT_TEST_TOPIC            "topic"
-#define MQTT_TEST_TOPIC_LEN        sizeof( MQTT_TEST_TOPIC ) - 1
+#define MQTT_TEST_TOPIC                  "topic"
+#define MQTT_TEST_TOPIC_LEN              sizeof( MQTT_TEST_TOPIC ) - 1
 
 /**
  * @brief Length of the client identifier.
  */
-#define CLIENT_IDENTIFIER_LEN      sizeof( CLIENT_IDENTIFIER ) - 1
+#define CLIENT_IDENTIFIER_LEN            sizeof( CLIENT_IDENTIFIER ) - 1
 
-#define MQTT_TEST_BUFFER_LENGTH    ( 1024 )
+/* MQTT CONNECT flags. */
+#define MQTT_CONNECT_FLAG_CLEAN          ( 1 )            /**< @brief Clean session. */
+#define MQTT_CONNECT_FLAG_WILL           ( 2 )            /**< @brief Will present. */
+#define MQTT_CONNECT_FLAG_WILL_QOS1      ( 3 )            /**< @brief Will QoS 1. */
+#define MQTT_CONNECT_FLAG_WILL_QOS2      ( 4 )            /**< @brief Will QoS 2. */
+#define MQTT_CONNECT_FLAG_WILL_RETAIN    ( 5 )            /**< @brief Will retain. */
+#define MQTT_CONNECT_FLAG_PASSWORD       ( 6 )            /**< @brief Password present. */
+#define MQTT_CONNECT_FLAG_USERNAME       ( 7 )            /**< @brief User name present. */
+
+/**
+ * @brief Set a bit in an 8-bit unsigned integer.
+ */
+#define UINT8_SET_BIT( x, position )      ( ( x ) = ( uint8_t ) ( ( x ) | ( 0x01U << ( position ) ) ) )
+
+/**
+ * @brief Macro for checking if a bit is set in a 1-byte unsigned int.
+ *
+ * @param[in] x The unsigned int to check.
+ * @param[in] position Which bit to check.
+ */
+#define UINT8_CHECK_BIT( x, position )    ( ( ( x ) & ( 0x01U << ( position ) ) ) == ( 0x01U << ( position ) ) )
+
+/**
+ * @brief Get the high byte of a 16-bit unsigned integer.
+ */
+#define UINT16_HIGH_BYTE( x )             ( ( uint8_t ) ( ( x ) >> 8 ) )
+
+/**
+ * @brief Get the low byte of a 16-bit unsigned integer.
+ */
+#define UINT16_LOW_BYTE( x )              ( ( uint8_t ) ( ( x ) & 0x00ffU ) )
+
+/**
+ * @brief Maximum number of bytes in the Remaining Length field is four according
+ * to MQTT 3.1.1 spec.
+ */
+#define MQTT_REMAINING_BUFFER_MAX_LENGTH    ( 4 )
+
+/**
+ * @brief Length of the MQTT network buffer.
+ */
+#define MQTT_TEST_BUFFER_LENGTH             ( 1024 )
+
+static uint8_t remainingLengthBuffer[ MQTT_REMAINING_BUFFER_MAX_LENGTH ] = { 0 };
+
+static uint8_t encodedStringBuffer[ MQTT_TEST_BUFFER_LENGTH ] = { 0 };
 
 static uint8_t mqttBuffer[ MQTT_TEST_BUFFER_LENGTH ] = { 0 };
 
@@ -100,14 +150,203 @@ static void setupWillInfo( MQTTPublishInfo_t * const pWillInfo )
     pWillInfo->retain = true;
 }
 
+static size_t encodeRemainingLength( uint8_t * pDestination,
+                                     size_t length )
+{
+    uint8_t lengthByte;
+    uint8_t * pLengthEnd = NULL;
+    size_t remainingLength = length;
+
+    TEST_ASSERT_NOT_NULL( pDestination );
+
+    pLengthEnd = pDestination;
+
+    /* This algorithm is copied from the MQTT v3.1.1 spec. */
+    do
+    {
+        lengthByte = ( uint8_t ) ( remainingLength % 128U );
+        remainingLength = remainingLength / 128U;
+
+        /* Set the high bit of this byte, indicating that there's more data. */
+        if( remainingLength > 0U )
+        {
+            UINT8_SET_BIT( lengthByte, 7 );
+        }
+
+        /* Output a single encoded byte. */
+        *pLengthEnd = lengthByte;
+        pLengthEnd++;
+    } while( remainingLength > 0U );
+
+    return ( size_t ) ( pLengthEnd - pDestination );
+}
+
+static size_t encodeString( uint8_t * pDestination,
+                            const char * source,
+                            uint16_t sourceLength )
+{
+    uint8_t * pBuffer = NULL;
+
+    /* Typecast const char * typed source buffer to const uint8_t *.
+     * This is to use same type buffers in memcpy. */
+    const uint8_t * pSourceBuffer = ( const uint8_t * ) source;
+
+    TEST_ASSERT_NOT_NULL( pDestination );
+
+    pBuffer = pDestination;
+
+    /* The first byte of a UTF-8 string is the high byte of the string length. */
+    *pBuffer = UINT16_HIGH_BYTE( sourceLength );
+    pBuffer++;
+
+    /* The second byte of a UTF-8 string is the low byte of the string length. */
+    *pBuffer = UINT16_LOW_BYTE( sourceLength );
+    pBuffer++;
+
+    /* Copy the string into pBuffer. */
+    ( void ) memcpy( pBuffer, pSourceBuffer, sourceLength );
+
+    /* Return the pointer to the end of the encoded string. */
+    pBuffer += sourceLength;
+
+    return ( size_t ) ( pBuffer - pDestination );
+}
+
+static void verifySerializedConnectPacket( const MQTTConnectInfo_t * const pConnectInfo,
+                                           const MQTTPublishInfo_t * const pWillInfo,
+                                           size_t remainingLength,
+                                           const MQTTFixedBuffer_t * const pBuffer )
+{
+    uint8_t connectFlags = 0U;
+    uint8_t encodedRemainingLength = 0U;
+    uint8_t encodedStringLength = 0U;
+    uint8_t * pIndex = NULL;
+
+    pIndex = pBuffer->pBuffer;
+    /* The first byte in the CONNECT packet is the control packet type. */
+    TEST_ASSERT_EQUAL( MQTT_PACKET_TYPE_CONNECT, *pIndex );
+    pIndex++;
+
+    /* The remaining length of the CONNECT packet is encoded starting from the
+     * second byte. The remaining length does not include the length of the fixed
+     * header or the encoding of the remaining length. */
+    encodedRemainingLength = encodeRemainingLength( remainingLengthBuffer, remainingLength );
+    TEST_ASSERT_EQUAL_MEMORY( remainingLengthBuffer, pIndex, encodedRemainingLength );
+    pIndex += encodedRemainingLength;
+
+    /* The string "MQTT" is placed at the beginning of the CONNECT packet's variable
+     * header. This string is 4 bytes long. */
+    encodedStringLength = encodeString( encodedStringBuffer, "MQTT", 4 );
+    TEST_ASSERT_EQUAL_MEMORY( encodedStringBuffer, pIndex, encodedStringLength );
+    pIndex += encodedStringLength;
+
+    /* The MQTT protocol version is the second field of the variable header. */
+    TEST_ASSERT_EQUAL( MQTT_VERSION_3_1_1, *pIndex );
+    pIndex++;
+
+    /* Set the clean session flag if needed. */
+    if( pConnectInfo->cleanSession == true )
+    {
+        UINT8_SET_BIT( connectFlags, MQTT_CONNECT_FLAG_CLEAN );
+    }
+
+    /* Set the flags for username and password if provided. */
+    if( pConnectInfo->pUserName != NULL )
+    {
+        UINT8_SET_BIT( connectFlags, MQTT_CONNECT_FLAG_USERNAME );
+    }
+
+    if( pConnectInfo->pPassword != NULL )
+    {
+        UINT8_SET_BIT( connectFlags, MQTT_CONNECT_FLAG_PASSWORD );
+    }
+
+    /* Set will flag if a Last Will and Testament is provided. */
+    if( pWillInfo != NULL )
+    {
+        UINT8_SET_BIT( connectFlags, MQTT_CONNECT_FLAG_WILL );
+
+        /* Flags only need to be changed for Will QoS 1 or 2. */
+        if( pWillInfo->qos == MQTTQoS1 )
+        {
+            UINT8_SET_BIT( connectFlags, MQTT_CONNECT_FLAG_WILL_QOS1 );
+        }
+        else if( pWillInfo->qos == MQTTQoS2 )
+        {
+            UINT8_SET_BIT( connectFlags, MQTT_CONNECT_FLAG_WILL_QOS2 );
+        }
+        else
+        {
+            /* Empty else MISRA 15.7 */
+        }
+
+        if( pWillInfo->retain == true )
+        {
+            UINT8_SET_BIT( connectFlags, MQTT_CONNECT_FLAG_WILL_RETAIN );
+        }
+    }
+
+    TEST_ASSERT_EQUAL( connectFlags, *pIndex );
+    pIndex++;
+
+    /* Verify the 2 bytes of the keep alive interval into the CONNECT packet. */
+    TEST_ASSERT_EQUAL( pConnectInfo->keepAliveSeconds,
+                       UINT16_HIGH_BYTE( pConnectInfo->keepAliveSeconds ) );
+    TEST_ASSERT_EQUAL( pConnectInfo->keepAliveSeconds,
+                       UINT16_LOW_BYTE( pConnectInfo->keepAliveSeconds ) );
+    pIndex += 2;
+
+    /* Verify the client identifier into the CONNECT packet. */
+    encodedStringLength = encodeString( encodedStringBuffer,
+                                        pConnectInfo->pClientIdentifier,
+                                        pConnectInfo->clientIdentifierLength );
+    TEST_ASSERT_EQUAL_MEMORY( encodedStringBuffer, pIndex, encodedStringLength );
+    pIndex += encodedStringLength;
+
+    /* Verify the will topic name and message into the CONNECT packet if provided. */
+    if( pWillInfo != NULL )
+    {
+        encodedStringLength = encodeString( encodedStringBuffer,
+                                            pWillInfo->pTopicName,
+                                            pWillInfo->topicNameLength );
+        TEST_ASSERT_EQUAL_MEMORY( encodedStringBuffer, pIndex, encodedStringLength );
+        pIndex += encodedStringLength;
+        encodedStringLength = encodeString( encodedStringBuffer,
+                                            pWillInfo->pPayload,
+                                            ( uint16_t ) pWillInfo->payloadLength );
+        TEST_ASSERT_EQUAL_MEMORY( encodedStringBuffer, pIndex, encodedStringLength );
+        pIndex += encodedStringLength;
+    }
+
+    /* Verify the user name if provided. */
+    if( pConnectInfo->pUserName != NULL )
+    {
+        encodedStringLength = encodeString( encodedStringBuffer,
+                                            pConnectInfo->pUserName,
+                                            pConnectInfo->userNameLength );
+        TEST_ASSERT_EQUAL_MEMORY( encodedStringBuffer, pIndex, encodedStringLength );
+        pIndex += encodedStringLength;
+    }
+
+    /* Verify the password if provided. */
+    if( pConnectInfo->pPassword != NULL )
+    {
+        encodedStringLength = encodeString( encodedStringBuffer,
+                                            pConnectInfo->pPassword,
+                                            pConnectInfo->passwordLength );
+        TEST_ASSERT_EQUAL_MEMORY( encodedStringBuffer, pIndex, encodedStringLength );
+        pIndex += encodedStringLength;
+    }
+}
+
 /**
  * @brief Successfully call Mqtt_SerializeConnect using different parameters
  * until we have full coverage on the private method, serializeConnectPacket(...).
  */
-void test_Mqtt_SerializeConnect_invalid_params()
+void test_MQTT_SerializeConnect_invalid_params()
 {
     MQTTStatus_t mqttStatus = MQTTSuccess;
-    size_t remainingLength, packetSize;
+    size_t remainingLength = 0, packetSize = 0;
     MQTTFixedBuffer_t networkBuffer;
     MQTTConnectInfo_t connectInfo;
 
@@ -136,13 +375,13 @@ void test_Mqtt_SerializeConnect_invalid_params()
 }
 
 /**
- * @brief This method calls Mqtt_SerializeConnect successfully using different parameters
+ * @brief This method calls MQTT_SerializeConnect successfully using different parameters
  * until we have full coverage on the private method, serializeConnectPacket(...).
  */
-void test_Mqtt_SerializeConnect_happy_path()
+void test_MQTT_SerializeConnect_happy_paths()
 {
     MQTTStatus_t mqttStatus = MQTTSuccess;
-    size_t remainingLength, packetSize;
+    size_t remainingLength = 0, packetSize = 0;
     MQTTFixedBuffer_t networkBuffer;
     MQTTConnectInfo_t connectInfo;
     MQTTPublishInfo_t willInfo;
@@ -158,9 +397,13 @@ void test_Mqtt_SerializeConnect_happy_path()
                                             &remainingLength,
                                             &packetSize );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    /* Make sure buffer has enough space. */
+    TEST_ASSERT_GREATER_OR_EQUAL( packetSize, networkBuffer.size );
     mqttStatus = MQTT_SerializeConnect( &connectInfo, &willInfo,
                                         remainingLength, &networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    verifySerializedConnectPacket( &connectInfo, &willInfo,
+                                   remainingLength, &networkBuffer );
 
     /* Repeat with QoS2. */
     willInfo.qos = MQTTQoS2;
@@ -169,9 +412,13 @@ void test_Mqtt_SerializeConnect_happy_path()
                                             &remainingLength,
                                             &packetSize );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    /* Make sure buffer has enough space. */
+    TEST_ASSERT_GREATER_OR_EQUAL( packetSize, networkBuffer.size );
     mqttStatus = MQTT_SerializeConnect( &connectInfo, &willInfo,
                                         remainingLength, &networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    verifySerializedConnectPacket( &connectInfo, &willInfo,
+                                   remainingLength, &networkBuffer );
 }
 
 /* ========================================================================== */

--- a/tools/cmake/filePaths.cmake
+++ b/tools/cmake/filePaths.cmake
@@ -1,6 +1,0 @@
-# Set some global path variables.
-get_filename_component(__root_dir "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
-set(ROOT_DIR ${__root_dir} CACHE INTERNAL "C SDK source root.")
-set(DEMOS_DIR "${ROOT_DIR}/demos" CACHE INTERNAL "C SDK demos root.")
-set(MODULES_DIR "${ROOT_DIR}/libraries" CACHE INTERNAL "C SDK modules root.")
-set(3RDPARTY_DIR "${MODULES_DIR}/3rdparty" CACHE INTERNAL "3rdparty libraries root.")

--- a/tools/cmock/create_test.cmake
+++ b/tools/cmock/create_test.cmake
@@ -44,7 +44,7 @@ function(create_test test_name
     foreach(dependency IN LISTS dep_list)
         add_dependencies(${test_name} ${dependency})
     endforeach()
-    target_link_libraries(${test_name} -lgcov)
+    target_link_libraries(${test_name} -lgcov -lunity)
     target_link_directories(${test_name}  PUBLIC
                             ${CMAKE_CURRENT_BINARY_DIR}/lib
             )


### PR DESCRIPTION
Create two methods that achieve 100% branch coverage on MQTT_SerializeConnect:
- `test_MQTT_SerializeConnect_invalid_params` calls Mqtt_SerializeConnect using NULL parameters and insufficient buffer size until we receive all possible MQTTBadParameter and MQTTNoMemory errors.
- `test_MQTT_SerializeConnect_happy_paths` calls MQTT_SerializeConnect successfully using different parameters until we have full coverage on the private method, serializeConnectPacket(...).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
