### PR TITLE
Update HTTPClient_InitializeRequestHeaders unit test for consistency

### DIFF
--- a/libraries/standard/http/utest/http_utest.c
+++ b/libraries/standard/http/utest/http_utest.c
@@ -99,7 +99,6 @@ static HTTPRequestHeaders_t testHeaders = { 0 };
 static _headers_t expectedHeaders = { 0 };
 static int testRangeStart = 0;
 static int testRangeEnd = 0;
-static uint8_t httpBuffer[ HTTP_TEST_BUFFER_LEN ] = { 0 };
 static const uint8_t * pValueLoc = NULL;
 static size_t valueLen = 0u;
 static HTTPResponse_t testResponse = { 0 };
@@ -293,9 +292,9 @@ void tearDown( void )
     memset( &testHeaders, 0, sizeof( testHeaders ) );
     memset( testBuffer, 0, sizeof( testBuffer ) );
     memset( &expectedHeaders, 0, sizeof( expectedHeaders ) );
-        << << << < HEAD memset( &testResponse,
-                                0,
-                                sizeof( testResponse ) );
+    memset( &testResponse,
+            0,
+            sizeof( testResponse ) );
     pValueLoc = NULL;
     valueLen = 0u;
     pValueLoc = NULL;
@@ -310,7 +309,6 @@ void tearDown( void )
     expectedValCbRetVal = 0;
     valueLenToReturn = 0u;
     invokeHeaderCompleteCallback = 0u;
-    == == == =
 }
 
 /* Called at the beginning of the whole suite. */
@@ -322,10 +320,6 @@ void suiteSetUp()
 int suiteTearDown( int numFailures )
 {
     return numFailures;
-
-    >> >> >> > 413847c ... Use expectedHeaders struct
-
-    for expected headers data
 }
 
 /* ============== Testing HTTPClient_InitializeRequestHeaders =============== */

--- a/libraries/standard/http/utest/http_utest.c
+++ b/libraries/standard/http/utest/http_utest.c
@@ -379,7 +379,6 @@ void test_Http_InitializeRequestHeaders_Happy_path()
                          HTTP_HOST_FIELD, HTTP_TEST_HOST_VALUE,
                          HTTP_CONNECTION_FIELD, HTTP_CONNECTION_CLOSE_VALUE );
     /* Make sure that the entire pre-existing data was printed to the buffer. */
-    TEST_ASSERT_EQUAL( expectedHeaders.dataLen, numBytes );
     TEST_ASSERT_GREATER_THAN( 0, numBytes );
     TEST_ASSERT_LESS_THAN( sizeof( expectedHeaders.buffer ), ( size_t ) numBytes );
 
@@ -456,7 +455,6 @@ void test_Http_InitializeRequestHeaders_Req_info()
                          HTTP_USER_AGENT_FIELD, HTTP_USER_AGENT_VALUE,
                          HTTP_HOST_FIELD, HTTP_TEST_HOST_VALUE,
                          HTTP_CONNECTION_FIELD, HTTP_CONNECTION_KEEP_ALIVE_VALUE );
-    TEST_ASSERT_EQUAL( expectedHeaders.dataLen, numBytes );
     /* Make sure that the entire pre-existing data was printed to the buffer. */
     TEST_ASSERT_GREATER_THAN( 0, numBytes );
     TEST_ASSERT_LESS_THAN( sizeof( expectedHeaders.buffer ), ( size_t ) numBytes );

--- a/libraries/standard/http/utest/http_utest.c
+++ b/libraries/standard/http/utest/http_utest.c
@@ -291,9 +291,9 @@ void tearDown( void )
     memset( &testHeaders, 0, sizeof( testHeaders ) );
     memset( testBuffer, 0, sizeof( testBuffer ) );
     memset( &expectedHeaders, 0, sizeof( expectedHeaders ) );
-    memset( &testResponse,
-            0,
-            sizeof( testResponse ) );
+        << << << < HEAD memset( &testResponse,
+                                0,
+                                sizeof( testResponse ) );
     pValueLoc = NULL;
     valueLen = 0u;
     pValueLoc = NULL;
@@ -308,6 +308,22 @@ void tearDown( void )
     expectedValCbRetVal = 0;
     valueLenToReturn = 0u;
     invokeHeaderCompleteCallback = 0u;
+    == == == =
+}
+
+/* called at the beginning of the whole suite */
+void suiteSetUp()
+{
+}
+
+/* called at the end of the whole suite */
+int suiteTearDown( int numFailures )
+{
+    return numFailures;
+
+    >> >> >> > 413847c ... Use expectedHeaders struct
+
+    for expected headers data
 }
 
 /* ============== Testing HTTPClient_InitializeRequestHeaders =============== */
@@ -336,7 +352,7 @@ static void setupRequestInfo( HTTPRequestInfo_t * pRequestInfo )
 static void setupBuffer( HTTPRequestHeaders_t * pRequestHeaders,
                          size_t bufferLen )
 {
-    pRequestHeaders->pBuffer = httpBuffer;
+    pRequestHeaders->pBuffer = testBuffer;
     pRequestHeaders->bufferLen = bufferLen;
 }
 
@@ -345,31 +361,32 @@ static void setupBuffer( HTTPRequestHeaders_t * pRequestHeaders,
  */
 void test_Http_InitializeRequestHeaders_happy_path()
 {
-    HTTPStatus_t test_err = HTTP_INTERNAL_ERROR;
+    HTTPStatus_t test_error = HTTP_INTERNAL_ERROR;
     HTTPRequestHeaders_t requestHeaders = { 0 };
     HTTPRequestInfo_t requestInfo = { 0 };
-    size_t expectedHeaderLen = HTTP_TEST_MAX_INITIALIZED_HEADER_LEN;
-    char expectedHeader[ HTTP_TEST_INITIALIZED_HEADER_BUFFER_LEN ] = { 0 };
+
+    expectedHeaders.dataLen = HTTP_TEST_MAX_INITIALIZED_HEADER_LEN;
     int numBytes = 0;
 
     setupRequestInfo( &requestInfo );
-    setupBuffer( &requestHeaders, expectedHeaderLen );
+    setupBuffer( &requestHeaders, expectedHeaders.dataLen );
 
     /* Happy Path testing. */
-    expectedHeaderLen = HTTP_TEST_PREFIX_HEADER_LEN +
-                        HTTP_CONNECTION_CLOSE_VALUE_LEN;
-    numBytes = snprintf( expectedHeader, expectedHeaderLen + 1,
+    expectedHeaders.dataLen = HTTP_TEST_PREFIX_HEADER_LEN +
+                              HTTP_CONNECTION_CLOSE_VALUE_LEN;
+    numBytes = snprintf( ( char * ) expectedHeaders.buffer, expectedHeaders.dataLen + 1,
                          HTTP_TEST_HEADER_FORMAT,
                          HTTP_METHOD_GET, HTTP_TEST_REQUEST_PATH,
                          HTTP_PROTOCOL_VERSION,
                          HTTP_USER_AGENT_FIELD, HTTP_USER_AGENT_VALUE,
                          HTTP_HOST_FIELD, HTTP_TEST_HOST_VALUE,
                          HTTP_CONNECTION_FIELD, HTTP_CONNECTION_CLOSE_VALUE );
-    TEST_ASSERT_EQUAL( numBytes, expectedHeaderLen );
-    test_err = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL_MEMORY( requestHeaders.pBuffer, expectedHeader, expectedHeaderLen );
-    TEST_ASSERT_EQUAL( requestHeaders.headersLen, expectedHeaderLen );
-    TEST_ASSERT_EQUAL( test_err, HTTP_SUCCESS );
+    TEST_ASSERT_EQUAL( expectedHeaders.dataLen, numBytes );
+    test_error = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
+    TEST_ASSERT_EQUAL_MEMORY( requestHeaders.pBuffer, expectedHeaders.buffer,
+                              expectedHeaders.dataLen );
+    TEST_ASSERT_EQUAL( expectedHeaders.dataLen, requestHeaders.headersLen );
+    TEST_ASSERT_EQUAL( HTTP_SUCCESS, test_error );
 }
 
 /**
@@ -377,38 +394,36 @@ void test_Http_InitializeRequestHeaders_happy_path()
  */
 void test_Http_InitializeRequestHeaders_invalid_params()
 {
-    HTTPStatus_t test_err = HTTP_INTERNAL_ERROR;
+    HTTPStatus_t test_error = HTTP_INTERNAL_ERROR;
     HTTPRequestHeaders_t requestHeaders = { 0 };
     HTTPRequestInfo_t requestInfo = { 0 };
-    size_t expectedHeaderLen = HTTP_TEST_MAX_INITIALIZED_HEADER_LEN;
-    char expectedHeader[ HTTP_TEST_INITIALIZED_HEADER_BUFFER_LEN ] = { 0 };
 
     /* Test NULL parameters, following order of else-if blocks. */
-    test_err = HTTPClient_InitializeRequestHeaders( NULL, &requestInfo );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_err );
+    test_error = HTTPClient_InitializeRequestHeaders( NULL, &requestInfo );
+    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_error );
     /* TEST requestInfo.pBuffer == NULL */
-    test_err = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_err );
-    requestHeaders.pBuffer = httpBuffer;
+    test_error = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
+    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_error );
+    requestHeaders.pBuffer = testBuffer;
     requestHeaders.bufferLen = HTTP_TEST_INITIALIZED_HEADER_BUFFER_LEN;
-    test_err = HTTPClient_InitializeRequestHeaders( &requestHeaders, NULL );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_err );
+    test_error = HTTPClient_InitializeRequestHeaders( &requestHeaders, NULL );
+    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_error );
     /* Test requestInfo members are NULL */
-    test_err = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_err );
+    test_error = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
+    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_error );
     requestInfo.method = HTTP_METHOD_GET;
-    test_err = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_err );
+    test_error = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
+    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_error );
     requestInfo.pHost = HTTP_TEST_HOST_VALUE;
-    test_err = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_err );
+    test_error = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
+    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_error );
     requestInfo.pPath = HTTP_TEST_REQUEST_PATH;
     requestInfo.pathLen = HTTP_TEST_REQUEST_PATH_LEN;
-    test_err = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_err );
+    test_error = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
+    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_error );
     requestInfo.methodLen = HTTP_METHOD_GET_LEN;
-    test_err = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_err );
+    test_error = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
+    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_error );
     requestInfo.hostLen = HTTP_TEST_HOST_VALUE_LEN;
 }
 
@@ -419,37 +434,38 @@ void test_Http_InitializeRequestHeaders_invalid_params()
  */
 void test_Http_InitializeRequestHeaders_req_info()
 {
-    HTTPStatus_t test_err = HTTP_INTERNAL_ERROR;
+    HTTPStatus_t test_error = HTTP_INTERNAL_ERROR;
     HTTPRequestHeaders_t requestHeaders = { 0 };
     HTTPRequestInfo_t requestInfo = { 0 };
-    size_t expectedHeaderLen = HTTP_TEST_MAX_INITIALIZED_HEADER_LEN;
-    char expectedHeader[ HTTP_TEST_INITIALIZED_HEADER_BUFFER_LEN ] = { 0 };
+
+    expectedHeaders.dataLen = HTTP_TEST_MAX_INITIALIZED_HEADER_LEN;
     int numBytes = 0;
 
     setupRequestInfo( &requestInfo );
-    setupBuffer( &requestHeaders, expectedHeaderLen );
+    setupBuffer( &requestHeaders, expectedHeaders.dataLen );
 
     requestInfo.pPath = 0;
     requestInfo.flags = HTTP_REQUEST_KEEP_ALIVE_FLAG;
-    expectedHeaderLen = HTTP_TEST_PREFIX_HEADER_LEN -
-                        HTTP_TEST_REQUEST_PATH_LEN +
-                        HTTP_EMPTY_PATH_LEN +
-                        HTTP_CONNECTION_KEEP_ALIVE_VALUE_LEN;
-    numBytes = snprintf( expectedHeader, expectedHeaderLen + 1,
+    expectedHeaders.dataLen = HTTP_TEST_PREFIX_HEADER_LEN -
+                              HTTP_TEST_REQUEST_PATH_LEN +
+                              HTTP_EMPTY_PATH_LEN +
+                              HTTP_CONNECTION_KEEP_ALIVE_VALUE_LEN;
+    numBytes = snprintf( ( char * ) expectedHeaders.buffer, expectedHeaders.dataLen + 1,
                          HTTP_TEST_HEADER_FORMAT,
                          HTTP_METHOD_GET, HTTP_EMPTY_PATH,
                          HTTP_PROTOCOL_VERSION,
                          HTTP_USER_AGENT_FIELD, HTTP_USER_AGENT_VALUE,
                          HTTP_HOST_FIELD, HTTP_TEST_HOST_VALUE,
                          HTTP_CONNECTION_FIELD, HTTP_CONNECTION_KEEP_ALIVE_VALUE );
-    TEST_ASSERT_EQUAL( expectedHeaderLen, numBytes );
+    TEST_ASSERT_EQUAL( expectedHeaders.dataLen, numBytes );
 
-    requestHeaders.pBuffer = httpBuffer;
-    requestHeaders.bufferLen = expectedHeaderLen;
-    test_err = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL_MEMORY( requestHeaders.pBuffer, expectedHeader, expectedHeaderLen );
-    TEST_ASSERT_EQUAL( expectedHeaderLen, requestHeaders.headersLen );
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, test_err );
+    requestHeaders.pBuffer = testBuffer;
+    requestHeaders.bufferLen = expectedHeaders.dataLen;
+    test_error = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
+    TEST_ASSERT_EQUAL_MEMORY( requestHeaders.pBuffer, expectedHeaders.buffer,
+                              expectedHeaders.dataLen );
+    TEST_ASSERT_EQUAL( expectedHeaders.dataLen, requestHeaders.headersLen );
+    TEST_ASSERT_EQUAL( HTTP_SUCCESS, test_error );
 }
 
 /**
@@ -458,19 +474,19 @@ void test_Http_InitializeRequestHeaders_req_info()
  */
 void test_Http_InitializeRequestHeaders_insufficient_memory()
 {
-    HTTPStatus_t test_err = HTTP_INTERNAL_ERROR;
+    HTTPStatus_t test_error = HTTP_INTERNAL_ERROR;
     HTTPRequestHeaders_t requestHeaders = { 0 };
     HTTPRequestInfo_t requestInfo = { 0 };
-    size_t expectedHeaderLen = HTTP_TEST_MAX_INITIALIZED_HEADER_LEN;
-    char expectedHeader[ HTTP_TEST_INITIALIZED_HEADER_BUFFER_LEN ] = { 0 };
+
+    expectedHeaders.dataLen = HTTP_TEST_MAX_INITIALIZED_HEADER_LEN;
 
     setupRequestInfo( &requestInfo );
-    setupBuffer( &requestHeaders, expectedHeaderLen );
+    setupBuffer( &requestHeaders, expectedHeaders.dataLen );
 
     requestHeaders.bufferLen = HTTP_TEST_REQUEST_LINE_LEN - 1;
 
-    test_err = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( HTTP_INSUFFICIENT_MEMORY, test_err );
+    test_error = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
+    TEST_ASSERT_EQUAL( HTTP_INSUFFICIENT_MEMORY, test_error );
     TEST_ASSERT_TRUE( strncmp( ( char * ) requestHeaders.pBuffer,
                                HTTP_TEST_REQUEST_LINE,
                                HTTP_TEST_REQUEST_LINE_LEN ) != 0 );

--- a/libraries/standard/http/utest/http_utest.c
+++ b/libraries/standard/http/utest/http_utest.c
@@ -439,7 +439,7 @@ void test_Http_InitializeRequestHeaders_Invalid_Params()
  * header is set to "keep-alive" when HTTP_REQUEST_KEEP_ALIVE_FLAG in requestHeaders
  * is activated.
  */
-void test_Http_InitializeRequestHeaders_Req_info()
+void test_Http_InitializeRequestHeaders_ReqInfo()
 {
     HTTPStatus_t httpStatus = HTTP_INTERNAL_ERROR;
     HTTPRequestHeaders_t requestHeaders = { 0 };
@@ -479,7 +479,7 @@ void test_Http_InitializeRequestHeaders_Req_info()
  * @brief Test HTTP_INSUFFICIENT_MEMORY from having requestHeaders.bufferLen less than
  * what is required to fit HTTP_TEST_REQUEST_LINE.
  */
-void test_Http_InitializeRequestHeaders_insufficient_memory()
+void test_Http_InitializeRequestHeaders_InsufficientMemory()
 {
     HTTPStatus_t httpStatus = HTTP_INTERNAL_ERROR;
     HTTPRequestHeaders_t requestHeaders = { 0 };

--- a/libraries/standard/http/utest/http_utest.c
+++ b/libraries/standard/http/utest/http_utest.c
@@ -270,6 +270,8 @@ static void addRangeToExpectedHeaders( _headers_t * expectedHeaders,
 }
 
 /* ============================ UNITY FIXTURES ============================== */
+
+/* Called before each test method. */
 void setUp( void )
 {
     testResponse.pBuffer = ( uint8_t * ) &pTestResponse[ 0 ];
@@ -284,7 +286,7 @@ void setUp( void )
     http_errno_description_IgnoreAndReturn( "Mocked HTTP Parser Status" );
 }
 
-/* called before each testcase */
+/* Called after each test method. */
 void tearDown( void )
 {
     retCode = HTTP_NOT_SUPPORTED;
@@ -311,12 +313,12 @@ void tearDown( void )
     == == == =
 }
 
-/* called at the beginning of the whole suite */
+/* Called at the beginning of the whole suite. */
 void suiteSetUp()
 {
 }
 
-/* called at the end of the whole suite */
+/* Called at the end of the whole suite. */
 int suiteTearDown( int numFailures )
 {
     return numFailures;
@@ -401,27 +403,32 @@ void test_Http_InitializeRequestHeaders_Invalid_params()
     /* Test NULL parameters, following order of else-if blocks. */
     httpStatus = HTTPClient_InitializeRequestHeaders( NULL, &requestInfo );
     TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );
+
     /* TEST requestInfo.pBuffer == NULL */
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
     TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );
     requestHeaders.pBuffer = testBuffer;
     requestHeaders.bufferLen = HTTP_TEST_INITIALIZED_HEADER_BUFFER_LEN;
+
     /* Test requestInfo == NULL. */
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders, NULL );
     TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );
-    /* Test requestInfo members are NULL */
+
+    /* Test requestInfo.method == NULL. */
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
     TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );
     requestInfo.method = HTTP_METHOD_GET;
+
+    /* Test requestInfo.pHost == NULL. */
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
     TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );
+
+    /* Test requestInfo.methodLen == 0. */
     requestInfo.pHost = HTTP_TEST_HOST_VALUE;
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
     TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );
-    requestInfo.pPath = HTTP_TEST_REQUEST_PATH;
-    requestInfo.pathLen = HTTP_TEST_REQUEST_PATH_LEN;
-    httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );
+
+    /* Test requestInfo.hostLen == 0. */
     requestInfo.methodLen = HTTP_METHOD_GET_LEN;
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
     TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, httpStatus );

--- a/libraries/standard/http/utest/http_utest.c
+++ b/libraries/standard/http/utest/http_utest.c
@@ -365,15 +365,14 @@ void test_Http_InitializeRequestHeaders_happy_path()
     HTTPRequestHeaders_t requestHeaders = { 0 };
     HTTPRequestInfo_t requestInfo = { 0 };
 
-    expectedHeaders.dataLen = HTTP_TEST_MAX_INITIALIZED_HEADER_LEN;
+    expectedHeaders.dataLen = HTTP_TEST_PREFIX_HEADER_LEN +
+                              HTTP_CONNECTION_CLOSE_VALUE_LEN;
     int numBytes = 0;
 
     setupRequestInfo( &requestInfo );
     setupBuffer( &requestHeaders, expectedHeaders.dataLen );
 
     /* Happy Path testing. */
-    expectedHeaders.dataLen = HTTP_TEST_PREFIX_HEADER_LEN +
-                              HTTP_CONNECTION_CLOSE_VALUE_LEN;
     numBytes = snprintf( ( char * ) expectedHeaders.buffer, expectedHeaders.dataLen + 1,
                          HTTP_TEST_HEADER_FORMAT,
                          HTTP_METHOD_GET, HTTP_TEST_REQUEST_PATH,
@@ -438,7 +437,10 @@ void test_Http_InitializeRequestHeaders_req_info()
     HTTPRequestHeaders_t requestHeaders = { 0 };
     HTTPRequestInfo_t requestInfo = { 0 };
 
-    expectedHeaders.dataLen = HTTP_TEST_MAX_INITIALIZED_HEADER_LEN;
+    expectedHeaders.dataLen = HTTP_TEST_PREFIX_HEADER_LEN -
+                              HTTP_TEST_REQUEST_PATH_LEN +
+                              HTTP_EMPTY_PATH_LEN +
+                              HTTP_CONNECTION_KEEP_ALIVE_VALUE_LEN;
     int numBytes = 0;
 
     setupRequestInfo( &requestInfo );
@@ -446,10 +448,6 @@ void test_Http_InitializeRequestHeaders_req_info()
 
     requestInfo.pPath = 0;
     requestInfo.flags = HTTP_REQUEST_KEEP_ALIVE_FLAG;
-    expectedHeaders.dataLen = HTTP_TEST_PREFIX_HEADER_LEN -
-                              HTTP_TEST_REQUEST_PATH_LEN +
-                              HTTP_EMPTY_PATH_LEN +
-                              HTTP_CONNECTION_KEEP_ALIVE_VALUE_LEN;
     numBytes = snprintf( ( char * ) expectedHeaders.buffer, expectedHeaders.dataLen + 1,
                          HTTP_TEST_HEADER_FORMAT,
                          HTTP_METHOD_GET, HTTP_EMPTY_PATH,

--- a/libraries/standard/http/utest/http_utest.c
+++ b/libraries/standard/http/utest/http_utest.c
@@ -360,7 +360,7 @@ static void setupBuffer( HTTPRequestHeaders_t * pRequestHeaders )
 /**
  * @brief Test happy path with zero-initialized requestHeaders and requestInfo.
  */
-void test_Http_InitializeRequestHeaders_Happy_path()
+void test_Http_InitializeRequestHeaders_Happy_Path()
 {
     HTTPStatus_t httpStatus = HTTP_INTERNAL_ERROR;
     HTTPRequestHeaders_t requestHeaders = { 0 };
@@ -394,7 +394,7 @@ void test_Http_InitializeRequestHeaders_Happy_path()
 /**
  * @brief Test NULL parameters, following order of else-if blocks in the HTTP library.
  */
-void test_Http_InitializeRequestHeaders_Invalid_params()
+void test_Http_InitializeRequestHeaders_Invalid_Params()
 {
     HTTPStatus_t httpStatus = HTTP_INTERNAL_ERROR;
     HTTPRequestHeaders_t requestHeaders = { 0 };

--- a/libraries/standard/http/utest/http_utest.c
+++ b/libraries/standard/http/utest/http_utest.c
@@ -385,30 +385,30 @@ void test_Http_InitializeRequestHeaders_invalid_params()
 
     /* Test NULL parameters, following order of else-if blocks. */
     test_err = HTTPClient_InitializeRequestHeaders( NULL, &requestInfo );
-    TEST_ASSERT_EQUAL( test_err, HTTP_INVALID_PARAMETER );
+    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_err );
     /* TEST requestInfo.pBuffer == NULL */
     test_err = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( test_err, HTTP_INVALID_PARAMETER );
+    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_err );
     requestHeaders.pBuffer = httpBuffer;
     requestHeaders.bufferLen = HTTP_TEST_INITIALIZED_HEADER_BUFFER_LEN;
     test_err = HTTPClient_InitializeRequestHeaders( &requestHeaders, NULL );
-    TEST_ASSERT_EQUAL( test_err, HTTP_INVALID_PARAMETER );
+    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_err );
     /* Test requestInfo members are NULL */
     test_err = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( test_err, HTTP_INVALID_PARAMETER );
+    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_err );
     requestInfo.method = HTTP_METHOD_GET;
     test_err = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( test_err, HTTP_INVALID_PARAMETER );
+    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_err );
     requestInfo.pHost = HTTP_TEST_HOST_VALUE;
     test_err = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( test_err, HTTP_INVALID_PARAMETER );
+    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_err );
     requestInfo.pPath = HTTP_TEST_REQUEST_PATH;
     requestInfo.pathLen = HTTP_TEST_REQUEST_PATH_LEN;
     test_err = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( test_err, HTTP_INVALID_PARAMETER );
+    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_err );
     requestInfo.methodLen = HTTP_METHOD_GET_LEN;
     test_err = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( test_err, HTTP_INVALID_PARAMETER );
+    TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, test_err );
     requestInfo.hostLen = HTTP_TEST_HOST_VALUE_LEN;
 }
 
@@ -442,14 +442,14 @@ void test_Http_InitializeRequestHeaders_req_info()
                          HTTP_USER_AGENT_FIELD, HTTP_USER_AGENT_VALUE,
                          HTTP_HOST_FIELD, HTTP_TEST_HOST_VALUE,
                          HTTP_CONNECTION_FIELD, HTTP_CONNECTION_KEEP_ALIVE_VALUE );
-    TEST_ASSERT_EQUAL( numBytes, expectedHeaderLen );
+    TEST_ASSERT_EQUAL( expectedHeaderLen, numBytes );
 
     requestHeaders.pBuffer = httpBuffer;
     requestHeaders.bufferLen = expectedHeaderLen;
     test_err = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
     TEST_ASSERT_EQUAL_MEMORY( requestHeaders.pBuffer, expectedHeader, expectedHeaderLen );
-    TEST_ASSERT_EQUAL( requestHeaders.headersLen, expectedHeaderLen );
-    TEST_ASSERT_EQUAL( test_err, HTTP_SUCCESS );
+    TEST_ASSERT_EQUAL( expectedHeaderLen, requestHeaders.headersLen );
+    TEST_ASSERT_EQUAL( HTTP_SUCCESS, test_err );
 }
 
 /**
@@ -470,7 +470,7 @@ void test_Http_InitializeRequestHeaders_insufficient_memory()
     requestHeaders.bufferLen = HTTP_TEST_REQUEST_LINE_LEN - 1;
 
     test_err = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL( test_err, HTTP_INSUFFICIENT_MEMORY );
+    TEST_ASSERT_EQUAL( HTTP_INSUFFICIENT_MEMORY, test_err );
     TEST_ASSERT_TRUE( strncmp( ( char * ) requestHeaders.pBuffer,
                                HTTP_TEST_REQUEST_LINE,
                                HTTP_TEST_REQUEST_LINE_LEN ) != 0 );

--- a/libraries/standard/http/utest/http_utest.c
+++ b/libraries/standard/http/utest/http_utest.c
@@ -93,7 +93,7 @@ static const char * pTestResponse = "HTTP/1.1 200 OK\r\n"
 #define HEADER_NOT_IN_BUFFER    "header-not-in-buffer"
 
 /* File-scoped Global variables */
-static HTTPStatus_t retCode = HTTP_NOT_SUPPORTED;
+static HTTPStatus_t retCode = HTTP_INTERNAL_ERROR;
 static uint8_t testBuffer[ HTTP_TEST_BUFFER_SIZE ] = { 0 };
 static HTTPRequestHeaders_t testHeaders = { 0 };
 static _headers_t expectedHeaders = { 0 };

--- a/libraries/standard/http/utest/http_utest.c
+++ b/libraries/standard/http/utest/http_utest.c
@@ -381,10 +381,10 @@ void test_Http_InitializeRequestHeaders_Happy_path()
                          HTTP_CONNECTION_FIELD, HTTP_CONNECTION_CLOSE_VALUE );
     TEST_ASSERT_EQUAL( expectedHeaders.dataLen, numBytes );
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL_MEMORY( requestHeaders.pBuffer, expectedHeaders.buffer,
-                              expectedHeaders.dataLen );
-    TEST_ASSERT_EQUAL( expectedHeaders.dataLen, requestHeaders.headersLen );
     TEST_ASSERT_EQUAL( HTTP_SUCCESS, httpStatus );
+    TEST_ASSERT_EQUAL( expectedHeaders.dataLen, requestHeaders.headersLen );
+    TEST_ASSERT_EQUAL_MEMORY( expectedHeaders.buffer, requestHeaders.pBuffer,
+                              expectedHeaders.dataLen );
 }
 
 /**
@@ -458,10 +458,10 @@ void test_Http_InitializeRequestHeaders_Req_info()
     requestHeaders.pBuffer = testBuffer;
     requestHeaders.bufferLen = expectedHeaders.dataLen;
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders, &requestInfo );
-    TEST_ASSERT_EQUAL_MEMORY( requestHeaders.pBuffer, expectedHeaders.buffer,
-                              expectedHeaders.dataLen );
-    TEST_ASSERT_EQUAL( expectedHeaders.dataLen, requestHeaders.headersLen );
     TEST_ASSERT_EQUAL( HTTP_SUCCESS, httpStatus );
+    TEST_ASSERT_EQUAL( expectedHeaders.dataLen, requestHeaders.headersLen );
+    TEST_ASSERT_EQUAL_MEMORY( expectedHeaders.buffer, requestHeaders.pBuffer,
+                              expectedHeaders.dataLen );
 }
 
 /**

--- a/libraries/standard/http/utest/http_utest.c
+++ b/libraries/standard/http/utest/http_utest.c
@@ -347,9 +347,9 @@ static void setupRequestInfo( HTTPRequestInfo_t * pRequestInfo )
 }
 
 /**
+ * @brief Initialize pRequestHeaders with static buffer.
  *
  * @param[in] pRequestHeaders Request header buffer information.
- * @param[in] bufferLen Size of the buffer.
  */
 static void setupBuffer( HTTPRequestHeaders_t * pRequestHeaders )
 {

--- a/libraries/standard/http/utest/http_utest.c
+++ b/libraries/standard/http/utest/http_utest.c
@@ -479,7 +479,7 @@ void test_Http_InitializeRequestHeaders_ReqInfo()
  * @brief Test HTTP_INSUFFICIENT_MEMORY from having requestHeaders.bufferLen less than
  * what is required to fit HTTP_TEST_REQUEST_LINE.
  */
-void test_Http_InitializeRequestHeaders_InsufficientMemory()
+void test_Http_InitializeRequestHeaders_Insufficient_Memory()
 {
     HTTPStatus_t httpStatus = HTTP_INTERNAL_ERROR;
     HTTPRequestHeaders_t requestHeaders = { 0 };


### PR DESCRIPTION
*Description of changes:*
- Follow (expected, actual) order for TEST_ASSERT_EQUAL
- Use expectedHeaders struct for expected headers data.
- Use testBuffer and remove httpBuffer
- Remove unused variables
- Fix warnings

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
