### PR TITLE
test: MQTT_SerializeDisconnect unit tests using Unity Framework

### DIFF
--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -8,45 +8,50 @@
 /**
  * @brief MQTT protocol version 3.1.1.
  */
-#define MQTT_VERSION_3_1_1               ( ( uint8_t ) 4U )
+#define MQTT_VERSION_3_1_1                  ( ( uint8_t ) 4U )
 
 /**
  * @brief Test-defined macro for MQTT username.
  */
-#define MQTT_TEST_USERNAME               "username"
-#define MQTT_TEST_USERNAME_LEN           ( sizeof( MQTT_TEST_USERNAME ) - 1 )
+#define MQTT_TEST_USERNAME                  "username"
+#define MQTT_TEST_USERNAME_LEN              ( sizeof( MQTT_TEST_USERNAME ) - 1 )
 
 /**
  * @brief Test-defined macro for MQTT password.
  */
-#define MQTT_TEST_PASSWORD               "password"
-#define MQTT_TEST_PASSWORD_LEN           ( sizeof( MQTT_TEST_PASSWORD ) - 1 )
+#define MQTT_TEST_PASSWORD                  "password"
+#define MQTT_TEST_PASSWORD_LEN              ( sizeof( MQTT_TEST_PASSWORD ) - 1 )
 
 /**
  * @brief Test-defined macro for MQTT topic.
  */
-#define MQTT_TEST_TOPIC                  "topic"
-#define MQTT_TEST_TOPIC_LEN              ( sizeof( MQTT_TEST_TOPIC ) - 1 )
+#define MQTT_TEST_TOPIC                     "topic"
+#define MQTT_TEST_TOPIC_LEN                 ( sizeof( MQTT_TEST_TOPIC ) - 1 )
 
 /**
  * @brief Length of the client identifier.
  */
-#define MQTT_CLIENT_IDENTIFIER_LEN       ( sizeof( MQTT_CLIENT_IDENTIFIER ) - 1 )
+#define MQTT_CLIENT_IDENTIFIER_LEN          ( sizeof( MQTT_CLIENT_IDENTIFIER ) - 1 )
 
 /**
  * @brief Payload for will info.
  */
-#define MQTT_SAMPLE_PAYLOAD              "payload"
-#define MQTT_SAMPLE_PAYLOAD_LEN          ( sizeof( MQTT_SAMPLE_PAYLOAD ) - 1 )
+#define MQTT_SAMPLE_PAYLOAD                 "payload"
+#define MQTT_SAMPLE_PAYLOAD_LEN             ( sizeof( MQTT_SAMPLE_PAYLOAD ) - 1 )
 
 /* MQTT CONNECT flags. */
-#define MQTT_CONNECT_FLAG_CLEAN          ( 1 )            /**< @brief Clean session. */
-#define MQTT_CONNECT_FLAG_WILL           ( 2 )            /**< @brief Will present. */
-#define MQTT_CONNECT_FLAG_WILL_QOS1      ( 3 )            /**< @brief Will QoS 1. */
-#define MQTT_CONNECT_FLAG_WILL_QOS2      ( 4 )            /**< @brief Will QoS 2. */
-#define MQTT_CONNECT_FLAG_WILL_RETAIN    ( 5 )            /**< @brief Will retain. */
-#define MQTT_CONNECT_FLAG_PASSWORD       ( 6 )            /**< @brief Password present. */
-#define MQTT_CONNECT_FLAG_USERNAME       ( 7 )            /**< @brief User name present. */
+#define MQTT_CONNECT_FLAG_CLEAN             ( 1 )         /**< @brief Clean session. */
+#define MQTT_CONNECT_FLAG_WILL              ( 2 )         /**< @brief Will present. */
+#define MQTT_CONNECT_FLAG_WILL_QOS1         ( 3 )         /**< @brief Will QoS 1. */
+#define MQTT_CONNECT_FLAG_WILL_QOS2         ( 4 )         /**< @brief Will QoS 2. */
+#define MQTT_CONNECT_FLAG_WILL_RETAIN       ( 5 )         /**< @brief Will retain. */
+#define MQTT_CONNECT_FLAG_PASSWORD          ( 6 )         /**< @brief Password present. */
+#define MQTT_CONNECT_FLAG_USERNAME          ( 7 )         /**< @brief User name present. */
+
+/**
+ * @brief The Remaining Length field of MQTT disconnect packets, per MQTT spec.
+ */
+#define MQTT_DISCONNECT_REMAINING_LENGTH    ( ( uint8_t ) 0 )
 
 /**
  * @brief Set a bit in an 8-bit unsigned integer.
@@ -553,6 +558,8 @@ void test_MQTT_SerializeDisconnect_happy_path()
 
     /* Make sure buffer has enough space. */
     mqttStatus = MQTT_SerializeDisconnect( &networkBuffer );
+    TEST_ASSERT_EQUAL( MQTT_PACKET_TYPE_DISCONNECT, networkBuffer.pBuffer[ 0 ] );
+    TEST_ASSERT_EQUAL( MQTT_DISCONNECT_REMAINING_LENGTH, networkBuffer.pBuffer[ 1 ] );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
 }
 

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -504,6 +504,17 @@ void test_MQTT_SerializeConnect_happy_paths()
 /* ==================  Testing MQTT_SerializeDisconnect ===================== */
 
 /**
+ * @brief Initialize pNetworkBuffer using static buffer.
+ *
+ * @param[in] pNetworkBuffer Network buffer provided for the context.
+ */
+static void setupNetworkBuffer( MQTTFixedBuffer_t * const pNetworkBuffer )
+{
+    pNetworkBuffer->pBuffer = mqttBuffer;
+    pNetworkBuffer->size = MQTT_TEST_BUFFER_LENGTH;
+}
+
+/**
  * @brief Call Mqtt_SerializeDisconnect using NULL pBuffer and insufficient buffer
  * size in order to receive MQTTBadParameter and MQTTNoMemory errors.
  */

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -504,8 +504,8 @@ void test_MQTT_SerializeConnect_happy_paths()
 /* ==================  Testing MQTT_SerializeDisconnect ===================== */
 
 /**
- * @brief Call Mqtt_SerializeDisconnect using NULL parameters and insufficient buffer
- * size until we receive all possible MQTTBadParameter and MQTTNoMemory errors.
+ * @brief Call Mqtt_SerializeDisconnect using NULL pBuffer and insufficient buffer
+ * size in order to receive MQTTBadParameter and MQTTNoMemory errors.
  */
 void test_MQTT_SerializeDisconnect_invalid_params()
 {

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -509,17 +509,6 @@ void test_MQTT_SerializeConnect_happy_paths()
 /* ==================  Testing MQTT_SerializeDisconnect ===================== */
 
 /**
- * @brief Initialize pNetworkBuffer using static buffer.
- *
- * @param[in] pNetworkBuffer Network buffer provided for the context.
- */
-static void setupNetworkBuffer( MQTTFixedBuffer_t * const pNetworkBuffer )
-{
-    pNetworkBuffer->pBuffer = mqttBuffer;
-    pNetworkBuffer->size = MQTT_TEST_BUFFER_LENGTH;
-}
-
-/**
  * @brief Call Mqtt_SerializeDisconnect using NULL pBuffer and insufficient buffer
  * size in order to receive MQTTBadParameter and MQTTNoMemory errors.
  */

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -501,4 +501,48 @@ void test_MQTT_SerializeConnect_happy_paths()
                                    remainingLength, &networkBuffer );
 }
 
+/* ==================  Testing MQTT_SerializeDisconnect ===================== */
+
+/**
+ * @brief Call Mqtt_SerializeDisconnect using NULL parameters and insufficient buffer
+ * size until we receive all possible MQTTBadParameter and MQTTNoMemory errors.
+ */
+void test_MQTT_SerializeDisconnect_invalid_params()
+{
+    MQTTStatus_t mqttStatus = MQTTSuccess;
+    size_t packetSize = 0;
+    MQTTFixedBuffer_t networkBuffer;
+
+    /* Test NULL pBuffer. */
+    mqttStatus = MQTT_SerializeDisconnect( NULL );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
+
+    /* Test disconnectPacketSize > pBuffer->size. */
+    /* Get MQTT disconnect packet size and remaining length. */
+    mqttStatus = MQTT_GetDisconnectPacketSize( &packetSize );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    networkBuffer.pBuffer = mqttBuffer;
+    networkBuffer.size = packetSize - 1;
+    mqttStatus = MQTT_SerializeDisconnect( &networkBuffer );
+    TEST_ASSERT_EQUAL( MQTTNoMemory, mqttStatus );
+}
+
+/**
+ * @brief This method calls MQTT_SerializeDisconnect successfully in order to
+ * get full coverage on the method.
+ */
+void test_MQTT_SerializeDisconnect_happy_path()
+{
+    MQTTStatus_t mqttStatus = MQTTSuccess;
+    size_t packetSize = 0;
+    MQTTFixedBuffer_t networkBuffer;
+
+    /* Fill structs to pass into methods to be tested. */
+    setupNetworkBuffer( &networkBuffer );
+
+    /* Make sure buffer has enough space. */
+    mqttStatus = MQTT_SerializeDisconnect( &networkBuffer );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+}
+
 /* ========================================================================== */

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -382,7 +382,7 @@ static void verifySerializedConnectPacket( const MQTTConnectInfo_t * const pConn
  * @brief Call Mqtt_SerializeConnect using NULL parameters and insufficient buffer
  * size until we receive all possible MQTTBadParameter and MQTTNoMemory errors.
  */
-void test_MQTT_SerializeConnect_invalid_params()
+void test_MQTT_SerializeConnect_Invalid_Params()
 {
     MQTTStatus_t mqttStatus = MQTTSuccess;
     size_t remainingLength = 0, packetSize = 0;
@@ -417,7 +417,7 @@ void test_MQTT_SerializeConnect_invalid_params()
  * @brief This method calls MQTT_SerializeConnect successfully using different parameters
  * until we have full coverage on the private method, serializeConnectPacket(...).
  */
-void test_MQTT_SerializeConnect_happy_paths()
+void test_MQTT_SerializeConnect_Happy_Paths()
 {
     MQTTStatus_t mqttStatus = MQTTSuccess;
     size_t remainingLength = 0, packetSize = 0;
@@ -512,7 +512,7 @@ void test_MQTT_SerializeConnect_happy_paths()
  * @brief Call Mqtt_SerializeDisconnect using NULL pBuffer and insufficient buffer
  * size in order to receive MQTTBadParameter and MQTTNoMemory errors.
  */
-void test_MQTT_SerializeDisconnect_invalid_params()
+void test_MQTT_SerializeDisconnect_Invalid_Params()
 {
     MQTTStatus_t mqttStatus = MQTTSuccess;
     size_t packetSize = 0;
@@ -536,7 +536,7 @@ void test_MQTT_SerializeDisconnect_invalid_params()
  * @brief This method calls MQTT_SerializeDisconnect successfully in order to
  * get full coverage on the method.
  */
-void test_MQTT_SerializeDisconnect_happy_path()
+void test_MQTT_SerializeDisconnect_Happy_Path()
 {
     MQTTStatus_t mqttStatus = MQTTSuccess;
     size_t packetSize = 0;

--- a/libraries/standard/mqtt/utest/mqtt_state_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_state_utest.c
@@ -4,8 +4,6 @@
 
 #define MQTT_PACKET_ID_INVALID    ( ( uint16_t ) 0U )
 
-#define MQTT_STATE_ARRAY_MAX_COUNT ( 10U )
-
 /* ============================   UNITY FIXTURES ============================ */
 void setUp( void )
 {
@@ -32,6 +30,7 @@ int suiteTearDown( int numFailures )
 static void resetPublishRecords( MQTTContext_t * pMqttContext )
 {
     int i = 0;
+
     for( ; i < MQTT_STATE_ARRAY_MAX_COUNT; i++ )
     {
         pMqttContext->outgoingPublishRecords[ i ].packetId = MQTT_PACKET_ID_INVALID;
@@ -60,6 +59,7 @@ static void fillRecord( MQTTPubAckInfo_t * records,
                         MQTTPublishState_t state )
 {
     int i;
+
     for( i = 0; i < MQTT_STATE_ARRAY_MAX_COUNT; i++ )
     {
         records[ i ].packetId = startingId + i;
@@ -220,7 +220,6 @@ void test_MQTT_UpdateStatePublish( void )
     state = MQTT_UpdateStatePublish( &mqttContext, PACKET_ID, operation, qos );
     TEST_ASSERT_EQUAL( MQTTPubRecSend, state );
     TEST_ASSERT_EQUAL( MQTTPubRecSend, mqttContext.incomingPublishRecords[ 0 ].publishState );
-
 }
 
 /* ========================================================================== */

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -36,7 +36,7 @@ int suiteTearDown( int numFailures )
 /**
  * @brief Test that MQTT_Init is able to update the context object correctly.
  */
-void test_MQTT_Init_Happy_path( void )
+void test_MQTT_Init_Happy_Path( void )
 {
     MQTTStatus_t mqttStatus;
     MQTTContext_t context;
@@ -57,7 +57,7 @@ void test_MQTT_Init_Happy_path( void )
 /**
  * @brief Test that any NULL parameter causes MQTT_Init to return MQTTBadParameter.
  */
-void test_MQTT_Init_Invalid_params( void )
+void test_MQTT_Init_Invalid_Params( void )
 {
     MQTTStatus_t mqttStatus;
     MQTTContext_t context;

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -28,7 +28,6 @@ void suiteSetUp()
 /* Called at the end of the whole suite. */
 int suiteTearDown( int numFailures )
 {
-    return numFailures;
 }
 
 /* ============================   Testing MQTT_Init ========================= */

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -11,12 +11,12 @@
 /* ============================   UNITY FIXTURES ============================ */
 
 /* Called before each test method. */
-void setUp( void )
+void setUp()
 {
 }
 
 /* Called after each test method. */
-void tearDown( void )
+void tearDown()
 {
 }
 
@@ -28,6 +28,7 @@ void suiteSetUp()
 /* Called at the end of the whole suite. */
 int suiteTearDown( int numFailures )
 {
+    return numFailures;
 }
 
 /* ============================   Testing MQTT_Init ========================= */


### PR DESCRIPTION
Create two methods that achieve 100% branch coverage on MQTT_SerializeDisconnect:
- `test_MQTT_SerializeDisconnect_invalid_params` calls Mqtt_SerializeDisconnect using NULL pBuffer and insufficient buffer size in order to receive MQTTBadParameter and MQTTNoMemory errors.
- `test_MQTT_SerializeDisconnect_happy_path` calls MQTT_SerializeDisconnect successfully in order to get full coverage on the method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
