### PR TITLE
Update Minimum CMake Version check in Root

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Project information.
-cmake_minimum_required( VERSION 3.5.0 )
+cmake_minimum_required( VERSION 3.13.0 )
 project( AwsIotDeviceSdkEmbeddedC
          VERSION 4.0.2
          LANGUAGES C )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Update `cmake_minimum_required` in root of repo. The previous setup allowed using an outdated version on demos which require a newer `add_executable` function signature.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
