### PR TITLE
Fix typo in MQTT_GetPingReqPacketSize causing linking error

### DIFF
--- a/libraries/standard/mqtt/include/mqtt_lightweight.h
+++ b/libraries/standard/mqtt/include/mqtt_lightweight.h
@@ -465,7 +465,7 @@ MQTTStatus_t MQTT_SerializeDisconnect( const MQTTFixedBuffer_t * const pBuffer )
  *
  * @return  #MQTTSuccess or #MQTTBadParameter if pPacketSize is NULL.
  */
-MQTTStatus_t MQTT_GetPingreqPacketSize( size_t * pPacketSize );
+MQTTStatus_t MQTT_GetPingReqPacketSize( size_t * pPacketSize );
 
 /**
  * @brief Serialize an MQTT PINGREQ packet into the given buffer.

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -958,7 +958,6 @@ static MQTTStatus_t deserializeSuback( const MQTTPacketInfo_t * const pSuback,
     assert( pPacketIdentifier != NULL );
 
     size_t remainingLength = pSuback->remainingLength;
-
     const uint8_t * pVariableHeader = pSuback->pRemainingData;
 
     /* A SUBACK must have a remaining length of at least 3 to accommodate the

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -957,8 +957,8 @@ static MQTTStatus_t deserializeSuback( const MQTTPacketInfo_t * const pSuback,
     assert( pSuback != NULL );
     assert( pPacketIdentifier != NULL );
 
-    size_t remainingLength;
-    remainingLength = pSuback->remainingLength;
+    size_t remainingLength = pSuback->remainingLength;
+
     const uint8_t * pVariableHeader = pSuback->pRemainingData;
 
     /* A SUBACK must have a remaining length of at least 3 to accommodate the

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -957,7 +957,8 @@ static MQTTStatus_t deserializeSuback( const MQTTPacketInfo_t * const pSuback,
     assert( pSuback != NULL );
     assert( pPacketIdentifier != NULL );
 
-    size_t remainingLength = pSuback->remainingLength;
+    size_t remainingLength;
+    remainingLength = pSuback->remainingLength;
     const uint8_t * pVariableHeader = pSuback->pRemainingData;
 
     /* A SUBACK must have a remaining length of at least 3 to accommodate the
@@ -1862,7 +1863,7 @@ MQTTStatus_t MQTT_SerializeDisconnect( const MQTTFixedBuffer_t * const pBuffer )
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_GetPingreqPacketSize( size_t * pPacketSize )
+MQTTStatus_t MQTT_GetPingReqPacketSize( size_t * pPacketSize )
 {
     MQTTStatus_t status = MQTTSuccess;
 


### PR DESCRIPTION
*Description of changes:*
Fix typo causing MQTT unit test and demo builds to fail with linker error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
