### PR TITLE
test: Add CMock unit tests for MQTT_ProcessLoop

### DIFF
--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -26,6 +26,8 @@
 
 #define MQTT_NO_TIMEOUT_MS           ( 0U )
 
+static uint8_t currentPacketType = 0;
+
 /**
  * @brief Time at the beginning of each test. Note that this is not updated with
  * a real clock. Instead, we simply increment this variable.
@@ -205,6 +207,251 @@ static void setupCallbacks( MQTTApplicationCallbacks_t * pCallbacks )
 {
     pCallbacks->appCallback = eventCallback;
     pCallbacks->getTime = getTime;
+}
+
+
+/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
+ * to get full coverage on handleIncomingPublish. */
+static MQTTStatus_t modifyIncomingPacketPublish( MQTTTransportRecvFunc_t readFunc,
+                                                 MQTTNetworkContext_t networkContext,
+                                                 MQTTPacketInfo_t * pIncomingPacket,
+                                                 int cmock_num_calls )
+{
+    /* Remove unsued parameter warnings. */
+    ( void ) readFunc;
+    ( void ) networkContext;
+    ( void ) cmock_num_calls;
+
+    pIncomingPacket->type = MQTT_PACKET_TYPE_PUBLISH;
+    return MQTTSuccess;
+}
+
+/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
+ * to get full coverage on handleIncomingAck by setting the type to PUBACK. */
+static MQTTStatus_t modifyIncomingPacketPubAck( MQTTTransportRecvFunc_t readFunc,
+                                                MQTTNetworkContext_t networkContext,
+                                                MQTTPacketInfo_t * pIncomingPacket,
+                                                int cmock_num_calls )
+{
+    /* Remove unused parameter warnings. */
+    ( void ) readFunc;
+    ( void ) networkContext;
+    ( void ) cmock_num_calls;
+
+    pIncomingPacket->type = MQTT_PACKET_TYPE_PUBACK;
+    return MQTTSuccess;
+}
+
+/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
+ * to get full coverage on handleIncomingAck by setting the type to PUBREC. */
+static MQTTStatus_t modifyIncomingPacketPubRec( MQTTTransportRecvFunc_t readFunc,
+                                                MQTTNetworkContext_t networkContext,
+                                                MQTTPacketInfo_t * pIncomingPacket,
+                                                int cmock_num_calls )
+{
+    /* Remove unsued parameter warnings. */
+    ( void ) readFunc;
+    ( void ) networkContext;
+    ( void ) cmock_num_calls;
+
+    pIncomingPacket->type = MQTT_PACKET_TYPE_PUBREC;
+    return MQTTSuccess;
+}
+
+/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
+ * to get full coverage on handleIncomingAck by setting the type to PUBREL. */
+static MQTTStatus_t modifyIncomingPacketPubRel( MQTTTransportRecvFunc_t readFunc,
+                                                MQTTNetworkContext_t networkContext,
+                                                MQTTPacketInfo_t * pIncomingPacket,
+                                                int cmock_num_calls )
+{
+    /* Remove unused parameter warnings. */
+    ( void ) readFunc;
+    ( void ) networkContext;
+    ( void ) cmock_num_calls;
+
+    pIncomingPacket->type = MQTT_PACKET_TYPE_PUBREL;
+    return MQTTSuccess;
+}
+
+/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
+ * to get full coverage on handleIncomingAck by setting the type to PUBCOMP. */
+static MQTTStatus_t modifyIncomingPacketPubComp( MQTTTransportRecvFunc_t readFunc,
+                                                 MQTTNetworkContext_t networkContext,
+                                                 MQTTPacketInfo_t * pIncomingPacket,
+                                                 int cmock_num_calls )
+{
+    /* Remove unused parameter warnings. */
+    ( void ) readFunc;
+    ( void ) networkContext;
+    ( void ) cmock_num_calls;
+
+    pIncomingPacket->type = MQTT_PACKET_TYPE_PUBCOMP;
+    return MQTTSuccess;
+}
+
+/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
+ * to get full coverage on handleIncomingAck by setting the type to PINGRESP. */
+static MQTTStatus_t modifyIncomingPacketPingResp( MQTTTransportRecvFunc_t readFunc,
+                                                  MQTTNetworkContext_t networkContext,
+                                                  MQTTPacketInfo_t * pIncomingPacket,
+                                                  int cmock_num_calls )
+{
+    /* Remove unused parameter warnings. */
+    ( void ) readFunc;
+    ( void ) networkContext;
+    ( void ) cmock_num_calls;
+
+    pIncomingPacket->type = MQTT_PACKET_TYPE_PINGRESP;
+    return MQTTSuccess;
+}
+
+/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
+ * to get full coverage on handleIncomingAck by setting the type to SUBACK. */
+static MQTTStatus_t modifyIncomingPacketSubAck( MQTTTransportRecvFunc_t readFunc,
+                                                MQTTNetworkContext_t networkContext,
+                                                MQTTPacketInfo_t * pIncomingPacket,
+                                                int cmock_num_calls )
+{
+    /* Remove unused parameter warnings. */
+    ( void ) readFunc;
+    ( void ) networkContext;
+    ( void ) cmock_num_calls;
+
+    pIncomingPacket->type = MQTT_PACKET_TYPE_SUBACK;
+    return MQTTSuccess;
+}
+
+/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
+ * to get full coverage on handleIncomingAck by setting the type to UNSUBACK. */
+static MQTTStatus_t modifyIncomingPacketUnsubAck( MQTTTransportRecvFunc_t readFunc,
+                                                  MQTTNetworkContext_t networkContext,
+                                                  MQTTPacketInfo_t * pIncomingPacket,
+                                                  int cmock_num_calls )
+{
+    /* Remove unused parameter warnings. */
+    ( void ) readFunc;
+    ( void ) networkContext;
+    ( void ) cmock_num_calls;
+
+    pIncomingPacket->type = MQTT_PACKET_TYPE_UNSUBACK;
+    return MQTTSuccess;
+}
+
+/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
+ * to get full coverage on handleIncomingAck by setting the type to CONNECT. */
+static MQTTStatus_t modifyIncomingPacket( MQTTTransportRecvFunc_t readFunc,
+                                          MQTTNetworkContext_t networkContext,
+                                          MQTTPacketInfo_t * pIncomingPacket,
+                                          int cmock_num_calls )
+{
+    /* Remove unused parameter warnings. */
+    ( void ) readFunc;
+    ( void ) networkContext;
+    ( void ) cmock_num_calls;
+
+    pIncomingPacket->type = currentPacketType;
+    return MQTTSuccess;
+}
+
+static void expectProcessLoopCalls( MQTTStatus_t deserializeStatus,
+                                    MQTTPublishState_t deserializeUpdatedState,
+                                    MQTTStatus_t serializeStatus,
+                                    MQTTPublishState_t serializeUpdatedState,
+                                    MQTTStatus_t processLoopStatus,
+                                    bool incomingPublish )
+{
+    MQTTStatus_t mqttStatus;
+    MQTTContext_t context;
+    MQTTTransportInterface_t transport;
+    MQTTFixedBuffer_t networkBuffer;
+    MQTTApplicationCallbacks_t callbacks;
+    bool expectMoreCalls = true;
+
+    setupTransportInterface( &transport );
+    setupCallbacks( &callbacks );
+    setupNetworkBuffer( &networkBuffer );
+
+    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+
+    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacket );
+
+    /* Note that this could be any packet type that isn't handled by MQTT_ProcessLoop
+     * such as MQTT_PACKET_TYPE_SUBSCRIBE. */
+    if( currentPacketType == MQTT_PACKET_TYPE_CONNECT )
+    {
+        expectMoreCalls = false;
+    }
+
+    if( expectMoreCalls )
+    {
+        if( incomingPublish )
+        {
+            MQTT_DeserializePublish_ExpectAnyArgsAndReturn( deserializeStatus );
+        }
+        else
+        {
+            MQTT_DeserializeAck_ExpectAnyArgsAndReturn( deserializeStatus );
+        }
+
+        if( ( deserializeStatus != MQTTSuccess ) ||
+            ( currentPacketType == MQTT_PACKET_TYPE_PINGRESP ) ||
+            ( currentPacketType == MQTT_PACKET_TYPE_SUBACK ) ||
+            ( currentPacketType == MQTT_PACKET_TYPE_UNSUBACK ) )
+        {
+            expectMoreCalls = false;
+        }
+    }
+
+    if( expectMoreCalls )
+    {
+        if( incomingPublish )
+        {
+            MQTT_UpdateStatePublish_ExpectAnyArgsAndReturn( deserializeUpdatedState );
+        }
+        else
+        {
+            MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( deserializeUpdatedState );
+        }
+
+        if( deserializeUpdatedState == MQTTPublishDone )
+        {
+            expectMoreCalls = false;
+        }
+    }
+
+    if( expectMoreCalls )
+    {
+        MQTT_SerializeAck_ExpectAnyArgsAndReturn( serializeStatus );
+
+        if( serializeStatus != MQTTSuccess )
+        {
+            expectMoreCalls = false;
+        }
+    }
+
+    if( expectMoreCalls )
+    {
+        MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( serializeUpdatedState );
+    }
+
+    /* Expect the above calls when running MQTT_ProcessLoop. */
+    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
+    TEST_ASSERT_EQUAL( processLoopStatus, mqttStatus );
+
+    if( mqttStatus = MQTTSuccess )
+    {
+        if( currentPacketType == MQTT_PACKET_TYPE_PUBLISH )
+        {
+            TEST_ASSERT_TRUE( context.controlPacketSent );
+        }
+
+        if( currentPacketType == MQTT_PACKET_TYPE_PINGRESP )
+        {
+            TEST_ASSERT_FALSE( context.waitingForPingResp );
+        }
+    }
 }
 
 /* ========================================================================== */
@@ -681,190 +928,23 @@ void test_MQTT_ProcessLoop_invalid_params( void )
     MQTT_ProcessLoop( NULL, MQTT_NO_TIMEOUT_MS );
 }
 
-/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
- * to get full coverage on handleIncomingPublish. */
-static MQTTStatus_t modifyIncomingPacketPublish( MQTTTransportRecvFunc_t readFunc,
-                                                 MQTTNetworkContext_t networkContext,
-                                                 MQTTPacketInfo_t * pIncomingPacket,
-                                                 int cmock_num_calls )
-{
-    /* Remove unsued parameter warnings. */
-    ( void ) readFunc;
-    ( void ) networkContext;
-    ( void ) cmock_num_calls;
-
-    pIncomingPacket->type = MQTT_PACKET_TYPE_PUBLISH;
-    return MQTTSuccess;
-}
-
-/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
- * to get full coverage on handleIncomingAck by setting the type to PUBACK. */
-static MQTTStatus_t modifyIncomingPacketPubAck( MQTTTransportRecvFunc_t readFunc,
-                                                MQTTNetworkContext_t networkContext,
-                                                MQTTPacketInfo_t * pIncomingPacket,
-                                                int cmock_num_calls )
-{
-    /* Remove unused parameter warnings. */
-    ( void ) readFunc;
-    ( void ) networkContext;
-    ( void ) cmock_num_calls;
-
-    pIncomingPacket->type = MQTT_PACKET_TYPE_PUBACK;
-    return MQTTSuccess;
-}
-
-/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
- * to get full coverage on handleIncomingAck by setting the type to PUBREC. */
-static MQTTStatus_t modifyIncomingPacketPubRec( MQTTTransportRecvFunc_t readFunc,
-                                                MQTTNetworkContext_t networkContext,
-                                                MQTTPacketInfo_t * pIncomingPacket,
-                                                int cmock_num_calls )
-{
-    /* Remove unsued parameter warnings. */
-    ( void ) readFunc;
-    ( void ) networkContext;
-    ( void ) cmock_num_calls;
-
-    pIncomingPacket->type = MQTT_PACKET_TYPE_PUBREC;
-    return MQTTSuccess;
-}
-
-/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
- * to get full coverage on handleIncomingAck by setting the type to PUBREL. */
-static MQTTStatus_t modifyIncomingPacketPubRel( MQTTTransportRecvFunc_t readFunc,
-                                                MQTTNetworkContext_t networkContext,
-                                                MQTTPacketInfo_t * pIncomingPacket,
-                                                int cmock_num_calls )
-{
-    /* Remove unused parameter warnings. */
-    ( void ) readFunc;
-    ( void ) networkContext;
-    ( void ) cmock_num_calls;
-
-    pIncomingPacket->type = MQTT_PACKET_TYPE_PUBREL;
-    return MQTTSuccess;
-}
-
-/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
- * to get full coverage on handleIncomingAck by setting the type to PUBCOMP. */
-static MQTTStatus_t modifyIncomingPacketPubComp( MQTTTransportRecvFunc_t readFunc,
-                                                 MQTTNetworkContext_t networkContext,
-                                                 MQTTPacketInfo_t * pIncomingPacket,
-                                                 int cmock_num_calls )
-{
-    /* Remove unused parameter warnings. */
-    ( void ) readFunc;
-    ( void ) networkContext;
-    ( void ) cmock_num_calls;
-
-    pIncomingPacket->type = MQTT_PACKET_TYPE_PUBCOMP;
-    return MQTTSuccess;
-}
-
-/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
- * to get full coverage on handleIncomingAck by setting the type to PINGRESP. */
-static MQTTStatus_t modifyIncomingPacketPingResp( MQTTTransportRecvFunc_t readFunc,
-                                                  MQTTNetworkContext_t networkContext,
-                                                  MQTTPacketInfo_t * pIncomingPacket,
-                                                  int cmock_num_calls )
-{
-    /* Remove unused parameter warnings. */
-    ( void ) readFunc;
-    ( void ) networkContext;
-    ( void ) cmock_num_calls;
-
-    pIncomingPacket->type = MQTT_PACKET_TYPE_PINGRESP;
-    return MQTTSuccess;
-}
-
-/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
- * to get full coverage on handleIncomingAck by setting the type to SUBACK. */
-static MQTTStatus_t modifyIncomingPacketSubAck( MQTTTransportRecvFunc_t readFunc,
-                                                MQTTNetworkContext_t networkContext,
-                                                MQTTPacketInfo_t * pIncomingPacket,
-                                                int cmock_num_calls )
-{
-    /* Remove unused parameter warnings. */
-    ( void ) readFunc;
-    ( void ) networkContext;
-    ( void ) cmock_num_calls;
-
-    pIncomingPacket->type = MQTT_PACKET_TYPE_SUBACK;
-    return MQTTSuccess;
-}
-
-/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
- * to get full coverage on handleIncomingAck by setting the type to UNSUBACK. */
-static MQTTStatus_t modifyIncomingPacketUnsubAck( MQTTTransportRecvFunc_t readFunc,
-                                                  MQTTNetworkContext_t networkContext,
-                                                  MQTTPacketInfo_t * pIncomingPacket,
-                                                  int cmock_num_calls )
-{
-    /* Remove unused parameter warnings. */
-    ( void ) readFunc;
-    ( void ) networkContext;
-    ( void ) cmock_num_calls;
-
-    pIncomingPacket->type = MQTT_PACKET_TYPE_UNSUBACK;
-    return MQTTSuccess;
-}
-
-/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
- * to get full coverage on handleIncomingAck by setting the type to CONNECT. */
-static MQTTStatus_t modifyIncomingPacketConnect( MQTTTransportRecvFunc_t readFunc,
-                                                 MQTTNetworkContext_t networkContext,
-                                                 MQTTPacketInfo_t * pIncomingPacket,
-                                                 int cmock_num_calls )
-{
-    /* Remove unused parameter warnings. */
-    ( void ) readFunc;
-    ( void ) networkContext;
-    ( void ) cmock_num_calls;
-
-    pIncomingPacket->type = MQTT_PACKET_TYPE_CONNECT;
-    return MQTTSuccess;
-}
-
 /**
  * @brief Test coverage for handleIncomingPublish by using a CMock callback to
  * modify incomingPacket.
  */
 void test_MQTT_ProcessLoop_handleIncomingPublish_happy_paths( void )
 {
-    MQTTStatus_t mqttStatus;
-    MQTTContext_t context;
-    MQTTTransportInterface_t transport;
-    MQTTFixedBuffer_t networkBuffer;
-    MQTTApplicationCallbacks_t callbacks;
-
-    setupTransportInterface( &transport );
-    setupCallbacks( &callbacks );
-    setupNetworkBuffer( &networkBuffer );
-
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
-    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
-
     /* Assume QoS = 1 so that a PUBACK will be sent after receiving PUBLISH. */
-    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketPublish );
-    MQTT_DeserializePublish_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_UpdateStatePublish_ExpectAnyArgsAndReturn( MQTTPubAckSend );
-    MQTT_SerializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTPublishDone );
-
-    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
-    TEST_ASSERT_TRUE( context.controlPacketSent );
-    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    currentPacketType = MQTT_PACKET_TYPE_PUBLISH;
+    expectProcessLoopCalls( MQTTSuccess, MQTTPubAckSend,
+                            MQTTSuccess, MQTTPublishDone,
+                            MQTTSuccess, true );
 
     /* Assume QoS = 2 so that a PUBREC will be sent after receiving PUBLISH. */
-    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketPublish );
-    MQTT_DeserializePublish_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_UpdateStatePublish_ExpectAnyArgsAndReturn( MQTTPubRecSend );
-    MQTT_SerializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTPubRecPending );
-
-    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
-    TEST_ASSERT_TRUE( context.controlPacketSent );
-    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    currentPacketType = MQTT_PACKET_TYPE_PUBLISH;
+    expectProcessLoopCalls( MQTTSuccess, MQTTPubRecSend,
+                            MQTTSuccess, MQTTPubRelPending,
+                            MQTTSuccess, true );
 }
 
 /**
@@ -873,57 +953,11 @@ void test_MQTT_ProcessLoop_handleIncomingPublish_happy_paths( void )
  */
 void test_MQTT_ProcessLoop_handleIncomingPublish_sad_paths( void )
 {
-    MQTTStatus_t mqttStatus;
-    MQTTContext_t context;
-    MQTTTransportInterface_t transport;
-    MQTTFixedBuffer_t networkBuffer;
-    MQTTApplicationCallbacks_t callbacks;
-
-    setupTransportInterface( &transport );
-    setupCallbacks( &callbacks );
-    setupNetworkBuffer( &networkBuffer );
-
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
-    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
-
     /* Verify that error is propagated when deserialization fails. */
-    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketPublish );
-    MQTT_DeserializePublish_ExpectAnyArgsAndReturn( MQTTBadResponse );
-
-    /* Run the method to test. */
-    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
-    TEST_ASSERT_EQUAL( MQTTBadResponse, mqttStatus );
-}
-
-void expectPacketPath()
-{
-    /* Mock the receiving of a PUBREC packet type through a callback. */
-    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketPubRec );
-    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTPubRelSend );
-    MQTT_SerializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTPubCompPending );
-}
-
-void test_MQTT_ProcessLoop_example( void )
-{
-    MQTTStatus_t mqttStatus;
-    MQTTContext_t context;
-    MQTTTransportInterface_t transport;
-    MQTTFixedBuffer_t networkBuffer;
-    MQTTApplicationCallbacks_t callbacks;
-
-    setupTransportInterface( &transport );
-    setupCallbacks( &callbacks );
-    setupNetworkBuffer( &networkBuffer );
-
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
-    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
-
-    expectPacketPath();
-
-    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
-    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    currentPacketType = MQTT_PACKET_TYPE_PUBLISH;
+    expectProcessLoopCalls( MQTTBadResponse, MQTTStateNull,
+                            MQTTBadResponse, MQTTStateNull,
+                            MQTTBadResponse, true );
 }
 
 /**
@@ -932,143 +966,90 @@ void test_MQTT_ProcessLoop_example( void )
  */
 void test_MQTT_ProcessLoop_handleIncomingAck_happy_paths( void )
 {
-    MQTTStatus_t mqttStatus;
-    MQTTContext_t context;
-    MQTTTransportInterface_t transport;
-    MQTTFixedBuffer_t networkBuffer;
-    MQTTApplicationCallbacks_t callbacks;
-
-    setupTransportInterface( &transport );
-    setupCallbacks( &callbacks );
-    setupNetworkBuffer( &networkBuffer );
-
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
-    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
-
     /* Mock the receiving of a PUBACK packet type through a callback. */
-    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketPubAck );
-    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTPublishDone );
-
-    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
-    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    currentPacketType = MQTT_PACKET_TYPE_PUBACK;
+    expectProcessLoopCalls( MQTTSuccess, MQTTPublishDone,
+                            MQTTSuccess, MQTTPublishDone,
+                            MQTTSuccess, false );
 
     /* Mock the receiving of a PUBREC packet type through a callback. */
-    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketPubRec );
-    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTPubRelSend );
-    MQTT_SerializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTPubCompPending );
-
-    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
-    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    currentPacketType = MQTT_PACKET_TYPE_PUBREC;
+    expectProcessLoopCalls( MQTTSuccess, MQTTPubRelSend,
+                            MQTTSuccess, MQTTPubCompPending,
+                            MQTTSuccess, false );
 
     /* Mock the receiving of a PUBREL packet type through a callback. */
-    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketPubRel );
-    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTPubCompSend );
-    MQTT_SerializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTPublishDone );
-
-    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
-    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    currentPacketType = MQTT_PACKET_TYPE_PUBREL;
+    expectProcessLoopCalls( MQTTSuccess, MQTTPubCompSend,
+                            MQTTSuccess, MQTTPublishDone,
+                            MQTTSuccess, false );
 
     /* Mock the receiving of a PUBCOMP packet type through a callback. */
-    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketPubComp );
-    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTPublishDone );
-
-    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
-    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    currentPacketType = MQTT_PACKET_TYPE_PUBCOMP;
+    expectProcessLoopCalls( MQTTSuccess, MQTTPublishDone,
+                            MQTTSuccess, MQTTPublishDone,
+                            MQTTSuccess, false );
 
     /* Mock the receiving of a PINGRESP packet type through a callback. */
-    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketPingResp );
-    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
-    /* Run the method to test. */
-    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
-    TEST_ASSERT_FALSE( context.waitingForPingResp );
-    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    currentPacketType = MQTT_PACKET_TYPE_PINGRESP;
+    expectProcessLoopCalls( MQTTSuccess, MQTTStateNull,
+                            MQTTSuccess, MQTTStateNull,
+                            MQTTSuccess, false );
 
     /* Mock the receiving of a SUBACK packet type through a callback. */
-    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketSubAck );
-    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
-    /* Run the method to test. */
-    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
-    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    currentPacketType = MQTT_PACKET_TYPE_SUBACK;
+    expectProcessLoopCalls( MQTTSuccess, MQTTStateNull,
+                            MQTTSuccess, MQTTStateNull,
+                            MQTTSuccess, false );
 
     /* Mock the receiving of an UNSUBACK packet type through a callback. */
-    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketUnsubAck );
-    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
-    /* Run the method to test. */
-    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
-    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    currentPacketType = MQTT_PACKET_TYPE_UNSUBACK;
+    expectProcessLoopCalls( MQTTSuccess, MQTTStateNull,
+                            MQTTSuccess, MQTTStateNull,
+                            MQTTSuccess, false );
 }
 
 void test_MQTT_ProcessLoop_handleIncomingAck_sad_paths( void )
 {
-    MQTTStatus_t mqttStatus;
-    MQTTContext_t context;
-    MQTTTransportInterface_t transport;
-    MQTTFixedBuffer_t networkBuffer;
-    MQTTApplicationCallbacks_t callbacks;
-
-    setupTransportInterface( &transport );
-    setupCallbacks( &callbacks );
-    setupNetworkBuffer( &networkBuffer );
-
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
-    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
-
     /* Verify that error is propagated when deserialization fails upon
      * receiving a CONNECT or some other unknown packet type. */
-    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketConnect );
-    /* Run the method to test. */
-    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
-    TEST_ASSERT_EQUAL( MQTTBadResponse, mqttStatus );
+    currentPacketType = MQTT_PACKET_TYPE_CONNECT;
+    expectProcessLoopCalls( MQTTBadResponse, MQTTStateNull,
+                            MQTTBadResponse, MQTTStateNull,
+                            MQTTBadResponse, false );
 
     /* Verify that error is propagated when serialization fails upon
      * receiving a PUBREC then sending a PUBREL. */
-    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketPubRec );
-    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTPubRelSend );
-    MQTT_SerializeAck_ExpectAnyArgsAndReturn( MQTTNoMemory );
-    /* Run the method to test. */
-    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
-    TEST_ASSERT_EQUAL( MQTTSendFailed, mqttStatus );
+    currentPacketType = MQTT_PACKET_TYPE_PUBREC;
+    expectProcessLoopCalls( MQTTSuccess, MQTTPubRelSend,
+                            MQTTNoMemory, MQTTStateNull,
+                            MQTTSendFailed, false );
 
     /* Verify that error is propagated when deserialization fails upon
      * receiving a PUBACK. */
-    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketPubAck );
-    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTBadResponse );
-    /* Run the method to test. */
-    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
-    TEST_ASSERT_EQUAL( MQTTBadResponse, mqttStatus );
+    currentPacketType = MQTT_PACKET_TYPE_PUBACK;
+    expectProcessLoopCalls( MQTTBadResponse, MQTTStateNull,
+                            MQTTBadResponse, MQTTStateNull,
+                            MQTTBadResponse, false );
 
     /* Verify that error is propagated when deserialization fails upon
      * receiving a PINGRESP. */
-    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketPingResp );
-    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTBadResponse );
-    /* Run the method to test. */
-    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
-    TEST_ASSERT_FALSE( context.waitingForPingResp );
-    TEST_ASSERT_EQUAL( MQTTBadResponse, mqttStatus );
+    currentPacketType = MQTT_PACKET_TYPE_PINGRESP;
+    expectProcessLoopCalls( MQTTBadResponse, MQTTStateNull,
+                            MQTTBadResponse, MQTTStateNull,
+                            MQTTBadResponse, false );
 
     /* Verify that error is propagated when deserialization fails upon
      * receiving a SUBACK. */
-    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketSubAck );
-    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTBadResponse );
-    /* Run the method to test. */
-    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
-    TEST_ASSERT_EQUAL( MQTTBadResponse, mqttStatus );
+    currentPacketType = MQTT_PACKET_TYPE_SUBACK;
+    expectProcessLoopCalls( MQTTBadResponse, MQTTStateNull,
+                            MQTTBadResponse, MQTTStateNull,
+                            MQTTBadResponse, false );
 
     /* Verify that MQTTIllegalState is returned if MQTT_UpdateStateAck(...)
      * provides an unknown state such as MQTTStateNull to sendPublishAcks(...). */
-    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketPubRec );
-    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTPubRelSend );
-    MQTT_SerializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTStateNull );
-    /* Run the method to test. */
-    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
-    TEST_ASSERT_EQUAL( MQTTIllegalState, mqttStatus );
+    currentPacketType = MQTT_PACKET_TYPE_PUBREC;
+    expectProcessLoopCalls( MQTTSuccess, MQTTPubRelSend,
+                            MQTTSuccess, MQTTStateNull,
+                            MQTTIllegalState, false );
 }

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -993,7 +993,7 @@ void test_MQTT_GetPacketId( void )
 /**
  * @brief Test that NULL pContext causes MQTT_ProcessLoop to return MQTTBadParameter.
  */
-void test_MQTT_ProcessLoop_invalid_params( void )
+void test_MQTT_ProcessLoop_Invalid_Params( void )
 {
     MQTTStatus_t mqttStatus = MQTT_ProcessLoop( NULL, MQTT_NO_TIMEOUT_MS );
 
@@ -1005,7 +1005,7 @@ void test_MQTT_ProcessLoop_invalid_params( void )
  * handleIncomingPublish(...),
  * that results in the process loop returning successfully.
  */
-void test_MQTT_ProcessLoop_handleIncomingPublish_happy_paths( void )
+void test_MQTT_ProcessLoop_handleIncomingPublish_Happy_Paths( void )
 {
     MQTTStatus_t mqttStatus;
     MQTTContext_t context;
@@ -1040,7 +1040,7 @@ void test_MQTT_ProcessLoop_handleIncomingPublish_happy_paths( void )
  * handleIncomingPublish(...),
  * that results in the process loop returning an error.
  */
-void test_MQTT_ProcessLoop_handleIncomingPublish_error_paths( void )
+void test_MQTT_ProcessLoop_handleIncomingPublish_Error_Paths( void )
 {
     MQTTStatus_t mqttStatus;
     MQTTContext_t context;
@@ -1071,7 +1071,7 @@ void test_MQTT_ProcessLoop_handleIncomingPublish_error_paths( void )
  * handleIncomingAck(...),
  * that results in the process loop returning successfully.
  */
-void test_MQTT_ProcessLoop_handleIncomingAck_happy_paths( void )
+void test_MQTT_ProcessLoop_handleIncomingAck_Happy_Paths( void )
 {
     MQTTStatus_t mqttStatus;
     MQTTContext_t context;
@@ -1143,7 +1143,7 @@ void test_MQTT_ProcessLoop_handleIncomingAck_happy_paths( void )
  * handleIncomingAck(...),
  * that results in the process loop returning an error.
  */
-void test_MQTT_ProcessLoop_handleIncomingAck_error_paths( void )
+void test_MQTT_ProcessLoop_handleIncomingAck_Error_Paths( void )
 {
     MQTTStatus_t mqttStatus;
     MQTTContext_t context;
@@ -1208,7 +1208,7 @@ void test_MQTT_ProcessLoop_handleIncomingAck_error_paths( void )
  * handleKeepAlive(...),
  * that results in the process loop returning successfully.
  */
-void test_MQTT_ProcessLoop_handleKeepAlive_happy_paths( void )
+void test_MQTT_ProcessLoop_handleKeepAlive_Happy_Paths( void )
 {
     MQTTStatus_t mqttStatus;
     MQTTContext_t context;
@@ -1271,7 +1271,7 @@ void test_MQTT_ProcessLoop_handleKeepAlive_happy_paths( void )
  * handleKeepAlive(...),
  * that results in the process loop returning an error.
  */
-void test_MQTT_ProcessLoop_handleKeepAlive_error_paths( void )
+void test_MQTT_ProcessLoop_handleKeepAlive_Error_Paths( void )
 {
     MQTTStatus_t mqttStatus;
     MQTTContext_t context;
@@ -1302,7 +1302,7 @@ void test_MQTT_ProcessLoop_handleKeepAlive_error_paths( void )
  * iterations of the process loop, resulting in returning MQTTRecvFailed.
  * This allows us to have full branch and line coverage.
  */
-void test_MQTT_ProcessLoop_multiple_iterations( void )
+void test_MQTT_ProcessLoop_Multiple_Iterations( void )
 {
     MQTTStatus_t mqttStatus;
     MQTTContext_t context;

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -887,6 +887,8 @@ void test_MQTT_GetPacketId( void )
     TEST_ASSERT_EQUAL_INT( 1, mqttContext.nextPacketId );
 }
 
+/* ========================================================================== */
+
 /**
  * @brief Test that NULL pContext causes MQTT_ProcessLoop to return MQTTBadParameter.
  */

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -1161,8 +1161,8 @@ void test_MQTT_ProcessLoop_handleIncomingAck_error_paths( void )
                             MQTTBadResponse, MQTTStateNull,
                             MQTTBadResponse, false );
 
-    /* Verify that MQTTSendFailed is propagated when serialization fails upon
-     * receiving a PUBREC then responding with a PUBREL. */
+    /* Verify that MQTTSendFailed is propagated when receiving a PUBREC
+     * then failing when serializing a PUBREL to send in response. */
     currentPacketType = MQTT_PACKET_TYPE_PUBREC;
     expectProcessLoopCalls( &context, MQTTSuccess, MQTTPubRelSend,
                             MQTTNoMemory, MQTTStateNull,

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -72,6 +72,7 @@
  */
 #define MQTT_TIMER_OVERFLOW_TIMEOUT_MS      ( 10 )
 
+#define MQTT_SAMPLE_TRANSPORT_INTERFACE     ( 0 )
 
 /**
  * @brief The packet type to be received by the process loop.
@@ -168,7 +169,6 @@ static void eventCallback( MQTTContext_t * pContext,
                            uint16_t packetIdentifier,
                            MQTTPublishInfo_t * pPublishInfo )
 {
-    ( void ) pContext;
     ( void ) pPacketInfo;
     ( void ) packetIdentifier;
     ( void ) pPublishInfo;
@@ -191,7 +191,7 @@ static int32_t transportSendSuccess( MQTTNetworkContext_t pContext,
                                      const void * pBuffer,
                                      size_t bytesToWrite )
 {
-    ( void ) pContext;
+    TEST_ASSERT_EQUAL( MQTT_SAMPLE_TRANSPORT_INTERFACE, pContext );
     ( void ) pBuffer;
     return bytesToWrite;
 }
@@ -216,7 +216,7 @@ static int32_t transportRecvSuccess( MQTTNetworkContext_t pContext,
                                      void * pBuffer,
                                      size_t bytesToRead )
 {
-    ( void ) pContext;
+    TEST_ASSERT_EQUAL( MQTT_SAMPLE_TRANSPORT_INTERFACE, pContext );
     ( void ) pBuffer;
     return bytesToRead;
 }
@@ -252,7 +252,7 @@ static int32_t transportRecvOneByte( MQTTNetworkContext_t pContext,
  */
 static void setupTransportInterface( MQTTTransportInterface_t * pTransport )
 {
-    pTransport->networkContext = 0;
+    pTransport->networkContext = MQTT_SAMPLE_TRANSPORT_INTERFACE;
     pTransport->send = transportSendSuccess;
     pTransport->recv = transportRecvSuccess;
 }
@@ -904,13 +904,17 @@ void test_MQTT_ProcessLoop_handleIncomingPublish_Happy_Paths( void )
 
     modifyIncomingPacketStatus = MQTTSuccess;
 
-    /* Assume QoS = 1 so that a PUBACK will be sent after receiving PUBLISH. */
+    /* Assume QoS = 1 so that a PUBACK will be sent after receiving PUBLISH.
+     * That is, expectProcessLoopCalls will take on the following parameters:
+     * incomingPublish=true and stateAfterDeserialize=MQTTPubAckSend. */
     currentPacketType = MQTT_PACKET_TYPE_PUBLISH;
     expectProcessLoopCalls( &context, MQTTSuccess, MQTTPubAckSend,
                             MQTTSuccess, MQTTPublishDone,
                             MQTTSuccess, true );
 
-    /* Assume QoS = 2 so that a PUBREC will be sent after receiving PUBLISH. */
+    /* Assume QoS = 2 so that a PUBREC will be sent after receiving PUBLISH.
+     * That is, expectProcessLoopCalls will take on the following parameters:
+     * incomingPublish=true and stateAfterDeserialize=MQTTPubRecSend. */
     currentPacketType = MQTT_PACKET_TYPE_PUBLISH;
     expectProcessLoopCalls( &context, MQTTSuccess, MQTTPubRecSend,
                             MQTTSuccess, MQTTPubRelPending,

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -3,9 +3,6 @@
 
 #include "unity.h"
 
-#include "mock_mqtt_state.h"
-#include "mock_mqtt_lightweight.h"
-
 /* Include paths for public enums, structures, and macros. */
 #include "mqtt.h"
 
@@ -699,6 +696,103 @@ static MQTTStatus_t modifyIncomingPacketPublish( MQTTTransportRecvFunc_t readFun
     return MQTTSuccess;
 }
 
+/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
+ * to get full coverage on handleIncomingAck by setting the type to PUBACK. */
+static MQTTStatus_t modifyIncomingPacketPubAck( MQTTTransportRecvFunc_t readFunc,
+                                                MQTTNetworkContext_t networkContext,
+                                                MQTTPacketInfo_t * pIncomingPacket,
+                                                int cmock_num_calls )
+{
+    /* Remove unsued parameter warnings. */
+    ( void ) readFunc;
+    ( void ) networkContext;
+    ( void ) cmock_num_calls;
+
+    pIncomingPacket->type = MQTT_PACKET_TYPE_PUBACK;
+    return MQTTSuccess;
+}
+
+/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
+ * to get full coverage on handleIncomingAck by setting the type to PUBREC. */
+static MQTTStatus_t modifyIncomingPacketPubRec( MQTTTransportRecvFunc_t readFunc,
+                                                MQTTNetworkContext_t networkContext,
+                                                MQTTPacketInfo_t * pIncomingPacket,
+                                                int cmock_num_calls )
+{
+    /* Remove unsued parameter warnings. */
+    ( void ) readFunc;
+    ( void ) networkContext;
+    ( void ) cmock_num_calls;
+
+    pIncomingPacket->type = MQTT_PACKET_TYPE_PUBREC;
+    return MQTTSuccess;
+}
+
+/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
+ * to get full coverage on handleIncomingAck by setting the type to PUBREL. */
+static MQTTStatus_t modifyIncomingPacketPubRel( MQTTTransportRecvFunc_t readFunc,
+                                                MQTTNetworkContext_t networkContext,
+                                                MQTTPacketInfo_t * pIncomingPacket,
+                                                int cmock_num_calls )
+{
+    /* Remove unsued parameter warnings. */
+    ( void ) readFunc;
+    ( void ) networkContext;
+    ( void ) cmock_num_calls;
+
+    pIncomingPacket->type = MQTT_PACKET_TYPE_PUBREL;
+    return MQTTSuccess;
+}
+
+/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
+ * to get full coverage on handleIncomingAck by setting the type to PUBCOMP. */
+static MQTTStatus_t modifyIncomingPacketPubComp( MQTTTransportRecvFunc_t readFunc,
+                                                 MQTTNetworkContext_t networkContext,
+                                                 MQTTPacketInfo_t * pIncomingPacket,
+                                                 int cmock_num_calls )
+{
+    /* Remove unsued parameter warnings. */
+    ( void ) readFunc;
+    ( void ) networkContext;
+    ( void ) cmock_num_calls;
+
+    pIncomingPacket->type = MQTT_PACKET_TYPE_PUBCOMP;
+    return MQTTSuccess;
+}
+
+/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
+ * to get full coverage on handleIncomingAck by setting the type to PINGRESP. */
+static MQTTStatus_t modifyIncomingPacketPingResp( MQTTTransportRecvFunc_t readFunc,
+                                                  MQTTNetworkContext_t networkContext,
+                                                  MQTTPacketInfo_t * pIncomingPacket,
+                                                  int cmock_num_calls )
+{
+    /* Remove unsued parameter warnings. */
+    ( void ) readFunc;
+    ( void ) networkContext;
+    ( void ) cmock_num_calls;
+
+    pIncomingPacket->type = MQTT_PACKET_TYPE_PINGRESP;
+    return MQTTSuccess;
+}
+
+
+/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
+ * to get full coverage on handleIncomingAck by setting the type to SUBACK. */
+static MQTTStatus_t modifyIncomingPacketSubAck( MQTTTransportRecvFunc_t readFunc,
+                                                MQTTNetworkContext_t networkContext,
+                                                MQTTPacketInfo_t * pIncomingPacket,
+                                                int cmock_num_calls )
+{
+    /* Remove unsued parameter warnings. */
+    ( void ) readFunc;
+    ( void ) networkContext;
+    ( void ) cmock_num_calls;
+
+    pIncomingPacket->type = MQTT_PACKET_TYPE_SUBACK;
+    return MQTTSuccess;
+}
+
 /**
  * @brief Test coverage for handleIncomingPublish by using a CMock callback to
  * modify incomingPacket.
@@ -713,15 +807,77 @@ void test_MQTT_ProcessLoop_handleIncomingPublish( void )
 
     setupTransportInterface( &transport );
     setupCallbacks( &callbacks );
+    setupNetworkBuffer( &networkBuffer );
 
     mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
 
     MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketPublish );
-    MQTT_DeserializePublish_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_UpdateStatePublish_ExpectAnyArgsAndReturn( MQTTSuccess );
+    /*MQTT_DeserializePublish_ExpectAnyArgsAndReturn( MQTTSuccess ); */
+    MQTT_DeserializePublish_Expect();
+    MQTT_UpdateStatePublish_ExpectAnyArgsAndReturn( MQTTPubAckSend );
+    MQTT_SerializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
+    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTPublishDone );
 
     mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
+    TEST_ASSERT_TRUE( context.controlPacketSent );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+}
 
+/**
+ * @brief Test coverage for handleIncomingAck by using a CMock callback to
+ * modify incomingPacket.
+ */
+void test_MQTT_ProcessLoop_handleIncomingAck( void )
+{
+    MQTTStatus_t mqttStatus;
+    MQTTContext_t context;
+    MQTTTransportInterface_t transport;
+    MQTTFixedBuffer_t networkBuffer;
+    MQTTApplicationCallbacks_t callbacks;
+
+    setupTransportInterface( &transport );
+    setupCallbacks( &callbacks );
+    setupNetworkBuffer( &networkBuffer );
+
+    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+
+    /* Mock the receiving of a PUBACK packet type through a callback. */
+    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketPubAck );
+    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
+    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTPublishDone );
+
+    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+
+    /* Mock the receiving of a PUBREC packet type through a callback. */
+    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketPubRec );
+    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
+    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTPubRelSend );
+    MQTT_SerializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
+    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTPubCompPending );
+
+    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+
+    /* Mock the receiving of a PUBREL packet type through a callback. */
+    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketPubRel );
+    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
+    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTPubCompSend );
+    MQTT_SerializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
+    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTPublishDone );
+
+    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+
+    /* Mock the receiving of a PUBCOMP packet type through a callback. */
+    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketPubComp );
+    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
+    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTPublishDone );
+    MQTT_SerializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
+    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTStateNull );
+
+    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
 }

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -163,6 +163,12 @@ static void setupNetworkBuffer( MQTTFixedBuffer_t * const pNetworkBuffer )
 
 /**
  * @brief Mocked MQTT event callback.
+ *
+ * @param[in] pContext MQTT context pointer.
+ * @param[in] pPacketInfo Packet Info pointer for the incoming packet.
+ * @param[in] packetIdentifier Packet identifier of the incoming packet.
+ * @param[in] pPublishInfo Deserialized publish info pointer for the incoming
+ * packet.
  */
 static void eventCallback( MQTTContext_t * pContext,
                            MQTTPacketInfo_t * pPacketInfo,
@@ -186,6 +192,13 @@ static uint32_t getTime( void )
 
 /**
  * @brief Mocked successful transport send.
+ *
+ * @param[in] tcpSocket TCP socket.
+ * @param[in] pMessage Data to send.
+ * @param[in] bytesToWrite Length of data to send.
+ *
+ * @return Number of bytes sent; negative value on error;
+ * 0 for timeout or 0 bytes sent.
  */
 static int32_t transportSendSuccess( MQTTNetworkContext_t pContext,
                                      const void * pBuffer,
@@ -211,6 +224,12 @@ static int32_t transportSendFailure( MQTTNetworkContext_t pContext,
 
 /**
  * @brief Mocked successful transport read.
+ *
+ * @param[in] tcpSocket TCP socket.
+ * @param[out] pBuffer Buffer for receiving data.
+ * @param[in] bytesToRead Size of pBuffer.
+ *
+ * @return Number of bytes received; negative value on error.
  */
 static int32_t transportRecvSuccess( MQTTNetworkContext_t pContext,
                                      void * pBuffer,
@@ -249,6 +268,8 @@ static int32_t transportRecvOneByte( MQTTNetworkContext_t pContext,
 /**
  * @brief Initialize the transport interface with the mocked functions for
  * send and receive.
+ *
+ * @brief param[in] pTransport The transport interface to use with the context.
  */
 static void setupTransportInterface( MQTTTransportInterface_t * pTransport )
 {
@@ -260,6 +281,8 @@ static void setupTransportInterface( MQTTTransportInterface_t * pTransport )
 /**
  * @brief Initialize our event and time callback with the mocked functions
  * defined for the purposes this test.
+ *
+ * @brief param[in] pCallbacks Callbacks to use with the context.
  */
 static void setupCallbacks( MQTTApplicationCallbacks_t * pCallbacks )
 {
@@ -1202,9 +1225,9 @@ void test_MQTT_ProcessLoop_Receive_Failed( void )
 }
 
 /**
- * @brief This test mocks a failing transport receive and runs multiple
- * iterations of the process loop, resulting in returning MQTTRecvFailed.
- * This allows us to have full branch and line coverage.
+ * @brief Set the initial entry time close to the maximum value, causing
+ * an overflow. This test then checks that the process loop still runs for the
+ * expected number of iterations in spite of this.
  */
 void test_MQTT_ProcessLoop_Timer_Overflow( void )
 {

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -404,9 +404,9 @@ static MQTTStatus_t modifyPacketSize( size_t * pPacketSize,
  */
 static void expectProcessLoopCalls( MQTTContext_t * const pContext,
                                     MQTTStatus_t deserializeStatus,
-                                    MQTTPublishState_t updatedStateAfterDeserialize,
+                                    MQTTPublishState_t stateAfterDeserialize,
                                     MQTTStatus_t serializeStatus,
-                                    MQTTPublishState_t updatedStateAfterSerialize,
+                                    MQTTPublishState_t stateAfterSerialize,
                                     MQTTStatus_t processLoopStatus,
                                     bool incomingPublish )
 {
@@ -467,14 +467,14 @@ static void expectProcessLoopCalls( MQTTContext_t * const pContext,
     {
         if( incomingPublish )
         {
-            MQTT_UpdateStatePublish_ExpectAnyArgsAndReturn( updatedStateAfterDeserialize );
+            MQTT_UpdateStatePublish_ExpectAnyArgsAndReturn( stateAfterDeserialize );
         }
         else
         {
-            MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( updatedStateAfterDeserialize );
+            MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( stateAfterDeserialize );
         }
 
-        if( updatedStateAfterDeserialize == MQTTPublishDone )
+        if( stateAfterDeserialize == MQTTPublishDone )
         {
             expectMoreCalls = false;
         }
@@ -496,7 +496,7 @@ static void expectProcessLoopCalls( MQTTContext_t * const pContext,
     /* Update the state based on the sent packet. */
     if( expectMoreCalls )
     {
-        MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( updatedStateAfterSerialize );
+        MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( stateAfterSerialize );
     }
 
     /* Expect the above calls when running MQTT_ProcessLoop. */

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -72,7 +72,10 @@
  */
 #define MQTT_TIMER_OVERFLOW_TIMEOUT_MS      ( 10 )
 
-#define MQTT_SAMPLE_TRANSPORT_INTERFACE     ( 0 )
+/**
+ * @brief A sample network context that we set to NULL.
+ */
+#define MQTT_SAMPLE_NETWORK_CONTEXT         ( 0 )
 
 /**
  * @brief The packet type to be received by the process loop.
@@ -204,7 +207,7 @@ static int32_t transportSendSuccess( MQTTNetworkContext_t pContext,
                                      const void * pBuffer,
                                      size_t bytesToWrite )
 {
-    TEST_ASSERT_EQUAL( MQTT_SAMPLE_TRANSPORT_INTERFACE, pContext );
+    TEST_ASSERT_EQUAL( MQTT_SAMPLE_NETWORK_CONTEXT, pContext );
     ( void ) pBuffer;
     return bytesToWrite;
 }
@@ -235,7 +238,7 @@ static int32_t transportRecvSuccess( MQTTNetworkContext_t pContext,
                                      void * pBuffer,
                                      size_t bytesToRead )
 {
-    TEST_ASSERT_EQUAL( MQTT_SAMPLE_TRANSPORT_INTERFACE, pContext );
+    TEST_ASSERT_EQUAL( MQTT_SAMPLE_NETWORK_CONTEXT, pContext );
     ( void ) pBuffer;
     return bytesToRead;
 }
@@ -273,7 +276,7 @@ static int32_t transportRecvOneByte( MQTTNetworkContext_t pContext,
  */
 static void setupTransportInterface( MQTTTransportInterface_t * pTransport )
 {
-    pTransport->networkContext = MQTT_SAMPLE_TRANSPORT_INTERFACE;
+    pTransport->networkContext = MQTT_SAMPLE_NETWORK_CONTEXT;
     pTransport->send = transportSendSuccess;
     pTransport->recv = transportRecvSuccess;
 }

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -890,4 +890,35 @@ void test_MQTT_ProcessLoop_handleIncomingAck( void )
 
     mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+
+
+    /* Mock the receiving of a PINGRESP packet type through a callback. */
+    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketPingResp );
+    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
+    /* Run the method to test. */
+    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
+    TEST_ASSERT_FALSE( context.waitingForPingResp );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    /* Verify that error is propagated when deserialization fails. */
+    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketPingResp );
+    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTBadResponse );
+    /* Run the method to test. */
+    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
+    TEST_ASSERT_FALSE( context.waitingForPingResp );
+    TEST_ASSERT_EQUAL( MQTTBadResponse, mqttStatus );
+
+
+    /* Mock the receiving of a SUBACK packet type through a callback. */
+    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketSubAck );
+    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
+    /* Run the method to test. */
+    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    /* Verify that error is propagated when deserialization fails. */
+    MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacketSubAck );
+    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTBadResponse );
+    /* Run the method to test. */
+    mqttStatus = MQTT_ProcessLoop( &context, MQTT_NO_TIMEOUT_MS );
+    TEST_ASSERT_FALSE( context.waitingForPingResp );
+    TEST_ASSERT_EQUAL( MQTTBadResponse, mqttStatus );
 }

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -12,43 +12,43 @@
 /**
  * @brief A valid starting packet ID per MQTT spec. Start from 1.
  */
-#define MQTT_NEXT_PACKET_ID_START    ( 1 )
+#define MQTT_FIRST_VALID_PACKET_ID    ( 1 )
 
 /**
  * @brief A PINGREQ packet is always 2 bytes in size, defined by MQTT 3.1.1 spec.
  */
-#define MQTT_PACKET_PINGREQ_SIZE     ( 2U )
+#define MQTT_PACKET_PINGREQ_SIZE      ( 2U )
 
 /**
  * @brief A packet type not handled by MQTT_ProcessLoop.
  */
-#define MQTT_PACKET_TYPE_INVALID     ( 0U )
+#define MQTT_PACKET_TYPE_INVALID      ( 0U )
 
 /**
  * @brief Number of milliseconds in a second.
  */
-#define MQTT_ONE_SECOND_TO_MS        ( 1000U )
+#define MQTT_ONE_SECOND_TO_MS         ( 1000U )
 
 /**
  * @brief Length of the MQTT network buffer.
  */
-#define MQTT_TEST_BUFFER_LENGTH      ( 128 )
+#define MQTT_TEST_BUFFER_LENGTH       ( 128 )
 
 /**
  * @brief Length of time spent for single test case with
  * multiple iterations spent in the process loop for coverage.
  */
-#define MQTT_SAMPLE_TIMEOUT_MS       ( 1U )
+#define MQTT_SAMPLE_TIMEOUT_MS        ( 1U )
 
 /**
  * @brief Zero timeout in the process loop implies one iteration.
  */
-#define MQTT_NO_TIMEOUT_MS           ( 0U )
+#define MQTT_NO_TIMEOUT_MS            ( 0U )
 
 /**
  * @brief Sample length of remaining serialized data.
  */
-#define SAMPLE_REMAINING_LENGTH      ( 64 )
+#define SAMPLE_REMAINING_LENGTH       ( 64 )
 
 /**
  * @brief The packet type to be received by the process loop.
@@ -102,31 +102,6 @@ int suiteTearDown( int numFailures )
 /* ========================================================================== */
 
 /**
- * @brief Mock successful transport send, and write data into buffer for
- * verification.
- */
-static int32_t mockSend( MQTTNetworkContext_t context,
-                         const void * pMessage,
-                         size_t bytesToSend )
-{
-    const uint8_t * buffer = ( const uint8_t * ) pMessage;
-    /* Treat network context as pointer to buffer for mocking. */
-    uint8_t * mockNetwork = ( *( uint8_t ** ) context );
-    size_t bytesSent = 0;
-
-    while( bytesSent++ < bytesToSend )
-    {
-        /* Write single byte and advance buffer. */
-        *mockNetwork++ = *buffer++;
-    }
-
-    /* Move stream by bytes sent. */
-    ( *( uint8_t ** ) context ) = mockNetwork;
-
-    return bytesToSend;
-}
-
-/**
  * @brief Initialize pNetworkBuffer using static buffer.
  *
  * @param[in] pNetworkBuffer Network buffer provided for the context.
@@ -159,6 +134,31 @@ static void eventCallback( MQTTContext_t * pContext,
 static uint32_t getTime( void )
 {
     return globalEntryTime++;
+}
+
+/**
+ * @brief Mock successful transport send, and write data into buffer for
+ * verification.
+ */
+static int32_t mockSend( MQTTNetworkContext_t context,
+                         const void * pMessage,
+                         size_t bytesToSend )
+{
+    const uint8_t * buffer = ( const uint8_t * ) pMessage;
+    /* Treat network context as pointer to buffer for mocking. */
+    uint8_t * mockNetwork = ( *( uint8_t ** ) context );
+    size_t bytesSent = 0;
+
+    while( bytesSent++ < bytesToSend )
+    {
+        /* Write single byte and advance buffer. */
+        *mockNetwork++ = *buffer++;
+    }
+
+    /* Move stream by bytes sent. */
+    ( *( uint8_t ** ) context ) = mockNetwork;
+
+    return bytesToSend;
 }
 
 /**
@@ -245,134 +245,6 @@ static void setupCallbacks( MQTTApplicationCallbacks_t * pCallbacks )
 }
 
 /* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
- * to get full coverage on handleIncomingPublish. */
-static MQTTStatus_t modifyIncomingPacketPublish( MQTTTransportRecvFunc_t readFunc,
-                                                 MQTTNetworkContext_t networkContext,
-                                                 MQTTPacketInfo_t * pIncomingPacket,
-                                                 int cmock_num_calls )
-{
-    /* Remove unsued parameter warnings. */
-    ( void ) readFunc;
-    ( void ) networkContext;
-    ( void ) cmock_num_calls;
-
-    pIncomingPacket->type = MQTT_PACKET_TYPE_PUBLISH;
-    return MQTTSuccess;
-}
-
-/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
- * to get full coverage on handleIncomingAck by setting the type to PUBACK. */
-static MQTTStatus_t modifyIncomingPacketPubAck( MQTTTransportRecvFunc_t readFunc,
-                                                MQTTNetworkContext_t networkContext,
-                                                MQTTPacketInfo_t * pIncomingPacket,
-                                                int cmock_num_calls )
-{
-    /* Remove unused parameter warnings. */
-    ( void ) readFunc;
-    ( void ) networkContext;
-    ( void ) cmock_num_calls;
-
-    pIncomingPacket->type = MQTT_PACKET_TYPE_PUBACK;
-    return MQTTSuccess;
-}
-
-/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
- * to get full coverage on handleIncomingAck by setting the type to PUBREC. */
-static MQTTStatus_t modifyIncomingPacketPubRec( MQTTTransportRecvFunc_t readFunc,
-                                                MQTTNetworkContext_t networkContext,
-                                                MQTTPacketInfo_t * pIncomingPacket,
-                                                int cmock_num_calls )
-{
-    /* Remove unsued parameter warnings. */
-    ( void ) readFunc;
-    ( void ) networkContext;
-    ( void ) cmock_num_calls;
-
-    pIncomingPacket->type = MQTT_PACKET_TYPE_PUBREC;
-    return MQTTSuccess;
-}
-
-/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
- * to get full coverage on handleIncomingAck by setting the type to PUBREL. */
-static MQTTStatus_t modifyIncomingPacketPubRel( MQTTTransportRecvFunc_t readFunc,
-                                                MQTTNetworkContext_t networkContext,
-                                                MQTTPacketInfo_t * pIncomingPacket,
-                                                int cmock_num_calls )
-{
-    /* Remove unused parameter warnings. */
-    ( void ) readFunc;
-    ( void ) networkContext;
-    ( void ) cmock_num_calls;
-
-    pIncomingPacket->type = MQTT_PACKET_TYPE_PUBREL;
-    return MQTTSuccess;
-}
-
-/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
- * to get full coverage on handleIncomingAck by setting the type to PUBCOMP. */
-static MQTTStatus_t modifyIncomingPacketPubComp( MQTTTransportRecvFunc_t readFunc,
-                                                 MQTTNetworkContext_t networkContext,
-                                                 MQTTPacketInfo_t * pIncomingPacket,
-                                                 int cmock_num_calls )
-{
-    /* Remove unused parameter warnings. */
-    ( void ) readFunc;
-    ( void ) networkContext;
-    ( void ) cmock_num_calls;
-
-    pIncomingPacket->type = MQTT_PACKET_TYPE_PUBCOMP;
-    return MQTTSuccess;
-}
-
-/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
- * to get full coverage on handleIncomingAck by setting the type to PINGRESP. */
-static MQTTStatus_t modifyIncomingPacketPingResp( MQTTTransportRecvFunc_t readFunc,
-                                                  MQTTNetworkContext_t networkContext,
-                                                  MQTTPacketInfo_t * pIncomingPacket,
-                                                  int cmock_num_calls )
-{
-    /* Remove unused parameter warnings. */
-    ( void ) readFunc;
-    ( void ) networkContext;
-    ( void ) cmock_num_calls;
-
-    pIncomingPacket->type = MQTT_PACKET_TYPE_PINGRESP;
-    return MQTTSuccess;
-}
-
-/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
- * to get full coverage on handleIncomingAck by setting the type to SUBACK. */
-static MQTTStatus_t modifyIncomingPacketSubAck( MQTTTransportRecvFunc_t readFunc,
-                                                MQTTNetworkContext_t networkContext,
-                                                MQTTPacketInfo_t * pIncomingPacket,
-                                                int cmock_num_calls )
-{
-    /* Remove unused parameter warnings. */
-    ( void ) readFunc;
-    ( void ) networkContext;
-    ( void ) cmock_num_calls;
-
-    pIncomingPacket->type = MQTT_PACKET_TYPE_SUBACK;
-    return MQTTSuccess;
-}
-
-/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
- * to get full coverage on handleIncomingAck by setting the type to UNSUBACK. */
-static MQTTStatus_t modifyIncomingPacketUnsubAck( MQTTTransportRecvFunc_t readFunc,
-                                                  MQTTNetworkContext_t networkContext,
-                                                  MQTTPacketInfo_t * pIncomingPacket,
-                                                  int cmock_num_calls )
-{
-    /* Remove unused parameter warnings. */
-    ( void ) readFunc;
-    ( void ) networkContext;
-    ( void ) cmock_num_calls;
-
-    pIncomingPacket->type = MQTT_PACKET_TYPE_UNSUBACK;
-    return MQTTSuccess;
-}
-
-/* Mocked MQTT_GetIncomingPacketTypeAndLength callback that modifies pIncomingPacket
  * to get full coverage on handleIncomingAck by setting the type to CONNECT. */
 static MQTTStatus_t modifyIncomingPacket( MQTTTransportRecvFunc_t readFunc,
                                           MQTTNetworkContext_t networkContext,
@@ -390,20 +262,6 @@ static MQTTStatus_t modifyIncomingPacket( MQTTTransportRecvFunc_t readFunc,
 }
 
 /**
- * @brief MQTT_GetPingreqPacketSize callback used by CMock for setting the size
- * of a PINGREQ packet and returns successfully.
- */
-static MQTTStatus_t modifyPacketSize( size_t * pPacketSize,
-                                      int cmock_num_calls )
-{
-    /* Remove unused parameter warnings. */
-    ( void ) cmock_num_calls;
-
-    *pPacketSize = MQTT_PACKET_PINGREQ_SIZE;
-    return MQTTSuccess;
-}
-
-/**
  * @brief This helper function is used to expect any calls from the process loop
  * to mocked functions belonging to an external header file. Its parameters
  * are used to provide return values for these mocked functions.
@@ -417,6 +275,8 @@ static void expectProcessLoopCalls( MQTTContext_t * const pContext,
                                     bool incomingPublish )
 {
     MQTTStatus_t mqttStatus = MQTTSuccess;
+    MQTTPacketInfo_t incomingPacket = { 0 };
+    size_t pingreqSize = MQTT_PACKET_PINGREQ_SIZE;
     bool expectMoreCalls = true;
 
     MQTT_GetIncomingPacketTypeAndLength_Stub( modifyIncomingPacket );
@@ -440,7 +300,9 @@ static void expectProcessLoopCalls( MQTTContext_t * const pContext,
         if( ( pContext->waitingForPingResp == false ) &&
             ( pContext->keepAliveIntervalSec != 0U ) )
         {
-            MQTT_GetPingreqPacketSize_Stub( modifyPacketSize );
+            MQTT_GetPingreqPacketSize_ExpectAnyArgsAndReturn( MQTTSuccess );
+            /* Replace pointer parameter being passed to the method. */
+            MQTT_GetPingreqPacketSize_ReturnThruPtr_pPacketSize( &pingreqSize );
             MQTT_SerializePingreq_ExpectAnyArgsAndReturn( serializeStatus );
         }
 
@@ -540,7 +402,7 @@ void test_MQTT_Init_Happy_Path( void )
     mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     TEST_ASSERT_EQUAL( MQTTNotConnected, context.connectStatus );
-    TEST_ASSERT_EQUAL( MQTT_NEXT_PACKET_ID_START, context.nextPacketId );
+    TEST_ASSERT_EQUAL( MQTT_FIRST_VALID_PACKET_ID, context.nextPacketId );
     /* These Unity assertions take pointers and compare their contents. */
     TEST_ASSERT_EQUAL_MEMORY( &transport, &context.transportInterface, sizeof( transport ) );
     TEST_ASSERT_EQUAL_MEMORY( &callbacks, &context.callbacks, sizeof( callbacks ) );

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -428,7 +428,7 @@ static void expectProcessLoopCalls( MQTTContext_t * const pContext,
         expectMoreCalls = false;
     }
 
-    /* When no data is available, the process loop tries to send a keep alive. */
+    /* When no data is available, the process loop tries to send a PINGREQ. */
     if( modifyIncomingPacketStatus == MQTTNoDataAvailable )
     {
         if( ( pContext->waitingForPingResp == false ) &&
@@ -1052,7 +1052,8 @@ void test_MQTT_ProcessLoop_handleIncomingPublish_error_paths( void )
     modifyIncomingPacketStatus = MQTTSuccess;
 
     /* Verify that error is propagated when deserialization fails by returning
-     * MQTTBadResponse. Any parameters beyond that are actually irrelevant. */
+     * MQTTBadResponse. Any parameters beyond that are actually irrelevant
+     * because they are only used as return values for non-expected calls. */
     currentPacketType = MQTT_PACKET_TYPE_PUBLISH;
     expectProcessLoopCalls( &context, MQTTBadResponse, MQTTStateNull,
                             MQTTBadResponse, MQTTStateNull,

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -32,7 +32,7 @@
 /**
  * @brief Length of the MQTT network buffer.
  */
-#define MQTT_TEST_BUFFER_LENGTH      ( 1024 )
+#define MQTT_TEST_BUFFER_LENGTH      ( 128 )
 
 /**
  * @brief Length of time spent for single test case with
@@ -44,6 +44,11 @@
  * @brief Zero timeout in the process loop implies one iteration.
  */
 #define MQTT_NO_TIMEOUT_MS           ( 0U )
+
+/**
+ * @brief Sample length of remaining serialized data.
+ */
+#define SAMPLE_REMAINING_LENGTH      ( 64 )
 
 /**
  * @brief The packet type to be received by the process loop.
@@ -380,6 +385,7 @@ static MQTTStatus_t modifyIncomingPacket( MQTTTransportRecvFunc_t readFunc,
     ( void ) cmock_num_calls;
 
     pIncomingPacket->type = currentPacketType;
+    pIncomingPacket->remainingLength = SAMPLE_REMAINING_LENGTH;
     return modifyIncomingPacketStatus;
 }
 

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -25,7 +25,7 @@
 #define MQTT_PACKET_TYPE_INVALID     ( 0U )
 
 /**
- * @brief Number of seconds in a millisecond.
+ * @brief Number of milliseconds in a second.
  */
 #define MQTT_ONE_SECOND_TO_MS        ( 1000U )
 
@@ -1243,8 +1243,8 @@ void test_MQTT_ProcessLoop_handleKeepAlive_happy_paths( void )
     context.waitingForPingResp = true;
     context.keepAliveIntervalSec = 1;
     context.lastPacketTime = 0;
-    context.pingReqSendTimeMs = getTime();
-    context.pingRespTimeoutMs = getTime();
+    context.pingReqSendTimeMs = MQTT_ONE_SECOND_TO_MS;
+    context.pingRespTimeoutMs = MQTT_ONE_SECOND_TO_MS;
     expectProcessLoopCalls( &context, MQTTStateNull, MQTTStateNull,
                             MQTTSuccess, MQTTStateNull,
                             MQTTSuccess, false );


### PR DESCRIPTION
*Description of changes:*
The follow test cases covers all branches (minus asserts) for `MQTT_ProcessLoop` and all its calls to private methods (`handleKeepAlive`, `handleIncomingPublish`, `handleIncomingAck`, `sendPublishAcks`):
- `test_MQTT_ProcessLoop_invalid_params`:
Test that NULL `pContext` causes `MQTT_ProcessLoop` to return `MQTTBadParameter`.
- `test_MQTT_ProcessLoop_handleIncomingPublish_happy_paths`:
This test case covers all calls to the private method,
`handleIncomingPublish(...)`,
that results in the process loop returning successfully.
- `test_MQTT_ProcessLoop_handleIncomingPublish_error_paths`: 
This test case covers all calls to the private method,
`handleIncomingPublish(...)`,
that results in the process loop returning an error.
- `test_MQTT_ProcessLoop_handleIncomingAck_happy_paths`: 
This test case covers all calls to the private method,
`handleIncomingAck(...)`,
that results in the process loop returning successfully.
- `test_MQTT_ProcessLoop_handleIncomingAck_error_paths`: 
This test case covers all calls to the private method,
`handleIncomingAck(...)`,
that results in the process loop returning an error.
- `test_MQTT_ProcessLoop_handleKeepAlive_happy_paths`: 
This test case covers all calls to the private method,
`handleKeepAlive(...)`,
that results in the process loop returning successfully.
- `test_MQTT_ProcessLoop_handleKeepAlive_error_paths`: 
This test case covers all calls to the private method,
`handleKeepAlive(...)`,
that results in the process loop returning an error.
- `test_MQTT_ProcessLoop_multiple_iterations`: 
This test mocks a failing transport receive and runs multiple iterations of the process loop, resulting in returning `MQTTRecvFailed`. This allows us to have full branch and line coverage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
