### PR TITLE
Ci/coverity integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ set_property( GLOBAL PROPERTY USE_FOLDERS ON )
 # Use C90.
 set( CMAKE_C_STANDARD 90 )
 set( CMAKE_C_STANDARD_REQUIRED ON )
+set( CMAKE_THREAD_PREFER_PTHREAD ON )
+
+find_package(Threads REQUIRED)
 
 # Do not allow in-source build.
 if( ${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,6 @@ set_property( GLOBAL PROPERTY USE_FOLDERS ON )
 # Use C90.
 set( CMAKE_C_STANDARD 90 )
 set( CMAKE_C_STANDARD_REQUIRED ON )
-set( CMAKE_THREAD_PREFER_PTHREAD ON )
-
-find_package(Threads REQUIRED)
 
 # Do not allow in-source build.
 if( ${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR} )

--- a/demos/mqtt/mqtt_demo_basic_tls/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_basic_tls/CMakeLists.txt
@@ -5,6 +5,9 @@ add_executable(${DEMO_NAME})
 set(OPENSSL_USE_STATIC_LIBS TRUE)
 find_package(OpenSSL REQUIRED)
 
+set( CMAKE_THREAD_PREFER_PTHREAD ON )
+find_package(Threads REQUIRED)
+
 target_sources(
     ${DEMO_NAME}
     PRIVATE

--- a/demos/mqtt/mqtt_demo_basic_tls/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_basic_tls/CMakeLists.txt
@@ -17,6 +17,8 @@ target_link_libraries(
         mqtt
         OpenSSL::Crypto
         OpenSSL::SSL
+        Threads::Threads
+        ${CMAKE_DL_LIBS}
 )
 
 target_include_directories(

--- a/demos/mqtt/mqtt_demo_basic_tls/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_basic_tls/CMakeLists.txt
@@ -20,7 +20,9 @@ target_link_libraries(
         mqtt
         OpenSSL::Crypto
         OpenSSL::SSL
+	# SSL uses Threads and on some platforms require explicit linking.
         Threads::Threads
+	# SSL uses Dynamic Loading and on some platforms requires explicit linking.
         ${CMAKE_DL_LIBS}
 )
 

--- a/tools/coverity/misra.config
+++ b/tools/coverity/misra.config
@@ -1,0 +1,46 @@
+// MISRA C-2012 Rules
+
+{
+    version : "2.0",
+    standard : "c2012",
+    title: "Coverity MISRA Configuration",
+    deviations : [
+        // Disable the following rules.
+        {
+            deviation: "Directive 4.5",
+            reason: "Allow names that MISRA considers ambiguous (such as enum IOT_MQTT_CONNECT and function IotMqtt_Connect)."
+        },
+        {
+            deviation: "Directive 4.8",
+            reason: "Allow inclusion of unused types. Header files for a specific port, which are needed by all files, may define types that are not used by a specific file."
+        },
+        {
+            deviation: "Directive 4.9",
+            reason: "Allow inclusion of function like macros. Logging is done using function like macros."
+        },
+        {
+            deviation: "Rule 2.4",
+            reason: "Allow unused tags. Some compilers warn if types are not tagged."
+        },
+        {
+            deviation: "Rule 2.5",
+            reason: "Allow unused macros. Library headers may define macros intended for the application's use, but not used by a specific file."
+        },
+        {
+            deviation: "Rule 3.1",
+            reason: "Allow nested comments. Documentation blocks contain comments for example code."
+        },
+        {
+            deviation: "Rule 11.5",
+            reason: "Allow casts from void *. Contexts are passed as void * and must be cast to the correct data type before use."
+        },
+        {
+            deviation: "Rule 21.1",
+            reason: "Allow use of all names."
+        },
+        {
+            deviation: "Rule 21.2",
+            reason: "Allow use of all names."
+        }
+    ]
+}


### PR DESCRIPTION
*Description of changes:* Changes to enable static analysis in CI:

1) Add MISRA config for coverity from `v4_beta` branch. This provides a set of MISRA rules that are unconditionally ignored.
2) Explicitly link `pthreads` and `CMAKE_DL_LIBS`. These are used by SSL and on some environments (such as our build nodes) CMake has trouble reasoning about the existence of these libraries or if they are required. The `CMAKE_THREAD_PREFER_PTHREAD` setting and `${CMAKE_DL_LIBS}` appear to be best practices.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
