### PR TITLE
HTTPClient_InitializeRequestHeaders - Do not automatically write "Connection: close"

### DIFF
--- a/libraries/standard/http/include/http_client.h
+++ b/libraries/standard/http/include/http_client.h
@@ -444,7 +444,7 @@ typedef struct HTTPResponse
  *     User-Agent: <HTTP_USER_AGENT_VALUE>
  *     Host: <#HTTPRequestInfo_t.pHost>
  *
- * Note that "Connection" header value can be added and set to "keep-alive" by
+ * Note that "Connection" header can be added and set to "keep-alive" by
  * activating the HTTP_REQUEST_KEEP_ALIVE_FLAG in #HTTPRequestInfo_t.flags.
  *
  * @param[in] pRequestHeaders Request header buffer information.

--- a/libraries/standard/http/include/http_client.h
+++ b/libraries/standard/http/include/http_client.h
@@ -443,10 +443,9 @@ typedef struct HTTPResponse
  *     <#HTTPRequestInfo_t.method> <#HTTPRequestInfo_t.pPath> <HTTP_PROTOCOL_VERSION>
  *     User-Agent: <HTTP_USER_AGENT_VALUE>
  *     Host: <#HTTPRequestInfo_t.pHost>
- *     Connection: close
  *
- * Note that Connection header value can be changed to keep-alive by setting
- * the HTTP_REQUEST_KEEP_ALIVE_FLAG in #HTTPRequestInfo_t.flags.
+ * Note that "Connection" header value can be added and set to "keep-alive" by
+ * activating the HTTP_REQUEST_KEEP_ALIVE_FLAG in #HTTPRequestInfo_t.flags.
  *
  * @param[in] pRequestHeaders Request header buffer information.
  * @param[in] pRequestInfo Initial request header configurations.

--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -502,7 +502,7 @@ HTTPStatus_t HTTPClient_InitializeRequestHeaders( HTTPRequestHeaders_t * pReques
 
     if( returnStatus == HTTP_SUCCESS )
     {
-        if( HTTP_REQUEST_KEEP_ALIVE_FLAG & pRequestInfo->flags )
+        if( ( HTTP_REQUEST_KEEP_ALIVE_FLAG & pRequestInfo->flags ) != 0u )
         {
             /* Write "Connection: keep-alive". */
             returnStatus = addHeader( pRequestHeaders,
@@ -510,15 +510,6 @@ HTTPStatus_t HTTPClient_InitializeRequestHeaders( HTTPRequestHeaders_t * pReques
                                       HTTP_CONNECTION_FIELD_LEN,
                                       ( const uint8_t * ) HTTP_CONNECTION_KEEP_ALIVE_VALUE,
                                       HTTP_CONNECTION_KEEP_ALIVE_VALUE_LEN );
-        }
-        else
-        {
-            /* Write "Connection: close". */
-            returnStatus = addHeader( pRequestHeaders,
-                                      ( const uint8_t * ) HTTP_CONNECTION_FIELD,
-                                      HTTP_CONNECTION_FIELD_LEN,
-                                      ( const uint8_t * ) HTTP_CONNECTION_CLOSE_VALUE,
-                                      HTTP_CONNECTION_CLOSE_VALUE_LEN );
         }
     }
 


### PR DESCRIPTION
As discussed with @sarenameas, we don't want to write `Connection: close` header by default in `HTTPClient_InitializeRequestHeaders `. We only have a flag for `HTTP_REQUEST_KEEP_ALIVE_FLAG` because client can always close the connection themselves through the application or choose to add the header through `HTTPClient_AddHeader`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
