### PR TITLE
MQTT - handling re-sends when a session is reestablished.

### DIFF
--- a/libraries/standard/mqtt/include/mqtt.h
+++ b/libraries/standard/mqtt/include/mqtt.h
@@ -25,6 +25,13 @@
 #include "mqtt_config.h"
 #include "mqtt_lightweight.h"
 
+/**
+ * @brief Invalid packet identifier.
+ *
+ * Zero is an invalid packet identifier as per MQTT v3.1.1 spec.
+ */
+#define MQTT_PACKET_ID_INVALID    ( ( uint16_t ) 0U )
+
 struct MQTTApplicationCallbacks;
 typedef struct MQTTApplicationCallbacks   MQTTApplicationCallbacks_t;
 

--- a/libraries/standard/mqtt/include/mqtt_state.h
+++ b/libraries/standard/mqtt/include/mqtt_state.h
@@ -27,6 +27,13 @@
 #define MQTT_STATE_CURSOR_INITIALIZER    ( size_t ) 0
 
 /**
+ * @brief Invalid packet identifier.
+ *
+ * Zero is an invalid packet identifier as per MQTT v3.1.1 spec.
+ */
+#define MQTT_PACKET_ID_INVALID           ( ( uint16_t ) 0U )
+
+/**
  * @brief Value indicating either send or receive.
  */
 typedef enum MQTTStateOperation

--- a/libraries/standard/mqtt/include/mqtt_state.h
+++ b/libraries/standard/mqtt/include/mqtt_state.h
@@ -27,13 +27,6 @@
 #define MQTT_STATE_CURSOR_INITIALIZER    ( size_t ) 0
 
 /**
- * @brief Invalid packet identifier.
- *
- * Zero is an invalid packet identifier as per MQTT v3.1.1 spec.
- */
-#define MQTT_PACKET_ID_INVALID           ( ( uint16_t ) 0U )
-
-/**
  * @brief Value indicating either send or receive.
  */
 typedef enum MQTTStateOperation
@@ -124,5 +117,21 @@ MQTTPublishState_t MQTT_UpdateStateAck( MQTTContext_t * pMqttContext,
 uint16_t MQTT_StateSelect( const MQTTContext_t * pMqttContext,
                            MQTTPublishState_t searchState,
                            MQTTStateCursor_t * pCursor );
+
+/**
+ * @brief Get the publish state for the publish packet with the given packet id.
+ *
+ * @param[in] pMqttContext Initialized MQTT context.
+ * @param[in] packetId The packet id of the packet to search for.
+ * @param[in] incomingPublish Whether to search for the publish packet in
+ * incoming publish records or the outgoing publish records. True for searching
+ * in incoming publish record; false for searching outgoing publish record.
+ *
+ * @return #MQTTStateNull if no publish packet found or if invalid parameters
+ * are passed; state of the publish packet with given packet id otherwise.
+ */
+MQTTPublishState_t MQTT_GetPacketState( const MQTTContext_t * pMqttContext,
+                                        uint16_t packetId,
+                                        bool incomingPublish );
 
 #endif /* ifndef MQTT_STATE_H */

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -695,14 +695,9 @@ static MQTTStatus_t processPublishFlags( uint8_t publishFlags,
         LogDebug( ( "Retain bit is %d.", pPublishInfo->retain ) );
 
         /* Parse the DUP bit. */
-        if( UINT8_CHECK_BIT( publishFlags, MQTT_PUBLISH_FLAG_DUP ) )
-        {
-            LogDebug( ( "DUP is 1." ) );
-        }
-        else
-        {
-            LogDebug( ( "DUP is 0." ) );
-        }
+        pPublishInfo->dup = UINT8_CHECK_BIT( publishFlags, MQTT_PUBLISH_FLAG_DUP );
+
+        LogDebug( ( "Dup bit is %d.", pPublishInfo->dup ) );
     }
 
     return status;

--- a/libraries/standard/mqtt/src/mqtt_state.c
+++ b/libraries/standard/mqtt/src/mqtt_state.c
@@ -622,3 +622,37 @@ uint16_t MQTT_StateSelect( const MQTTContext_t * pMqttContext,
 
     return packetId;
 }
+
+MQTTPublishState_t MQTT_GetPacketState( const MQTTContext_t * pMqttContext,
+                                        uint16_t packetId,
+                                        bool incomingPublish )
+{
+    MQTTPublishState_t publishState = MQTTStateNull;
+    const MQTTPubAckInfo_t * records = NULL;
+    int index = 0;
+
+    if( pMqttContext == NULL )
+    {
+        LogError( ( "pMqttContext cannot be NULL." ) );
+    }
+    else if( packetId == MQTT_PACKET_ID_INVALID )
+    {
+        LogError( ( "packet ID cannot be 0." ) );
+    }
+    else
+    {
+        records = ( incomingPublish ) ? pMqttContext->incomingPublishRecords
+                  : pMqttContext->outgoingPublishRecords;
+
+        for( ; index < MQTT_STATE_ARRAY_MAX_COUNT; index++ )
+        {
+            if( records[ index ].packetId == packetId )
+            {
+                publishState = records[ index ].publishState;
+                break;
+            }
+        }
+    }
+
+    return publishState;
+}

--- a/libraries/standard/mqtt/src/mqtt_state.c
+++ b/libraries/standard/mqtt/src/mqtt_state.c
@@ -22,7 +22,6 @@
 #include <assert.h>
 #include "mqtt_state.h"
 
-#define MQTT_PACKET_ID_INVALID    ( uint16_t ) 0U
 
 /**
  * @brief Test if a transition to new state is possible, when dealing with PUBLISHes.

--- a/libraries/standard/mqtt/utest/mqtt_state_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_state_utest.c
@@ -433,3 +433,39 @@ void test_MQTT_StateSelect( void )
     TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, packetId );
     TEST_ASSERT_EQUAL( MQTT_STATE_ARRAY_MAX_COUNT, outgoingCursor );
 }
+
+/* ========================================================================== */
+
+void test_MQTT_GetPacketState( void )
+{
+    MQTTContext_t mqttContext = { 0 };
+    MQTTPublishState_t publishState = MQTTStateNull;
+    const uint16_t PACKET_ID = 1;
+    const size_t index = MQTT_STATE_ARRAY_MAX_COUNT / 2;
+
+    /* Invalid parameters. */
+    publishState = MQTT_GetPacketState( NULL, PACKET_ID, true );
+    TEST_ASSERT_EQUAL( MQTTStateNull, publishState );
+    publishState = MQTT_GetPacketState( &mqttContext, MQTT_PACKET_ID_INVALID, true );
+    TEST_ASSERT_EQUAL( MQTTStateNull, publishState );
+
+    /* Packet not present in records. */
+    /* Incoming. */
+    publishState = MQTT_GetPacketState( &mqttContext, PACKET_ID, true );
+    TEST_ASSERT_EQUAL( MQTTStateNull, publishState );
+
+    /* Outgoing. */
+    publishState = MQTT_GetPacketState( &mqttContext, PACKET_ID, false );
+    TEST_ASSERT_EQUAL( MQTTStateNull, publishState );
+
+    /* Packet present in records. */
+    /* Incoming. */
+    addToRecord( mqttContext.incomingPublishRecords, index, PACKET_ID, MQTTQoS1, MQTTPubAckSend );
+    publishState = MQTT_GetPacketState( &mqttContext, PACKET_ID, true );
+    TEST_ASSERT_EQUAL( MQTTPubAckSend, publishState );
+
+    /* Outgoing. */
+    addToRecord( mqttContext.outgoingPublishRecords, index, PACKET_ID, MQTTQoS1, MQTTPublishSend );
+    publishState = MQTT_GetPacketState( &mqttContext, PACKET_ID, false );
+    TEST_ASSERT_EQUAL( MQTTPublishSend, publishState );
+}


### PR DESCRIPTION
*Description of changes:*
Handling the resend and receive of duplicate packets when an MQTT session is reestablished.

These are the cases that is handled in this PR,

When a session is reestablished,
Outgoing publishes:
1. Resend PUBLISHes for which and ack is not received(PUBACK and PUBREC).
2. Resend PUBRELs for PUBLISHes for which PUBCOMP was not received.

Incoming publishes:  
1. Handle duplicate QoS1 and QoS2 PUBLISHes
2. Handle duplicate PUBRELs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
