### PR TITLE
Fix: HTTP header context initialization and usage of transport send

### DIFF
--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -1519,7 +1519,7 @@ static HTTPStatus_t sendHttpData( const HTTPTransportInterface_t * pTransport,
 {
     HTTPStatus_t returnStatus = HTTP_SUCCESS;
     const uint8_t * pIndex = pData;
-    int32_t bytesSent = 0;
+    int32_t transportStatus = 0;
     size_t bytesRemaining = dataLen;
 
     assert( pTransport != NULL );
@@ -1529,18 +1529,18 @@ static HTTPStatus_t sendHttpData( const HTTPTransportInterface_t * pTransport,
     /* Loop until all data is sent. */
     while( bytesRemaining > 0UL )
     {
-        bytesSent = pTransport->send( pTransport->pContext,
-                                      pData,
-                                      dataLen );
+        transportStatus = pTransport->send( pTransport->pContext,
+                                            pIndex,
+                                            bytesRemaining );
 
-        if( bytesSent > 0 )
+        if( transportStatus > 0 )
         {
-            bytesRemaining -= ( size_t ) bytesSent;
-            pIndex += bytesSent;
+            bytesRemaining -= ( size_t ) transportStatus;
+            pIndex += transportStatus;
             LogDebug( ( "Sent HTTP data over the transport: "
                         "BytesSent=%d, BytesRemaining=%ul, "
                         "TotalBytesSent=%d.",
-                        bytesSent,
+                        transportStatus,
                         bytesRemaining,
                         dataLen - bytesRemaining ) );
         }
@@ -1548,7 +1548,7 @@ static HTTPStatus_t sendHttpData( const HTTPTransportInterface_t * pTransport,
         {
             LogError( ( "Failed to send HTTP data: Transport send()"
                         " returned error: TransportStatus=%d.",
-                        bytesSent ) );
+                        transportStatus ) );
             returnStatus = HTTP_NETWORK_ERROR;
             break;
         }
@@ -1558,7 +1558,7 @@ static HTTPStatus_t sendHttpData( const HTTPTransportInterface_t * pTransport,
     {
         LogDebug( ( "Sent HTTP data over the transport: "
                     "BytesSent=%d.",
-                    bytesSent ) );
+                    transportStatus ) );
     }
 
     return returnStatus;

--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -1545,7 +1545,7 @@ static HTTPStatus_t sendHttpData( const HTTPTransportInterface_t * pTransport,
         else if( ( size_t ) transportStatus > bytesRemaining )
         {
             LogError( ( "Failed to send HTTP data: Transport send()"
-                        " wrote more data than what was expected: "
+                        " wrote more bytes than what was expected: "
                         "BytesSent=%d, BytesRemaining=%lu.",
                         transportStatus,
                         bytesRemaining ) );

--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -886,7 +886,7 @@ static HTTPStatus_t processHttpParserError( http_parser * pHttpParser )
 
         case HPE_HEADER_OVERFLOW:
             LogError( ( "Response parsing error: Header byte limit "
-                        "exceeded: HeaderByteLimit=%d.",
+                        "exceeded: HeaderByteLimit=%d",
                         HTTP_MAX_RESPONSE_HEADERS_SIZE_BYTES ) );
             returnStatus = HTTP_SECURITY_ALERT_RESPONSE_HEADERS_SIZE_LIMIT_EXCEEDED;
             break;
@@ -1537,7 +1537,7 @@ static HTTPStatus_t sendHttpData( const HTTPTransportInterface_t * pTransport,
         if( transportStatus < 0 )
         {
             LogError( ( "Failed to send HTTP data: Transport send()"
-                        " returned error: TransportStatus=%d.",
+                        " returned error: TransportStatus=%d",
                         transportStatus ) );
             returnStatus = HTTP_NETWORK_ERROR;
             break;
@@ -1545,8 +1545,8 @@ static HTTPStatus_t sendHttpData( const HTTPTransportInterface_t * pTransport,
         else if( ( size_t ) transportStatus > bytesRemaining )
         {
             LogError( ( "Failed to send HTTP data: Transport send()"
-                        " wrote more bytes than what was expected: "
-                        "BytesSent=%d, BytesRemaining=%lu.",
+                        " wrote more data than what was expected: "
+                        "BytesSent=%d, BytesRemaining=%lu",
                         transportStatus,
                         bytesRemaining ) );
             returnStatus = HTTP_NETWORK_ERROR;
@@ -1558,7 +1558,7 @@ static HTTPStatus_t sendHttpData( const HTTPTransportInterface_t * pTransport,
             pIndex += transportStatus;
             LogDebug( ( "Sent HTTP data over the transport: "
                         "BytesSent=%d, BytesRemaining=%lu, "
-                        "TotalBytesSent=%d.",
+                        "TotalBytesSent=%d",
                         transportStatus,
                         bytesRemaining,
                         dataLen - bytesRemaining ) );
@@ -1568,7 +1568,7 @@ static HTTPStatus_t sendHttpData( const HTTPTransportInterface_t * pTransport,
     if( returnStatus == HTTP_SUCCESS )
     {
         LogDebug( ( "Sent HTTP data over the transport: "
-                    "BytesSent=%d.",
+                    "BytesSent=%d",
                     transportStatus ) );
     }
 
@@ -1686,7 +1686,7 @@ HTTPStatus_t receiveHttpData( const HTTPTransportInterface_t * pTransport,
     if( transportStatus < 0 )
     {
         LogError( ( "Failed to receive HTTP data: Transport recv() "
-                    "returned error: TransportStatus=%d.",
+                    "returned error: TransportStatus=%d",
                     transportStatus ) );
         returnStatus = HTTP_NETWORK_ERROR;
     }
@@ -1695,8 +1695,8 @@ HTTPStatus_t receiveHttpData( const HTTPTransportInterface_t * pTransport,
         /* There is a bug in the transport recv if more bytes are reported
          * to have been read than the bytes asked for. */
         LogError( ( "Failed to receive HTTP data: Transport recv() "
-                    " read more bytes than requested: BytesRead=%d, "
-                    "RequestedBytes=%lu",
+                    " read more bytes than requested: BytesReceived=%d, "
+                    "BytesRequested=%lu",
                     transportStatus,
                     ( unsigned long ) bufferLen ) );
         returnStatus = HTTP_NETWORK_ERROR;
@@ -1705,7 +1705,7 @@ HTTPStatus_t receiveHttpData( const HTTPTransportInterface_t * pTransport,
     {
         /* Some or all of the specified data was received. */
         *pBytesReceived = ( size_t ) ( transportStatus );
-        LogDebug( ( "Received data from the transport: BytesReceived=%d.",
+        LogDebug( ( "Received data from the transport: BytesReceived=%d",
                     transportStatus ) );
     }
     else

--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -1545,8 +1545,8 @@ static HTTPStatus_t sendHttpData( const HTTPTransportInterface_t * pTransport,
         else if( ( size_t ) transportStatus > bytesRemaining )
         {
             LogError( ( "Failed to send HTTP data: Transport send()"
-                        " attempted to write more data than what was expected: "
-                        "RequestedBytes=%d, BytesRemaining=%ul.",
+                        " wrote more data than what was expected: "
+                        "BytesSent=%d, BytesRemaining=%ul.",
                         transportStatus,
                         bytesRemaining ) );
             returnStatus = HTTP_NETWORK_ERROR;

--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -1546,7 +1546,7 @@ static HTTPStatus_t sendHttpData( const HTTPTransportInterface_t * pTransport,
         {
             LogError( ( "Failed to send HTTP data: Transport send()"
                         " wrote more data than what was expected: "
-                        "BytesSent=%d, BytesRemaining=%ul.",
+                        "BytesSent=%d, BytesRemaining=%lu.",
                         transportStatus,
                         bytesRemaining ) );
             returnStatus = HTTP_NETWORK_ERROR;
@@ -1557,7 +1557,7 @@ static HTTPStatus_t sendHttpData( const HTTPTransportInterface_t * pTransport,
             bytesRemaining -= ( size_t ) transportStatus;
             pIndex += transportStatus;
             LogDebug( ( "Sent HTTP data over the transport: "
-                        "BytesSent=%d, BytesRemaining=%ul, "
+                        "BytesSent=%d, BytesRemaining=%lu, "
                         "TotalBytesSent=%d.",
                         transportStatus,
                         bytesRemaining,

--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -1997,8 +1997,6 @@ static int findHeaderValueParserCallback( http_parser * pHttpParser,
     assert( pContext->pValueLoc != NULL );
     assert( pContext->pValueLen != NULL );
 
-    pContext = ( findHeaderContext_t * ) pHttpParser->data;
-
     /* The header value found flag should not be set. */
     assert( pContext->valueFound == 0u );
 

--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -1933,7 +1933,7 @@ static int findHeaderFieldParserCallback( http_parser * pHttpParser,
                                           const char * pFieldLoc,
                                           size_t fieldLen )
 {
-    findHeaderContext_t * pContext = NULL;
+    findHeaderContext_t * pContext = pHttpParser->data;
 
     assert( pHttpParser != NULL );
     assert( pFieldLoc != NULL );
@@ -1974,7 +1974,7 @@ static int findHeaderValueParserCallback( http_parser * pHttpParser,
                                           size_t valueLen )
 {
     int retCode = HTTP_PARSER_CONTINUE_PARSING;
-    findHeaderContext_t * pContext = NULL;
+    findHeaderContext_t * pContext = pHttpParser->data;
 
     assert( pHttpParser != NULL );
     assert( pVaLueLoc != NULL );

--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -1533,7 +1533,26 @@ static HTTPStatus_t sendHttpData( const HTTPTransportInterface_t * pTransport,
                                             pIndex,
                                             bytesRemaining );
 
-        if( transportStatus > 0 )
+        /* A transport status of less than zero is an error. */
+        if( transportStatus < 0 )
+        {
+            LogError( ( "Failed to send HTTP data: Transport send()"
+                        " returned error: TransportStatus=%d.",
+                        transportStatus ) );
+            returnStatus = HTTP_NETWORK_ERROR;
+            break;
+        }
+        else if( ( size_t ) transportStatus > bytesRemaining )
+        {
+            LogError( ( "Failed to send HTTP data: Transport send()"
+                        " attempted to write more data than what was expected: "
+                        "RequestedBytes=%d, BytesRemaining=%ul.",
+                        transportStatus,
+                        bytesRemaining ) );
+            returnStatus = HTTP_NETWORK_ERROR;
+            break;
+        }
+        else
         {
             bytesRemaining -= ( size_t ) transportStatus;
             pIndex += transportStatus;
@@ -1543,14 +1562,6 @@ static HTTPStatus_t sendHttpData( const HTTPTransportInterface_t * pTransport,
                         transportStatus,
                         bytesRemaining,
                         dataLen - bytesRemaining ) );
-        }
-        else
-        {
-            LogError( ( "Failed to send HTTP data: Transport send()"
-                        " returned error: TransportStatus=%d.",
-                        transportStatus ) );
-            returnStatus = HTTP_NETWORK_ERROR;
-            break;
         }
     }
 

--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -1547,7 +1547,7 @@ static HTTPStatus_t sendHttpData( const HTTPTransportInterface_t * pTransport,
         else
         {
             LogError( ( "Failed to send HTTP data: Transport send()"
-                        " returned error: TransportStatus=%d",
+                        " returned error: TransportStatus=%d.",
                         bytesSent ) );
             returnStatus = HTTP_NETWORK_ERROR;
             break;
@@ -1556,9 +1556,9 @@ static HTTPStatus_t sendHttpData( const HTTPTransportInterface_t * pTransport,
 
     if( returnStatus == HTTP_SUCCESS )
     {
-        LogDebug( ( "Sent HTTP data over the transport: BytesSent "
-                    "=%d.",
-                    transportStatus ) );
+        LogDebug( ( "Sent HTTP data over the transport: "
+                    "BytesSent=%d.",
+                    bytesSent ) );
     }
 
     return returnStatus;

--- a/libraries/standard/http/utest/http_send_utest.c
+++ b/libraries/standard/http/utest/http_send_utest.c
@@ -297,9 +297,9 @@ static int32_t transportSendLessThanBytesToWrite( HTTPNetworkContext_t * pContex
 }
 
 /* Application transport send that writes more bytes than expected. */
-static int32_t transportSendMoreThanBytesToRead( HTTPNetworkContext_t * pContext,
-                                                 const void * pBuffer,
-                                                 size_t bytesToWrite )
+static int32_t transportSendMoreThanBytesToWrite( HTTPNetworkContext_t * pContext,
+                                                  const void * pBuffer,
+                                                  size_t bytesToWrite )
 {
     ( void ) pContext;
     ( void ) pBuffer;
@@ -1283,7 +1283,7 @@ void test_HTTPClient_Send_send_too_many_bytes( void )
 
     http_parser_init_Ignore();
 
-    transportInterface.send = transportSendMoreThanBytesToRead;
+    transportInterface.send = transportSendMoreThanBytesToWrite;
     returnStatus = HTTPClient_Send( &transportInterface,
                                     &requestHeaders,
                                     NULL,

--- a/libraries/standard/http/utest/http_send_utest.c
+++ b/libraries/standard/http/utest/http_send_utest.c
@@ -296,6 +296,18 @@ static int32_t transportSendLessThanBytesToWrite( HTTPNetworkContext_t * pContex
     return retVal;
 }
 
+/* Application transport send that writes more bytes than expected. */
+static int32_t transportSendMoreThanBytesToRead( HTTPNetworkContext_t * pContext,
+                                                 const void * pBuffer,
+                                                 size_t bytesToWrite )
+{
+    ( void ) pContext;
+    ( void ) pBuffer;
+
+    return( bytesToWrite + 1 );
+}
+
+
 /* Application transport receive interface that sends the bytes specified in
  * firstPartBytes on the first call, then sends the rest of the response in the
  * second call. The response to send is set in pNetworkData and the current
@@ -1245,13 +1257,33 @@ void test_HTTPClient_Send_network_error_response( void )
 
 /* Test when more bytes are received than expected, when receiving a response
  * from the network. */
-void test_HTTPClient_Send_too_many_bytes_response( void )
+void test_HTTPClient_Send_recv_too_many_bytes( void )
 {
     HTTPStatus_t returnStatus = HTTP_SUCCESS;
 
     http_parser_init_Ignore();
 
     transportInterface.recv = transportRecvMoreThanBytesToRead;
+    returnStatus = HTTPClient_Send( &transportInterface,
+                                    &requestHeaders,
+                                    NULL,
+                                    0,
+                                    &response,
+                                    0 );
+    TEST_ASSERT_EQUAL( HTTP_NETWORK_ERROR, returnStatus );
+}
+
+/*-----------------------------------------------------------*/
+
+/* Test when more bytes are sent than expected, when sending data
+ * over the socket. */
+void test_HTTPClient_Send_send_too_many_bytes( void )
+{
+    HTTPStatus_t returnStatus = HTTP_SUCCESS;
+
+    http_parser_init_Ignore();
+
+    transportInterface.send = transportSendMoreThanBytesToRead;
     returnStatus = HTTPClient_Send( &transportInterface,
                                     &requestHeaders,
                                     NULL,

--- a/libraries/standard/http/utest/http_send_utest.c
+++ b/libraries/standard/http/utest/http_send_utest.c
@@ -1201,10 +1201,10 @@ void test_HTTPClient_Send_less_bytes_request_body( void )
 
     returnStatus = HTTPClient_Send( &transportInterface,
                                     &requestHeaders,
-                                    NULL,
-                                    0,
+                                    ( uint8_t * ) HTTP_TEST_REQUEST_PUT_BODY,
+                                    HTTP_TEST_REQUEST_PUT_BODY_LENGTH,
                                     &response,
-                                    0 );
+                                    HTTP_SEND_DISABLE_CONTENT_LENGTH_FLAG );
 
     TEST_ASSERT_EQUAL( HTTP_SUCCESS, returnStatus );
     TEST_ASSERT_EQUAL( response.pBuffer + ( sizeof( HTTP_STATUS_LINE_OK ) - 1 ), response.pHeaders );


### PR DESCRIPTION
This PR makes the following fixes for the HTTP Client Library:
- `findHeaderContext_t * pContext` is set AFTER the assert checks in `findHeaderFieldParserCallback` and `findHeaderValueParserCallback`.
- `sendHttpData` assumes that all data can be sent after a single invocation of transport send. However, if the socket write buffer is too small for all data being sent, this will not be the case. 
    - `test_HTTPClient_Send_less_bytes_request_headers` and `test_HTTPClient_Send_less_bytes_request_body` are updated to return successfully because of the above change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
