### PR TITLE
Test: Add remaining coverage for HTTP Client Library

### DIFF
--- a/libraries/standard/http/include/http_client.h
+++ b/libraries/standard/http/include/http_client.h
@@ -349,8 +349,8 @@ typedef enum HTTPStatus
  *
  * The memory for the header data buffer is supplied by the user. Information in
  * the buffer will be filled by calling #HTTPClient_InitializeRequestHeaders and
- * #HTTPClient_AddHeader. This buffer may be automatically filled with the 
- * Content-Length header in #HTTPClient_Send, please see 
+ * #HTTPClient_AddHeader. This buffer may be automatically filled with the
+ * Content-Length header in #HTTPClient_Send, please see
  * HTTP_MAX_CONTENT_LENGTH_HEADER_LENGTH for the maximum amount of space needed
  * to accommodate the Content-Length header.
  */
@@ -430,9 +430,9 @@ typedef struct HTTPClient_ResponseHeaderParsingCallback
      * @param[in] statusCode The HTTP response status-code.
      */
     void ( * onHeaderCallback )( void * pContext,
-                                 const uint8_t * fieldLoc,
+                                 const char * fieldLoc,
                                  size_t fieldLen,
-                                 const uint8_t * valueLoc,
+                                 const char * valueLoc,
                                  size_t valueLen,
                                  uint16_t statusCode );
 
@@ -584,9 +584,9 @@ HTTPStatus_t HTTPClient_InitializeRequestHeaders( HTTPRequestHeaders_t * pReques
  * - #HTTP_INSUFFICIENT_MEMORY (If application-provided buffer is not large enough to hold headers.)
  */
 HTTPStatus_t HTTPClient_AddHeader( HTTPRequestHeaders_t * pRequestHeaders,
-                                   const uint8_t * pField,
+                                   const char * pField,
                                    size_t fieldLen,
-                                   const uint8_t * pValue,
+                                   const char * pValue,
                                    size_t valueLen );
 
 /**
@@ -643,7 +643,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  *
  * If #HTTP_SEND_DISABLE_CONTENT_LENGTH_FLAG is not set in parameter @p flags,
  * then the Content-Length to be sent to the server is automatically written to
- * @p pRequestHeaders. The Content-Length will not be written when there is 
+ * @p pRequestHeaders. The Content-Length will not be written when there is
  * no request body. If there is not enough room in the buffer to write the
  * Content-Length then #HTTP_INSUFFICIENT_MEMORY is returned. Please see
  * #HTTP_MAX_CONTENT_LENGTH_HEADER_LENGTH for the maximum Content-Length header
@@ -708,11 +708,11 @@ HTTPStatus_t HTTPClient_Send( const HTTPTransportInterface_t * pTransport,
  * incomplete until #HTTPClient_Send returns.
  *
  * @param[in] pResponse The buffer containing the completed HTTP response.
- * @param[in] pHeaderName The header field name to read.
- * @param[in] headerNameLen The length of the header field name in bytes.
- * @param[out] pHeaderValueLoc This will be populated with the location of the
+ * @param[in] pField The header field name to read.
+ * @param[in] fieldLen The length of the header field name in bytes.
+ * @param[out] pValueLoc This will be populated with the location of the
  * header value in the response buffer, #HTTPResponse_t.pBuffer.
- * @param[out] pHeaderValueLen This will be populated with the length of the
+ * @param[out] pValueLen This will be populated with the length of the
  * header value in bytes.
  *
  * @return One of the following:
@@ -723,10 +723,10 @@ HTTPStatus_t HTTPClient_Send( const HTTPTransportInterface_t * pTransport,
  * - #HTTP_PARSER_INTERNAL_ERROR(If an error in the response parser.)
  */
 HTTPStatus_t HTTPClient_ReadHeader( const HTTPResponse_t * pResponse,
-                                    const uint8_t * pHeaderName,
-                                    size_t headerNameLen,
-                                    const uint8_t ** pHeaderValueLoc,
-                                    size_t * pHeaderValueLen );
+                                    const char * pField,
+                                    size_t fieldLen,
+                                    const char ** pValueLoc,
+                                    size_t * pValueLen );
 
 /**
  * @brief Error code to string conversion utility for HTTP Client library.

--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -83,9 +83,9 @@ static HTTPStatus_t sendHttpBody( const HTTPTransportInterface_t * pTransport,
  * application buffer, then #HTTP_INSUFFICIENT_MEMORY is returned.
  */
 static HTTPStatus_t addHeader( HTTPRequestHeaders_t * pRequestHeaders,
-                               const uint8_t * pField,
+                               const char * pField,
                                size_t fieldLen,
-                               const uint8_t * pValue,
+                               const char * pValue,
                                size_t valueLen );
 
 /**
@@ -189,9 +189,9 @@ static HTTPStatus_t writeRequestLine( HTTPRequestHeaders_t * pRequestHeaders,
  */
 static HTTPStatus_t findHeaderInResponse( const uint8_t * pBuffer,
                                           size_t bufferLen,
-                                          const uint8_t * pField,
+                                          const char * pField,
                                           size_t fieldLen,
-                                          const uint8_t ** pValueLoc,
+                                          const char ** pValueLoc,
                                           size_t * pValueLen );
 
 /**
@@ -595,7 +595,7 @@ static int httpParserOnHeaderFieldCallback( http_parser * pHttpParser,
      * to NULL in the preceding httpParseOnStatusFieldCallback(). */
     if( pResponse->pHeaders == NULL )
     {
-        pResponse->pHeaders = ( const uint8_t * ) pLoc;
+        pResponse->pHeaders = pLoc;
     }
 
     /* Set the location of what to parse next. */
@@ -1111,9 +1111,9 @@ static uint8_t convertInt32ToAscii( int32_t value,
 /*-----------------------------------------------------------*/
 
 static HTTPStatus_t addHeader( HTTPRequestHeaders_t * pRequestHeaders,
-                               const uint8_t * pField,
+                               const char * pField,
                                size_t fieldLen,
-                               const uint8_t * pValue,
+                               const char * pValue,
                                size_t valueLen )
 {
     HTTPStatus_t returnStatus = HTTP_SUCCESS;
@@ -1321,9 +1321,9 @@ HTTPStatus_t HTTPClient_InitializeRequestHeaders( HTTPRequestHeaders_t * pReques
     {
         /* Write "User-Agent: <Value>". */
         returnStatus = addHeader( pRequestHeaders,
-                                  ( const uint8_t * ) HTTP_USER_AGENT_FIELD,
+                                  HTTP_USER_AGENT_FIELD,
                                   HTTP_USER_AGENT_FIELD_LEN,
-                                  ( const uint8_t * ) HTTP_USER_AGENT_VALUE,
+                                  HTTP_USER_AGENT_VALUE,
                                   HTTP_USER_AGENT_VALUE_LEN );
     }
 
@@ -1331,9 +1331,9 @@ HTTPStatus_t HTTPClient_InitializeRequestHeaders( HTTPRequestHeaders_t * pReques
     {
         /* Write "Host: <Value>". */
         returnStatus = addHeader( pRequestHeaders,
-                                  ( const uint8_t * ) HTTP_HOST_FIELD,
+                                  HTTP_HOST_FIELD,
                                   HTTP_HOST_FIELD_LEN,
-                                  ( const uint8_t * ) pRequestInfo->pHost,
+                                  pRequestInfo->pHost,
                                   pRequestInfo->hostLen );
     }
 
@@ -1343,9 +1343,9 @@ HTTPStatus_t HTTPClient_InitializeRequestHeaders( HTTPRequestHeaders_t * pReques
         {
             /* Write "Connection: keep-alive". */
             returnStatus = addHeader( pRequestHeaders,
-                                      ( const uint8_t * ) HTTP_CONNECTION_FIELD,
+                                      HTTP_CONNECTION_FIELD,
                                       HTTP_CONNECTION_FIELD_LEN,
-                                      ( const uint8_t * ) HTTP_CONNECTION_KEEP_ALIVE_VALUE,
+                                      HTTP_CONNECTION_KEEP_ALIVE_VALUE,
                                       HTTP_CONNECTION_KEEP_ALIVE_VALUE_LEN );
         }
     }
@@ -1356,9 +1356,9 @@ HTTPStatus_t HTTPClient_InitializeRequestHeaders( HTTPRequestHeaders_t * pReques
 /*-----------------------------------------------------------*/
 
 HTTPStatus_t HTTPClient_AddHeader( HTTPRequestHeaders_t * pRequestHeaders,
-                                   const uint8_t * pField,
+                                   const char * pField,
                                    size_t fieldLen,
-                                   const uint8_t * pValue,
+                                   const char * pValue,
                                    size_t valueLen )
 {
     HTTPStatus_t returnStatus = HTTP_SUCCESS;
@@ -1502,9 +1502,9 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
 
         /* Add the Range Request header field and value to the buffer. */
         returnStatus = addHeader( pRequestHeaders,
-                                  ( const uint8_t * ) HTTP_RANGE_REQUEST_HEADER_FIELD,
+                                  HTTP_RANGE_REQUEST_HEADER_FIELD,
                                   HTTP_RANGE_REQUEST_HEADER_FIELD_LEN,
-                                  ( const uint8_t * ) rangeValueBuffer,
+                                  rangeValueBuffer,
                                   rangeValueLength );
     }
 
@@ -1592,9 +1592,9 @@ static HTTPStatus_t addContentLengthHeader( HTTPRequestHeaders_t * pRequestHeade
                                                       sizeof( pContentLengthValue ) );
 
     returnStatus = addHeader( pRequestHeaders,
-                              ( const uint8_t * ) HTTP_CONTENT_LENGTH_FIELD,
+                              HTTP_CONTENT_LENGTH_FIELD,
                               HTTP_CONTENT_LENGTH_FIELD_LEN,
-                              ( const uint8_t * ) pContentLengthValue,
+                              pContentLengthValue,
                               contentLengthValueNumBytes );
 
     if( returnStatus != HTTP_SUCCESS )
@@ -1657,7 +1657,7 @@ static HTTPStatus_t sendHttpBody( const HTTPTransportInterface_t * pTransport,
 
     /* Send the request body. */
     LogDebug( ( "Sending the HTTP request body: BodyBytes=%d",
-                reqBodyBufLen ) );
+                ( int32_t ) reqBodyBufLen ) );
     returnStatus = sendHttpData( pTransport, pRequestBodyBuf, reqBodyBufLen );
 
     return returnStatus;
@@ -1971,7 +1971,7 @@ static int findHeaderFieldParserCallback( http_parser * pHttpParser,
 
     /* Check whether the parsed header matches the header we are looking for. */
     if( ( fieldLen == pContext->fieldLen ) &&
-        ( memcmp( pContext->pField, ( const uint8_t * ) pFieldLoc, fieldLen ) == 0 ) )
+        ( memcmp( pContext->pField, pFieldLoc, fieldLen ) == 0 ) )
     {
         LogDebug( ( "Found header field in response: "
                     "HeaderName=%.*s, HeaderLocation=0x%x",
@@ -2018,7 +2018,7 @@ static int findHeaderValueParserCallback( http_parser * pHttpParser,
                     pContext->fieldLen, pContext->pField, pVaLueLoc ) );
 
         /* Populate the output parameters with the location of the header value in the response buffer. */
-        *pContext->pValueLoc = ( const uint8_t * ) pVaLueLoc;
+        *pContext->pValueLoc = pVaLueLoc;
         *pContext->pValueLen = valueLen;
 
         /* Set the header value found flag. */
@@ -2064,9 +2064,9 @@ static int findHeaderOnHeaderCompleteCallback( http_parser * pHttpParser )
 
 static HTTPStatus_t findHeaderInResponse( const uint8_t * pBuffer,
                                           size_t bufferLen,
-                                          const uint8_t * pField,
+                                          const char * pField,
                                           size_t fieldLen,
-                                          const uint8_t ** pValueLoc,
+                                          const char ** pValueLoc,
                                           size_t * pValueLen )
 {
     HTTPStatus_t returnStatus = HTTP_SUCCESS;
@@ -2182,10 +2182,10 @@ static HTTPStatus_t findHeaderInResponse( const uint8_t * pBuffer,
 /*-----------------------------------------------------------*/
 
 HTTPStatus_t HTTPClient_ReadHeader( const HTTPResponse_t * pResponse,
-                                    const uint8_t * pHeaderName,
-                                    size_t headerNameLen,
-                                    const uint8_t ** pHeaderValueLoc,
-                                    size_t * pHeaderValueLen )
+                                    const char * pField,
+                                    size_t fieldLen,
+                                    const char ** pValueLoc,
+                                    size_t * pValueLen )
 {
     HTTPStatus_t returnStatus = HTTP_SUCCESS;
 
@@ -2205,23 +2205,23 @@ HTTPStatus_t HTTPClient_ReadHeader( const HTTPResponse_t * pResponse,
                     "Buffer len should be > 0." ) );
         returnStatus = HTTP_INVALID_PARAMETER;
     }
-    else if( pHeaderName == NULL )
+    else if( pField == NULL )
     {
         LogError( ( "Parameter check failed: Input header name is NULL." ) );
         returnStatus = HTTP_INVALID_PARAMETER;
     }
-    else if( headerNameLen == 0u )
+    else if( fieldLen == 0u )
     {
         LogError( ( "Parameter check failed: Input header name length is 0: "
-                    "headerNameLen should be > 0." ) );
+                    "fieldLen should be > 0." ) );
         returnStatus = HTTP_INVALID_PARAMETER;
     }
-    else if( pHeaderValueLoc == NULL )
+    else if( pValueLoc == NULL )
     {
         LogError( ( "Parameter check failed: Output parameter for header value location is NULL." ) );
         returnStatus = HTTP_INVALID_PARAMETER;
     }
-    else if( pHeaderValueLen == NULL )
+    else if( pValueLen == NULL )
     {
         LogError( ( "Parameter check failed: Output parameter for header value length is NULL." ) );
         returnStatus = HTTP_INVALID_PARAMETER;
@@ -2235,10 +2235,10 @@ HTTPStatus_t HTTPClient_ReadHeader( const HTTPResponse_t * pResponse,
     {
         returnStatus = findHeaderInResponse( pResponse->pBuffer,
                                              pResponse->bufferLen,
-                                             pHeaderName,
-                                             headerNameLen,
-                                             pHeaderValueLoc,
-                                             pHeaderValueLen );
+                                             pField,
+                                             fieldLen,
+                                             pValueLoc,
+                                             pValueLen );
     }
 
     return returnStatus;

--- a/libraries/standard/http/src/private/http_client_internal.h
+++ b/libraries/standard/http/src/private/http_client_internal.h
@@ -146,12 +146,12 @@ typedef enum HTTPParsingState_t
  */
 typedef struct findHeaderContext
 {
-    const uint8_t * pField;     /**< The field that is being searched for. */
-    size_t fieldLen;            /**< The length of pField. */
-    const uint8_t ** pValueLoc; /**< The location of the value found in the buffer. */
-    size_t * pValueLen;         /**< the length of the value found. */
-    uint8_t fieldFound;         /**< Indicates that the header field was found during parsing. */
-    uint8_t valueFound;         /**< Indicates that the header value was found during parsing. */
+    const char * pField;     /**< The field that is being searched for. */
+    size_t fieldLen;         /**< The length of pField. */
+    const char ** pValueLoc; /**< The location of the value found in the buffer. */
+    size_t * pValueLen;      /**< the length of the value found. */
+    uint8_t fieldFound;      /**< Indicates that the header field was found during parsing. */
+    uint8_t valueFound;      /**< Indicates that the header value was found during parsing. */
 } findHeaderContext_t;
 
 /**

--- a/libraries/standard/http/utest/http_config.h
+++ b/libraries/standard/http/utest/http_config.h
@@ -16,7 +16,7 @@
 
 /* Configure name and log level for the HTTP library. */
 #define LIBRARY_LOG_NAME     "HTTP"
-#define LIBRARY_LOG_LEVEL    LOG_INFO
+#define LIBRARY_LOG_LEVEL    LOG_DEBUG
 
 #include "logging_stack.h"
 

--- a/libraries/standard/http/utest/http_utest.c
+++ b/libraries/standard/http/utest/http_utest.c
@@ -119,8 +119,14 @@ static const char * pTestResponse = "HTTP/1.1 200 OK\r\n"
                                     "header_not_in_buffer: test-value3\r\n"
                                     "\r\n";
 
-#define HEADER_IN_BUFFER        "test-header1"
-#define HEADER_NOT_IN_BUFFER    "header-not-in-buffer"
+#define HEADER_INVALID_PARAMS        "Header"
+#define HEADER_INVALID_PARAMS_LEN    ( sizeof( HEADER_INVALID_PARAMS ) - 1 )
+
+#define HEADER_IN_BUFFER             "test-header1"
+#define HEADER_IN_BUFFER_LEN         ( sizeof( HEADER_IN_BUFFER ) - 1 )
+
+#define HEADER_NOT_IN_BUFFER         "header-not-in-buffer"
+#define HEADER_NOT_IN_BUFFER_LEN     ( sizeof( HEADER_NOT_IN_BUFFER ) - 1 )
 
 /* File-scoped Global variables */
 static HTTPStatus_t retCode = HTTP_SUCCESS;
@@ -1070,8 +1076,8 @@ void test_Http_ReadHeader_Invalid_Params( void )
 {
     /* Response parameter is NULL. */
     retCode = HTTPClient_ReadHeader( NULL,
-                                     ( const uint8_t * ) "Header",
-                                     strlen( "Header" ),
+                                     ( const uint8_t * ) HEADER_INVALID_PARAMS,
+                                     HEADER_INVALID_PARAMS_LEN,
                                      &pValueLoc,
                                      &valueLen );
     TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, retCode );
@@ -1080,8 +1086,8 @@ void test_Http_ReadHeader_Invalid_Params( void )
     tearDown();
     testResponse.pBuffer = NULL;
     retCode = HTTPClient_ReadHeader( &testResponse,
-                                     ( const uint8_t * ) "Header",
-                                     strlen( "Header" ),
+                                     ( const uint8_t * ) HEADER_INVALID_PARAMS,
+                                     HEADER_INVALID_PARAMS_LEN,
                                      &pValueLoc,
                                      &valueLen );
     TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, retCode );
@@ -1090,8 +1096,8 @@ void test_Http_ReadHeader_Invalid_Params( void )
     tearDown();
     testResponse.bufferLen = 0;
     retCode = HTTPClient_ReadHeader( &testResponse,
-                                     ( const uint8_t * ) "Header",
-                                     strlen( "Header" ),
+                                     ( const uint8_t * ) HEADER_INVALID_PARAMS,
+                                     HEADER_INVALID_PARAMS_LEN,
                                      &pValueLoc,
                                      &valueLen );
     TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, retCode );
@@ -1100,7 +1106,7 @@ void test_Http_ReadHeader_Invalid_Params( void )
     tearDown();
     retCode = HTTPClient_ReadHeader( &testResponse,
                                      NULL,
-                                     strlen( "Header" ),
+                                     HEADER_INVALID_PARAMS_LEN,
                                      &pValueLoc,
                                      &valueLen );
     TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, retCode );
@@ -1108,7 +1114,7 @@ void test_Http_ReadHeader_Invalid_Params( void )
     /* Header field length is 0. */
     tearDown();
     retCode = HTTPClient_ReadHeader( &testResponse,
-                                     ( const uint8_t * ) "Header",
+                                     ( const uint8_t * ) HEADER_INVALID_PARAMS,
                                      0u,
                                      &pValueLoc,
                                      &valueLen );
@@ -1117,15 +1123,15 @@ void test_Http_ReadHeader_Invalid_Params( void )
     /* Invalid output parameters. */
     tearDown();
     retCode = HTTPClient_ReadHeader( &testResponse,
-                                     ( const uint8_t * ) "Header",
-                                     strlen( "Header" ),
+                                     ( const uint8_t * ) HEADER_INVALID_PARAMS,
+                                     HEADER_INVALID_PARAMS_LEN,
                                      NULL,
                                      &valueLen );
     TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, retCode );
     tearDown();
     retCode = HTTPClient_ReadHeader( &testResponse,
-                                     ( const uint8_t * ) "Header",
-                                     strlen( "Header" ),
+                                     ( const uint8_t * ) HEADER_INVALID_PARAMS,
+                                     HEADER_INVALID_PARAMS_LEN,
                                      &pValueLoc,
                                      NULL );
     TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, retCode );
@@ -1156,12 +1162,12 @@ void test_Http_ReadHeader_Header_Not_In_Response( void )
     testResponse.bufferLen = strlen( pTestResponse );
     retCode = HTTPClient_ReadHeader( &testResponse,
                                      ( const uint8_t * ) HEADER_NOT_IN_BUFFER,
-                                     strlen( HEADER_NOT_IN_BUFFER ),
+                                     HEADER_NOT_IN_BUFFER_LEN,
                                      &pValueLoc,
                                      &valueLen );
     TEST_ASSERT_EQUAL( HTTP_HEADER_NOT_FOUND, retCode );
 
-    /* Repeat the test above but with fieldLenToReturn == strlen( HEADER_NOT_IN_BUFFER ).
+    /* Repeat the test above but with fieldLenToReturn == HEADER_NOT_IN_BUFFER_LEN.
      * Doing this allows us to take the branch where the actual contents
      * of the fields are compared rather than just the length. */
     setUp();
@@ -1169,10 +1175,10 @@ void test_Http_ReadHeader_Header_Not_In_Response( void )
     http_parser_init_ExpectAnyArgs();
     http_parser_settings_init_ExpectAnyArgs();
     /* Ensure that the header field does NOT match what we're searching. */
+    TEST_ASSERT_EQUAL( otherHeaderFieldInRespLen, HEADER_NOT_IN_BUFFER_LEN );
     TEST_ASSERT_TRUE( memcmp( &pTestResponse[ otherHeaderFieldInRespLoc ],
                               HEADER_NOT_IN_BUFFER,
-                              strlen( HEADER_NOT_IN_BUFFER ) ) != 0 );
-
+                              HEADER_NOT_IN_BUFFER_LEN ) != 0 );
     /* Configure the http_parser_execute mock. */
     invokeHeaderFieldCallback = 1u;
     invokeHeaderValueCallback = 1u;
@@ -1189,7 +1195,7 @@ void test_Http_ReadHeader_Header_Not_In_Response( void )
     testResponse.bufferLen = strlen( pTestResponse );
     retCode = HTTPClient_ReadHeader( &testResponse,
                                      ( const uint8_t * ) HEADER_NOT_IN_BUFFER,
-                                     strlen( HEADER_NOT_IN_BUFFER ),
+                                     HEADER_NOT_IN_BUFFER_LEN,
                                      &pValueLoc,
                                      &valueLen );
     TEST_ASSERT_EQUAL( HTTP_HEADER_NOT_FOUND, retCode );
@@ -1223,7 +1229,7 @@ void test_Http_ReadHeader_Invalid_Response_Only_Header_Field_Found()
     testResponse.bufferLen = strlen( pResponseWithoutValue );
     retCode = HTTPClient_ReadHeader( &testResponse,
                                      ( const uint8_t * ) HEADER_IN_BUFFER,
-                                     strlen( HEADER_IN_BUFFER ),
+                                     HEADER_IN_BUFFER_LEN,
                                      &pValueLoc,
                                      &valueLen );
     TEST_ASSERT_EQUAL( HTTP_INVALID_RESPONSE, retCode );
@@ -1256,7 +1262,7 @@ void test_Http_ReadHeader_Invalid_Response_No_Headers_Complete_Ending()
     testResponse.bufferLen = strlen( pResponseWithoutHeaders );
     retCode = HTTPClient_ReadHeader( &testResponse,
                                      ( const uint8_t * ) HEADER_NOT_IN_BUFFER,
-                                     strlen( HEADER_NOT_IN_BUFFER ),
+                                     HEADER_NOT_IN_BUFFER_LEN,
                                      &pValueLoc,
                                      &valueLen );
     TEST_ASSERT_EQUAL( HTTP_INVALID_RESPONSE, retCode );
@@ -1287,7 +1293,7 @@ void test_Http_ReadHeader_With_HttpParser_Internal_Error()
     /* Call the function under test. */
     retCode = HTTPClient_ReadHeader( &testResponse,
                                      ( const uint8_t * ) HEADER_IN_BUFFER,
-                                     strlen( HEADER_IN_BUFFER ),
+                                     HEADER_IN_BUFFER_LEN,
                                      &pValueLoc,
                                      &valueLen );
     TEST_ASSERT_EQUAL( HTTP_PARSER_INTERNAL_ERROR, retCode );
@@ -1316,7 +1322,7 @@ void test_Http_ReadHeader_Happy_Path()
     /* Call the function under test. */
     retCode = HTTPClient_ReadHeader( &testResponse,
                                      ( const uint8_t * ) HEADER_IN_BUFFER,
-                                     strlen( HEADER_IN_BUFFER ),
+                                     HEADER_IN_BUFFER_LEN,
                                      &pValueLoc,
                                      &valueLen );
     TEST_ASSERT_EQUAL( HTTP_SUCCESS, retCode );

--- a/libraries/standard/http/utest/http_utest.c
+++ b/libraries/standard/http/utest/http_utest.c
@@ -1151,6 +1151,34 @@ void test_Http_ReadHeader_Header_Not_In_Response( void )
                                      &pValueLoc,
                                      &valueLen );
     TEST_ASSERT_EQUAL( HTTP_HEADER_NOT_FOUND, retCode );
+
+    /* Repeat the test above but with length of value in callback equal to
+     * header that is not in the response headers. */
+    setUp();
+    /* Add expectations for http_parser dependencies. */
+    http_parser_init_ExpectAnyArgs();
+    http_parser_settings_init_ExpectAnyArgs();
+
+    /* Configure the http_parser_execute mock. */
+    invokeHeaderFieldCallback = 1u;
+    invokeHeaderValueCallback = 1u;
+    pFieldLocToReturn = &pTestResponse[ headerFieldInRespLoc ];
+    fieldLenToReturn = strlen( HEADER_NOT_IN_BUFFER );
+    pValueLocToReturn = &pTestResponse[ headerValInRespLoc ];
+    valueLenToReturn = headerValInRespLen;
+    expectedValCbRetVal = HTTP_PARSER_CONTINUE_PARSING;
+    invokeHeaderCompleteCallback = 1u;
+    parserErrNo = HPE_OK;
+    http_parser_execute_ExpectAnyArgsAndReturn( strlen( pTestResponse ) );
+
+    /* Call the function under test. */
+    testResponse.bufferLen = strlen( pTestResponse );
+    retCode = HTTPClient_ReadHeader( &testResponse,
+                                     ( const uint8_t * ) HEADER_NOT_IN_BUFFER,
+                                     strlen( HEADER_NOT_IN_BUFFER ),
+                                     &pValueLoc,
+                                     &valueLen );
+    TEST_ASSERT_EQUAL( HTTP_HEADER_NOT_FOUND, retCode );
 }
 
 /**

--- a/libraries/standard/http/utest/http_utest.c
+++ b/libraries/standard/http/utest/http_utest.c
@@ -1168,6 +1168,10 @@ void test_Http_ReadHeader_Header_Not_In_Response( void )
     /* Add expectations for http_parser dependencies. */
     http_parser_init_ExpectAnyArgs();
     http_parser_settings_init_ExpectAnyArgs();
+    /* Ensure that the header field does NOT match what we're searching. */
+    TEST_ASSERT_TRUE( memcmp( &pTestResponse[ otherHeaderFieldInRespLoc ],
+                              HEADER_NOT_IN_BUFFER,
+                              strlen( HEADER_NOT_IN_BUFFER ) ) != 0 );
 
     /* Configure the http_parser_execute mock. */
     invokeHeaderFieldCallback = 1u;

--- a/libraries/standard/http/utest/http_utest.c
+++ b/libraries/standard/http/utest/http_utest.c
@@ -324,6 +324,8 @@ void tearDown()
     memset( &testResponse,
             0,
             sizeof( testResponse ) );
+    testResponse.pBuffer = testBuffer;
+    testResponse.bufferLen = strlen( pTestResponse );
     pValueLoc = NULL;
     valueLen = 0u;
     pValueLoc = NULL;
@@ -1044,6 +1046,7 @@ void test_Http_ReadHeader_Invalid_Params( void )
 
     /* Underlying buffer is NULL in the response parameter. */
     tearDown();
+    testResponse.pBuffer = NULL;
     retCode = HTTPClient_ReadHeader( &testResponse,
                                      ( const uint8_t * ) "Header",
                                      strlen( "Header" ),
@@ -1053,6 +1056,7 @@ void test_Http_ReadHeader_Invalid_Params( void )
 
     /* Response buffer size is zero. */
     tearDown();
+    testResponse.bufferLen = 0;
     retCode = HTTPClient_ReadHeader( &testResponse,
                                      ( const uint8_t * ) "Header",
                                      strlen( "Header" ),
@@ -1062,7 +1066,6 @@ void test_Http_ReadHeader_Invalid_Params( void )
 
     /* Header field name is NULL. */
     tearDown();
-    testResponse.bufferLen = strlen( pTestResponse );
     retCode = HTTPClient_ReadHeader( &testResponse,
                                      NULL,
                                      strlen( "Header" ),
@@ -1072,7 +1075,6 @@ void test_Http_ReadHeader_Invalid_Params( void )
 
     /* Header field length is 0. */
     tearDown();
-    testResponse.bufferLen = strlen( pTestResponse );
     retCode = HTTPClient_ReadHeader( &testResponse,
                                      ( const uint8_t * ) "Header",
                                      0u,
@@ -1082,7 +1084,6 @@ void test_Http_ReadHeader_Invalid_Params( void )
 
     /* Invalid output parameters. */
     tearDown();
-    testResponse.bufferLen = strlen( pTestResponse );
     retCode = HTTPClient_ReadHeader( &testResponse,
                                      ( const uint8_t * ) "Header",
                                      strlen( "Header" ),
@@ -1090,7 +1091,6 @@ void test_Http_ReadHeader_Invalid_Params( void )
                                      &valueLen );
     TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, retCode );
     tearDown();
-    testResponse.bufferLen = strlen( pTestResponse );
     retCode = HTTPClient_ReadHeader( &testResponse,
                                      ( const uint8_t * ) "Header",
                                      strlen( "Header" ),

--- a/libraries/standard/http/utest/http_utest.c
+++ b/libraries/standard/http/utest/http_utest.c
@@ -1109,7 +1109,14 @@ void test_Http_ReadHeader_Header_Not_In_Response( void )
     http_parser_settings_init_ExpectAnyArgs();
 
     /* Configure the http_parser_execute mock. */
-    invokeHeaderCompleteCallback = 0u;
+    invokeHeaderFieldCallback = 1u;
+    invokeHeaderValueCallback = 1u;
+    pFieldLocToReturn = &pTestResponse[ headerFieldInRespLoc ];
+    fieldLenToReturn = headerFieldInRespLen;
+    pValueLocToReturn = &pTestResponse[ headerValInRespLoc ];
+    valueLenToReturn = headerValInRespLen;
+    expectedValCbRetVal = HTTP_PARSER_CONTINUE_PARSING;
+    invokeHeaderCompleteCallback = 1u;
     parserErrNo = HPE_OK;
     http_parser_execute_ExpectAnyArgsAndReturn( strlen( pTestResponse ) );
 

--- a/libraries/standard/http/utest/http_utest.c
+++ b/libraries/standard/http/utest/http_utest.c
@@ -1153,7 +1153,7 @@ void test_Http_ReadHeader_Header_Not_In_Response( void )
     TEST_ASSERT_EQUAL( HTTP_HEADER_NOT_FOUND, retCode );
 
     /* Repeat the test above but with length of value in callback equal to
-     * header that is not in the response headers. */
+     * length of header that is not in the response headers. */
     setUp();
     /* Add expectations for http_parser dependencies. */
     http_parser_init_ExpectAnyArgs();

--- a/libraries/standard/http/utest/http_utest.c
+++ b/libraries/standard/http/utest/http_utest.c
@@ -135,7 +135,7 @@ static HTTPRequestHeaders_t testHeaders = { 0 };
 static _headers_t expectedHeaders = { 0 };
 static int testRangeStart = 0;
 static int testRangeEnd = 0;
-static const uint8_t * pValueLoc = NULL;
+static const char * pValueLoc = NULL;
 static size_t valueLen = 0u;
 static HTTPResponse_t testResponse = { 0 };
 static const size_t headerFieldInRespLoc = 44;
@@ -254,13 +254,15 @@ static void setupBuffersWithPreexistingHeader( HTTPRequestHeaders_t * testReques
                                                const char * preexistingData )
 {
     size_t dataLen = strlen( preexistingData );
+    int numBytes = 0;
 
     testRequestHeaders->pBuffer = testBuffer;
     testRequestHeaders->bufferLen = bufferSize;
-    int numBytes = snprintf( ( char * ) testRequestHeaders->pBuffer,
-                             bufferSize,
-                             "%s",
-                             preexistingData );
+
+    numBytes = snprintf( ( char * ) testRequestHeaders->pBuffer,
+                         bufferSize,
+                         "%s",
+                         preexistingData );
     /* Make sure that the entire pre-existing data was printed to the buffer. */
     TEST_ASSERT_GREATER_THAN( 0, numBytes );
     TEST_ASSERT_LESS_THAN( bufferSize, ( size_t ) numBytes );
@@ -574,7 +576,8 @@ void test_Http_AddHeader_Happy_Path()
     setupBuffer( &requestHeaders );
 
     /* Add 1 because snprintf(...) writes a null byte at the end. */
-    numBytes = snprintf( expectedHeaders.buffer, sizeof( expectedHeaders.buffer ),
+    numBytes = snprintf( ( char * ) expectedHeaders.buffer,
+                         sizeof( expectedHeaders.buffer ),
                          HTTP_TEST_SINGLE_HEADER_FORMAT,
                          HTTP_TEST_HEADER_REQUEST_LINE,
                          HTTP_TEST_HEADER_FIELD, HTTP_TEST_HEADER_VALUE );
@@ -663,7 +666,8 @@ void test_Http_AddHeader_Extra_Header_Sufficient_Memory()
     setupBuffer( &requestHeaders );
 
     /* Add 1 because snprintf(...) writes a null byte at the end. */
-    numBytes = snprintf( expectedHeaders.buffer, sizeof( expectedHeaders.buffer ),
+    numBytes = snprintf( ( char * ) expectedHeaders.buffer,
+                         sizeof( expectedHeaders.buffer ),
                          HTTP_TEST_DOUBLE_HEADER_FORMAT,
                          HTTP_TEST_HEADER_REQUEST_LINE,
                          HTTP_TEST_HEADER_FIELD, HTTP_TEST_HEADER_VALUE,
@@ -685,9 +689,9 @@ void test_Http_AddHeader_Extra_Header_Sufficient_Memory()
 
     /* Run the method to test. */
     httpStatus = HTTPClient_AddHeader( &requestHeaders,
-                                       ( uint8_t * ) HTTP_TEST_HEADER_FIELD,
+                                       HTTP_TEST_HEADER_FIELD,
                                        HTTP_TEST_HEADER_FIELD_LEN,
-                                       ( uint8_t * ) HTTP_TEST_HEADER_VALUE,
+                                       HTTP_TEST_HEADER_VALUE,
                                        HTTP_TEST_HEADER_VALUE_LEN );
     TEST_ASSERT_EQUAL( expectedHeaders.dataLen, requestHeaders.headersLen );
     TEST_ASSERT_EQUAL_MEMORY( expectedHeaders.buffer,
@@ -707,7 +711,8 @@ void test_Http_AddHeader_Extra_Header_Insufficient_Memory()
     setupBuffer( &requestHeaders );
 
     /* Add 1 because snprintf(...) writes a null byte at the end. */
-    numBytes = snprintf( expectedHeaders.buffer, sizeof( expectedHeaders.buffer ),
+    numBytes = snprintf( ( char * ) expectedHeaders.buffer,
+                         sizeof( expectedHeaders.buffer ),
                          HTTP_TEST_SINGLE_HEADER_FORMAT,
                          HTTP_TEST_HEADER_REQUEST_LINE,
                          HTTP_TEST_HEADER_FIELD, HTTP_TEST_HEADER_VALUE );
@@ -730,9 +735,9 @@ void test_Http_AddHeader_Extra_Header_Insufficient_Memory()
 
     /* Run the method to test. */
     httpStatus = HTTPClient_AddHeader( &requestHeaders,
-                                       ( uint8_t * ) HTTP_TEST_HEADER_FIELD,
+                                       HTTP_TEST_HEADER_FIELD,
                                        HTTP_TEST_HEADER_FIELD_LEN,
-                                       ( uint8_t * ) HTTP_TEST_HEADER_VALUE,
+                                       HTTP_TEST_HEADER_VALUE,
                                        HTTP_TEST_HEADER_VALUE_LEN );
     TEST_ASSERT_EQUAL( expectedHeaders.dataLen, requestHeaders.headersLen );
     TEST_ASSERT_EQUAL_MEMORY( expectedHeaders.buffer,
@@ -765,9 +770,9 @@ void test_Http_AddHeader_Single_Header_Insufficient_Memory()
 
     /* Run the method to test. */
     httpStatus = HTTPClient_AddHeader( &requestHeaders,
-                                       ( uint8_t * ) HTTP_TEST_HEADER_FIELD,
+                                       HTTP_TEST_HEADER_FIELD,
                                        HTTP_TEST_HEADER_FIELD_LEN,
-                                       ( uint8_t * ) HTTP_TEST_HEADER_VALUE,
+                                       HTTP_TEST_HEADER_VALUE,
                                        HTTP_TEST_HEADER_VALUE_LEN );
     TEST_ASSERT_EQUAL( HTTP_INSUFFICIENT_MEMORY, httpStatus );
 }
@@ -1076,7 +1081,7 @@ void test_Http_ReadHeader_Invalid_Params( void )
 {
     /* Response parameter is NULL. */
     retCode = HTTPClient_ReadHeader( NULL,
-                                     ( const uint8_t * ) HEADER_INVALID_PARAMS,
+                                     HEADER_INVALID_PARAMS,
                                      HEADER_INVALID_PARAMS_LEN,
                                      &pValueLoc,
                                      &valueLen );
@@ -1086,7 +1091,7 @@ void test_Http_ReadHeader_Invalid_Params( void )
     tearDown();
     testResponse.pBuffer = NULL;
     retCode = HTTPClient_ReadHeader( &testResponse,
-                                     ( const uint8_t * ) HEADER_INVALID_PARAMS,
+                                     HEADER_INVALID_PARAMS,
                                      HEADER_INVALID_PARAMS_LEN,
                                      &pValueLoc,
                                      &valueLen );
@@ -1096,7 +1101,7 @@ void test_Http_ReadHeader_Invalid_Params( void )
     tearDown();
     testResponse.bufferLen = 0;
     retCode = HTTPClient_ReadHeader( &testResponse,
-                                     ( const uint8_t * ) HEADER_INVALID_PARAMS,
+                                     HEADER_INVALID_PARAMS,
                                      HEADER_INVALID_PARAMS_LEN,
                                      &pValueLoc,
                                      &valueLen );
@@ -1114,7 +1119,7 @@ void test_Http_ReadHeader_Invalid_Params( void )
     /* Header field length is 0. */
     tearDown();
     retCode = HTTPClient_ReadHeader( &testResponse,
-                                     ( const uint8_t * ) HEADER_INVALID_PARAMS,
+                                     HEADER_INVALID_PARAMS,
                                      0u,
                                      &pValueLoc,
                                      &valueLen );
@@ -1123,14 +1128,14 @@ void test_Http_ReadHeader_Invalid_Params( void )
     /* Invalid output parameters. */
     tearDown();
     retCode = HTTPClient_ReadHeader( &testResponse,
-                                     ( const uint8_t * ) HEADER_INVALID_PARAMS,
+                                     HEADER_INVALID_PARAMS,
                                      HEADER_INVALID_PARAMS_LEN,
                                      NULL,
                                      &valueLen );
     TEST_ASSERT_EQUAL( HTTP_INVALID_PARAMETER, retCode );
     tearDown();
     retCode = HTTPClient_ReadHeader( &testResponse,
-                                     ( const uint8_t * ) HEADER_INVALID_PARAMS,
+                                     HEADER_INVALID_PARAMS,
                                      HEADER_INVALID_PARAMS_LEN,
                                      &pValueLoc,
                                      NULL );
@@ -1161,7 +1166,7 @@ void test_Http_ReadHeader_Header_Not_In_Response( void )
     /* Call the function under test. */
     testResponse.bufferLen = strlen( pTestResponse );
     retCode = HTTPClient_ReadHeader( &testResponse,
-                                     ( const uint8_t * ) HEADER_NOT_IN_BUFFER,
+                                     HEADER_NOT_IN_BUFFER,
                                      HEADER_NOT_IN_BUFFER_LEN,
                                      &pValueLoc,
                                      &valueLen );
@@ -1194,7 +1199,7 @@ void test_Http_ReadHeader_Header_Not_In_Response( void )
     /* Call the function under test. */
     testResponse.bufferLen = strlen( pTestResponse );
     retCode = HTTPClient_ReadHeader( &testResponse,
-                                     ( const uint8_t * ) HEADER_NOT_IN_BUFFER,
+                                     HEADER_NOT_IN_BUFFER,
                                      HEADER_NOT_IN_BUFFER_LEN,
                                      &pValueLoc,
                                      &valueLen );
@@ -1228,7 +1233,7 @@ void test_Http_ReadHeader_Invalid_Response_Only_Header_Field_Found()
     testResponse.pBuffer = ( uint8_t * ) &pResponseWithoutValue[ 0 ];
     testResponse.bufferLen = strlen( pResponseWithoutValue );
     retCode = HTTPClient_ReadHeader( &testResponse,
-                                     ( const uint8_t * ) HEADER_IN_BUFFER,
+                                     HEADER_IN_BUFFER,
                                      HEADER_IN_BUFFER_LEN,
                                      &pValueLoc,
                                      &valueLen );
@@ -1261,7 +1266,7 @@ void test_Http_ReadHeader_Invalid_Response_No_Headers_Complete_Ending()
     testResponse.pBuffer = ( uint8_t * ) &pResponseWithoutHeaders[ 0 ];
     testResponse.bufferLen = strlen( pResponseWithoutHeaders );
     retCode = HTTPClient_ReadHeader( &testResponse,
-                                     ( const uint8_t * ) HEADER_NOT_IN_BUFFER,
+                                     HEADER_NOT_IN_BUFFER,
                                      HEADER_NOT_IN_BUFFER_LEN,
                                      &pValueLoc,
                                      &valueLen );
@@ -1292,7 +1297,7 @@ void test_Http_ReadHeader_With_HttpParser_Internal_Error()
 
     /* Call the function under test. */
     retCode = HTTPClient_ReadHeader( &testResponse,
-                                     ( const uint8_t * ) HEADER_IN_BUFFER,
+                                     HEADER_IN_BUFFER,
                                      HEADER_IN_BUFFER_LEN,
                                      &pValueLoc,
                                      &valueLen );
@@ -1321,12 +1326,12 @@ void test_Http_ReadHeader_Happy_Path()
 
     /* Call the function under test. */
     retCode = HTTPClient_ReadHeader( &testResponse,
-                                     ( const uint8_t * ) HEADER_IN_BUFFER,
+                                     HEADER_IN_BUFFER,
                                      HEADER_IN_BUFFER_LEN,
                                      &pValueLoc,
                                      &valueLen );
     TEST_ASSERT_EQUAL( HTTP_SUCCESS, retCode );
-    TEST_ASSERT_EQUAL( ( const uint8_t * ) &pTestResponse[ headerValInRespLoc ], pValueLoc );
+    TEST_ASSERT_EQUAL( &pTestResponse[ headerValInRespLoc ], pValueLoc );
     TEST_ASSERT_EQUAL( headerValInRespLen, valueLen );
 }
 


### PR DESCRIPTION
*Summary of changes:*
- `test_Http_ReadHeader_Invalid_Params` was not correctly setting the buffer after each `tearDown`, leading to parameter checks being skipped.
- `test_Http_ReadHeader_Header_Not_In_Response` needed to invoke `http-parser` callbacks for full branch coverage.
- `test_Http_InitializeRequestHeaders_ReqInfo` needed to repeat the test with `pathLen==0` in order to have full branch coverage for `writeRequestLine`.
- Resolve some warnings involving passing `char *` type to `HTTPClient_AddHeader`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
