### PR TITLE
Add MQTT Receive Loop without keep alive

### DIFF
--- a/libraries/standard/mqtt/include/mqtt.h
+++ b/libraries/standard/mqtt/include/mqtt.h
@@ -125,6 +125,11 @@ struct MQTTContext
  * @brief Initialize an MQTT context.
  *
  * This function must be called on an MQTT context before any other function.
+ * 
+ * @note The getTime callback function must be defined. If there is no time
+ * implementation, it is the responsibility of the application to provide a
+ * dummy function to always return 0, and provide 0 timeouts for functions. This
+ * will ensure all time based functions will run for a single iteration.
  *
  * @brief param[in] pContext The context to initialize.
  * @brief param[in] pTransportInterface The transport interface to use with the context.
@@ -249,10 +254,6 @@ MQTTStatus_t MQTT_Disconnect( MQTTContext_t * pContext );
 /**
  * @brief Loop to receive packets from the transport interface. Handles keep
  * alive.
- *
- * @note This function assumes that pContext->callbacks.getTime is defined.
- * This is due to keep alive requiring a reliable method of calculating elapsed
- * time to determine if the keep alive interval has expired.
  *
  * @param[in] pContext Initialized and connected MQTT context.
  * @param[in] timeoutMs Minimum time in milliseconds that the receive loop will

--- a/libraries/standard/mqtt/include/mqtt.h
+++ b/libraries/standard/mqtt/include/mqtt.h
@@ -247,7 +247,12 @@ MQTTStatus_t MQTT_Unsubscribe( MQTTContext_t * pContext,
 MQTTStatus_t MQTT_Disconnect( MQTTContext_t * pContext );
 
 /**
- * @brief Loop to receive packets from the transport interface.
+ * @brief Loop to receive packets from the transport interface. Handles keep
+ * alive.
+ *
+ * @note This function assumes that pContext->callbacks.getTime is defined.
+ * This is due to keep alive requiring a reliable method of calculating elapsed
+ * time to determine if the keep alive interval has expired.
  *
  * @param[in] pContext Initialized and connected MQTT context.
  * @param[in] timeoutMs Minimum time in milliseconds that the receive loop will
@@ -264,6 +269,27 @@ MQTTStatus_t MQTT_Disconnect( MQTTContext_t * pContext );
  * #MQTTSuccess on success.
  */
 MQTTStatus_t MQTT_ProcessLoop( MQTTContext_t * pContext,
+                               uint32_t timeoutMs );
+
+/**
+ * @brief Loop to receive packets from the transport interface. Does not handle
+ * keep alive.
+ *
+ * @note Passing a timeout value of 0 will run the loop for a single iteration.
+ *
+ * @param[in] pContext Initialized and connected MQTT context.
+ * @param[in] timeoutMs Minimum time in milliseconds that the receive loop will
+ * run, unless an error occurs.
+ *
+ * @return #MQTTBadParameter if context is NULL;
+ * #MQTTRecvFailed if a network error occurs during reception;
+ * #MQTTSendFailed if a network error occurs while sending an ACK or PINGREQ;
+ * #MQTTBadResponse if an invalid packet is received;
+ * #MQTTIllegalState if an incoming QoS 1/2 publish or ack causes an
+ * invalid transition for the internal state machine;
+ * #MQTTSuccess on success.
+ */
+MQTTStatus_t MQTT_ReceiveLoop( MQTTContext_t * pContext,
                                uint32_t timeoutMs );
 
 /**

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -1546,6 +1546,7 @@ MQTTStatus_t MQTT_ReceiveLoop( MQTTContext_t * pContext,
     MQTTStatus_t status = MQTTBadParameter;
     MQTTGetCurrentTimeFunc_t getTimeStampMs = NULL;
     uint32_t entryTimeMs = 0U, remainingTimeMs = timeoutMs, elapsedTimeMs = 0U;
+    uint32_t adjustedTimeoutMs = timeoutMs;
 
     if( pContext != NULL )
     {
@@ -1554,6 +1555,8 @@ MQTTStatus_t MQTT_ReceiveLoop( MQTTContext_t * pContext,
         if( getTimeStampMs == NULL )
         {
             getTimeStampMs = getTimeStampNoSystemTime;
+            adjustedTimeoutMs = 0U;
+            remainingTimeMs = 0U;
         }
 
         entryTimeMs = getTimeStampMs();
@@ -1576,12 +1579,12 @@ MQTTStatus_t MQTT_ReceiveLoop( MQTTContext_t * pContext,
         /* Recalculate remaining time and check if loop should exit. */
         elapsedTimeMs = calculateElapsedTime( getTimeStampMs(), entryTimeMs );
 
-        if( elapsedTimeMs >= timeoutMs )
+        if( elapsedTimeMs >= adjustedTimeoutMs )
         {
             break;
         }
 
-        remainingTimeMs = timeoutMs - elapsedTimeMs;
+        remainingTimeMs = adjustedTimeoutMs - elapsedTimeMs;
     }
 
     return status;

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -708,7 +708,7 @@ static MQTTStatus_t handleIncomingAck( MQTTContext_t * pContext,
     MQTTPublishState_t publishRecordState = MQTTStateNull;
     uint16_t packetIdentifier;
     /* Need a dummy variable for MQTT_DeserializeAck(). */
-    bool sessionPresent = false, callAppCallback = true;
+    bool sessionPresent = false, callAppCallback = false;
     MQTTPubAckType_t ackType;
     MQTTEventCallback_t appCallback = NULL;
 
@@ -767,6 +767,7 @@ static MQTTStatus_t handleIncomingAck( MQTTContext_t * pContext,
         case MQTT_PACKET_TYPE_UNSUBACK:
             /* Deserialize and give these to the app provided callback. */
             status = MQTT_DeserializeAck( pIncomingPacket, &packetIdentifier, &sessionPresent );
+            callAppCallback = true;
             break;
 
         default:
@@ -1533,6 +1534,10 @@ MQTTStatus_t MQTT_ProcessLoop( MQTTContext_t * pContext,
     {
         status = receiveSingleIteration( pContext, remainingTimeMs, true );
 
+        /* We don't need to break here since the status is already checked in
+         * the loop condition, and we do not want multiple breaks in a loop.
+         * Calculating remaining time before exiting is fine since it does not
+         * affect the status. */
         if( status != MQTTSuccess )
         {
             LogError( ( "Exiting process loop. Error status=%s",
@@ -1589,6 +1594,10 @@ MQTTStatus_t MQTT_ReceiveLoop( MQTTContext_t * pContext,
     {
         status = receiveSingleIteration( pContext, remainingTimeMs, false );
 
+        /* We don't need to break here since the status is already checked in
+         * the loop condition, and we do not want multiple breaks in a loop.
+         * Calculating remaining time before exiting is fine since it does not
+         * affect the status. */
         if( status != MQTTSuccess )
         {
             LogError( ( "Exiting receive loop. Error status=%s",

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -1395,6 +1395,11 @@ void test_MQTT_ReceiveLoop( void )
     mqttStatus = MQTT_ReceiveLoop( NULL, MQTT_NO_TIMEOUT_MS );
     TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
 
+    /* Error case, for branch coverage. */
+    MQTT_GetIncomingPacketTypeAndLength_ExpectAnyArgsAndReturn( MQTTRecvFailed );
+    mqttStatus = MQTT_ReceiveLoop( &context, MQTT_NO_TIMEOUT_MS );
+    TEST_ASSERT_EQUAL( MQTTRecvFailed, mqttStatus );
+
     /* With time function. Keep Alive should not trigger.*/
     context.keepAliveIntervalSec = 1;
     MQTT_GetIncomingPacketTypeAndLength_IgnoreAndReturn( MQTTNoDataAvailable );


### PR DESCRIPTION
*Description of changes:*
Adds an API for a receive loop without keep alive. Also handles cases in the library when a `getTime` function is not defined by the application. In these cases, functions will run for a single iteration.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
