### PR TITLE
Fix remaining warnings in the http client code and tests.

### DIFF
--- a/libraries/standard/http/utest/http_send_utest.c
+++ b/libraries/standard/http/utest/http_send_utest.c
@@ -203,29 +203,29 @@ static HTTPClient_ResponseHeaderParsingCallback_t headerParsingCallback = { 0 };
 /* Application callback for intercepting the headers during the parse of a new
  * response from the mocked network interface. */
 static void onHeaderCallback( void * pContext,
-                              const uint8_t * fieldLoc,
+                              const char * fieldLoc,
                               size_t fieldLen,
-                              const uint8_t * valueLoc,
+                              const char * valueLoc,
                               size_t valueLen,
                               uint16_t statusCode )
 {
     ( void ) pContext;
     ( void ) statusCode;
 
-    if( strncmp( ( const char * ) fieldLoc, "Connection", fieldLen ) == 0 )
+    if( strncmp( fieldLoc, "Connection", fieldLen ) == 0 )
     {
-        if( strncmp( ( const char * ) valueLoc, "keep-alive", valueLen ) == 0 )
+        if( strncmp( valueLoc, "keep-alive", valueLen ) == 0 )
         {
             hasConnectionKeepAlive = 1;
         }
-        else if( strncmp( ( const char * ) valueLoc, "close", valueLen ) == 0 )
+        else if( strncmp( valueLoc, "close", valueLen ) == 0 )
         {
             hasConnectionClose = 1;
         }
     }
-    else if( strncmp( ( const char * ) fieldLoc, "Content-Length", fieldLen ) == 0 )
+    else if( strncmp( fieldLoc, "Content-Length", fieldLen ) == 0 )
     {
-        contentLength = strtoul( ( const char * ) valueLoc, NULL, 10 );
+        contentLength = strtoul( valueLoc, NULL, 10 );
     }
 
     headerCallbackCount++;


### PR DESCRIPTION
*Description of changes:*

Fix remaining warnings in the http client code and tests. There should be no warnings now except for in http_parser.h.

This whole review is just casting that was missed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
