### PR TITLE
Update HTTPNetworkContext_t to NetworkContext_t (struct ptr type)

### DIFF
--- a/demos/http/http_demo_basic_tls/demo_config.h
+++ b/demos/http/http_demo_basic_tls/demo_config.h
@@ -26,18 +26,24 @@
 /******* DO NOT CHANGE the following order ********/
 /**************************************************/
 
-/* Logging related header files are required to be included in the following order:
+/* Logging config definition and header files inclusion are required in the following order:
  * 1. Include the header file "logging_levels.h".
- * 2. Define LIBRARY_LOG_NAME and  LIBRARY_LOG_LEVEL.
- * 3. Include the header file "logging_stack.h".
+ * 2. Define the LIBRARY_LOG_NAME and LIBRARY_LOG_LEVEL macros depending on
+ * the logging configuration for DEMO.
+ * 3. Include the header file "logging_stack.h", if logging is enabled for DEMO.
  */
 
 /* Include header that defines log levels. */
 #include "logging_levels.h"
 
 /* Logging configuration for the Demo. */
-#define LIBRARY_LOG_NAME     "DEMO"
-#define LIBRARY_LOG_LEVEL    LOG_INFO
+#ifndef LIBRARY_LOG_NAME
+    #define LIBRARY_LOG_NAME    "DEMO"
+#endif
+
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL    LOG_INFO
+#endif
 
 #include "logging_stack.h"
 

--- a/demos/http/http_demo_basic_tls/http_config.h
+++ b/demos/http/http_demo_basic_tls/http_config.h
@@ -26,18 +26,23 @@
 /******* DO NOT CHANGE the following order ********/
 /**************************************************/
 
-/* Logging related header files are required to be included in the following order:
+/* Logging config definition and header files inclusion are required in the following order:
  * 1. Include the header file "logging_levels.h".
- * 2. Define LIBRARY_LOG_NAME and  LIBRARY_LOG_LEVEL.
- * 3. Include the header file "logging_stack.h".
+ * 2. Define the LIBRARY_LOG_NAME and LIBRARY_LOG_LEVEL macros depending on
+ * the logging configuration for HTTP.
+ * 3. Include the header file "logging_stack.h", if logging is enabled for HTTP.
  */
 
-/* Include header that defines log levels. */
 #include "logging_levels.h"
 
 /* Logging configuration for the HTTP library. */
-#define LIBRARY_LOG_NAME     "HTTP"
-#define LIBRARY_LOG_LEVEL    LOG_INFO
+#ifndef LIBRARY_LOG_NAME
+    #define LIBRARY_LOG_NAME    "HTTP"
+#endif
+
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL    LOG_INFO
+#endif
 
 #include "logging_stack.h"
 

--- a/demos/http/http_demo_basic_tls/http_demo_basic_tls.c
+++ b/demos/http/http_demo_basic_tls/http_demo_basic_tls.c
@@ -165,16 +165,11 @@ static uint8_t userBuffer[ USER_BUFFER_LENGTH ];
  *
  * @note For this TLS demo, the socket descriptor and SSL context is used.
  */
-struct HTTPNetworkContext
+struct NetworkContext
 {
     int tcpSocket;
     SSL * pSslContext;
 };
-
-/**
- * @brief Structure based on the definition of the HTTP network context.
- */
-static HTTPNetworkContext_t networkContext;
 
 /*-----------------------------------------------------------*/
 
@@ -216,7 +211,7 @@ static int tlsSetup( int tcpSocket,
  *
  * @return Number of bytes sent if successful; otherwise negative value on error.
  */
-static int32_t transportSend( HTTPNetworkContext_t * pContext,
+static int32_t transportSend( NetworkContext_t pNetworkContext,
                               const void * pBuffer,
                               size_t bytesToSend );
 
@@ -232,7 +227,7 @@ static int32_t transportSend( HTTPNetworkContext_t * pContext,
  *
  * @return Number of bytes received if successful; otherwise negative value on error.
  */
-static int32_t transportRecv( HTTPNetworkContext_t * pContext,
+static int32_t transportRecv( NetworkContext_t pNetworkContext,
                               void * pBuffer,
                               size_t bytesToRecv );
 
@@ -536,7 +531,7 @@ static int tlsSetup( int tcpSocket,
 
 /*-----------------------------------------------------------*/
 
-static int32_t transportSend( HTTPNetworkContext_t * pNetworkContext,
+static int32_t transportSend( NetworkContext_t pNetworkContext,
                               const void * pBuffer,
                               size_t bytesToSend )
 {
@@ -574,7 +569,7 @@ static int32_t transportSend( HTTPNetworkContext_t * pNetworkContext,
 
 /*-----------------------------------------------------------*/
 
-static int32_t transportRecv( HTTPNetworkContext_t * pNetworkContext,
+static int32_t transportRecv( NetworkContext_t pNetworkContext,
                               void * pBuffer,
                               size_t bytesToRecv )
 {
@@ -658,7 +653,7 @@ static int sendHttpRequest( const HTTPTransportInterface_t * pTransportInterface
 
     /* Set "Connection" HTTP header to "keep-alive" so that multiple requests
      * can be sent over the same established TCP connection. */
-    requestInfo.flags = HTTP_REQUEST_KEEP_ALIVE_FLAG;
+    requestInfo.reqFlags = HTTP_REQUEST_KEEP_ALIVE_FLAG;
 
     /* Set the buffer used for storing request headers. */
     requestHeaders.pBuffer = userBuffer;
@@ -748,6 +743,8 @@ int main( int argc,
     int returnStatus = EXIT_SUCCESS;
     /* The HTTP Client library transport layer interface. */
     HTTPTransportInterface_t transportInterface;
+    /* Structure based on the definition of the HTTP network context. */
+    struct NetworkContext networkContext;
 
     ( void ) argc;
     ( void ) argv;

--- a/demos/http/http_demo_plaintext/http_demo_plaintext.c
+++ b/demos/http/http_demo_plaintext/http_demo_plaintext.c
@@ -512,7 +512,7 @@ int main( int argc,
     }
 
     /* Send POST Request. */
-    if( returnStatus != EXIT_SUCCESS )
+    if( returnStatus == EXIT_SUCCESS )
     {
         returnStatus = sendHttpRequest( &transportInterface,
                                         SERVER_HOST,

--- a/demos/http/http_demo_plaintext/http_demo_plaintext.c
+++ b/demos/http/http_demo_plaintext/http_demo_plaintext.c
@@ -69,7 +69,7 @@ static uint8_t userBuffer[ USER_BUFFER_LENGTH ];
  *
  * @note An integer is used to store the descriptor of the socket.
  */
-struct HTTPNetworkContext
+struct NetworkContext
 {
     int tcpSocket;
 };
@@ -77,7 +77,7 @@ struct HTTPNetworkContext
 /**
  * @brief Structure based on the definition of the HTTP network context.
  */
-static HTTPNetworkContext_t socketContext;
+static struct NetworkContext socketContext;
 
 /**
  * @brief The HTTP Client library transport layer interface.
@@ -128,7 +128,7 @@ static int connectToServer( const char * pServer,
  *
  * @return Number of bytes sent if successful; otherwise negative value on error.
  */
-static int32_t transportSend( HTTPNetworkContext_t * pContext,
+static int32_t transportSend( NetworkContext_t pContext,
                               const void * pBuffer,
                               size_t bytesToSend );
 
@@ -144,7 +144,7 @@ static int32_t transportSend( HTTPNetworkContext_t * pContext,
  *
  * @return Number of bytes received if successful; otherwise negative value on error.
  */
-static int32_t transportRecv( HTTPNetworkContext_t * pContext,
+static int32_t transportRecv( NetworkContext_t pContext,
                               void * pBuffer,
                               size_t bytesToRecv );
 
@@ -308,7 +308,7 @@ static int connectToServer( const char * pServer,
 
 /*-----------------------------------------------------------*/
 
-static int32_t transportSend( HTTPNetworkContext_t * pContext,
+static int32_t transportSend( NetworkContext_t pContext,
                               const void * pBuffer,
                               size_t bytesToSend )
 {
@@ -331,7 +331,7 @@ static int32_t transportSend( HTTPNetworkContext_t * pContext,
 
 /*-----------------------------------------------------------*/
 
-static int32_t transportRecv( HTTPNetworkContext_t * pContext,
+static int32_t transportRecv( NetworkContext_t pContext,
                               void * pBuffer,
                               size_t bytesToRecv )
 {
@@ -464,6 +464,7 @@ int main( int argc,
           char ** argv )
 {
     int returnStatus = EXIT_SUCCESS;
+    NetworkContext_t pSocketContext = &socketContext;
 
     ( void ) argc;
     ( void ) argv;
@@ -471,14 +472,14 @@ int main( int argc,
     /**************************** Connect. ******************************/
 
     /* Establish TCP connection. */
-    returnStatus = connectToServer( SERVER_HOST, SERVER_PORT, &socketContext.tcpSocket );
+    returnStatus = connectToServer( SERVER_HOST, SERVER_PORT, &pSocketContext->tcpSocket );
 
     /* Define the transport interface. */
     if( returnStatus == EXIT_SUCCESS )
     {
         transportInterface.recv = transportRecv;
         transportInterface.send = transportSend;
-        transportInterface.pContext = &socketContext;
+        transportInterface.pContext = pSocketContext;
     }
 
     /*********************** Send HTTPS request. ************************/
@@ -521,10 +522,10 @@ int main( int argc,
 
     /************************** Disconnect. *****************************/
 
-    if( socketContext.tcpSocket != -1 )
+    if( pSocketContext->tcpSocket != -1 )
     {
-        ( void ) shutdown( socketContext.tcpSocket, SHUT_RDWR );
-        ( void ) close( socketContext.tcpSocket );
+        ( void ) shutdown( pSocketContext->tcpSocket, SHUT_RDWR );
+        ( void ) close( pSocketContext->tcpSocket );
     }
 
     return returnStatus;

--- a/libraries/standard/http/include/http_client.h
+++ b/libraries/standard/http/include/http_client.h
@@ -131,12 +131,12 @@
 #define HTTP_RANGE_REQUEST_END_OF_FILE              -1
 
 /**
- * @brief The HTTPNetworkContext is an incomplete type. The application must
- * define HTTPNetworkContext to the type of their network context. This context
+ * @brief The NetworkContext is an incomplete type. The application must
+ * define NetworkContext to the type of their network context. This context
  * is passed into the network interface functions.
  */
-struct HTTPNetworkContext;
-typedef struct HTTPNetworkContext HTTPNetworkContext_t;
+struct NetworkContext;
+typedef struct NetworkContext * NetworkContext_t;
 
 /**
  * @brief Transport interface for sending data over the network.
@@ -151,7 +151,7 @@ typedef struct HTTPNetworkContext HTTPNetworkContext_t;
  *
  * @return The number of bytes written or a negative network error code.
  */
-typedef int32_t ( * HTTPTransportSend_t )( HTTPNetworkContext_t * pContext,
+typedef int32_t ( * HTTPTransportSend_t )( NetworkContext_t pContext,
                                            const void * pBuffer,
                                            size_t bytesToWrite );
 
@@ -174,7 +174,7 @@ typedef int32_t ( * HTTPTransportSend_t )( HTTPNetworkContext_t * pContext,
  *
  * @return The number of bytes read or a negative error code.
  */
-typedef int32_t ( * HTTPTransportRecv_t )( HTTPNetworkContext_t * pContext,
+typedef int32_t ( * HTTPTransportRecv_t )( NetworkContext_t pContext,
                                            void * pBuffer,
                                            size_t bytesToRead );
 
@@ -183,9 +183,9 @@ typedef int32_t ( * HTTPTransportRecv_t )( HTTPNetworkContext_t * pContext,
  */
 typedef struct HTTPTransportInterface
 {
-    HTTPTransportRecv_t recv;        /**< Transport receive interface */
-    HTTPTransportSend_t send;        /**< Transport interface send interface. */
-    HTTPNetworkContext_t * pContext; /**< User defined transport interface context. */
+    HTTPTransportRecv_t recv;  /**< Transport receive interface */
+    HTTPTransportSend_t send;  /**< Transport interface send interface. */
+    NetworkContext_t pContext; /**< User defined transport interface context. */
 } HTTPTransportInterface_t;
 
 /**

--- a/libraries/standard/http/utest/http_send_utest.c
+++ b/libraries/standard/http/utest/http_send_utest.c
@@ -232,7 +232,7 @@ static void onHeaderCallback( void * pContext,
 }
 
 /* Successful application transport send interface. */
-static int32_t transportSendSuccess( HTTPNetworkContext_t * pContext,
+static int32_t transportSendSuccess( NetworkContext_t pContext,
                                      const void * pBuffer,
                                      size_t bytesToWrite )
 {
@@ -258,7 +258,7 @@ static int32_t transportSendSuccess( HTTPNetworkContext_t * pContext,
 /* Application transport send interface that returns a network error depending
 * on the call count. Set sendErrorCall to 0 to return an error on the
 * first call. Set sendErrorCall to 1 to return an error on the second call. */
-static int32_t transportSendNetworkError( HTTPNetworkContext_t * pContext,
+static int32_t transportSendNetworkError( NetworkContext_t pContext,
                                           const void * pBuffer,
                                           size_t bytesToWrite )
 {
@@ -279,7 +279,7 @@ static int32_t transportSendNetworkError( HTTPNetworkContext_t * pContext,
  * depending on the call count. Set sendPartialCall to 0 to return less bytes on
  * the first call. Set sendPartialCall to 1 to return less bytes on the second
  * call. */
-static int32_t transportSendLessThanBytesToWrite( HTTPNetworkContext_t * pContext,
+static int32_t transportSendLessThanBytesToWrite( NetworkContext_t pContext,
                                                   const void * pBuffer,
                                                   size_t bytesToWrite )
 {
@@ -297,7 +297,7 @@ static int32_t transportSendLessThanBytesToWrite( HTTPNetworkContext_t * pContex
 }
 
 /* Application transport send that writes more bytes than expected. */
-static int32_t transportSendMoreThanBytesToWrite( HTTPNetworkContext_t * pContext,
+static int32_t transportSendMoreThanBytesToWrite( NetworkContext_t pContext,
                                                   const void * pBuffer,
                                                   size_t bytesToWrite )
 {
@@ -313,7 +313,7 @@ static int32_t transportSendMoreThanBytesToWrite( HTTPNetworkContext_t * pContex
  * second call. The response to send is set in pNetworkData and the current
  * call count is kept track of in recvCurrentCall. This function will return
  * zero (timeout condition) when recvStopCall matches recvCurrentCall. */
-static int32_t transportRecvSuccess( HTTPNetworkContext_t * pContext,
+static int32_t transportRecvSuccess( NetworkContext_t pContext,
                                      void * pBuffer,
                                      size_t bytesToRead )
 {
@@ -351,7 +351,7 @@ static int32_t transportRecvSuccess( HTTPNetworkContext_t * pContext,
 }
 
 /* Application transport receive that return a network error. */
-static int32_t transportRecvNetworkError( HTTPNetworkContext_t * pContext,
+static int32_t transportRecvNetworkError( NetworkContext_t pContext,
                                           void * pBuffer,
                                           size_t bytesToRead )
 {
@@ -363,7 +363,7 @@ static int32_t transportRecvNetworkError( HTTPNetworkContext_t * pContext,
 }
 
 /* Application transport receive that returns more bytes read than expected. */
-static int32_t transportRecvMoreThanBytesToRead( HTTPNetworkContext_t * pContext,
+static int32_t transportRecvMoreThanBytesToRead( NetworkContext_t pContext,
                                                  void * pBuffer,
                                                  size_t bytesToRead )
 {


### PR DESCRIPTION
*Summary of changes*
- Rename `HTTPNetworkContext_t` to `NetworkContext_t` and use struct ptr type:
```c
/**
 * @brief The NetworkContext is an incomplete type. The application must
 * define NetworkContext to the type of their network context. This context
 * is passed into the network interface functions.
 */
struct NetworkContext;
typedef struct NetworkContext * NetworkContext_t;
```

- Update HTTP tests and demos to reflect this change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
