### PR TITLE
Fix MQTT MISRA violations

### DIFF
--- a/demos/logging-stack/logging_stack.h
+++ b/demos/logging-stack/logging_stack.h
@@ -40,7 +40,6 @@
 #define LOG_METADATA_ARGS      __FILE__, __LINE__
 
 /* Common macro for all logging interface macros. */
-/* TODO - Replace printf with an implementation function. */
 #if !defined( DISABLE_LOGGING )
     #define SdkLog( string )    printf string
 #else

--- a/demos/logging-stack/logging_stack.h
+++ b/demos/logging-stack/logging_stack.h
@@ -41,7 +41,9 @@
 
 /* Common macro for all logging interface macros. */
 /* TODO - Replace printf with an implementation function. */
-#define SdkLog( string )    printf string
+#ifndef SdkLog
+    #define SdkLog( string )    printf string
+#endif
 
 /* Check that LIBRARY_LOG_LEVEL is defined and has a valid value. */
 #if !defined( LIBRARY_LOG_LEVEL ) ||       \

--- a/demos/logging-stack/logging_stack.h
+++ b/demos/logging-stack/logging_stack.h
@@ -41,8 +41,10 @@
 
 /* Common macro for all logging interface macros. */
 /* TODO - Replace printf with an implementation function. */
-#ifndef SdkLog
+#if !defined( DISABLE_LOGGING )
     #define SdkLog( string )    printf string
+#else
+    #define SdkLog( string )
 #endif
 
 /* Check that LIBRARY_LOG_LEVEL is defined and has a valid value. */

--- a/demos/mqtt/mqtt_demo_lightweight/mqtt_demo_lightweight.c
+++ b/demos/mqtt/mqtt_demo_lightweight/mqtt_demo_lightweight.c
@@ -39,6 +39,7 @@
 
 /* Standard includes. */
 #include <stdlib.h>
+#include <string.h>
 
 /* POSIX socket includes. */
 #include <netdb.h>

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
@@ -588,7 +588,7 @@ static int establishMqttSession( MQTTContext_t * pContext,
     int status = EXIT_SUCCESS;
     MQTTStatus_t mqttStatus;
     MQTTConnectInfo_t connectInfo;
-    char sessionPresent;
+    bool sessionPresent;
     MQTTTransportInterface_t transport;
     MQTTFixedBuffer_t networkBuffer;
     MQTTApplicationCallbacks_t callbacks;

--- a/libraries/standard/mqtt/include/mqtt.h
+++ b/libraries/standard/mqtt/include/mqtt.h
@@ -134,10 +134,10 @@ struct MQTTContext
  * @return #MQTTBadParameter if invalid parameters are passed;
  * #MQTTSuccess otherwise.
  */
-MQTTStatus_t MQTT_Init( MQTTContext_t * const pContext,
-                        const MQTTTransportInterface_t * const pTransportInterface,
-                        const MQTTApplicationCallbacks_t * const pCallbacks,
-                        const MQTTFixedBuffer_t * const pNetworkBuffer );
+MQTTStatus_t MQTT_Init( MQTTContext_t * pContext,
+                        const MQTTTransportInterface_t * pTransportInterface,
+                        const MQTTApplicationCallbacks_t * pCallbacks,
+                        const MQTTFixedBuffer_t * pNetworkBuffer );
 
 /**
  * @brief Establish a MQTT session.
@@ -159,11 +159,11 @@ MQTTStatus_t MQTT_Init( MQTTContext_t * const pContext,
  * the #timeoutMs for CONNACK;
  * #MQTTSuccess otherwise.
  */
-MQTTStatus_t MQTT_Connect( MQTTContext_t * const pContext,
-                           const MQTTConnectInfo_t * const pConnectInfo,
-                           const MQTTPublishInfo_t * const pWillInfo,
+MQTTStatus_t MQTT_Connect( MQTTContext_t * pContext,
+                           const MQTTConnectInfo_t * pConnectInfo,
+                           const MQTTPublishInfo_t * pWillInfo,
                            uint32_t timeoutMs,
-                           bool * const pSessionPresent );
+                           bool * pSessionPresent );
 
 /**
  * @brief Sends MQTT SUBSCRIBE for the given list of topic filters to
@@ -180,8 +180,8 @@ MQTTStatus_t MQTT_Connect( MQTTContext_t * const pContext,
  * #MQTTSendFailed if transport write failed;
  * #MQTTSuccess otherwise.
  */
-MQTTStatus_t MQTT_Subscribe( MQTTContext_t * const pContext,
-                             const MQTTSubscribeInfo_t * const pSubscriptionList,
+MQTTStatus_t MQTT_Subscribe( MQTTContext_t * pContext,
+                             const MQTTSubscribeInfo_t * pSubscriptionList,
                              size_t subscriptionCount,
                              uint16_t packetId );
 
@@ -197,8 +197,8 @@ MQTTStatus_t MQTT_Subscribe( MQTTContext_t * const pContext,
  * #MQTTSendFailed if transport write failed;
  * #MQTTSuccess otherwise.
  */
-MQTTStatus_t MQTT_Publish( MQTTContext_t * const pContext,
-                           const MQTTPublishInfo_t * const pPublishInfo,
+MQTTStatus_t MQTT_Publish( MQTTContext_t * pContext,
+                           const MQTTPublishInfo_t * pPublishInfo,
                            uint16_t packetId );
 
 /**
@@ -211,7 +211,7 @@ MQTTStatus_t MQTT_Publish( MQTTContext_t * const pContext,
  * #MQTTSendFailed if transport write failed;
  * #MQTTSuccess otherwise.
  */
-MQTTStatus_t MQTT_Ping( MQTTContext_t * const pContext );
+MQTTStatus_t MQTT_Ping( MQTTContext_t * pContext );
 
 /**
  * @brief Sends MQTT UNSUBSCRIBE for the given list of topic filters to
@@ -228,8 +228,8 @@ MQTTStatus_t MQTT_Ping( MQTTContext_t * const pContext );
  * #MQTTSendFailed if transport write failed;
  * #MQTTSuccess otherwise.
  */
-MQTTStatus_t MQTT_Unsubscribe( MQTTContext_t * const pContext,
-                               const MQTTSubscribeInfo_t * const pSubscriptionList,
+MQTTStatus_t MQTT_Unsubscribe( MQTTContext_t * pContext,
+                               const MQTTSubscribeInfo_t * pSubscriptionList,
                                size_t subscriptionCount,
                                uint16_t packetId );
 
@@ -244,7 +244,7 @@ MQTTStatus_t MQTT_Unsubscribe( MQTTContext_t * const pContext,
  * #MQTTSendFailed if transport send failed;
  * #MQTTSuccess otherwise.
  */
-MQTTStatus_t MQTT_Disconnect( MQTTContext_t * const pContext );
+MQTTStatus_t MQTT_Disconnect( MQTTContext_t * pContext );
 
 /**
  * @brief Loop to receive packets from the transport interface.
@@ -263,7 +263,7 @@ MQTTStatus_t MQTT_Disconnect( MQTTContext_t * const pContext );
  * invalid transition for the internal state machine;
  * #MQTTSuccess on success.
  */
-MQTTStatus_t MQTT_ProcessLoop( MQTTContext_t * const pContext,
+MQTTStatus_t MQTT_ProcessLoop( MQTTContext_t * pContext,
                                uint32_t timeoutMs );
 
 /**
@@ -273,7 +273,7 @@ MQTTStatus_t MQTT_ProcessLoop( MQTTContext_t * const pContext,
  *
  * @return A non-zero number.
  */
-uint16_t MQTT_GetPacketId( MQTTContext_t * const pContext );
+uint16_t MQTT_GetPacketId( MQTTContext_t * pContext );
 
 /**
  * @brief Error code to string conversion for MQTT statuses.

--- a/libraries/standard/mqtt/include/mqtt_lightweight.h
+++ b/libraries/standard/mqtt/include/mqtt_lightweight.h
@@ -22,17 +22,17 @@
 #ifndef MQTT_LIGHTWEIGHT_H
 #define MQTT_LIGHTWEIGHT_H
 
-/* bools are only defined in C99+ */
-#if defined( __cplusplus ) || __STDC_VERSION__ >= 199901L
-    #include <stdbool.h>
-#elif !defined( bool )
-    #define bool     signed char
-    #define false    0
-    #define true     1
-#endif
-
 #include <stddef.h>
 #include <stdint.h>
+
+/* bools are only defined in C99+ */
+#if defined( __cplusplus ) || ( defined( __STDC_VERSION__ ) && ( __STDC_VERSION__ >= 199901L ) )
+    #include <stdbool.h>
+#elif !defined( bool )
+    #define bool     int8_t
+    #define false    ( int8_t ) 0
+    #define true     ( int8_t ) 1
+#endif
 
 /* Include config file before other headers. */
 #include "mqtt_config.h"

--- a/libraries/standard/mqtt/include/mqtt_lightweight.h
+++ b/libraries/standard/mqtt/include/mqtt_lightweight.h
@@ -479,10 +479,6 @@ MQTTStatus_t MQTT_GetPingreqPacketSize( size_t * pPacketSize );
  */
 MQTTStatus_t MQTT_SerializePingreq( const MQTTFixedBuffer_t * pBuffer );
 
-MQTTStatus_t MQTT_GetIncomingPacket( MQTTTransportRecvFunc_t recvFunc,
-                                     MQTTNetworkContext_t networkContext,
-                                     MQTTPacketInfo_t * pIncomingPacket );
-
 /**
  * @brief Deserialize an MQTT PUBLISH packet.
  *

--- a/libraries/standard/mqtt/include/mqtt_lightweight.h
+++ b/libraries/standard/mqtt/include/mqtt_lightweight.h
@@ -271,10 +271,10 @@ struct MQTTPacketInfo
  * @return #MQTTBadParameter if the packet would exceed the size allowed by the
  * MQTT spec; #MQTTSuccess otherwise.
  */
-MQTTStatus_t MQTT_GetConnectPacketSize( const MQTTConnectInfo_t * const pConnectInfo,
-                                        const MQTTPublishInfo_t * const pWillInfo,
-                                        size_t * const pRemainingLength,
-                                        size_t * const pPacketSize );
+MQTTStatus_t MQTT_GetConnectPacketSize( const MQTTConnectInfo_t * pConnectInfo,
+                                        const MQTTPublishInfo_t * pWillInfo,
+                                        size_t * pRemainingLength,
+                                        size_t * pPacketSize );
 
 /**
  * @brief Serialize an MQTT CONNECT packet in the given buffer.
@@ -288,10 +288,10 @@ MQTTStatus_t MQTT_GetConnectPacketSize( const MQTTConnectInfo_t * const pConnect
  * #MQTTBadParameter if invalid parameters are passed;
  * #MQTTSuccess otherwise.
  */
-MQTTStatus_t MQTT_SerializeConnect( const MQTTConnectInfo_t * const pConnectInfo,
-                                    const MQTTPublishInfo_t * const pWillInfo,
+MQTTStatus_t MQTT_SerializeConnect( const MQTTConnectInfo_t * pConnectInfo,
+                                    const MQTTPublishInfo_t * pWillInfo,
                                     size_t remainingLength,
-                                    const MQTTFixedBuffer_t * const pBuffer );
+                                    const MQTTFixedBuffer_t * pBuffer );
 
 /**
  * @brief Get packet size and Remaining Length of an MQTT SUBSCRIBE packet.
@@ -304,7 +304,7 @@ MQTTStatus_t MQTT_SerializeConnect( const MQTTConnectInfo_t * const pConnectInfo
  * @return #MQTTBadParameter if the packet would exceed the size allowed by the
  * MQTT spec; #MQTTSuccess otherwise.
  */
-MQTTStatus_t MQTT_GetSubscribePacketSize( const MQTTSubscribeInfo_t * const pSubscriptionList,
+MQTTStatus_t MQTT_GetSubscribePacketSize( const MQTTSubscribeInfo_t * pSubscriptionList,
                                           size_t subscriptionCount,
                                           size_t * pRemainingLength,
                                           size_t * pPacketSize );
@@ -322,11 +322,11 @@ MQTTStatus_t MQTT_GetSubscribePacketSize( const MQTTSubscribeInfo_t * const pSub
  * #MQTTBadParameter if invalid parameters are passed;
  * #MQTTSuccess otherwise.
  */
-MQTTStatus_t MQTT_SerializeSubscribe( const MQTTSubscribeInfo_t * const pSubscriptionList,
+MQTTStatus_t MQTT_SerializeSubscribe( const MQTTSubscribeInfo_t * pSubscriptionList,
                                       size_t subscriptionCount,
                                       uint16_t packetId,
                                       size_t remainingLength,
-                                      const MQTTFixedBuffer_t * const pBuffer );
+                                      const MQTTFixedBuffer_t * pBuffer );
 
 /**
  * @brief Get packet size and Remaining Length of an MQTT UNSUBSCRIBE packet.
@@ -339,7 +339,7 @@ MQTTStatus_t MQTT_SerializeSubscribe( const MQTTSubscribeInfo_t * const pSubscri
  * @return #MQTTBadParameter if the packet would exceed the size allowed by the
  * MQTT spec; #MQTTSuccess otherwise.
  */
-MQTTStatus_t MQTT_GetUnsubscribePacketSize( const MQTTSubscribeInfo_t * const pSubscriptionList,
+MQTTStatus_t MQTT_GetUnsubscribePacketSize( const MQTTSubscribeInfo_t * pSubscriptionList,
                                             size_t subscriptionCount,
                                             size_t * pRemainingLength,
                                             size_t * pPacketSize );
@@ -357,11 +357,11 @@ MQTTStatus_t MQTT_GetUnsubscribePacketSize( const MQTTSubscribeInfo_t * const pS
  * #MQTTBadParameter if invalid parameters are passed;
  * #MQTTSuccess otherwise.
  */
-MQTTStatus_t MQTT_SerializeUnsubscribe( const MQTTSubscribeInfo_t * const pSubscriptionList,
+MQTTStatus_t MQTT_SerializeUnsubscribe( const MQTTSubscribeInfo_t * pSubscriptionList,
                                         size_t subscriptionCount,
                                         uint16_t packetId,
                                         size_t remainingLength,
-                                        const MQTTFixedBuffer_t * const pBuffer );
+                                        const MQTTFixedBuffer_t * pBuffer );
 
 /**
  * @brief Get the packet size and remaining length of an MQTT PUBLISH packet.
@@ -373,9 +373,9 @@ MQTTStatus_t MQTT_SerializeUnsubscribe( const MQTTSubscribeInfo_t * const pSubsc
  * @return #MQTTBadParameter if the packet would exceed the size allowed by the
  * MQTT spec or if invalid parameters are passed; #MQTTSuccess otherwise.
  */
-MQTTStatus_t MQTT_GetPublishPacketSize( const MQTTPublishInfo_t * const pPublishInfo,
-                                        size_t * const pRemainingLength,
-                                        size_t * const pPacketSize );
+MQTTStatus_t MQTT_GetPublishPacketSize( const MQTTPublishInfo_t * pPublishInfo,
+                                        size_t * pRemainingLength,
+                                        size_t * pPacketSize );
 
 /**
  * @brief Serialize an MQTT PUBLISH packet in the given buffer.
@@ -394,10 +394,10 @@ MQTTStatus_t MQTT_GetPublishPacketSize( const MQTTPublishInfo_t * const pPublish
  * #MQTTBadParameter if invalid parameters are passed;
  * #MQTTSuccess otherwise.
  */
-MQTTStatus_t MQTT_SerializePublish( const MQTTPublishInfo_t * const pPublishInfo,
+MQTTStatus_t MQTT_SerializePublish( const MQTTPublishInfo_t * pPublishInfo,
                                     uint16_t packetId,
                                     size_t remainingLength,
-                                    const MQTTFixedBuffer_t * const pBuffer );
+                                    const MQTTFixedBuffer_t * pBuffer );
 
 /**
  * @brief Serialize an MQTT PUBLISH packet header in the given buffer.
@@ -418,11 +418,11 @@ MQTTStatus_t MQTT_SerializePublish( const MQTTPublishInfo_t * const pPublishInfo
  * #MQTTBadParameter if invalid parameters are passed;
  * #MQTTSuccess otherwise.
  */
-MQTTStatus_t MQTT_SerializePublishHeader( const MQTTPublishInfo_t * const pPublishInfo,
+MQTTStatus_t MQTT_SerializePublishHeader( const MQTTPublishInfo_t * pPublishInfo,
                                           uint16_t packetId,
                                           size_t remainingLength,
-                                          const MQTTFixedBuffer_t * const pBuffer,
-                                          size_t * const pHeaderSize );
+                                          const MQTTFixedBuffer_t * pBuffer,
+                                          size_t * pHeaderSize );
 
 /**
  * @brief Serialize an MQTT PUBACK, PUBREC, PUBREL, or PUBCOMP into the given
@@ -435,7 +435,7 @@ MQTTStatus_t MQTT_SerializePublishHeader( const MQTTPublishInfo_t * const pPubli
  *
  * @return #MQTTBadParameter, #MQTTNoMemory, or #MQTTSuccess.
  */
-MQTTStatus_t MQTT_SerializeAck( const MQTTFixedBuffer_t * const pBuffer,
+MQTTStatus_t MQTT_SerializeAck( const MQTTFixedBuffer_t * pBuffer,
                                 uint8_t packetType,
                                 uint16_t packetId );
 
@@ -457,7 +457,7 @@ MQTTStatus_t MQTT_GetDisconnectPacketSize( size_t * pPacketSize );
  * #MQTTBadParameter if invalid parameters are passed;
  * #MQTTSuccess otherwise.
  */
-MQTTStatus_t MQTT_SerializeDisconnect( const MQTTFixedBuffer_t * const pBuffer );
+MQTTStatus_t MQTT_SerializeDisconnect( const MQTTFixedBuffer_t * pBuffer );
 
 /**
  * @brief Get the size of an MQTT PINGREQ packet.
@@ -477,11 +477,11 @@ MQTTStatus_t MQTT_GetPingreqPacketSize( size_t * pPacketSize );
  * #MQTTBadParameter if invalid parameters are passed;
  * #MQTTSuccess otherwise.
  */
-MQTTStatus_t MQTT_SerializePingreq( const MQTTFixedBuffer_t * const pBuffer );
+MQTTStatus_t MQTT_SerializePingreq( const MQTTFixedBuffer_t * pBuffer );
 
 MQTTStatus_t MQTT_GetIncomingPacket( MQTTTransportRecvFunc_t recvFunc,
                                      MQTTNetworkContext_t networkContext,
-                                     MQTTPacketInfo_t * const pIncomingPacket );
+                                     MQTTPacketInfo_t * pIncomingPacket );
 
 /**
  * @brief Deserialize an MQTT PUBLISH packet.
@@ -492,9 +492,9 @@ MQTTStatus_t MQTT_GetIncomingPacket( MQTTTransportRecvFunc_t recvFunc,
  *
  * @return #MQTTBadParameter, #MQTTBadResponse, or #MQTTSuccess.
  */
-MQTTStatus_t MQTT_DeserializePublish( const MQTTPacketInfo_t * const pIncomingPacket,
-                                      uint16_t * const pPacketId,
-                                      MQTTPublishInfo_t * const pPublishInfo );
+MQTTStatus_t MQTT_DeserializePublish( const MQTTPacketInfo_t * pIncomingPacket,
+                                      uint16_t * pPacketId,
+                                      MQTTPublishInfo_t * pPublishInfo );
 
 /**
  * @brief Deserialize an MQTT CONNACK, SUBACK, UNSUBACK, PUBACK, PUBREC, PUBREL,
@@ -507,9 +507,9 @@ MQTTStatus_t MQTT_DeserializePublish( const MQTTPacketInfo_t * const pIncomingPa
  *
  * @return #MQTTBadParameter, #MQTTBadResponse, or #MQTTSuccess.
  */
-MQTTStatus_t MQTT_DeserializeAck( const MQTTPacketInfo_t * const pIncomingPacket,
-                                  uint16_t * const pPacketId,
-                                  bool * const pSessionPresent );
+MQTTStatus_t MQTT_DeserializeAck( const MQTTPacketInfo_t * pIncomingPacket,
+                                  uint16_t * pPacketId,
+                                  bool * pSessionPresent );
 
 /**
  * @brief Extract MQTT packet type and length from incoming packet.

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -75,7 +75,7 @@ static MQTTPubAckType_t getAckFromPacketType( uint8_t packetType );
  *
  * @return Number of bytes received, or negative number on network error.
  */
-static int32_t recvExact( const MQTTContext_t * const pContext,
+static int32_t recvExact( const MQTTContext_t * pContext,
                           size_t bytesToRecv,
                           uint32_t timeoutMs );
 
@@ -124,7 +124,7 @@ static uint8_t getAckTypeToSend( MQTTPublishState_t state );
  *
  * @return #MQTTSuccess, #MQTTIllegalState or #MQTTSendFailed.
  */
-static MQTTStatus_t sendPublishAcks( MQTTContext_t * const pContext,
+static MQTTStatus_t sendPublishAcks( MQTTContext_t * pContext,
                                      uint16_t packetId,
                                      MQTTPublishState_t publishState );
 
@@ -136,7 +136,7 @@ static MQTTStatus_t sendPublishAcks( MQTTContext_t * const pContext,
  * @return #MQTTKeepAliveTimeout if a PINGRESP is not received in time,
  * #MQTTSendFailed if the PINGREQ cannot be sent, or #MQTTSuccess.
  */
-static MQTTStatus_t handleKeepAlive( MQTTContext_t * const pContext );
+static MQTTStatus_t handleKeepAlive( MQTTContext_t * pContext );
 
 /**
  * @brief Handle received MQTT PUBLISH packet.
@@ -146,7 +146,7 @@ static MQTTStatus_t handleKeepAlive( MQTTContext_t * const pContext );
  *
  * @return MQTTSuccess, MQTTIllegalState or deserialization error.
  */
-static MQTTStatus_t handleIncomingPublish( MQTTContext_t * const pContext,
+static MQTTStatus_t handleIncomingPublish( MQTTContext_t * pContext,
                                            MQTTPacketInfo_t * pIncomingPacket );
 
 /**
@@ -157,7 +157,7 @@ static MQTTStatus_t handleIncomingPublish( MQTTContext_t * const pContext,
  *
  * @return MQTTSuccess, MQTTIllegalState, or deserialization error.
  */
-static MQTTStatus_t handleIncomingAck( MQTTContext_t * const pContext,
+static MQTTStatus_t handleIncomingAck( MQTTContext_t * pContext,
                                        MQTTPacketInfo_t * pIncomingPacket );
 
 /**
@@ -171,8 +171,8 @@ static MQTTStatus_t handleIncomingAck( MQTTContext_t * const pContext,
  * @return #MQTTBadParameter if invalid parameters are passed;
  * #MQTTSuccess otherwise.
  */
-static MQTTStatus_t validateSubscribeUnsubscribeParams( const MQTTContext_t * const pContext,
-                                                        const MQTTSubscribeInfo_t * const pSubscriptionList,
+static MQTTStatus_t validateSubscribeUnsubscribeParams( const MQTTContext_t * pContext,
+                                                        const MQTTSubscribeInfo_t * pSubscriptionList,
                                                         size_t subscriptionCount,
                                                         uint16_t packetId );
 
@@ -186,8 +186,8 @@ static MQTTStatus_t validateSubscribeUnsubscribeParams( const MQTTContext_t * co
  * @return #MQTTSendFailed if transport write failed;
  * #MQTTSuccess otherwise.
  */
-static MQTTStatus_t sendPublish( MQTTContext_t * const pContext,
-                                 const MQTTPublishInfo_t * const pPublishInfo,
+static MQTTStatus_t sendPublish( MQTTContext_t * pContext,
+                                 const MQTTPublishInfo_t * pPublishInfo,
                                  size_t headerSize );
 
 /**
@@ -306,7 +306,7 @@ static MQTTPubAckType_t getAckFromPacketType( uint8_t packetType )
 
 /*-----------------------------------------------------------*/
 
-static int32_t recvExact( const MQTTContext_t * const pContext,
+static int32_t recvExact( const MQTTContext_t * pContext,
                           size_t bytesToRecv,
                           uint32_t timeoutMs )
 {
@@ -502,7 +502,7 @@ static uint8_t getAckTypeToSend( MQTTPublishState_t state )
 
 /*-----------------------------------------------------------*/
 
-static MQTTStatus_t sendPublishAcks( MQTTContext_t * const pContext,
+static MQTTStatus_t sendPublishAcks( MQTTContext_t * pContext,
                                      uint16_t packetId,
                                      MQTTPublishState_t publishState )
 {
@@ -562,7 +562,7 @@ static MQTTStatus_t sendPublishAcks( MQTTContext_t * const pContext,
 
 /*-----------------------------------------------------------*/
 
-static MQTTStatus_t handleKeepAlive( MQTTContext_t * const pContext )
+static MQTTStatus_t handleKeepAlive( MQTTContext_t * pContext )
 {
     MQTTStatus_t status = MQTTSuccess;
     uint32_t now = 0U, keepAliveMs = 0U;
@@ -595,7 +595,7 @@ static MQTTStatus_t handleKeepAlive( MQTTContext_t * const pContext )
 
 /*-----------------------------------------------------------*/
 
-static MQTTStatus_t handleIncomingPublish( MQTTContext_t * const pContext,
+static MQTTStatus_t handleIncomingPublish( MQTTContext_t * pContext,
                                            MQTTPacketInfo_t * pIncomingPacket )
 {
     MQTTStatus_t status = MQTTBadParameter;
@@ -640,7 +640,7 @@ static MQTTStatus_t handleIncomingPublish( MQTTContext_t * const pContext,
 
 /*-----------------------------------------------------------*/
 
-static MQTTStatus_t handleIncomingAck( MQTTContext_t * const pContext,
+static MQTTStatus_t handleIncomingAck( MQTTContext_t * pContext,
                                        MQTTPacketInfo_t * pIncomingPacket )
 {
     MQTTStatus_t status = MQTTBadResponse;
@@ -727,8 +727,8 @@ static MQTTStatus_t handleIncomingAck( MQTTContext_t * const pContext,
 
 /*-----------------------------------------------------------*/
 
-static MQTTStatus_t validateSubscribeUnsubscribeParams( const MQTTContext_t * const pContext,
-                                                        const MQTTSubscribeInfo_t * const pSubscriptionList,
+static MQTTStatus_t validateSubscribeUnsubscribeParams( const MQTTContext_t * pContext,
+                                                        const MQTTSubscribeInfo_t * pSubscriptionList,
                                                         size_t subscriptionCount,
                                                         uint16_t packetId )
 {
@@ -763,8 +763,8 @@ static MQTTStatus_t validateSubscribeUnsubscribeParams( const MQTTContext_t * co
 
 /*-----------------------------------------------------------*/
 
-static MQTTStatus_t sendPublish( MQTTContext_t * const pContext,
-                                 const MQTTPublishInfo_t * const pPublishInfo,
+static MQTTStatus_t sendPublish( MQTTContext_t * pContext,
+                                 const MQTTPublishInfo_t * pPublishInfo,
                                  size_t headerSize )
 {
     MQTTStatus_t status = MQTTSuccess;
@@ -898,10 +898,10 @@ static MQTTStatus_t receiveConnack( const MQTTContext_t * pContext,
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_Init( MQTTContext_t * const pContext,
-                        const MQTTTransportInterface_t * const pTransportInterface,
-                        const MQTTApplicationCallbacks_t * const pCallbacks,
-                        const MQTTFixedBuffer_t * const pNetworkBuffer )
+MQTTStatus_t MQTT_Init( MQTTContext_t * pContext,
+                        const MQTTTransportInterface_t * pTransportInterface,
+                        const MQTTApplicationCallbacks_t * pCallbacks,
+                        const MQTTFixedBuffer_t * pNetworkBuffer )
 {
     MQTTStatus_t status = MQTTSuccess;
 
@@ -937,11 +937,11 @@ MQTTStatus_t MQTT_Init( MQTTContext_t * const pContext,
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_Connect( MQTTContext_t * const pContext,
-                           const MQTTConnectInfo_t * const pConnectInfo,
-                           const MQTTPublishInfo_t * const pWillInfo,
+MQTTStatus_t MQTT_Connect( MQTTContext_t * pContext,
+                           const MQTTConnectInfo_t * pConnectInfo,
+                           const MQTTPublishInfo_t * pWillInfo,
                            uint32_t timeoutMs,
-                           bool * const pSessionPresent )
+                           bool * pSessionPresent )
 {
     size_t remainingLength = 0UL, packetSize = 0UL;
     int32_t bytesSent;
@@ -1023,8 +1023,8 @@ MQTTStatus_t MQTT_Connect( MQTTContext_t * const pContext,
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_Subscribe( MQTTContext_t * const pContext,
-                             const MQTTSubscribeInfo_t * const pSubscriptionList,
+MQTTStatus_t MQTT_Subscribe( MQTTContext_t * pContext,
+                             const MQTTSubscribeInfo_t * pSubscriptionList,
                              size_t subscriptionCount,
                              uint16_t packetId )
 {
@@ -1083,8 +1083,8 @@ MQTTStatus_t MQTT_Subscribe( MQTTContext_t * const pContext,
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_Publish( MQTTContext_t * const pContext,
-                           const MQTTPublishInfo_t * const pPublishInfo,
+MQTTStatus_t MQTT_Publish( MQTTContext_t * pContext,
+                           const MQTTPublishInfo_t * pPublishInfo,
                            uint16_t packetId )
 {
     size_t remainingLength = 0UL, packetSize = 0UL, headerSize = 0UL;
@@ -1190,7 +1190,7 @@ MQTTStatus_t MQTT_Publish( MQTTContext_t * const pContext,
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_Ping( MQTTContext_t * const pContext )
+MQTTStatus_t MQTT_Ping( MQTTContext_t * pContext )
 {
     int32_t bytesSent = 0;
     MQTTStatus_t status = MQTTSuccess;
@@ -1250,8 +1250,8 @@ MQTTStatus_t MQTT_Ping( MQTTContext_t * const pContext )
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_Unsubscribe( MQTTContext_t * const pContext,
-                               const MQTTSubscribeInfo_t * const pSubscriptionList,
+MQTTStatus_t MQTT_Unsubscribe( MQTTContext_t * pContext,
+                               const MQTTSubscribeInfo_t * pSubscriptionList,
                                size_t subscriptionCount,
                                uint16_t packetId )
 {
@@ -1310,7 +1310,7 @@ MQTTStatus_t MQTT_Unsubscribe( MQTTContext_t * const pContext,
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_Disconnect( MQTTContext_t * const pContext )
+MQTTStatus_t MQTT_Disconnect( MQTTContext_t * pContext )
 {
     size_t packetSize;
     int32_t bytesSent;
@@ -1366,7 +1366,7 @@ MQTTStatus_t MQTT_Disconnect( MQTTContext_t * const pContext )
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_ProcessLoop( MQTTContext_t * const pContext,
+MQTTStatus_t MQTT_ProcessLoop( MQTTContext_t * pContext,
                                uint32_t timeoutMs )
 {
     MQTTStatus_t status = MQTTBadParameter;
@@ -1461,7 +1461,7 @@ MQTTStatus_t MQTT_ProcessLoop( MQTTContext_t * const pContext,
 
 /*-----------------------------------------------------------*/
 
-uint16_t MQTT_GetPacketId( MQTTContext_t * const pContext )
+uint16_t MQTT_GetPacketId( MQTTContext_t * pContext )
 {
     uint16_t packetId = 0U;
 

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -169,7 +169,7 @@ typedef enum MQTTSubscriptionType
 static void serializePublishCommon( const MQTTPublishInfo_t * pPublishInfo,
                                     size_t remainingLength,
                                     uint16_t packetIdentifier,
-                                    const MQTTFixedBuffer_t * const pFixedBuffer,
+                                    const MQTTFixedBuffer_t * pFixedBuffer,
                                     bool serializePayload );
 
 /**
@@ -222,11 +222,11 @@ static MQTTStatus_t calculateSubscriptionPacketSize( const MQTTSubscribeInfo_t *
  * #MQTTBadParameter if invalid parameters are passed;
  * #MQTTSuccess otherwise.
  */
-static MQTTStatus_t validateSubscriptionSerializeParams( const MQTTSubscribeInfo_t * const pSubscriptionList,
+static MQTTStatus_t validateSubscriptionSerializeParams( const MQTTSubscribeInfo_t * pSubscriptionList,
                                                          size_t subscriptionCount,
                                                          uint16_t packetId,
                                                          size_t remainingLength,
-                                                         const MQTTFixedBuffer_t * const pBuffer );
+                                                         const MQTTFixedBuffer_t * pBuffer );
 
 /**
  * @brief Serialize an MQTT CONNECT packet in the given buffer.
@@ -237,10 +237,10 @@ static MQTTStatus_t validateSubscriptionSerializeParams( const MQTTSubscribeInfo
  * @param[out] pBuffer Buffer for packet serialization.
  *
  */
-static void serializeConnectPacket( const MQTTConnectInfo_t * const pConnectInfo,
-                                    const MQTTPublishInfo_t * const pWillInfo,
+static void serializeConnectPacket( const MQTTConnectInfo_t * pConnectInfo,
+                                    const MQTTPublishInfo_t * pWillInfo,
                                     size_t remainingLength,
-                                    const MQTTFixedBuffer_t * const pBuffer );
+                                    const MQTTFixedBuffer_t * pBuffer );
 
 /*-----------------------------------------------------------*/
 
@@ -432,7 +432,7 @@ static bool calculatePublishPacketSize( const MQTTPublishInfo_t * pPublishInfo,
 static void serializePublishCommon( const MQTTPublishInfo_t * pPublishInfo,
                                     size_t remainingLength,
                                     uint16_t packetIdentifier,
-                                    const MQTTFixedBuffer_t * const pFixedBuffer,
+                                    const MQTTFixedBuffer_t * pFixedBuffer,
                                     bool serializePayload )
 {
     uint8_t * pIndex = NULL;
@@ -653,7 +653,7 @@ static MQTTStatus_t checkPublishRemainingLength( size_t remainingLength,
 /*-----------------------------------------------------------*/
 
 static MQTTStatus_t processPublishFlags( uint8_t publishFlags,
-                                         MQTTPublishInfo_t * const pPublishInfo )
+                                         MQTTPublishInfo_t * pPublishInfo )
 {
     MQTTStatus_t status = MQTTSuccess;
 
@@ -734,8 +734,8 @@ static void logConnackResponse( uint8_t responseCode )
 
 /*-----------------------------------------------------------*/
 
-static MQTTStatus_t deserializeConnack( const MQTTPacketInfo_t * const pConnack,
-                                        bool * const pSessionPresent )
+static MQTTStatus_t deserializeConnack( const MQTTPacketInfo_t * pConnack,
+                                        bool * pSessionPresent )
 {
     MQTTStatus_t status = MQTTSuccess;
     const uint8_t * pRemainingData = NULL;
@@ -935,7 +935,7 @@ static MQTTStatus_t readSubackStatus( size_t statusCount,
 
 /*-----------------------------------------------------------*/
 
-static MQTTStatus_t deserializeSuback( const MQTTPacketInfo_t * const pSuback,
+static MQTTStatus_t deserializeSuback( const MQTTPacketInfo_t * pSuback,
                                        uint16_t * pPacketIdentifier )
 {
     MQTTStatus_t status = MQTTSuccess;
@@ -971,11 +971,11 @@ static MQTTStatus_t deserializeSuback( const MQTTPacketInfo_t * const pSuback,
 
 /*-----------------------------------------------------------*/
 
-static MQTTStatus_t validateSubscriptionSerializeParams( const MQTTSubscribeInfo_t * const pSubscriptionList,
+static MQTTStatus_t validateSubscriptionSerializeParams( const MQTTSubscribeInfo_t * pSubscriptionList,
                                                          size_t subscriptionCount,
                                                          uint16_t packetId,
                                                          size_t remainingLength,
-                                                         const MQTTFixedBuffer_t * const pBuffer )
+                                                         const MQTTFixedBuffer_t * pBuffer )
 {
     MQTTStatus_t status = MQTTSuccess;
 
@@ -1022,9 +1022,9 @@ static MQTTStatus_t validateSubscriptionSerializeParams( const MQTTSubscribeInfo
 
 /*-----------------------------------------------------------*/
 
-static MQTTStatus_t deserializePublish( const MQTTPacketInfo_t * const pIncomingPacket,
-                                        uint16_t * const pPacketId,
-                                        MQTTPublishInfo_t * const pPublishInfo )
+static MQTTStatus_t deserializePublish( const MQTTPacketInfo_t * pIncomingPacket,
+                                        uint16_t * pPacketId,
+                                        MQTTPublishInfo_t * pPublishInfo )
 {
     MQTTStatus_t status = MQTTSuccess;
     const uint8_t * pVariableHeader, * pPacketIdentifierHigh;
@@ -1111,7 +1111,7 @@ static MQTTStatus_t deserializePublish( const MQTTPacketInfo_t * const pIncoming
 
 /*-----------------------------------------------------------*/
 
-static MQTTStatus_t deserializeSimpleAck( const MQTTPacketInfo_t * const pAck,
+static MQTTStatus_t deserializeSimpleAck( const MQTTPacketInfo_t * pAck,
                                           uint16_t * pPacketIdentifier )
 {
     MQTTStatus_t status = MQTTSuccess;
@@ -1146,7 +1146,7 @@ static MQTTStatus_t deserializeSimpleAck( const MQTTPacketInfo_t * const pAck,
 
 /*-----------------------------------------------------------*/
 
-static MQTTStatus_t deserializePingresp( const MQTTPacketInfo_t * const pPingresp )
+static MQTTStatus_t deserializePingresp( const MQTTPacketInfo_t * pPingresp )
 {
     MQTTStatus_t status = MQTTSuccess;
 
@@ -1166,10 +1166,10 @@ static MQTTStatus_t deserializePingresp( const MQTTPacketInfo_t * const pPingres
 
 /*-----------------------------------------------------------*/
 
-static void serializeConnectPacket( const MQTTConnectInfo_t * const pConnectInfo,
-                                    const MQTTPublishInfo_t * const pWillInfo,
+static void serializeConnectPacket( const MQTTConnectInfo_t * pConnectInfo,
+                                    const MQTTPublishInfo_t * pWillInfo,
                                     size_t remainingLength,
-                                    const MQTTFixedBuffer_t * const pBuffer )
+                                    const MQTTFixedBuffer_t * pBuffer )
 {
     uint8_t connectFlags = 0U;
     uint8_t * pIndex = NULL;
@@ -1284,10 +1284,10 @@ static void serializeConnectPacket( const MQTTConnectInfo_t * const pConnectInfo
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_GetConnectPacketSize( const MQTTConnectInfo_t * const pConnectInfo,
-                                        const MQTTPublishInfo_t * const pWillInfo,
-                                        size_t * const pRemainingLength,
-                                        size_t * const pPacketSize )
+MQTTStatus_t MQTT_GetConnectPacketSize( const MQTTConnectInfo_t * pConnectInfo,
+                                        const MQTTPublishInfo_t * pWillInfo,
+                                        size_t * pRemainingLength,
+                                        size_t * pPacketSize )
 {
     MQTTStatus_t status = MQTTSuccess;
     size_t remainingLength;
@@ -1363,10 +1363,10 @@ MQTTStatus_t MQTT_GetConnectPacketSize( const MQTTConnectInfo_t * const pConnect
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_SerializeConnect( const MQTTConnectInfo_t * const pConnectInfo,
-                                    const MQTTPublishInfo_t * const pWillInfo,
+MQTTStatus_t MQTT_SerializeConnect( const MQTTConnectInfo_t * pConnectInfo,
+                                    const MQTTPublishInfo_t * pWillInfo,
                                     size_t remainingLength,
-                                    const MQTTFixedBuffer_t * const pBuffer )
+                                    const MQTTFixedBuffer_t * pBuffer )
 {
     MQTTStatus_t status = MQTTSuccess;
 
@@ -1409,7 +1409,7 @@ MQTTStatus_t MQTT_SerializeConnect( const MQTTConnectInfo_t * const pConnectInfo
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_GetSubscribePacketSize( const MQTTSubscribeInfo_t * const pSubscriptionList,
+MQTTStatus_t MQTT_GetSubscribePacketSize( const MQTTSubscribeInfo_t * pSubscriptionList,
                                           size_t subscriptionCount,
                                           size_t * pRemainingLength,
                                           size_t * pPacketSize )
@@ -1454,11 +1454,11 @@ MQTTStatus_t MQTT_GetSubscribePacketSize( const MQTTSubscribeInfo_t * const pSub
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_SerializeSubscribe( const MQTTSubscribeInfo_t * const pSubscriptionList,
+MQTTStatus_t MQTT_SerializeSubscribe( const MQTTSubscribeInfo_t * pSubscriptionList,
                                       size_t subscriptionCount,
                                       uint16_t packetId,
                                       size_t remainingLength,
-                                      const MQTTFixedBuffer_t * const pBuffer )
+                                      const MQTTFixedBuffer_t * pBuffer )
 {
     size_t i = 0;
     uint8_t * pIndex = NULL;
@@ -1508,7 +1508,7 @@ MQTTStatus_t MQTT_SerializeSubscribe( const MQTTSubscribeInfo_t * const pSubscri
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_GetUnsubscribePacketSize( const MQTTSubscribeInfo_t * const pSubscriptionList,
+MQTTStatus_t MQTT_GetUnsubscribePacketSize( const MQTTSubscribeInfo_t * pSubscriptionList,
                                             size_t subscriptionCount,
                                             size_t * pRemainingLength,
                                             size_t * pPacketSize )
@@ -1553,11 +1553,11 @@ MQTTStatus_t MQTT_GetUnsubscribePacketSize( const MQTTSubscribeInfo_t * const pS
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_SerializeUnsubscribe( const MQTTSubscribeInfo_t * const pSubscriptionList,
+MQTTStatus_t MQTT_SerializeUnsubscribe( const MQTTSubscribeInfo_t * pSubscriptionList,
                                         size_t subscriptionCount,
                                         uint16_t packetId,
                                         size_t remainingLength,
-                                        const MQTTFixedBuffer_t * const pBuffer )
+                                        const MQTTFixedBuffer_t * pBuffer )
 {
     MQTTStatus_t status = MQTTSuccess;
     size_t i = 0;
@@ -1604,9 +1604,9 @@ MQTTStatus_t MQTT_SerializeUnsubscribe( const MQTTSubscribeInfo_t * const pSubsc
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_GetPublishPacketSize( const MQTTPublishInfo_t * const pPublishInfo,
-                                        size_t * const pRemainingLength,
-                                        size_t * const pPacketSize )
+MQTTStatus_t MQTT_GetPublishPacketSize( const MQTTPublishInfo_t * pPublishInfo,
+                                        size_t * pRemainingLength,
+                                        size_t * pPacketSize )
 {
     MQTTStatus_t status = MQTTSuccess;
 
@@ -1645,10 +1645,10 @@ MQTTStatus_t MQTT_GetPublishPacketSize( const MQTTPublishInfo_t * const pPublish
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_SerializePublish( const MQTTPublishInfo_t * const pPublishInfo,
+MQTTStatus_t MQTT_SerializePublish( const MQTTPublishInfo_t * pPublishInfo,
                                     uint16_t packetId,
                                     size_t remainingLength,
-                                    const MQTTFixedBuffer_t * const pBuffer )
+                                    const MQTTFixedBuffer_t * pBuffer )
 {
     MQTTStatus_t status = MQTTSuccess;
 
@@ -1703,11 +1703,11 @@ MQTTStatus_t MQTT_SerializePublish( const MQTTPublishInfo_t * const pPublishInfo
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_SerializePublishHeader( const MQTTPublishInfo_t * const pPublishInfo,
+MQTTStatus_t MQTT_SerializePublishHeader( const MQTTPublishInfo_t * pPublishInfo,
                                           uint16_t packetId,
                                           size_t remainingLength,
-                                          const MQTTFixedBuffer_t * const pBuffer,
-                                          size_t * const pHeaderSize )
+                                          const MQTTFixedBuffer_t * pBuffer,
+                                          size_t * pHeaderSize )
 {
     MQTTStatus_t status = MQTTSuccess;
 
@@ -1772,7 +1772,7 @@ MQTTStatus_t MQTT_SerializePublishHeader( const MQTTPublishInfo_t * const pPubli
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_SerializeAck( const MQTTFixedBuffer_t * const pBuffer,
+MQTTStatus_t MQTT_SerializeAck( const MQTTFixedBuffer_t * pBuffer,
                                 uint8_t packetType,
                                 uint16_t packetId )
 {
@@ -1842,7 +1842,7 @@ MQTTStatus_t MQTT_GetDisconnectPacketSize( size_t * pPacketSize )
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_SerializeDisconnect( const MQTTFixedBuffer_t * const pBuffer )
+MQTTStatus_t MQTT_SerializeDisconnect( const MQTTFixedBuffer_t * pBuffer )
 {
     MQTTStatus_t status = MQTTSuccess;
 
@@ -1896,7 +1896,7 @@ MQTTStatus_t MQTT_GetPingreqPacketSize( size_t * pPacketSize )
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_SerializePingreq( const MQTTFixedBuffer_t * const pBuffer )
+MQTTStatus_t MQTT_SerializePingreq( const MQTTFixedBuffer_t * pBuffer )
 {
     MQTTStatus_t status = MQTTSuccess;
 
@@ -1932,16 +1932,16 @@ MQTTStatus_t MQTT_SerializePingreq( const MQTTFixedBuffer_t * const pBuffer )
 
 MQTTStatus_t MQTT_GetIncomingPacket( MQTTTransportRecvFunc_t recvFunc,
                                      MQTTNetworkContext_t networkContext,
-                                     MQTTPacketInfo_t * const pIncomingPacket )
+                                     MQTTPacketInfo_t * pIncomingPacket )
 {
     return MQTTSuccess;
 }
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_DeserializePublish( const MQTTPacketInfo_t * const pIncomingPacket,
-                                      uint16_t * const pPacketId,
-                                      MQTTPublishInfo_t * const pPublishInfo )
+MQTTStatus_t MQTT_DeserializePublish( const MQTTPacketInfo_t * pIncomingPacket,
+                                      uint16_t * pPacketId,
+                                      MQTTPublishInfo_t * pPublishInfo )
 {
     MQTTStatus_t status = MQTTSuccess;
 
@@ -1970,9 +1970,9 @@ MQTTStatus_t MQTT_DeserializePublish( const MQTTPacketInfo_t * const pIncomingPa
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_DeserializeAck( const MQTTPacketInfo_t * const pIncomingPacket,
-                                  uint16_t * const pPacketId,
-                                  bool * const pSessionPresent )
+MQTTStatus_t MQTT_DeserializeAck( const MQTTPacketInfo_t * pIncomingPacket,
+                                  uint16_t * pPacketId,
+                                  bool * pSessionPresent )
 {
     MQTTStatus_t status = MQTTSuccess;
 

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -689,13 +689,8 @@ static MQTTStatus_t processPublishFlags( uint8_t publishFlags,
     {
         LogDebug( ( "QoS is %d.", pPublishInfo->qos ) );
 
-        /* Parse the Retain bit.
-         * Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
-         * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
-         * The violation can only be resolved if the variable is of a boolean type, which is
-         * not present in C89. */
-        /* coverity[misra_c_2012_rule_10_5_violation] */
-        pPublishInfo->retain = ( bool ) UINT8_CHECK_BIT( publishFlags, MQTT_PUBLISH_FLAG_RETAIN );
+        /* Parse the Retain bit. */
+        pPublishInfo->retain = ( UINT8_CHECK_BIT( publishFlags, MQTT_PUBLISH_FLAG_RETAIN ) ) ? true : false;
 
         LogDebug( ( "Retain bit is %d.", pPublishInfo->retain ) );
 
@@ -1038,7 +1033,6 @@ static MQTTStatus_t deserializePublish( const MQTTPacketInfo_t * pIncomingPacket
     assert( pPacketId != NULL );
     assert( pPublishInfo != NULL );
     pVariableHeader = pIncomingPacket->pRemainingData;
-
     /* The flags are the lower 4 bits of the first byte in PUBLISH. */
     status = processPublishFlags( ( pIncomingPacket->type & 0x0FU ), pPublishInfo );
 

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -466,13 +466,13 @@ static void serializePublishCommon( const MQTTPublishInfo_t * pPublishInfo,
         /* Empty else MISRA 15.7 */
     }
 
-    if( pPublishInfo->retain )
+    if( pPublishInfo->retain == true )
     {
         LogDebug( ( "Adding retain bit in PUBLISH flags." ) );
         UINT8_SET_BIT( publishFlags, MQTT_PUBLISH_FLAG_RETAIN );
     }
 
-    if( pPublishInfo->dup )
+    if( pPublishInfo->dup == true )
     {
         LogDebug( ( "Adding dup bit in PUBLISH flags." ) );
         UINT8_SET_BIT( publishFlags, MQTT_PUBLISH_FLAG_DUP );
@@ -504,7 +504,7 @@ static void serializePublishCommon( const MQTTPublishInfo_t * pPublishInfo,
      * This will help reduce an unnecessary copy of the payload into the buffer.
      */
     if( ( pPublishInfo->payloadLength > 0U ) &&
-        ( serializePayload ) )
+        ( serializePayload == true ) )
     {
         LogDebug( ( "Copying PUBLISH payload of length =%lu to buffer",
                     pPublishInfo->payloadLength ) );
@@ -690,7 +690,7 @@ static MQTTStatus_t processPublishFlags( uint8_t publishFlags,
         LogDebug( ( "QoS is %d.", pPublishInfo->qos ) );
 
         /* Parse the Retain bit. */
-        pPublishInfo->retain = UINT8_CHECK_BIT( publishFlags, MQTT_PUBLISH_FLAG_RETAIN );
+        pPublishInfo->retain = ( bool ) UINT8_CHECK_BIT( publishFlags, MQTT_PUBLISH_FLAG_RETAIN );
 
         LogDebug( ( "Retain bit is %d.", pPublishInfo->retain ) );
 
@@ -2053,7 +2053,7 @@ MQTTStatus_t MQTT_GetIncomingPacketTypeAndLength( MQTTTransportRecvFunc_t readFu
     if( bytesReceived == 1 )
     {
         /* Check validity. */
-        if( incomingPacketValid( pIncomingPacket->type ) )
+        if( incomingPacketValid( pIncomingPacket->type ) == true )
         {
             pIncomingPacket->remainingLength = getRemainingLength( readFunc, networkContext );
 

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -1936,15 +1936,6 @@ MQTTStatus_t MQTT_SerializePingreq( const MQTTFixedBuffer_t * pBuffer )
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_GetIncomingPacket( MQTTTransportRecvFunc_t recvFunc,
-                                     MQTTNetworkContext_t networkContext,
-                                     MQTTPacketInfo_t * pIncomingPacket )
-{
-    return MQTTSuccess;
-}
-
-/*-----------------------------------------------------------*/
-
 MQTTStatus_t MQTT_DeserializePublish( const MQTTPacketInfo_t * pIncomingPacket,
                                       uint16_t * pPacketId,
                                       MQTTPublishInfo_t * pPublishInfo )

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -689,7 +689,12 @@ static MQTTStatus_t processPublishFlags( uint8_t publishFlags,
     {
         LogDebug( ( "QoS is %d.", pPublishInfo->qos ) );
 
-        /* Parse the Retain bit. */
+        /* Parse the Retain bit.
+         * Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
+         * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
+         * The violation can only be resolved if the variable is of a boolean type, which is
+         * not present in C89. */
+        /* coverity[misra_c_2012_rule_10_5_violation] */
         pPublishInfo->retain = ( bool ) UINT8_CHECK_BIT( publishFlags, MQTT_PUBLISH_FLAG_RETAIN );
 
         LogDebug( ( "Retain bit is %d.", pPublishInfo->retain ) );
@@ -1033,6 +1038,7 @@ static MQTTStatus_t deserializePublish( const MQTTPacketInfo_t * pIncomingPacket
     assert( pPacketId != NULL );
     assert( pPublishInfo != NULL );
     pVariableHeader = pIncomingPacket->pRemainingData;
+
     /* The flags are the lower 4 bits of the first byte in PUBLISH. */
     status = processPublishFlags( ( pIncomingPacket->type & 0x0FU ), pPublishInfo );
 

--- a/libraries/standard/mqtt/src/mqtt_state.c
+++ b/libraries/standard/mqtt/src/mqtt_state.c
@@ -128,12 +128,7 @@ static bool validateTransitionPublish( MQTTPublishState_t currentState,
             /* Transitions from null occur when storing a new entry into the record. */
             if( opType == MQTT_RECEIVE )
             {
-                /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
-                 * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
-                 * The violation can only be resolved if the variable is of a boolean type, which is
-                 * not present in C89. */
-                /* coverity[misra_c_2012_rule_10_5_violation] */
-                isValid = ( bool ) ( ( newState == MQTTPubAckSend ) || ( newState == MQTTPubRecSend ) );
+                isValid = ( ( newState == MQTTPubAckSend ) || ( newState == MQTTPubRecSend ) ) ? true : false;
             }
 
             break;
@@ -145,21 +140,11 @@ static bool validateTransitionPublish( MQTTPublishState_t currentState,
             switch( qos )
             {
                 case MQTTQoS1:
-                    /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
-                     * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
-                     * The violation can only be resolved if the variable is of a boolean type, which is
-                     * not present in C89. */
-                    /* coverity[misra_c_2012_rule_10_5_violation] */
-                    isValid = ( bool ) ( newState == MQTTPubAckPending );
+                    isValid = ( newState == MQTTPubAckPending ) ? true : false;
                     break;
 
                 case MQTTQoS2:
-                    /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
-                     * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
-                     * The violation can only be resolved if the variable is of a boolean type, which is
-                     * not present in C89. */
-                    /* coverity[misra_c_2012_rule_10_5_violation] */
-                    isValid = ( bool ) ( newState == MQTTPubRecPending );
+                    isValid = ( newState == MQTTPubRecPending ) ? true : false;
                     break;
 
                 default:
@@ -188,79 +173,37 @@ static bool validateTransitionAck( MQTTPublishState_t currentState,
         /* Incoming publish, QoS 1. */
         case MQTTPubAckPending:
             /* Outgoing publish, QoS 1. */
-
-            /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
-             * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
-             * The violation can only be resolved if the variable is of a boolean type, which is
-             * not present in C89. */
-            /* coverity[misra_c_2012_rule_10_5_violation] */
-            isValid = ( bool ) ( newState == MQTTPublishDone );
+            isValid = ( newState == MQTTPublishDone ) ? true : false;
             break;
 
         case MQTTPubRecSend:
             /* Incoming publish, QoS 2. */
-
-            /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
-             * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
-             * The violation can only be resolved if the variable is of a boolean type, which is
-             * not present in C89. */
-            /* coverity[misra_c_2012_rule_10_5_violation] */
-            isValid = ( bool ) ( newState == MQTTPubRelPending );
+            isValid = ( newState == MQTTPubRelPending ) ? true : false;
             break;
 
         case MQTTPubRelPending:
             /* Incoming publish, QoS 2. */
-
-            /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
-             * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
-             * The violation can only be resolved if the variable is of a boolean type, which is
-             * not present in C89. */
-            /* coverity[misra_c_2012_rule_10_5_violation] */
-            isValid = ( bool ) ( newState == MQTTPubCompSend );
+            isValid = ( newState == MQTTPubCompSend ) ? true : false;
             break;
 
         case MQTTPubCompSend:
             /* Incoming publish, QoS 2. */
-
-            /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
-             * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
-             * The violation can only be resolved if the variable is of a boolean type, which is
-             * not present in C89. */
-            /* coverity[misra_c_2012_rule_10_5_violation] */
-            isValid = ( bool ) ( newState == MQTTPublishDone );
+            isValid = ( newState == MQTTPublishDone ) ? true : false;
             break;
 
         case MQTTPubRecPending:
             /* Outgoing publish, Qos 2. */
-
-            /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
-             * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
-             * The violation can only be resolved if the variable is of a boolean type, which is
-             * not present in C89. */
-            /* coverity[misra_c_2012_rule_10_5_violation] */
-            isValid = ( bool ) ( newState == MQTTPubRelSend );
+            isValid = ( newState == MQTTPubRelSend ) ? true : false;
             break;
 
         case MQTTPubRelSend:
             /* Outgoing publish, Qos 2. */
-
-            /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
-             * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
-             * The violation can only be resolved if the variable is of a boolean type, which is
-             * not present in C89. */
-            /* coverity[misra_c_2012_rule_10_5_violation] */
-            isValid = ( bool ) ( newState == MQTTPubCompPending );
+            isValid = ( newState == MQTTPubCompPending ) ? true : false;
             break;
 
         case MQTTPubCompPending:
             /* Outgoing publish, Qos 2. */
-
-            /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
-             * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
-             * The violation can only be resolved if the variable is of a boolean type, which is
-             * not present in C89. */
-            /* coverity[misra_c_2012_rule_10_5_violation] */
-            isValid = ( bool ) ( newState == MQTTPublishDone );
+            isValid = ( newState == MQTTPublishDone ) ? true : false;
             break;
 
         case MQTTPublishDone:
@@ -287,21 +230,11 @@ static bool isPublishOutgoing( MQTTPubAckType_t packetType,
         case MQTTPuback:
         case MQTTPubrec:
         case MQTTPubcomp:
-            /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
-             * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
-             * The violation can only be resolved if the variable is of a boolean type, which is
-             * not present in C89. */
-            /* coverity[misra_c_2012_rule_10_5_violation] */
-            isOutgoing = ( bool ) ( opType == MQTT_RECEIVE );
+            isOutgoing = ( opType == MQTT_RECEIVE ) ? true : false;
             break;
 
         case MQTTPubrel:
-            /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
-             * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
-             * The violation can only be resolved if the variable is of a boolean type, which is
-             * not present in C89. */
-            /* coverity[misra_c_2012_rule_10_5_violation] */
-            isOutgoing = ( bool ) ( opType == MQTT_SEND );
+            isOutgoing = ( opType == MQTT_SEND ) ? true : false;
             break;
 
         default:
@@ -554,23 +487,12 @@ MQTTPublishState_t MQTT_CalculateStateAck( MQTTPubAckType_t packetType,
 {
     MQTTPublishState_t calculatedState = MQTTStateNull;
     /* There are more QoS2 cases than QoS1, so initialize to that. */
-
-    /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
-     * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
-     * The violation can only be resolved if the variable is of a boolean type, which is
-     * not present in C89. */
-    /* coverity[misra_c_2012_rule_10_5_violation] */
-    bool qosValid = ( bool ) ( qos == MQTTQoS2 );
+    bool qosValid = ( qos == MQTTQoS2 ) ? true : false;
 
     switch( packetType )
     {
         case MQTTPuback:
-            /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
-             * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
-             * The violation can only be resolved if the variable is of a boolean type, which is
-             * not present in C89. */
-            /* coverity[misra_c_2012_rule_10_5_violation] */
-            qosValid = ( bool ) ( qos == MQTTQoS1 );
+            qosValid = ( qos == MQTTQoS1 ) ? true : false;
             calculatedState = MQTTPublishDone;
             break;
 
@@ -649,13 +571,7 @@ MQTTStatus_t MQTT_UpdateStateAck( MQTTContext_t * pMqttContext,
     if( recordIndex < MQTT_STATE_ARRAY_MAX_COUNT )
     {
         newState = MQTT_CalculateStateAck( packetType, opType, qos );
-
-        /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
-         * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
-         * The violation can only be resolved if the variable is of a boolean type, which is
-         * not present in C89. */
-        /* coverity[misra_c_2012_rule_10_5_violation] */
-        shouldDeleteRecord = ( bool ) ( newState == MQTTPublishDone );
+        shouldDeleteRecord = ( newState == MQTTPublishDone ) ? true : false;
         isTransitionValid = validateTransitionAck( currentState, newState );
 
         if( isTransitionValid == true )

--- a/libraries/standard/mqtt/src/mqtt_state.c
+++ b/libraries/standard/mqtt/src/mqtt_state.c
@@ -128,6 +128,11 @@ static bool validateTransitionPublish( MQTTPublishState_t currentState,
             /* Transitions from null occur when storing a new entry into the record. */
             if( opType == MQTT_RECEIVE )
             {
+                /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
+                 * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
+                 * The violation can only be resolved if the variable is of a boolean type, which is
+                 * not present in C89. */
+                /* coverity[misra_c_2012_rule_10_5_violation] */
                 isValid = ( bool ) ( ( newState == MQTTPubAckSend ) || ( newState == MQTTPubRecSend ) );
             }
 
@@ -140,10 +145,20 @@ static bool validateTransitionPublish( MQTTPublishState_t currentState,
             switch( qos )
             {
                 case MQTTQoS1:
+                    /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
+                     * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
+                     * The violation can only be resolved if the variable is of a boolean type, which is
+                     * not present in C89. */
+                    /* coverity[misra_c_2012_rule_10_5_violation] */
                     isValid = ( bool ) ( newState == MQTTPubAckPending );
                     break;
 
                 case MQTTQoS2:
+                    /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
+                     * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
+                     * The violation can only be resolved if the variable is of a boolean type, which is
+                     * not present in C89. */
+                    /* coverity[misra_c_2012_rule_10_5_violation] */
                     isValid = ( bool ) ( newState == MQTTPubRecPending );
                     break;
 
@@ -173,36 +188,78 @@ static bool validateTransitionAck( MQTTPublishState_t currentState,
         /* Incoming publish, QoS 1. */
         case MQTTPubAckPending:
             /* Outgoing publish, QoS 1. */
+
+            /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
+             * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
+             * The violation can only be resolved if the variable is of a boolean type, which is
+             * not present in C89. */
+            /* coverity[misra_c_2012_rule_10_5_violation] */
             isValid = ( bool ) ( newState == MQTTPublishDone );
             break;
 
         case MQTTPubRecSend:
             /* Incoming publish, QoS 2. */
+
+            /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
+             * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
+             * The violation can only be resolved if the variable is of a boolean type, which is
+             * not present in C89. */
+            /* coverity[misra_c_2012_rule_10_5_violation] */
             isValid = ( bool ) ( newState == MQTTPubRelPending );
             break;
 
         case MQTTPubRelPending:
             /* Incoming publish, QoS 2. */
+
+            /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
+             * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
+             * The violation can only be resolved if the variable is of a boolean type, which is
+             * not present in C89. */
+            /* coverity[misra_c_2012_rule_10_5_violation] */
             isValid = ( bool ) ( newState == MQTTPubCompSend );
             break;
 
         case MQTTPubCompSend:
             /* Incoming publish, QoS 2. */
+
+            /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
+             * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
+             * The violation can only be resolved if the variable is of a boolean type, which is
+             * not present in C89. */
+            /* coverity[misra_c_2012_rule_10_5_violation] */
             isValid = ( bool ) ( newState == MQTTPublishDone );
             break;
 
         case MQTTPubRecPending:
             /* Outgoing publish, Qos 2. */
+
+            /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
+             * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
+             * The violation can only be resolved if the variable is of a boolean type, which is
+             * not present in C89. */
+            /* coverity[misra_c_2012_rule_10_5_violation] */
             isValid = ( bool ) ( newState == MQTTPubRelSend );
             break;
 
         case MQTTPubRelSend:
             /* Outgoing publish, Qos 2. */
+
+            /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
+             * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
+             * The violation can only be resolved if the variable is of a boolean type, which is
+             * not present in C89. */
+            /* coverity[misra_c_2012_rule_10_5_violation] */
             isValid = ( bool ) ( newState == MQTTPubCompPending );
             break;
 
         case MQTTPubCompPending:
             /* Outgoing publish, Qos 2. */
+
+            /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
+             * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
+             * The violation can only be resolved if the variable is of a boolean type, which is
+             * not present in C89. */
+            /* coverity[misra_c_2012_rule_10_5_violation] */
             isValid = ( bool ) ( newState == MQTTPublishDone );
             break;
 
@@ -230,10 +287,20 @@ static bool isPublishOutgoing( MQTTPubAckType_t packetType,
         case MQTTPuback:
         case MQTTPubrec:
         case MQTTPubcomp:
+            /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
+             * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
+             * The violation can only be resolved if the variable is of a boolean type, which is
+             * not present in C89. */
+            /* coverity[misra_c_2012_rule_10_5_violation] */
             isOutgoing = ( bool ) ( opType == MQTT_RECEIVE );
             break;
 
         case MQTTPubrel:
+            /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
+             * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
+             * The violation can only be resolved if the variable is of a boolean type, which is
+             * not present in C89. */
+            /* coverity[misra_c_2012_rule_10_5_violation] */
             isOutgoing = ( bool ) ( opType == MQTT_SEND );
             break;
 
@@ -487,11 +554,22 @@ MQTTPublishState_t MQTT_CalculateStateAck( MQTTPubAckType_t packetType,
 {
     MQTTPublishState_t calculatedState = MQTTStateNull;
     /* There are more QoS2 cases than QoS1, so initialize to that. */
+
+    /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
+     * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
+     * The violation can only be resolved if the variable is of a boolean type, which is
+     * not present in C89. */
+    /* coverity[misra_c_2012_rule_10_5_violation] */
     bool qosValid = ( bool ) ( qos == MQTTQoS2 );
 
     switch( packetType )
     {
         case MQTTPuback:
+            /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
+             * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
+             * The violation can only be resolved if the variable is of a boolean type, which is
+             * not present in C89. */
+            /* coverity[misra_c_2012_rule_10_5_violation] */
             qosValid = ( bool ) ( qos == MQTTQoS1 );
             calculatedState = MQTTPublishDone;
             break;
@@ -571,6 +649,12 @@ MQTTStatus_t MQTT_UpdateStateAck( MQTTContext_t * pMqttContext,
     if( recordIndex < MQTT_STATE_ARRAY_MAX_COUNT )
     {
         newState = MQTT_CalculateStateAck( packetType, opType, qos );
+
+        /* Removing the below cast results in a MISRA 10.3 violation (required, implicit cast
+         * from a boolean), and keeping it results in a 10.5 violation (advisory, explicit cast).
+         * The violation can only be resolved if the variable is of a boolean type, which is
+         * not present in C89. */
+        /* coverity[misra_c_2012_rule_10_5_violation] */
         shouldDeleteRecord = ( bool ) ( newState == MQTTPublishDone );
         isTransitionValid = validateTransitionAck( currentState, newState );
 

--- a/libraries/standard/mqtt/src/mqtt_state.c
+++ b/libraries/standard/mqtt/src/mqtt_state.c
@@ -128,7 +128,7 @@ static bool validateTransitionPublish( MQTTPublishState_t currentState,
             /* Transitions from null occur when storing a new entry into the record. */
             if( opType == MQTT_RECEIVE )
             {
-                isValid = ( newState == MQTTPubAckSend ) || ( newState == MQTTPubRecSend );
+                isValid = ( bool ) ( ( newState == MQTTPubAckSend ) || ( newState == MQTTPubRecSend ) );
             }
 
             break;
@@ -140,11 +140,11 @@ static bool validateTransitionPublish( MQTTPublishState_t currentState,
             switch( qos )
             {
                 case MQTTQoS1:
-                    isValid = ( newState == MQTTPubAckPending );
+                    isValid = ( bool ) ( newState == MQTTPubAckPending );
                     break;
 
                 case MQTTQoS2:
-                    isValid = ( newState == MQTTPubRecPending );
+                    isValid = ( bool ) ( newState == MQTTPubRecPending );
                     break;
 
                 default:
@@ -173,37 +173,37 @@ static bool validateTransitionAck( MQTTPublishState_t currentState,
         /* Incoming publish, QoS 1. */
         case MQTTPubAckPending:
             /* Outgoing publish, QoS 1. */
-            isValid = ( newState == MQTTPublishDone );
+            isValid = ( bool ) ( newState == MQTTPublishDone );
             break;
 
         case MQTTPubRecSend:
             /* Incoming publish, QoS 2. */
-            isValid = ( newState == MQTTPubRelPending );
+            isValid = ( bool ) ( newState == MQTTPubRelPending );
             break;
 
         case MQTTPubRelPending:
             /* Incoming publish, QoS 2. */
-            isValid = ( newState == MQTTPubCompSend );
+            isValid = ( bool ) ( newState == MQTTPubCompSend );
             break;
 
         case MQTTPubCompSend:
             /* Incoming publish, QoS 2. */
-            isValid = ( newState == MQTTPublishDone );
+            isValid = ( bool ) ( newState == MQTTPublishDone );
             break;
 
         case MQTTPubRecPending:
             /* Outgoing publish, Qos 2. */
-            isValid = ( newState == MQTTPubRelSend );
+            isValid = ( bool ) ( newState == MQTTPubRelSend );
             break;
 
         case MQTTPubRelSend:
             /* Outgoing publish, Qos 2. */
-            isValid = ( newState == MQTTPubCompPending );
+            isValid = ( bool ) ( newState == MQTTPubCompPending );
             break;
 
         case MQTTPubCompPending:
             /* Outgoing publish, Qos 2. */
-            isValid = ( newState == MQTTPublishDone );
+            isValid = ( bool ) ( newState == MQTTPublishDone );
             break;
 
         case MQTTPublishDone:
@@ -230,11 +230,11 @@ static bool isPublishOutgoing( MQTTPubAckType_t packetType,
         case MQTTPuback:
         case MQTTPubrec:
         case MQTTPubcomp:
-            isOutgoing = ( opType == MQTT_RECEIVE );
+            isOutgoing = ( bool ) ( opType == MQTT_RECEIVE );
             break;
 
         case MQTTPubrel:
-            isOutgoing = ( opType == MQTT_SEND );
+            isOutgoing = ( bool ) ( opType == MQTT_SEND );
             break;
 
         default:
@@ -328,7 +328,7 @@ static void updateRecord( MQTTPubAckInfo_t * records,
                           MQTTPublishState_t newState,
                           bool shouldDelete )
 {
-    if( shouldDelete )
+    if( shouldDelete == true )
     {
         records[ recordIndex ].packetId = MQTT_PACKET_ID_INVALID;
         records[ recordIndex ].qos = MQTTQoS0;
@@ -450,7 +450,7 @@ MQTTStatus_t MQTT_UpdateStatePublish( MQTTContext_t * pMqttContext,
         newState = MQTT_CalculateStatePublish( opType, qos );
         isTransitionValid = validateTransitionPublish( currentState, newState, opType, qos );
 
-        if( isTransitionValid )
+        if( isTransitionValid == true )
         {
             /* addRecord will check for collisions. */
             if( opType == MQTT_RECEIVE )
@@ -487,12 +487,12 @@ MQTTPublishState_t MQTT_CalculateStateAck( MQTTPubAckType_t packetType,
 {
     MQTTPublishState_t calculatedState = MQTTStateNull;
     /* There are more QoS2 cases than QoS1, so initialize to that. */
-    bool qosValid = ( qos == MQTTQoS2 );
+    bool qosValid = ( bool ) ( qos == MQTTQoS2 );
 
     switch( packetType )
     {
         case MQTTPuback:
-            qosValid = ( qos == MQTTQoS1 );
+            qosValid = ( bool ) ( qos == MQTTQoS1 );
             calculatedState = MQTTPublishDone;
             break;
 
@@ -520,7 +520,7 @@ MQTTPublishState_t MQTT_CalculateStateAck( MQTTPubAckType_t packetType,
     }
 
     /* Sanity check, make sure ack and QoS agree. */
-    if( !qosValid )
+    if( qosValid == false )
     {
         calculatedState = MQTTStateNull;
     }
@@ -552,7 +552,7 @@ MQTTStatus_t MQTT_UpdateStateAck( MQTTContext_t * pMqttContext,
     }
     else
     {
-        if( isOutgoingPublish )
+        if( isOutgoingPublish == true )
         {
             records = pMqttContext->outgoingPublishRecords;
         }
@@ -571,10 +571,10 @@ MQTTStatus_t MQTT_UpdateStateAck( MQTTContext_t * pMqttContext,
     if( recordIndex < MQTT_STATE_ARRAY_MAX_COUNT )
     {
         newState = MQTT_CalculateStateAck( packetType, opType, qos );
-        shouldDeleteRecord = ( newState == MQTTPublishDone );
+        shouldDeleteRecord = ( bool ) ( newState == MQTTPublishDone );
         isTransitionValid = validateTransitionAck( currentState, newState );
 
-        if( isTransitionValid )
+        if( isTransitionValid == true )
         {
             updateRecord( records,
                           recordIndex,


### PR DESCRIPTION
*Description of changes:*
Fixes most MISRA violations in MQTT. The remaining violations with our current configuration are all 8.7 (External linkage for functions used in one translation unit), which is required for API functions. Note that the changes in commit "Remove useless const" aren't due to MISRA violations, we had just been adding const because we had them in v4_beta (due to other MISRA violations relating to function pointers). However, since C is pass by value I didn't find value in keeping them.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
