### PR TITLE
Remaining MISRA for the HTTP Client Library

### DIFF
--- a/demos/http/http_demo_plaintext/http_demo_plaintext.c
+++ b/demos/http/http_demo_plaintext/http_demo_plaintext.c
@@ -381,7 +381,7 @@ static int sendHttpRequest( const HTTPTransportInterface_t * pTransportInterface
 
     /* Set "Connection" HTTP header to "keep-alive" so that multiple requests
      * can be sent over the same established TCP connection. */
-    requestInfo.flags = HTTP_REQUEST_KEEP_ALIVE_FLAG;
+    requestInfo.reqFlags = HTTP_REQUEST_KEEP_ALIVE_FLAG;
 
     /* Set the buffer used for storing request headers. */
     requestHeaders.pBuffer = userBuffer;

--- a/libraries/standard/http/include/http_client.h
+++ b/libraries/standard/http/include/http_client.h
@@ -44,7 +44,7 @@
 
 /**
  * @section http_send_flags
- * @brief Values for #HTTPClient_Send flags parameter.
+ * @brief Values for #HTTPClient_Send sendFlags parameter.
  * These flags control some behavior of sending the request or receiving the
  * response.
  *
@@ -59,13 +59,13 @@
  * @brief Set this flag to disable automatically writing the Content-Length
  * header to send to the server.
  *
- * This flag is valid only for #HTTPClient_Send.flags.
+ * This flag is valid only for #HTTPClient_Send.sendFlags.
  */
 #define HTTP_SEND_DISABLE_CONTENT_LENGTH_FLAG    0x1U
 
 /**
  * @section http_request_flags
- * @brief Flags for #HTTPRequestInfo_t.flags.
+ * @brief Flags for #HTTPRequestInfo_t.reqFlags.
  * These flags control what headers are written or not to the
  * #HttpRequestHeaders_t.pBuffer by #HTTPClient_InitializeRequestHeaders.
  *
@@ -83,14 +83,14 @@
  * Setting this will cause a "Connection: Keep-Alive" to be written to the
  * request headers.
  *
- * This flag is valid only for #HTTPRequestInfo.flags.
+ * This flag is valid only for #HTTPRequestInfo.reqFlags.
  */
 #define HTTP_REQUEST_KEEP_ALIVE_FLAG    0x1U
 
 /**
  * @section http_response_flags
- * @brief Flags for #HTTPResponse_t.flags.
- * These flags are populated in #HTTPResponse_t.flags by the #HTTPClient_Send
+ * @brief Flags for #HTTPResponse_t.respFlags.
+ * These flags are populated in #HTTPResponse_t.respFlags by the #HTTPClient_Send
  * function.
  *
  * - #HTTP_RESPONSE_CONNECTION_CLOSE_FLAG <br>
@@ -105,14 +105,14 @@
  * If a "Connection: close" header is present the application should always
  * close the connection.
  *
- * This flag is valid only for #HTTPResponse_t.flags.
+ * This flag is valid only for #HTTPResponse_t.respFlags.
  */
 #define HTTP_RESPONSE_CONNECTION_CLOSE_FLAG         0x1U
 
 /**
  * @brief This will be set to true if header "Connection: Keep-Alive" is found.
  *
- * This flag is valid only for #HTTPResponse_t.flags.
+ * This flag is valid only for #HTTPResponse_t.respFlags.
  */
 #define HTTP_RESPONSE_CONNECTION_KEEP_ALIVE_FLAG    0x2U
 
@@ -279,7 +279,7 @@ typedef enum HTTPStatus
      * Functions that may return this value:
      * - #HTTPClient_Send
      */
-    HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_CHUNK_HEADER,
+    HTTP_SECURITY_ALERT_INVALID_CHUNK_HEADER,
 
     /**
      * @brief The server sent a response with an invalid character in the
@@ -288,7 +288,7 @@ typedef enum HTTPStatus
      * Functions that may return this value:
      * - #HTTPClient_Send
      */
-    HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_PROTOCOL_VERSION,
+    HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION,
 
     /**
      * @brief The server sent a response with an invalid character in the
@@ -297,7 +297,7 @@ typedef enum HTTPStatus
      * Functions that may return this value:
      * - #HTTPClient_Send
      */
-    HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_STATUS_CODE,
+    HTTP_SECURITY_ALERT_INVALID_STATUS_CODE,
 
     /**
      * @brief An invalid character was found in the HTTP response message.
@@ -305,7 +305,7 @@ typedef enum HTTPStatus
      * Functions that may return this value:
      * - #HTTPClient_Send
      */
-    HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_CHARACTER,
+    HTTP_SECURITY_ALERT_INVALID_CHARACTER,
 
     /**
      * @brief The response contains either an invalid character in the
@@ -315,7 +315,7 @@ typedef enum HTTPStatus
      * Functions that may return this value:
      * - #HTTPClient_Send
      */
-    HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_CONTENT_LENGTH,
+    HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH,
 
     /**
      * @brief An error occurred in the third-party parsing library.
@@ -409,7 +409,7 @@ typedef struct HTTPRequestInfo
     /**
      * @brief Flags to activate other request header configurations.
      */
-    uint32_t flags;
+    uint32_t reqFlags;
 } HTTPRequestInfo_t;
 
 
@@ -526,7 +526,7 @@ typedef struct HTTPResponse
      *
      * This is updated by #HTTPClient_Send.
      */
-    uint32_t flags;
+    uint32_t respFlags;
 } HTTPResponse_t;
 
 /**
@@ -544,7 +544,7 @@ typedef struct HTTPResponse
  *     Host: <#HTTPRequestInfo_t.pHost>
  *
  * Note that "Connection" header can be added and set to "keep-alive" by
- * activating the HTTP_REQUEST_KEEP_ALIVE_FLAG in #HTTPRequestInfo_t.flags.
+ * activating the HTTP_REQUEST_KEEP_ALIVE_FLAG in #HTTPRequestInfo_t.reqFlags.
  *
  * @param[in] pRequestHeaders Request header buffer information.
  * @param[in] pRequestInfo Initial request header configurations.
@@ -641,7 +641,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * body in @p pRequestBodyBuf over the transport. The response is received in
  * #HTTPResponse_t.pBuffer.
  *
- * If #HTTP_SEND_DISABLE_CONTENT_LENGTH_FLAG is not set in parameter @p flags,
+ * If #HTTP_SEND_DISABLE_CONTENT_LENGTH_FLAG is not set in parameter @p sendFlags,
  * then the Content-Length to be sent to the server is automatically written to
  * @p pRequestHeaders. The Content-Length will not be written when there is
  * no request body. If there is not enough room in the buffer to write the
@@ -653,11 +653,11 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * following errors are returned:
  * - #HTTP_SECURITY_ALERT_RESPONSE_HEADERS_SIZE_LIMIT_EXCEEDED
  * - #HTTP_SECURITY_ALERT_EXTRANEOUS_RESPONSE_DATA
- * - #HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_CHUNK_HEADER
- * - #HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_PROTOCOL_VERSION
- * - #HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_STATUS_CODE
- * - #HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_CHARACTER
- * - #HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_CONTENT_LENGTH
+ * - #HTTP_SECURITY_ALERT_INVALID_CHUNK_HEADER
+ * - #HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION
+ * - #HTTP_SECURITY_ALERT_INVALID_STATUS_CODE
+ * - #HTTP_SECURITY_ALERT_INVALID_CHARACTER
+ * - #HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH
  *
  * The @p pResponse returned is valid only if this function returns HTTP_SUCCESS.
  *
@@ -670,7 +670,7 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * @param[in] reqBodyBufLen The length of the request entity in bytes.
  * @param[in] pResponse The response message and some notable response
  * parameters will be returned here on success.
- * @param[in] pFlags Flags which modify the behavior of this function. Please
+ * @param[in] sendFlags Flags which modify the behavior of this function. Please
  * see @ref http_send_flags.
  *
  * @return One of the following:
@@ -685,18 +685,18 @@ HTTPStatus_t HTTPClient_AddRangeHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * Security alerts are listed below, please see #HTTPStatus_t for more information:
  * - #HTTP_SECURITY_ALERT_RESPONSE_HEADERS_SIZE_LIMIT_EXCEEDED
  * - #HTTP_SECURITY_ALERT_EXTRANEOUS_RESPONSE_DATA
- * - #HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_CHUNK_HEADER
- * - #HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_PROTOCOL_VERSION
- * - #HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_STATUS_CODE
- * - #HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_CHARACTER
- * - #HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_CONTENT_LENGTH
+ * - #HTTP_SECURITY_ALERT_INVALID_CHUNK_HEADER
+ * - #HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION
+ * - #HTTP_SECURITY_ALERT_INVALID_STATUS_CODE
+ * - #HTTP_SECURITY_ALERT_INVALID_CHARACTER
+ * - #HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH
  */
 HTTPStatus_t HTTPClient_Send( const HTTPTransportInterface_t * pTransport,
                               HTTPRequestHeaders_t * pRequestHeaders,
                               const uint8_t * pRequestBodyBuf,
                               size_t reqBodyBufLen,
                               HTTPResponse_t * pResponse,
-                              uint32_t flags );
+                              uint32_t sendFlags );
 
 /**
  * @brief Read a header from a buffer containing a complete HTTP response.

--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -101,9 +101,9 @@ static HTTPStatus_t addHeader( HTTPRequestHeaders_t * pRequestHeaders,
  * returned.
  */
 static HTTPStatus_t receiveHttpData( const HTTPTransportInterface_t * pTransport,
-                              uint8_t * pBuffer,
-                              size_t bufferLen,
-                              size_t * pBytesReceived );
+                                     uint8_t * pBuffer,
+                                     size_t bufferLen,
+                                     size_t * pBytesReceived );
 
 /**
  * @brief Get the status of the HTTP response given the parsing state and how
@@ -807,8 +807,9 @@ static int httpParserOnBodyCallback( http_parser * pHttpParser,
      * will follow the the chunked header. This body data is in a later location
      * and must be moved up in the buffer. When pLoc is greater than the current
      * end of the body, that signals the parser found a chunk header. */
+
     /* MISRA Rule 18.3 flags pLoc and pNextWriteLoc as pointing to two different
-     * objects. This rule is suppressed because both pNextWriteLoc and pLoc 
+     * objects. This rule is suppressed because both pNextWriteLoc and pLoc
      * point to a location in the response buffer. */
     /* coverity[pointer_parameter] */
     /* coverity[misra_c_2012_rule_18_3_violation] */
@@ -984,9 +985,9 @@ static HTTPStatus_t processHttpParserError( const http_parser * pHttpParser )
 /*-----------------------------------------------------------*/
 
 static HTTPStatus_t parseHttpResponse( HTTPParsingContext_t * pParsingContext,
-                                HTTPResponse_t * pResponse,
-                                size_t parseLen,
-                                uint8_t isHeadResponse )
+                                       HTTPResponse_t * pResponse,
+                                       size_t parseLen,
+                                       uint8_t isHeadResponse )
 {
     HTTPStatus_t returnStatus;
     http_parser_settings parserSettings = { 0 };
@@ -1121,7 +1122,7 @@ static HTTPStatus_t addHeader( HTTPRequestHeaders_t * pRequestHeaders,
                                size_t valueLen )
 {
     HTTPStatus_t returnStatus = HTTP_SUCCESS;
-    char * pBufferCur = (char*)( pRequestHeaders->pBuffer + pRequestHeaders->headersLen );
+    char * pBufferCur = ( char * ) ( pRequestHeaders->pBuffer + pRequestHeaders->headersLen );
     size_t toAddLen = 0u;
     size_t backtrackHeaderLen = pRequestHeaders->headersLen;
 
@@ -1198,7 +1199,7 @@ static HTTPStatus_t writeRequestLine( HTTPRequestHeaders_t * pRequestHeaders,
                                       size_t pathLen )
 {
     HTTPStatus_t returnStatus = HTTP_SUCCESS;
-    char * pBufferCur = (char*)( pRequestHeaders->pBuffer );
+    char * pBufferCur = ( char * ) ( pRequestHeaders->pBuffer );
     size_t toAddLen = methodLen +                 \
                       SPACE_CHARACTER_LEN +       \
                       SPACE_CHARACTER_LEN +       \
@@ -1531,8 +1532,9 @@ static HTTPStatus_t sendHttpData( const HTTPTransportInterface_t * pTransport,
     assert( pData != NULL );
 
     /* Loop until all data is sent. */
+
     /* MISCRA C-2012 Rule 15.4 flags multiple break statements in the while loop
-     * below. There are two only error conditions when reading data from the 
+     * below. There are two only error conditions when reading data from the
      * network which both need the loop to terminate. Both of these conditions
      * necessitate different error logs, so two different break statements are
      * required. */
@@ -1676,9 +1678,9 @@ static HTTPStatus_t sendHttpBody( const HTTPTransportInterface_t * pTransport,
 /*-----------------------------------------------------------*/
 
 static HTTPStatus_t receiveHttpData( const HTTPTransportInterface_t * pTransport,
-                              uint8_t * pBuffer,
-                              size_t bufferLen,
-                              size_t * pBytesReceived )
+                                     uint8_t * pBuffer,
+                                     size_t bufferLen,
+                                     size_t * pBytesReceived )
 {
     HTTPStatus_t returnStatus = HTTP_SUCCESS;
     int32_t transportStatus = 0;
@@ -2162,7 +2164,7 @@ static HTTPStatus_t findHeaderInResponse( const uint8_t * pBuffer,
      * value of "on_header_value" callback (related to the header value) should
      * cause the http_parser.http_errno to be "CB_header_value". */
     if( ( returnStatus == HTTP_SUCCESS ) &&
-        ( parser.http_errno != ( unsigned int )HPE_CB_header_value ) )
+        ( parser.http_errno != ( unsigned int ) HPE_CB_header_value ) )
     {
         LogError( ( "Header found in response but http-parser returned error: "
                     "ParserError=%s",
@@ -2174,7 +2176,7 @@ static HTTPStatus_t findHeaderInResponse( const uint8_t * pBuffer,
      * expected to be called which should cause the http_parser.http_errno to be
      * "OK" */
     else if( ( returnStatus == HTTP_HEADER_NOT_FOUND ) &&
-             ( parser.http_errno != ( unsigned int )( HPE_OK ) ) )
+             ( parser.http_errno != ( unsigned int ) ( HPE_OK ) ) )
     {
         LogError( ( "Header not found in response: http-parser returned error: "
                     "ParserError=%s",

--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -810,6 +810,7 @@ static int httpParserOnBodyCallback( http_parser * pHttpParser,
     /* MISRA Rule 18.3 flags pLoc and pNextWriteLoc as pointing to two different
      * objects. This rule is suppressed because both pNextWriteLoc and pLoc 
      * point to a location in the response buffer. */
+    /* coverity[pointer_parameter] */
     /* coverity[misra_c_2012_rule_18_3_violation] */
     if( pLoc > pNextWriteLoc )
     {

--- a/libraries/standard/http/src/private/http_client_internal.h
+++ b/libraries/standard/http/src/private/http_client_internal.h
@@ -23,57 +23,59 @@
 /**
  * @brief The HTTP protocol version of this library is HTTP/1.1.
  */
-#define HTTP_PROTOCOL_VERSION                   "HTTP/1.1"
-#define HTTP_PROTOCOL_VERSION_LEN               ( sizeof( HTTP_PROTOCOL_VERSION ) - 1u )
+#define HTTP_PROTOCOL_VERSION              "HTTP/1.1"
+#define HTTP_PROTOCOL_VERSION_LEN          ( sizeof( HTTP_PROTOCOL_VERSION ) - 1u )
 
 /**
  * @brief Default value when pRequestInfo->pPath == NULL.
  */
-#define HTTP_EMPTY_PATH                         "/"
-#define HTTP_EMPTY_PATH_LEN                     ( sizeof( HTTP_EMPTY_PATH ) - 1u )
+#define HTTP_EMPTY_PATH                    "/"
+#define HTTP_EMPTY_PATH_LEN                ( sizeof( HTTP_EMPTY_PATH ) - 1u )
 
 /**
  * @brief Consants for HTTP header formatting
  */
-#define HTTP_HEADER_LINE_SEPARATOR              "\r\n"
-#define HTTP_HEADER_LINE_SEPARATOR_LEN          ( sizeof( HTTP_HEADER_LINE_SEPARATOR ) - 1u )
-#define HTTP_HEADER_END_INDICATOR               "\r\n\r\n"
-#define HTTP_HEADER_END_INDICATOR_LEN           ( sizeof( HTTP_HEADER_END_INDICATOR ) - 1u )
-#define HTTP_HEADER_FIELD_SEPARATOR             ": "
-#define HTTP_HEADER_FIELD_SEPARATOR_LEN         ( sizeof( HTTP_HEADER_FIELD_SEPARATOR ) - 1u )
-#define SPACE_CHARACTER                         " "
-#define SPACE_CHARACTER_LEN                     ( sizeof( SPACE_CHARACTER ) - 1u )
-#define DASH_CHARACTER                          "-"
-#define DASH_CHARACTER_LEN                      ( sizeof( DASH_CHARACTER ) - 1u )
+#define HTTP_HEADER_LINE_SEPARATOR         "\r\n"
+#define HTTP_HEADER_LINE_SEPARATOR_LEN     ( sizeof( HTTP_HEADER_LINE_SEPARATOR ) - 1u )
+#define HTTP_HEADER_END_INDICATOR          "\r\n\r\n"
+#define HTTP_HEADER_END_INDICATOR_LEN      ( sizeof( HTTP_HEADER_END_INDICATOR ) - 1u )
+#define HTTP_HEADER_FIELD_SEPARATOR        ": "
+#define HTTP_HEADER_FIELD_SEPARATOR_LEN    ( sizeof( HTTP_HEADER_FIELD_SEPARATOR ) - 1u )
+#define SPACE_CHARACTER                    " "
+#define SPACE_CHARACTER_LEN                ( sizeof( SPACE_CHARACTER ) - 1u )
+#define DASH_CHARACTER                     "-"
+#define DASH_CHARACTER_LEN                 ( sizeof( DASH_CHARACTER ) - 1u )
 
 /**
  * @brief Constants for header fields added automatically during the request
  * initialization.
  */
-#define HTTP_USER_AGENT_FIELD                   "User-Agent"
-#define HTTP_USER_AGENT_FIELD_LEN               ( sizeof( HTTP_USER_AGENT_FIELD ) - 1u )
-#define HTTP_HOST_FIELD                         "Host"
-#define HTTP_HOST_FIELD_LEN                     ( sizeof( HTTP_HOST_FIELD ) - 1u )
-#define HTTP_USER_AGENT_VALUE_LEN               ( sizeof( HTTP_USER_AGENT_VALUE ) - 1u )
+#define HTTP_USER_AGENT_FIELD              "User-Agent"
+#define HTTP_USER_AGENT_FIELD_LEN          ( sizeof( HTTP_USER_AGENT_FIELD ) - 1u )
+#define HTTP_HOST_FIELD                    "Host"
+#define HTTP_HOST_FIELD_LEN                ( sizeof( HTTP_HOST_FIELD ) - 1u )
+#define HTTP_USER_AGENT_VALUE_LEN          ( sizeof( HTTP_USER_AGENT_VALUE ) - 1u )
 
 /**
  * @brief Constants for header fields added based on flags.
  */
-#define HTTP_CONNECTION_FIELD                   "Connection"
-#define HTTP_CONNECTION_FIELD_LEN               ( sizeof( HTTP_CONNECTION_FIELD ) - 1u )
-#define HTTP_CONTENT_LENGTH_FIELD               "Content-Length"
-#define HTTP_CONTENT_LENGTH_FIELD_LEN           ( sizeof( HTTP_CONTENT_LENGTH_FIELD ) - 1u )
+#define HTTP_CONNECTION_FIELD              "Connection"
+#define HTTP_CONNECTION_FIELD_LEN          ( sizeof( HTTP_CONNECTION_FIELD ) - 1u )
+#define HTTP_CONTENT_LENGTH_FIELD          "Content-Length"
+#define HTTP_CONTENT_LENGTH_FIELD_LEN      ( sizeof( HTTP_CONTENT_LENGTH_FIELD ) - 1u )
 
 /**
  * @brief Constants for header values added based on flags.
  */
-/* MISRA Rule 5.4 flags the following macro's name as ambiguous from the 
- * one postfixed with _LEN. This rule is suppressed for naming consistency with 
+
+/* MISRA Rule 5.4 flags the following macro's name as ambiguous from the
+ * one postfixed with _LEN. This rule is suppressed for naming consistency with
  * other HTTP header field and value string and length macros in this file.*/
 /* coverity[other_declaration] */
-#define HTTP_CONNECTION_KEEP_ALIVE_VALUE        "keep-alive"
+#define HTTP_CONNECTION_KEEP_ALIVE_VALUE    "keep-alive"
+
 /* MISRA Rule 5.4 flags the following macro's name as ambiguous from the one
- * above it. This rule is suppressed for naming consistency with other HTTP 
+ * above it. This rule is suppressed for naming consistency with other HTTP
  * header field and value string and length macros in this file.*/
 /* coverity[misra_c_2012_rule_5_4_violation] */
 #define HTTP_CONNECTION_KEEP_ALIVE_VALUE_LEN    ( sizeof( HTTP_CONNECTION_KEEP_ALIVE_VALUE ) - 1u )
@@ -81,23 +83,27 @@
 /**
  * @brief Constants relating to Range Requests.
  */
-/* MISRA Rule 5.4 flags the following macro's name as ambiguous from the 
- * one postfixed with _LEN. This rule is suppressed for naming consistency with 
+
+/* MISRA Rule 5.4 flags the following macro's name as ambiguous from the
+ * one postfixed with _LEN. This rule is suppressed for naming consistency with
  * other HTTP header field and value string and length macros in this file.*/
 /* coverity[other_declaration] */
-#define HTTP_RANGE_REQUEST_HEADER_FIELD               "Range"
+#define HTTP_RANGE_REQUEST_HEADER_FIELD    "Range"
+
 /* MISRA Rule 5.4 flags the following macro's name as ambiguous from the one
- * above it. This rule is suppressed for naming consistency with other HTTP 
+ * above it. This rule is suppressed for naming consistency with other HTTP
  * header field and value string and length macros in this file.*/
 /* coverity[misra_c_2012_rule_5_4_violation] */
-#define HTTP_RANGE_REQUEST_HEADER_FIELD_LEN           ( sizeof( HTTP_RANGE_REQUEST_HEADER_FIELD ) - 1u )
-/* MISRA Rule 5.4 flags the following macro's name as ambiguous from the 
- * one postfixed with _LEN. This rule is suppressed for naming consistency with 
+#define HTTP_RANGE_REQUEST_HEADER_FIELD_LEN    ( sizeof( HTTP_RANGE_REQUEST_HEADER_FIELD ) - 1u )
+
+/* MISRA Rule 5.4 flags the following macro's name as ambiguous from the
+ * one postfixed with _LEN. This rule is suppressed for naming consistency with
  * other HTTP header field and value string and length macros in this file.*/
 /* coverity[other_declaration] */
-#define HTTP_RANGE_REQUEST_HEADER_VALUE_PREFIX        "bytes="
+#define HTTP_RANGE_REQUEST_HEADER_VALUE_PREFIX    "bytes="
+
 /* MISRA Rule 5.4 flags the following macro's name as ambiguous from the one
- * above it. This rule is suppressed for naming consistency with other HTTP 
+ * above it. This rule is suppressed for naming consistency with other HTTP
  * header field and value string and length macros in this file.*/
 /* coverity[misra_c_2012_rule_5_4_violation] */
 #define HTTP_RANGE_REQUEST_HEADER_VALUE_PREFIX_LEN    ( sizeof( HTTP_RANGE_REQUEST_HEADER_VALUE_PREFIX ) - 1u )

--- a/libraries/standard/http/src/private/http_client_internal.h
+++ b/libraries/standard/http/src/private/http_client_internal.h
@@ -67,26 +67,38 @@
 /**
  * @brief Constants for header values added based on flags.
  */
+/* MISRA Rule 5.4 flags the following macro's name as ambiguous from the 
+ * one postfixed with _LEN. This rule is suppressed for naming consistency with 
+ * other HTTP header field and value string and length macros in this file.*/
+/* coverity[other_declaration] */
 #define HTTP_CONNECTION_KEEP_ALIVE_VALUE        "keep-alive"
 /* MISRA Rule 5.4 flags the following macro's name as ambiguous from the one
- * above it. This rule is suppressed for consistency with other HTTP header
- * string and length macros in this file. */
+ * above it. This rule is suppressed for naming consistency with other HTTP 
+ * header field and value string and length macros in this file.*/
 /* coverity[misra_c_2012_rule_5_4_violation] */
 #define HTTP_CONNECTION_KEEP_ALIVE_VALUE_LEN    ( sizeof( HTTP_CONNECTION_KEEP_ALIVE_VALUE ) - 1u )
 
 /**
  * @brief Constants relating to Range Requests.
  */
+/* MISRA Rule 5.4 flags the following macro's name as ambiguous from the 
+ * one postfixed with _LEN. This rule is suppressed for naming consistency with 
+ * other HTTP header field and value string and length macros in this file.*/
+/* coverity[other_declaration] */
 #define HTTP_RANGE_REQUEST_HEADER_FIELD               "Range"
 /* MISRA Rule 5.4 flags the following macro's name as ambiguous from the one
- * above it. This rule is suppressed for consistency with other HTTP header
- * string and length macros in this file. */
+ * above it. This rule is suppressed for naming consistency with other HTTP 
+ * header field and value string and length macros in this file.*/
 /* coverity[misra_c_2012_rule_5_4_violation] */
 #define HTTP_RANGE_REQUEST_HEADER_FIELD_LEN           ( sizeof( HTTP_RANGE_REQUEST_HEADER_FIELD ) - 1u )
+/* MISRA Rule 5.4 flags the following macro's name as ambiguous from the 
+ * one postfixed with _LEN. This rule is suppressed for naming consistency with 
+ * other HTTP header field and value string and length macros in this file.*/
+/* coverity[other_declaration] */
 #define HTTP_RANGE_REQUEST_HEADER_VALUE_PREFIX        "bytes="
 /* MISRA Rule 5.4 flags the following macro's name as ambiguous from the one
- * above it. This rule is suppressed for consistency with other HTTP header
- * string and length macros in this file. */
+ * above it. This rule is suppressed for naming consistency with other HTTP 
+ * header field and value string and length macros in this file.*/
 /* coverity[misra_c_2012_rule_5_4_violation] */
 #define HTTP_RANGE_REQUEST_HEADER_VALUE_PREFIX_LEN    ( sizeof( HTTP_RANGE_REQUEST_HEADER_VALUE_PREFIX ) - 1u )
 

--- a/libraries/standard/http/src/private/http_client_internal.h
+++ b/libraries/standard/http/src/private/http_client_internal.h
@@ -41,12 +41,8 @@
 #define HTTP_HEADER_END_INDICATOR_LEN           ( sizeof( HTTP_HEADER_END_INDICATOR ) - 1u )
 #define HTTP_HEADER_FIELD_SEPARATOR             ": "
 #define HTTP_HEADER_FIELD_SEPARATOR_LEN         ( sizeof( HTTP_HEADER_FIELD_SEPARATOR ) - 1u )
-#define COLON_CHARACTER                         ":"
-#define COLON_CHARACTER_LEN                     ( sizeof( COLON_CHARACTER ) - 1u )
 #define SPACE_CHARACTER                         " "
 #define SPACE_CHARACTER_LEN                     ( sizeof( SPACE_CHARACTER ) - 1u )
-#define EQUAL_CHARACTER                         "="
-#define EQUAL_CHARACTER_LEN                     ( sizeof( EQUAL_CHARACTER ) - 1u )
 #define DASH_CHARACTER                          "-"
 #define DASH_CHARACTER_LEN                      ( sizeof( DASH_CHARACTER ) - 1u )
 
@@ -72,17 +68,26 @@
  * @brief Constants for header values added based on flags.
  */
 #define HTTP_CONNECTION_KEEP_ALIVE_VALUE        "keep-alive"
+/* MISRA Rule 5.4 flags the following macro's name as ambiguous from the one
+ * above it. This rule is suppressed for consistency with other HTTP header
+ * string and length macros in this file. */
+/* coverity[misra_c_2012_rule_5_4_violation] */
 #define HTTP_CONNECTION_KEEP_ALIVE_VALUE_LEN    ( sizeof( HTTP_CONNECTION_KEEP_ALIVE_VALUE ) - 1u )
-#define HTTP_CONNECTION_CLOSE_VALUE             "close"
-#define HTTP_CONNECTION_CLOSE_VALUE_LEN         ( sizeof( HTTP_CONNECTION_CLOSE_VALUE ) - 1u )
-
 
 /**
  * @brief Constants relating to Range Requests.
  */
 #define HTTP_RANGE_REQUEST_HEADER_FIELD               "Range"
+/* MISRA Rule 5.4 flags the following macro's name as ambiguous from the one
+ * above it. This rule is suppressed for consistency with other HTTP header
+ * string and length macros in this file. */
+/* coverity[misra_c_2012_rule_5_4_violation] */
 #define HTTP_RANGE_REQUEST_HEADER_FIELD_LEN           ( sizeof( HTTP_RANGE_REQUEST_HEADER_FIELD ) - 1u )
 #define HTTP_RANGE_REQUEST_HEADER_VALUE_PREFIX        "bytes="
+/* MISRA Rule 5.4 flags the following macro's name as ambiguous from the one
+ * above it. This rule is suppressed for consistency with other HTTP header
+ * string and length macros in this file. */
+/* coverity[misra_c_2012_rule_5_4_violation] */
 #define HTTP_RANGE_REQUEST_HEADER_VALUE_PREFIX_LEN    ( sizeof( HTTP_RANGE_REQUEST_HEADER_VALUE_PREFIX ) - 1u )
 
 /**

--- a/libraries/standard/http/utest/http_send_utest.c
+++ b/libraries/standard/http/utest/http_send_utest.c
@@ -780,8 +780,8 @@ void test_HTTPClient_Send_HEAD_request_parse_whole_response( void )
     TEST_ASSERT_EQUAL( HTTP_STATUS_CODE_OK, response.statusCode );
     TEST_ASSERT_EQUAL( HTTP_TEST_RESPONSE_HEAD_CONTENT_LENGTH, response.contentLength );
     TEST_ASSERT_EQUAL( HTTP_TEST_RESPONSE_HEAD_HEADER_COUNT, response.headerCount );
-    TEST_ASSERT_BITS_HIGH( HTTP_RESPONSE_CONNECTION_CLOSE_FLAG, response.flags );
-    TEST_ASSERT_BITS_LOW( HTTP_RESPONSE_CONNECTION_KEEP_ALIVE_FLAG, response.flags );
+    TEST_ASSERT_BITS_HIGH( HTTP_RESPONSE_CONNECTION_CLOSE_FLAG, response.respFlags );
+    TEST_ASSERT_BITS_LOW( HTTP_RESPONSE_CONNECTION_KEEP_ALIVE_FLAG, response.respFlags );
 }
 
 /*-----------------------------------------------------------*/
@@ -818,8 +818,8 @@ void test_HTTPClient_Send_PUT_request_parse_whole_response( void )
     TEST_ASSERT_EQUAL( HTTP_STATUS_CODE_OK, response.statusCode );
     TEST_ASSERT_EQUAL( 0, response.contentLength );
     TEST_ASSERT_EQUAL( HTTP_TEST_RESPONSE_PUT_HEADER_COUNT, response.headerCount );
-    TEST_ASSERT_BITS_LOW( HTTP_RESPONSE_CONNECTION_CLOSE_FLAG, response.flags );
-    TEST_ASSERT_BITS_HIGH( HTTP_RESPONSE_CONNECTION_KEEP_ALIVE_FLAG, response.flags );
+    TEST_ASSERT_BITS_LOW( HTTP_RESPONSE_CONNECTION_CLOSE_FLAG, response.respFlags );
+    TEST_ASSERT_BITS_HIGH( HTTP_RESPONSE_CONNECTION_KEEP_ALIVE_FLAG, response.respFlags );
 }
 
 /*-----------------------------------------------------------*/
@@ -854,8 +854,8 @@ void test_HTTPClient_Send_GET_request_parse_whole_response( void )
     TEST_ASSERT_EQUAL( HTTP_STATUS_CODE_OK, response.statusCode );
     TEST_ASSERT_EQUAL( HTTP_TEST_RESPONSE_GET_CONTENT_LENGTH, response.contentLength );
     TEST_ASSERT_EQUAL( HTTP_TEST_RESPONSE_GET_HEADER_COUNT, response.headerCount );
-    TEST_ASSERT_BITS_HIGH( HTTP_RESPONSE_CONNECTION_CLOSE_FLAG, response.flags );
-    TEST_ASSERT_BITS_LOW( HTTP_RESPONSE_CONNECTION_KEEP_ALIVE_FLAG, response.flags );
+    TEST_ASSERT_BITS_HIGH( HTTP_RESPONSE_CONNECTION_CLOSE_FLAG, response.respFlags );
+    TEST_ASSERT_BITS_LOW( HTTP_RESPONSE_CONNECTION_KEEP_ALIVE_FLAG, response.respFlags );
 }
 
 /*-----------------------------------------------------------*/
@@ -886,8 +886,8 @@ void test_HTTPClient_Send_no_response_headers( void )
     TEST_ASSERT_EQUAL( HTTP_STATUS_CODE_OK, response.statusCode );
     TEST_ASSERT_EQUAL( 0, response.contentLength );
     TEST_ASSERT_EQUAL( 0, response.headerCount );
-    TEST_ASSERT_BITS_LOW( HTTP_RESPONSE_CONNECTION_CLOSE_FLAG, response.flags );
-    TEST_ASSERT_BITS_LOW( HTTP_RESPONSE_CONNECTION_KEEP_ALIVE_FLAG, response.flags );
+    TEST_ASSERT_BITS_LOW( HTTP_RESPONSE_CONNECTION_CLOSE_FLAG, response.respFlags );
+    TEST_ASSERT_BITS_LOW( HTTP_RESPONSE_CONNECTION_KEEP_ALIVE_FLAG, response.respFlags );
 }
 
 /*-----------------------------------------------------------*/
@@ -916,8 +916,8 @@ void test_HTTPClient_Send_parse_partial_header_field( void )
     TEST_ASSERT_EQUAL( HTTP_STATUS_CODE_OK, response.statusCode );
     TEST_ASSERT_EQUAL( HTTP_TEST_RESPONSE_HEAD_CONTENT_LENGTH, response.contentLength );
     TEST_ASSERT_EQUAL( HTTP_TEST_RESPONSE_HEAD_HEADER_COUNT, response.headerCount );
-    TEST_ASSERT_BITS_HIGH( HTTP_RESPONSE_CONNECTION_CLOSE_FLAG, response.flags );
-    TEST_ASSERT_BITS_LOW( HTTP_RESPONSE_CONNECTION_KEEP_ALIVE_FLAG, response.flags );
+    TEST_ASSERT_BITS_HIGH( HTTP_RESPONSE_CONNECTION_CLOSE_FLAG, response.respFlags );
+    TEST_ASSERT_BITS_LOW( HTTP_RESPONSE_CONNECTION_KEEP_ALIVE_FLAG, response.respFlags );
 }
 
 /*-----------------------------------------------------------*/
@@ -946,8 +946,8 @@ void test_HTTPClient_Send_parse_partial_header_value( void )
     TEST_ASSERT_EQUAL( HTTP_STATUS_CODE_OK, response.statusCode );
     TEST_ASSERT_EQUAL( HTTP_TEST_RESPONSE_HEAD_CONTENT_LENGTH, response.contentLength );
     TEST_ASSERT_EQUAL( HTTP_TEST_RESPONSE_HEAD_HEADER_COUNT, response.headerCount );
-    TEST_ASSERT_BITS_HIGH( HTTP_RESPONSE_CONNECTION_CLOSE_FLAG, response.flags );
-    TEST_ASSERT_BITS_LOW( HTTP_RESPONSE_CONNECTION_KEEP_ALIVE_FLAG, response.flags );
+    TEST_ASSERT_BITS_HIGH( HTTP_RESPONSE_CONNECTION_CLOSE_FLAG, response.respFlags );
+    TEST_ASSERT_BITS_LOW( HTTP_RESPONSE_CONNECTION_KEEP_ALIVE_FLAG, response.respFlags );
 }
 
 /*-----------------------------------------------------------*/
@@ -982,8 +982,8 @@ void test_HTTPClient_Send_parse_partial_body( void )
     TEST_ASSERT_EQUAL( HTTP_STATUS_CODE_OK, response.statusCode );
     TEST_ASSERT_EQUAL( HTTP_TEST_RESPONSE_GET_CONTENT_LENGTH, response.contentLength );
     TEST_ASSERT_EQUAL( HTTP_TEST_RESPONSE_GET_HEADER_COUNT, response.headerCount );
-    TEST_ASSERT_BITS_HIGH( HTTP_RESPONSE_CONNECTION_CLOSE_FLAG, response.flags );
-    TEST_ASSERT_BITS_LOW( HTTP_RESPONSE_CONNECTION_KEEP_ALIVE_FLAG, response.flags );
+    TEST_ASSERT_BITS_HIGH( HTTP_RESPONSE_CONNECTION_CLOSE_FLAG, response.respFlags );
+    TEST_ASSERT_BITS_LOW( HTTP_RESPONSE_CONNECTION_KEEP_ALIVE_FLAG, response.respFlags );
 }
 
 /*-----------------------------------------------------------*/
@@ -1017,8 +1017,8 @@ void test_HTTPClient_Send_parse_chunked_body( void )
     TEST_ASSERT_EQUAL( HTTP_STATUS_CODE_OK, response.statusCode );
     TEST_ASSERT_EQUAL( 0, response.contentLength );
     TEST_ASSERT_EQUAL( HTTP_TEST_RESPONSE_CHUNKED_HEADER_COUNT, response.headerCount );
-    TEST_ASSERT_BITS_LOW( HTTP_RESPONSE_CONNECTION_CLOSE_FLAG, response.flags );
-    TEST_ASSERT_BITS_HIGH( HTTP_RESPONSE_CONNECTION_KEEP_ALIVE_FLAG, response.flags );
+    TEST_ASSERT_BITS_LOW( HTTP_RESPONSE_CONNECTION_CLOSE_FLAG, response.respFlags );
+    TEST_ASSERT_BITS_HIGH( HTTP_RESPONSE_CONNECTION_KEEP_ALIVE_FLAG, response.respFlags );
 }
 
 /*-----------------------------------------------------------*/
@@ -1191,8 +1191,8 @@ void test_HTTPClient_Send_less_bytes_request_headers( void )
     TEST_ASSERT_EQUAL( HTTP_STATUS_CODE_OK, response.statusCode );
     TEST_ASSERT_EQUAL( 0, response.contentLength );
     TEST_ASSERT_EQUAL( HTTP_TEST_RESPONSE_PUT_HEADER_COUNT, response.headerCount );
-    TEST_ASSERT_BITS_LOW( HTTP_RESPONSE_CONNECTION_CLOSE_FLAG, response.flags );
-    TEST_ASSERT_BITS_HIGH( HTTP_RESPONSE_CONNECTION_KEEP_ALIVE_FLAG, response.flags );
+    TEST_ASSERT_BITS_LOW( HTTP_RESPONSE_CONNECTION_CLOSE_FLAG, response.respFlags );
+    TEST_ASSERT_BITS_HIGH( HTTP_RESPONSE_CONNECTION_KEEP_ALIVE_FLAG, response.respFlags );
 }
 
 /*-----------------------------------------------------------*/
@@ -1230,8 +1230,8 @@ void test_HTTPClient_Send_less_bytes_request_body( void )
     TEST_ASSERT_EQUAL( HTTP_STATUS_CODE_OK, response.statusCode );
     TEST_ASSERT_EQUAL( 0, response.contentLength );
     TEST_ASSERT_EQUAL( HTTP_TEST_RESPONSE_PUT_HEADER_COUNT, response.headerCount );
-    TEST_ASSERT_BITS_LOW( HTTP_RESPONSE_CONNECTION_CLOSE_FLAG, response.flags );
-    TEST_ASSERT_BITS_HIGH( HTTP_RESPONSE_CONNECTION_KEEP_ALIVE_FLAG, response.flags );
+    TEST_ASSERT_BITS_LOW( HTTP_RESPONSE_CONNECTION_CLOSE_FLAG, response.respFlags );
+    TEST_ASSERT_BITS_HIGH( HTTP_RESPONSE_CONNECTION_KEEP_ALIVE_FLAG, response.respFlags );
 }
 
 /*-----------------------------------------------------------*/
@@ -1487,7 +1487,7 @@ void test_HTTPClient_Send_parsing_errors( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_CHUNK_HEADER, returnStatus );
+    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_INVALID_CHUNK_HEADER, returnStatus );
 
     httpParsingErrno = HPE_CLOSED_CONNECTION;
     returnStatus = HTTPClient_Send( &transportInterface,
@@ -1505,7 +1505,7 @@ void test_HTTPClient_Send_parsing_errors( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_PROTOCOL_VERSION, returnStatus );
+    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_INVALID_PROTOCOL_VERSION, returnStatus );
 
     httpParsingErrno = HPE_INVALID_STATUS;
     returnStatus = HTTPClient_Send( &transportInterface,
@@ -1514,7 +1514,7 @@ void test_HTTPClient_Send_parsing_errors( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_STATUS_CODE, returnStatus );
+    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_INVALID_STATUS_CODE, returnStatus );
 
     httpParsingErrno = HPE_STRICT;
     returnStatus = HTTPClient_Send( &transportInterface,
@@ -1523,7 +1523,7 @@ void test_HTTPClient_Send_parsing_errors( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_CHARACTER, returnStatus );
+    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_INVALID_CHARACTER, returnStatus );
 
     httpParsingErrno = HPE_INVALID_CONSTANT;
     returnStatus = HTTPClient_Send( &transportInterface,
@@ -1532,7 +1532,7 @@ void test_HTTPClient_Send_parsing_errors( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_CHARACTER, returnStatus );
+    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_INVALID_CHARACTER, returnStatus );
 
     httpParsingErrno = HPE_LF_EXPECTED;
     returnStatus = HTTPClient_Send( &transportInterface,
@@ -1541,7 +1541,7 @@ void test_HTTPClient_Send_parsing_errors( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_CHARACTER, returnStatus );
+    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_INVALID_CHARACTER, returnStatus );
 
     httpParsingErrno = HPE_INVALID_HEADER_TOKEN;
     returnStatus = HTTPClient_Send( &transportInterface,
@@ -1550,7 +1550,7 @@ void test_HTTPClient_Send_parsing_errors( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_CHARACTER, returnStatus );
+    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_INVALID_CHARACTER, returnStatus );
 
     httpParsingErrno = HPE_INVALID_CONTENT_LENGTH;
     returnStatus = HTTPClient_Send( &transportInterface,
@@ -1559,7 +1559,7 @@ void test_HTTPClient_Send_parsing_errors( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_CONTENT_LENGTH, returnStatus );
+    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH, returnStatus );
 
     httpParsingErrno = HPE_UNEXPECTED_CONTENT_LENGTH;
     returnStatus = HTTPClient_Send( &transportInterface,
@@ -1568,7 +1568,7 @@ void test_HTTPClient_Send_parsing_errors( void )
                                     0,
                                     &response,
                                     0 );
-    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_MALFORMED_RESPONSE_INVALID_CONTENT_LENGTH, returnStatus );
+    TEST_ASSERT_EQUAL( HTTP_SECURITY_ALERT_INVALID_CONTENT_LENGTH, returnStatus );
 
     httpParsingErrno = HPE_UNKNOWN;
     returnStatus = HTTPClient_Send( &transportInterface,

--- a/libraries/standard/http/utest/http_utest.c
+++ b/libraries/standard/http/utest/http_utest.c
@@ -379,7 +379,7 @@ static void setupRequestInfo( HTTPRequestInfo_t * pRequestInfo )
     pRequestInfo->pathLen = HTTP_TEST_REQUEST_PATH_LEN;
     pRequestInfo->pHost = HTTP_TEST_HOST_VALUE;
     pRequestInfo->hostLen = HTTP_TEST_HOST_VALUE_LEN;
-    pRequestInfo->flags = 0;
+    pRequestInfo->reqFlags = 0;
 }
 
 /**
@@ -493,7 +493,7 @@ void test_Http_InitializeRequestHeaders_ReqInfo()
     setupBuffer( &requestHeaders );
 
     requestInfo.pPath = NULL;
-    requestInfo.flags = HTTP_REQUEST_KEEP_ALIVE_FLAG;
+    requestInfo.reqFlags = HTTP_REQUEST_KEEP_ALIVE_FLAG;
     numBytes = snprintf( ( char * ) expectedHeaders.buffer, sizeof( expectedHeaders.buffer ),
                          HTTP_TEST_EXTRA_HEADER_FORMAT,
                          HTTP_METHOD_GET, HTTP_EMPTY_PATH,
@@ -516,7 +516,7 @@ void test_Http_InitializeRequestHeaders_ReqInfo()
     /* Repeat the test above but with length of path == 0 for coverage. */
     requestInfo.pPath = HTTP_EMPTY_PATH;
     requestInfo.pathLen = 0;
-    requestInfo.flags = HTTP_REQUEST_KEEP_ALIVE_FLAG;
+    requestInfo.reqFlags = HTTP_REQUEST_KEEP_ALIVE_FLAG;
     numBytes = snprintf( ( char * ) expectedHeaders.buffer, sizeof( expectedHeaders.buffer ),
                          HTTP_TEST_EXTRA_HEADER_FORMAT,
                          HTTP_METHOD_GET, HTTP_EMPTY_PATH,


### PR DESCRIPTION
*Description of changes:*
- Annotations and fixes for MISRA rules 8.8,8.7, 15.4, 18.3, 2.5, 21.15, 21.16, 5.2, 5.7, 5.4.
- A complete set of rules not handled because they related to the usage of third-party header http_parser.h can be found in our internal document store. Please message me for details.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
