### PR TITLE
Rename MQTTNetworkContext_t to NetworkContext_t

### DIFF
--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_config.h
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_config.h
@@ -50,7 +50,7 @@
 
 /* Set network context to OpenSSL SSL context. */
 #include <openssl/ssl.h>
-typedef SSL * MQTTNetworkContext_t;
+typedef SSL * NetworkContext_t;
 
 /**
  * @brief The maximum number of MQTT PUBLISH messages that may be pending

--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -218,7 +218,7 @@ static int tlsSetup( int tcpSocket,
  * @return Number of bytes sent; negative value on error;
  * 0 for timeout or 0 bytes sent.
  */
-static int32_t transportSend( MQTTNetworkContext_t pSslContext,
+static int32_t transportSend( NetworkContext_t pSslContext,
                               const void * pMessage,
                               size_t bytesToSend );
 
@@ -232,7 +232,7 @@ static int32_t transportSend( MQTTNetworkContext_t pSslContext,
  * @return Number of bytes received; negative value on error;
  * 0 for timeout.
  */
-static int32_t transportRecv( MQTTNetworkContext_t pSslContext,
+static int32_t transportRecv( NetworkContext_t pSslContext,
                               void * pBuffer,
                               size_t bytesToRecv );
 
@@ -608,7 +608,7 @@ static int tlsSetup( int tcpSocket,
 
 /*-----------------------------------------------------------*/
 
-static int32_t transportSend( MQTTNetworkContext_t pSslContext,
+static int32_t transportSend( NetworkContext_t pSslContext,
                               const void * pMessage,
                               size_t bytesToSend )
 {
@@ -647,7 +647,7 @@ static int32_t transportSend( MQTTNetworkContext_t pSslContext,
 
 /*-----------------------------------------------------------*/
 
-static int32_t transportRecv( MQTTNetworkContext_t pSslContext,
+static int32_t transportRecv( NetworkContext_t pSslContext,
                               void * pBuffer,
                               size_t bytesToRecv )
 {

--- a/demos/mqtt/mqtt_demo_lightweight/mqtt_config.h
+++ b/demos/mqtt/mqtt_demo_lightweight/mqtt_config.h
@@ -48,6 +48,6 @@
 /************ End of logging configuration ****************/
 
 /* Set network context to socket (int). */
-typedef int MQTTNetworkContext_t;
+typedef int NetworkContext_t;
 
 #endif /* ifndef MQTT_CONFIG_H_ */

--- a/demos/mqtt/mqtt_demo_lightweight/mqtt_demo_lightweight.c
+++ b/demos/mqtt/mqtt_demo_lightweight/mqtt_demo_lightweight.c
@@ -426,7 +426,7 @@ static int connectToServer( const char * pServer,
  *
  * @return Number of bytes received or zero to indicate transportTimeout; negative value on error.
  */
-static int32_t transportRecv( MQTTNetworkContext_t tcpSocket,
+static int32_t transportRecv( NetworkContext_t tcpSocket,
                               void * pBuffer,
                               size_t bytesToRecv )
 {

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_config.h
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_config.h
@@ -49,7 +49,7 @@
 /************ End of logging configuration ****************/
 
 /* Set network context to socket (int). */
-typedef int MQTTNetworkContext_t;
+typedef int NetworkContext_t;
 
 /**
  * @brief The maximum number of MQTT PUBLISH messages that may be pending

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
@@ -192,7 +192,7 @@ static int connectToServer( const char * pServer,
  * @return Number of bytes sent; negative value on error;
  * 0 for timeout or 0 bytes sent.
  */
-static int32_t transportSend( MQTTNetworkContext_t tcpSocket,
+static int32_t transportSend( NetworkContext_t tcpSocket,
                               const void * pMessage,
                               size_t bytesToSend );
 
@@ -205,7 +205,7 @@ static int32_t transportSend( MQTTNetworkContext_t tcpSocket,
  *
  * @return Number of bytes received; negative value on error.
  */
-static int32_t transportRecv( MQTTNetworkContext_t tcpSocket,
+static int32_t transportRecv( NetworkContext_t tcpSocket,
                               void * pBuffer,
                               size_t bytesToRecv );
 
@@ -423,7 +423,7 @@ static int connectToServer( const char * pServer,
 
 /*-----------------------------------------------------------*/
 
-static int32_t transportSend( MQTTNetworkContext_t tcpSocket,
+static int32_t transportSend( NetworkContext_t tcpSocket,
                               const void * pMessage,
                               size_t bytesToSend )
 {
@@ -446,7 +446,7 @@ static int32_t transportSend( MQTTNetworkContext_t tcpSocket,
 
 /*-----------------------------------------------------------*/
 
-static int32_t transportRecv( MQTTNetworkContext_t tcpSocket,
+static int32_t transportRecv( NetworkContext_t tcpSocket,
                               void * pBuffer,
                               size_t bytesToRecv )
 {
@@ -602,7 +602,7 @@ static int establishMqttSession( MQTTContext_t * pContext,
     /* Fill in TransportInterface send and receive function pointers.
      * For this demo, TCP sockets are used to send and receive data
      * from network. Network context is socket file descriptor.*/
-    transport.networkContext = ( MQTTNetworkContext_t ) tcpSocket;
+    transport.networkContext = ( NetworkContext_t ) tcpSocket;
     transport.send = transportSend;
     transport.recv = transportRecv;
 

--- a/libraries/standard/mqtt/include/mqtt.h
+++ b/libraries/standard/mqtt/include/mqtt.h
@@ -38,7 +38,7 @@ typedef struct MQTTContext                MQTTContext_t;
 struct MQTTTransportInterface;
 typedef struct MQTTTransportInterface     MQTTTransportInterface_t;
 
-typedef int32_t (* MQTTTransportSendFunc_t )( MQTTNetworkContext_t context,
+typedef int32_t (* MQTTTransportSendFunc_t )( NetworkContext_t context,
                                               const void * pMessage,
                                               size_t bytesToSend );
 
@@ -82,7 +82,7 @@ struct MQTTTransportInterface
 {
     MQTTTransportSendFunc_t send;
     MQTTTransportRecvFunc_t recv;
-    MQTTNetworkContext_t networkContext;
+    NetworkContext_t networkContext;
 };
 
 struct MQTTApplicationCallbacks

--- a/libraries/standard/mqtt/include/mqtt_lightweight.h
+++ b/libraries/standard/mqtt/include/mqtt_lightweight.h
@@ -87,7 +87,7 @@ typedef struct MQTTPacketInfo      MQTTPacketInfo_t;
  *
  * @return The number of bytes received; negative value on failure.
  */
-typedef int32_t (* MQTTTransportRecvFunc_t )( MQTTNetworkContext_t context,
+typedef int32_t (* MQTTTransportRecvFunc_t )( NetworkContext_t context,
                                               void * pBuffer,
                                               size_t bytesToRecv );
 
@@ -520,7 +520,7 @@ MQTTStatus_t MQTT_DeserializeAck( const MQTTPacketInfo_t * pIncomingPacket,
  * #MQTTNoDataAvailable if there is nothing to read.
  */
 MQTTStatus_t MQTT_GetIncomingPacketTypeAndLength( MQTTTransportRecvFunc_t readFunc,
-                                                  MQTTNetworkContext_t networkContext,
+                                                  NetworkContext_t networkContext,
                                                   MQTTPacketInfo_t * pIncomingPacket );
 
 #endif /* ifndef MQTT_LIGHTWEIGHT_H */

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -523,7 +523,7 @@ static void serializePublishCommon( const MQTTPublishInfo_t * pPublishInfo,
 }
 
 static size_t getRemainingLength( MQTTTransportRecvFunc_t recvFunc,
-                                  MQTTNetworkContext_t networkContext )
+                                  NetworkContext_t networkContext )
 {
     size_t remainingLength = 0, multiplier = 1, bytesDecoded = 0, expectedSize = 0;
     uint8_t encodedByte = 0;
@@ -2034,7 +2034,7 @@ MQTTStatus_t MQTT_DeserializeAck( const MQTTPacketInfo_t * pIncomingPacket,
 /*-----------------------------------------------------------*/
 
 MQTTStatus_t MQTT_GetIncomingPacketTypeAndLength( MQTTTransportRecvFunc_t readFunc,
-                                                  MQTTNetworkContext_t networkContext,
+                                                  NetworkContext_t networkContext,
                                                   MQTTPacketInfo_t * pIncomingPacket )
 {
     MQTTStatus_t status = MQTTSuccess;

--- a/libraries/standard/mqtt/utest/mqtt_config.h
+++ b/libraries/standard/mqtt/utest/mqtt_config.h
@@ -23,7 +23,7 @@
 /************ End of logging configuration ****************/
 
 /* Set network context to double pointer to buffer (uint8_t**). */
-typedef uint8_t ** MQTTNetworkContext_t;
+typedef uint8_t ** NetworkContext_t;
 
 /**
  * @brief The maximum number of MQTT PUBLISH messages that may be pending

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -152,7 +152,7 @@ int suiteTearDown( int numFailures )
 /**
  * @brief Mock successful transport receive by reading data from a buffer.
  */
-static int32_t mockReceive( MQTTNetworkContext_t context,
+static int32_t mockReceive( NetworkContext_t context,
                             void * pBuffer,
                             size_t bytesToRecv )
 {
@@ -178,7 +178,7 @@ static int32_t mockReceive( MQTTNetworkContext_t context,
 /**
  * @brief Mock transport receive with no data available.
  */
-static int32_t mockReceiveNoData( MQTTNetworkContext_t context,
+static int32_t mockReceiveNoData( NetworkContext_t context,
                                   void * pBuffer,
                                   size_t bytesToRecv )
 {
@@ -188,7 +188,7 @@ static int32_t mockReceiveNoData( MQTTNetworkContext_t context,
 /**
  * @brief Mock transport receive failure.
  */
-static int32_t mockReceiveFailure( MQTTNetworkContext_t context,
+static int32_t mockReceiveFailure( NetworkContext_t context,
                                    void * pBuffer,
                                    size_t bytesToRecv )
 {
@@ -198,7 +198,7 @@ static int32_t mockReceiveFailure( MQTTNetworkContext_t context,
 /**
  * @brief Mock transport receive that succeeds once, then fails.
  */
-static int32_t mockReceiveSucceedThenFail( MQTTNetworkContext_t context,
+static int32_t mockReceiveSucceedThenFail( NetworkContext_t context,
                                            void * pBuffer,
                                            size_t bytesToRecv )
 {
@@ -1575,7 +1575,7 @@ void test_MQTT_GetIncomingPacketTypeAndLength( void )
     uint8_t * bufPtr = buffer;
 
     /* Dummy network context - pointer to pointer to a buffer. */
-    MQTTNetworkContext_t networkContext = ( MQTTNetworkContext_t ) &bufPtr;
+    NetworkContext_t networkContext = ( NetworkContext_t ) &bufPtr;
 
     buffer[ 0 ] = 0x20; /* CONN ACK */
     buffer[ 1 ] = 0x02; /* Remaining length. */

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -142,7 +142,7 @@ int suiteTearDown( int numFailures )
  * @brief Mock successful transport send, and write data into buffer for
  * verification.
  */
-static int32_t mockSend( MQTTNetworkContext_t context,
+static int32_t mockSend( NetworkContext_t context,
                          const void * pMessage,
                          size_t bytesToSend )
 {
@@ -213,7 +213,7 @@ static uint32_t getTime( void )
  * @return Number of bytes sent; negative value on error;
  * 0 for timeout or 0 bytes sent.
  */
-static int32_t transportSendSuccess( MQTTNetworkContext_t pContext,
+static int32_t transportSendSuccess( NetworkContext_t pContext,
                                      const void * pBuffer,
                                      size_t bytesToWrite )
 {
@@ -225,7 +225,7 @@ static int32_t transportSendSuccess( MQTTNetworkContext_t pContext,
 /**
  * @brief Mocked failed transport send.
  */
-static int32_t transportSendFailure( MQTTNetworkContext_t pContext,
+static int32_t transportSendFailure( NetworkContext_t pContext,
                                      const void * pBuffer,
                                      size_t bytesToWrite )
 {
@@ -238,7 +238,7 @@ static int32_t transportSendFailure( MQTTNetworkContext_t pContext,
 /**
  * @brief Mocked transport send that succeeds then fails.
  */
-static int32_t transportSendSucceedThenFail( MQTTNetworkContext_t context,
+static int32_t transportSendSucceedThenFail( NetworkContext_t context,
                                              const void * pMessage,
                                              size_t bytesToSend )
 {
@@ -266,7 +266,7 @@ static int32_t transportSendSucceedThenFail( MQTTNetworkContext_t context,
  *
  * @return Number of bytes received; negative value on error.
  */
-static int32_t transportRecvSuccess( MQTTNetworkContext_t pContext,
+static int32_t transportRecvSuccess( NetworkContext_t pContext,
                                      void * pBuffer,
                                      size_t bytesToRead )
 {
@@ -278,7 +278,7 @@ static int32_t transportRecvSuccess( MQTTNetworkContext_t pContext,
 /**
  * @brief Mocked failed transport read.
  */
-static int32_t transportRecvFailure( MQTTNetworkContext_t pContext,
+static int32_t transportRecvFailure( NetworkContext_t pContext,
                                      void * pBuffer,
                                      size_t bytesToRead )
 {
@@ -291,7 +291,7 @@ static int32_t transportRecvFailure( MQTTNetworkContext_t pContext,
 /**
  * @brief Mocked transport reading one byte at a time.
  */
-static int32_t transportRecvOneByte( MQTTNetworkContext_t pContext,
+static int32_t transportRecvOneByte( NetworkContext_t pContext,
                                      void * pBuffer,
                                      size_t bytesToRead )
 {
@@ -874,7 +874,7 @@ void test_MQTT_Disconnect( void )
     MQTTStatus_t status;
     uint8_t buffer[ 10 ];
     uint8_t * bufPtr = buffer;
-    MQTTNetworkContext_t networkContext = ( MQTTNetworkContext_t ) &bufPtr;
+    NetworkContext_t networkContext = ( NetworkContext_t ) &bufPtr;
     MQTTTransportInterface_t transport;
     MQTTFixedBuffer_t networkBuffer;
     MQTTApplicationCallbacks_t callbacks;


### PR DESCRIPTION
*Description of changes:*
Renames instances of `MQTTNetworkContext_t` to `NetworkContext_t`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
