### PR TITLE
Update logConnackResponse to log success response at Info level

### DIFF
--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -731,7 +731,7 @@ static void logConnackResponse( uint8_t responseCode )
     if( responseCode == 0u )
     {
         /* Log at Info level for a success CONNACK response. */
-        LogInfo( ( "%s", pConnecAckResponses[ 0 ] ) );
+        LogInfo( ( "%s", pConnackResponses[ 0 ] ) );
     }
     else
     {

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -728,8 +728,16 @@ static void logConnackResponse( uint8_t responseCode )
 
     assert( responseCode <= 5 );
 
-    /* Log an error based on the CONNACK response code. */
-    LogError( ( "%s", pConnackResponses[ responseCode ] ) );
+    if( responseCode == 0u )
+    {
+        /* Log at Info level for a success CONNACK response. */
+        LogInfo( ( "%s", pConnecAckResponses[ 0 ] ) );
+    }
+    else
+    {
+        /* Log an error based on the CONNACK response code. */
+        LogError( ( "%s", pConnackResponses[ responseCode ] ) );
+    }
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Fix issue that caused a success **CONNACK** response to be logged as error.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
