### PR TITLE
Verify minimum version required for OpenSSL and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This branch currently hosts development of the next iteration of the AWS IoT Emb
 This SDK builds with [CMake](https://cmake.org/), a cross-platform build tool.
 
 ### Prerequisites
-- CMake 3.5.0 or later and a C90 compiler.
+- CMake 3.13.0 or later and a C90 compiler.
 - A supported operating system. The ports provided with this repo are expected to work with all recent versions of the following operating systems, although we cannot guarantee the behavior on all systems.
-    - On Linux systems, installation of OpenSSL development libraries and header files, *version 1.0.2g or later*, are required. The OpenSSL development libraries are usually called something like `libssl-dev` or `openssl-devel` when installed through a package manager.
+    - On Linux systems, installation of OpenSSL development libraries and header files, *version 1.1.0 or later*, are required. The OpenSSL development libraries are usually called something like `libssl-dev` or `openssl-devel` when installed through a package manager.
 
 ### Build Steps
 1. Go to the root directory of this repository.

--- a/demos/http/http_demo_basic_tls/CMakeLists.txt
+++ b/demos/http/http_demo_basic_tls/CMakeLists.txt
@@ -6,7 +6,7 @@ set(OPENSSL_USE_STATIC_LIBS TRUE)
 find_package(OpenSSL REQUIRED)
 
 # Verify the minimum OpenSSL version required
-if( NOT OPENSSL_VERSION MATCHES "1.1$" )
+if( OPENSSL_VERSION MATCHES "0.9$" OR OPENSSL_VERSION MATCHES "1.0$"  )
     message( FATAL_ERROR "OpenSSL 1.1.0 or later required: OpenSSL ${OPENSSL_VERSION} found." )
 endif()
 

--- a/demos/http/http_demo_basic_tls/CMakeLists.txt
+++ b/demos/http/http_demo_basic_tls/CMakeLists.txt
@@ -5,6 +5,11 @@ add_executable(${DEMO_NAME})
 set(OPENSSL_USE_STATIC_LIBS TRUE)
 find_package(OpenSSL REQUIRED)
 
+# Verify the minimum OpenSSL version required
+if(NOT OPENSSL_VERSION MATCHES "1.1$")
+    message( FATAL_ERROR "OpenSSL 1.1.0 required: OpenSSL ${OPENSSL_VERSION} found." )
+endif()
+
 set( CMAKE_THREAD_PREFER_PTHREAD ON )
 find_package(Threads REQUIRED)
 

--- a/demos/http/http_demo_basic_tls/CMakeLists.txt
+++ b/demos/http/http_demo_basic_tls/CMakeLists.txt
@@ -6,8 +6,8 @@ set(OPENSSL_USE_STATIC_LIBS TRUE)
 find_package(OpenSSL REQUIRED)
 
 # Verify the minimum OpenSSL version required
-if(NOT OPENSSL_VERSION MATCHES "1.1$")
-    message( FATAL_ERROR "OpenSSL 1.1.0 required: OpenSSL ${OPENSSL_VERSION} found." )
+if( NOT OPENSSL_VERSION MATCHES "1.1$" )
+    message( FATAL_ERROR "OpenSSL 1.1.0 or later required: OpenSSL ${OPENSSL_VERSION} found." )
 endif()
 
 set( CMAKE_THREAD_PREFER_PTHREAD ON )

--- a/demos/mqtt/mqtt_demo_basic_tls/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_basic_tls/CMakeLists.txt
@@ -6,7 +6,7 @@ set(OPENSSL_USE_STATIC_LIBS TRUE)
 find_package(OpenSSL REQUIRED)
 
 # Verify the minimum OpenSSL version required
-if( NOT OPENSSL_VERSION MATCHES "1.1$" )
+if( OPENSSL_VERSION MATCHES "0.9$" OR OPENSSL_VERSION MATCHES "1.0$"  )
     message( FATAL_ERROR "OpenSSL 1.1.0 or later required: OpenSSL ${OPENSSL_VERSION} found." )
 endif()
 

--- a/demos/mqtt/mqtt_demo_basic_tls/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_basic_tls/CMakeLists.txt
@@ -5,6 +5,11 @@ add_executable(${DEMO_NAME})
 set(OPENSSL_USE_STATIC_LIBS TRUE)
 find_package(OpenSSL REQUIRED)
 
+# Verify the minimum OpenSSL version required
+if(NOT OPENSSL_VERSION MATCHES "1.1$")
+    message( FATAL_ERROR "OpenSSL 1.1.0 required: OpenSSL ${OPENSSL_VERSION} found." )
+endif()
+
 set( CMAKE_THREAD_PREFER_PTHREAD ON )
 find_package(Threads REQUIRED)
 

--- a/demos/mqtt/mqtt_demo_basic_tls/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_basic_tls/CMakeLists.txt
@@ -6,8 +6,8 @@ set(OPENSSL_USE_STATIC_LIBS TRUE)
 find_package(OpenSSL REQUIRED)
 
 # Verify the minimum OpenSSL version required
-if(NOT OPENSSL_VERSION MATCHES "1.1$")
-    message( FATAL_ERROR "OpenSSL 1.1.0 required: OpenSSL ${OPENSSL_VERSION} found." )
+if( NOT OPENSSL_VERSION MATCHES "1.1$" )
+    message( FATAL_ERROR "OpenSSL 1.1.0 or later required: OpenSSL ${OPENSSL_VERSION} found." )
 endif()
 
 set( CMAKE_THREAD_PREFER_PTHREAD ON )

--- a/demos/mqtt/mqtt_demo_mutual_auth/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_mutual_auth/CMakeLists.txt
@@ -5,6 +5,11 @@ add_executable(${DEMO_NAME})
 set(OPENSSL_USE_STATIC_LIBS TRUE)
 find_package(OpenSSL REQUIRED)
 
+# Verify the minimum OpenSSL version required
+if( OPENSSL_VERSION MATCHES "0.9$" OR OPENSSL_VERSION MATCHES "1.0$"  )
+    message( FATAL_ERROR "OpenSSL 1.1.0 or later required: OpenSSL ${OPENSSL_VERSION} found." )
+endif()
+
 set( CMAKE_THREAD_PREFER_PTHREAD ON )
 find_package(Threads REQUIRED)
 


### PR DESCRIPTION
OpenSSL 1.1.0 is the minimum version for TLS_client_method. A check is added to the CMake build.

CMake 3.13.0 is also the mimimum for add_executable to be called without a source. A check is already in place.

The README is updated to reflect above.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
