### PR TITLE
Address defects found during Coverity scan

### DIFF
--- a/libraries/standard/common/src/iot_taskpool.c
+++ b/libraries/standard/common/src/iot_taskpool.c
@@ -964,7 +964,7 @@ static IotTaskPoolError_t _initTaskPoolControlStructures( const IotTaskPoolInfo_
     bool timerInit = false;
 
     /* Zero out all data structures. */
-    memset( ( void * ) pTaskPool, 0x00, sizeof( IotTaskPool_t ) );
+    memset( ( void * ) pTaskPool, 0x00, sizeof( *pTaskPool ) );
 
     /* Initialize a job data structures that require no de-initialization.
      * All other data structures carry a value of 'NULL' before initialization.

--- a/ports/common/src/iot_network_metrics.c
+++ b/ports/common/src/iot_network_metrics.c
@@ -279,7 +279,8 @@ static void _getServerInfo( int socket,
             }
             else
             {
-                IotLogError( "(Socket %d) Failed to add port to IP address buffer." );
+                IotLogError( "(Socket %d) Failed to add port to IP address buffer.",
+                             socket );
             }
         }
         else


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

Defect 1:
        Wrong sizeof argument in iot_taskpool.c
Defect 2:
        Missing argument to printf format specifier in
iot_network_metrics.c

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
