### PR TITLE
MQTT - Handle resends

### DIFF
--- a/libraries/standard/mqtt/include/mqtt.h
+++ b/libraries/standard/mqtt/include/mqtt.h
@@ -132,7 +132,7 @@ struct MQTTContext
  * @brief Initialize an MQTT context.
  *
  * This function must be called on an MQTT context before any other function.
- * 
+ *
  * @note The getTime callback function must be defined. If there is no time
  * implementation, it is the responsibility of the application to provide a
  * dummy function to always return 0, and provide 0 timeouts for functions. This

--- a/libraries/standard/mqtt/include/mqtt.h
+++ b/libraries/standard/mqtt/include/mqtt.h
@@ -26,6 +26,13 @@
 #include "mqtt_config.h"
 #include "mqtt_lightweight.h"
 
+/**
+ * @brief Invalid packet identifier.
+ *
+ * Zero is an invalid packet identifier as per MQTT v3.1.1 spec.
+ */
+#define MQTT_PACKET_ID_INVALID    ( ( uint16_t ) 0U )
+
 struct MQTTApplicationCallbacks;
 typedef struct MQTTApplicationCallbacks   MQTTApplicationCallbacks_t;
 

--- a/libraries/standard/mqtt/include/mqtt_lightweight.h
+++ b/libraries/standard/mqtt/include/mqtt_lightweight.h
@@ -106,6 +106,7 @@ typedef enum MQTTStatus
     MQTTNoDataAvailable, /**< No data available from the transport interface. */
     MQTTIllegalState,    /**< An illegal state in the state record. */
     MQTTStateCollision,  /**< A collision with an existing state record entry. */
+    MQTTStateNotPresent, /**< A state is not present in the state record. */
     MQTTKeepAliveTimeout /**< Timeout while waiting for PINGRESP. */
 } MQTTStatus_t;
 

--- a/libraries/standard/mqtt/include/mqtt_lightweight.h
+++ b/libraries/standard/mqtt/include/mqtt_lightweight.h
@@ -106,7 +106,7 @@ typedef enum MQTTStatus
     MQTTNoDataAvailable, /**< No data available from the transport interface. */
     MQTTIllegalState,    /**< An illegal state in the state record. */
     MQTTStateCollision,  /**< A collision with an existing state record entry. */
-    MQTTStateNotPresent, /**< A state is not present in the state record. */
+    MQTTRecordNotPresent, /**< A record is not present in the state records. */
     MQTTKeepAliveTimeout /**< Timeout while waiting for PINGRESP. */
 } MQTTStatus_t;
 

--- a/libraries/standard/mqtt/include/mqtt_lightweight.h
+++ b/libraries/standard/mqtt/include/mqtt_lightweight.h
@@ -106,7 +106,6 @@ typedef enum MQTTStatus
     MQTTNoDataAvailable, /**< No data available from the transport interface. */
     MQTTIllegalState,    /**< An illegal state in the state record. */
     MQTTStateCollision,  /**< A collision with an existing state record entry. */
-    MQTTRecordNotPresent, /**< A record is not present in the state records. */
     MQTTKeepAliveTimeout /**< Timeout while waiting for PINGRESP. */
 } MQTTStatus_t;
 

--- a/libraries/standard/mqtt/include/mqtt_state.h
+++ b/libraries/standard/mqtt/include/mqtt_state.h
@@ -118,7 +118,7 @@ MQTTStatus_t MQTT_UpdateStateAck( MQTTContext_t * pMqttContext,
  * This function will need to be called to get the packet for which a PUBREL
  * need to be sent when a session is reestablished. Calling this function
  * repeatedly until packet id is 0 will give all the packets for which
- * a PUBREL need to be resent in the order.
+ * a PUBREL need to be resent in the correct order.
  *
  * @param[in] pMqttContext Initialized MQTT context.
  * @param[in,out] pCursor Index at which to start searching.
@@ -134,7 +134,7 @@ uint16_t MQTT_PubrelToResend( const MQTTContext_t * pMqttContext,
  * This function will need to be called to get the packet for which a publish
  * need to be sent when a session is reestablished. Calling this function
  * repeatedly until packet id is 0 will give all the packets for which
- * a publish need to be resent in the order.
+ * a publish need to be resent in the correct order.
  *
  * @param[in] pMqttContext Initialized MQTT context.
  * @param[in,out] pCursor Index at which to start searching.

--- a/libraries/standard/mqtt/include/mqtt_state.h
+++ b/libraries/standard/mqtt/include/mqtt_state.h
@@ -113,23 +113,12 @@ MQTTStatus_t MQTT_UpdateStateAck( MQTTContext_t * pMqttContext,
                                   MQTTPublishState_t * pNewState );
 
 /**
- * @brief Get the packet ID and index of a publish in a specified state.
+ * @brief Get the packet ID of next pending PUBREL ack to be resent.
  *
- * @param[in] pMqttContext Initialized MQTT context.
- * @param[in] searchState The state to search for.
- * @param[in,out] pCursor Index at which to start searching.
- */
-uint16_t MQTT_StateSelect( const MQTTContext_t * pMqttContext,
-                           MQTTPublishState_t searchState,
-                           MQTTStateCursor_t * pCursor );
-
-/**
- * @brief Get the packet ID of next pending PUBREL ack to be resend.
- *
- * This function will be called to get the packet for which a PUBREL
- * need to send when a session is reestablished. Calling this function
+ * This function will need to be called to get the packet for which a PUBREL
+ * need to be sent when a session is reestablished. Calling this function
  * repeatedly until packet id is 0 will give all the packets for which
- * a PUBREL need to be resent.
+ * a PUBREL need to be resent in the order.
  *
  * @param[in] pMqttContext Initialized MQTT context.
  * @param[in,out] pCursor Index at which to start searching.
@@ -138,6 +127,20 @@ uint16_t MQTT_StateSelect( const MQTTContext_t * pMqttContext,
 uint16_t MQTT_AckToResend( const MQTTContext_t * pMqttContext,
                            MQTTStateCursor_t * pCursor,
                            MQTTPublishState_t * pState );
+
+/**
+ * @brief Get the packet ID of next pending publish to be resent.
+ *
+ * This function will need to be called to get the packet for which a publish
+ * need to be sent when a session is reestablished. Calling this function
+ * repeatedly until packet id is 0 will give all the packets for which
+ * a publish need to be resent in the order.
+ *
+ * @param[in] pMqttContext Initialized MQTT context.
+ * @param[in,out] pCursor Index at which to start searching.
+ */
+uint16_t MQTT_PublishToResend( const MQTTContext_t * pMqttContext,
+                               MQTTStateCursor_t * pCursor );
 
 /**
  * @brief State to string conversion for state engine.

--- a/libraries/standard/mqtt/include/mqtt_state.h
+++ b/libraries/standard/mqtt/include/mqtt_state.h
@@ -124,6 +124,22 @@ uint16_t MQTT_StateSelect( const MQTTContext_t * pMqttContext,
                            MQTTStateCursor_t * pCursor );
 
 /**
+ * @brief Get the packet ID of next pending PUBREL ack to be resend.
+ *
+ * This function will be called to get the packet for which a PUBREL
+ * need to send when a session is reestablished. Calling this function
+ * repeatedly until packet id is 0 will give all the packets for which
+ * a PUBREL need to be resent.
+ *
+ * @param[in] pMqttContext Initialized MQTT context.
+ * @param[in,out] pCursor Index at which to start searching.
+ * @param[out] pState State indicating that PUBREL packet need to be sent.
+ */
+uint16_t MQTT_AckToResend( const MQTTContext_t * pMqttContext,
+                           MQTTStateCursor_t * pCursor,
+                           MQTTPublishState_t * pState );
+
+/**
  * @brief State to string conversion for state engine.
  *
  * @param[in] state The state to convert to a string.

--- a/libraries/standard/mqtt/include/mqtt_state.h
+++ b/libraries/standard/mqtt/include/mqtt_state.h
@@ -124,9 +124,9 @@ MQTTStatus_t MQTT_UpdateStateAck( MQTTContext_t * pMqttContext,
  * @param[in,out] pCursor Index at which to start searching.
  * @param[out] pState State indicating that PUBREL packet need to be sent.
  */
-uint16_t MQTT_AckToResend( const MQTTContext_t * pMqttContext,
-                           MQTTStateCursor_t * pCursor,
-                           MQTTPublishState_t * pState );
+uint16_t MQTT_PubrelToResend( const MQTTContext_t * pMqttContext,
+                              MQTTStateCursor_t * pCursor,
+                              MQTTPublishState_t * pState );
 
 /**
  * @brief Get the packet ID of next pending publish to be resent.

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -732,8 +732,8 @@ static MQTTStatus_t handleIncomingPublish( MQTTContext_t * pContext,
 
         if( status == MQTTSuccess )
         {
-            LogInfo( ( "State record updated. New state=%d.",
-                       publishRecordState ) );
+            LogInfo( ( "State record updated. New state=%s.",
+                       MQTT_State_strerror( publishRecordState ) ) );
         }
 
         /* A collision in the state engine and a duplicate flag set in the
@@ -809,8 +809,8 @@ static MQTTStatus_t handlePublishAcks( MQTTContext_t * pContext,
 
         if( status == MQTTSuccess )
         {
-            LogInfo( ( "State record updated. New state=%d.",
-                       publishRecordState ) );
+            LogInfo( ( "State record updated. New state=%s.",
+                       MQTT_State_strerror( publishRecordState ) ) );
         }
         else
         {
@@ -854,7 +854,6 @@ static MQTTStatus_t handleIncomingAck( MQTTContext_t * pContext,
      * at the end to reduce the complexity of this function. */
     bool invokeAppCallback = false;
     MQTTEventCallback_t appCallback = NULL;
-    bool pubrelRecordMissing = false;
 
     assert( pContext != NULL );
     assert( pIncomingPacket != NULL );
@@ -1505,7 +1504,7 @@ MQTTStatus_t MQTT_Publish( MQTTContext_t * pContext,
         if( status != MQTTSuccess )
         {
             LogError( ( "Update state for publish failed with status %s."
-                        " However PUBLISH packet is sent to the broker."
+                        " However PUBLISH packet was sent to the broker."
                         " Any further handling of ACKs for the packet Id"
                         " will fail.",
                         MQTT_Status_strerror( status ) ) );

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -760,7 +760,7 @@ static MQTTStatus_t handleIncomingPublish( MQTTContext_t * pContext,
          * before sending acks.
          * Application callback will be invoked for all publishes, except for
          * duplicate incoming publishes. */
-        if( ( duplicatePublish == false ) )
+        if( duplicatePublish == false )
         {
             pContext->callbacks.appCallback( pContext,
                                              pIncomingPacket,

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -1165,7 +1165,7 @@ static MQTTStatus_t resendPendingAcks( MQTTContext_t * pContext )
     assert( pContext != NULL );
 
     /* Get the next packet Id for which a PUBREL need to be resent. */
-    packetId = MQTT_AckToResend( pContext, &cursor, &state );
+    packetId = MQTT_PubrelToResend( pContext, &cursor, &state );
 
     /* Resend all the PUBREL acks after session is reestablished. */
     while( ( packetId != MQTT_PACKET_ID_INVALID ) &&
@@ -1173,7 +1173,7 @@ static MQTTStatus_t resendPendingAcks( MQTTContext_t * pContext )
     {
         status = sendPublishAcks( pContext, packetId, state );
 
-        packetId = MQTT_AckToResend( pContext, &cursor, &state );
+        packetId = MQTT_PubrelToResend( pContext, &cursor, &state );
     }
 
     return status;

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -694,14 +694,9 @@ static MQTTStatus_t processPublishFlags( uint8_t publishFlags,
         LogDebug( ( "Retain bit is %d.", pPublishInfo->retain ) );
 
         /* Parse the DUP bit. */
-        if( UINT8_CHECK_BIT( publishFlags, MQTT_PUBLISH_FLAG_DUP ) )
-        {
-            LogDebug( ( "DUP is 1." ) );
-        }
-        else
-        {
-            LogDebug( ( "DUP is 0." ) );
-        }
+        pPublishInfo->dup = ( UINT8_CHECK_BIT( publishFlags, MQTT_PUBLISH_FLAG_DUP ) ) ? true : false;
+
+        LogDebug( ( "Retain bit is %d.", pPublishInfo->retain ) );
     }
 
     return status;

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -696,7 +696,7 @@ static MQTTStatus_t processPublishFlags( uint8_t publishFlags,
         /* Parse the DUP bit. */
         pPublishInfo->dup = ( UINT8_CHECK_BIT( publishFlags, MQTT_PUBLISH_FLAG_DUP ) ) ? true : false;
 
-        LogDebug( ( "Retain bit is %d.", pPublishInfo->retain ) );
+        LogDebug( ( "DUP bit is %d.", pPublishInfo->dup ) );
     }
 
     return status;

--- a/libraries/standard/mqtt/src/mqtt_state.c
+++ b/libraries/standard/mqtt/src/mqtt_state.c
@@ -192,7 +192,7 @@ static MQTTStatus_t updateStateAck( MQTTPubAckInfo_t * records,
  * @param[in] opType Send or Receive.
  * @param[in] qos 0, 1, or 2.
  * @param[in] currentState Current state of the publish record.
- * @param[in,out] newState New state of the publish record.
+ * @param[in] newState New state of the publish record.
  *
  * @return #MQTTIllegalState, #MQTTStateCollision or #MQTTSuccess.
  */

--- a/libraries/standard/mqtt/src/mqtt_state.c
+++ b/libraries/standard/mqtt/src/mqtt_state.c
@@ -704,7 +704,11 @@ static MQTTStatus_t updateStateAck( MQTTPubAckInfo_t * records,
              * a PUBREL needs to be resent in case of a session reestablishment. */
             if( newState == MQTTPubRelSend )
             {
-                status = addRecord( records, MQTT_STATE_ARRAY_MAX_COUNT, packetId, MQTTQoS2, MQTTPubRelSend );
+                status = addRecord( records,
+                                    MQTT_STATE_ARRAY_MAX_COUNT,
+                                    packetId,
+                                    MQTTQoS2,
+                                    MQTTPubRelSend );
             }
         }
     }

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -1530,7 +1530,8 @@ void test_MQTT_DeserializePublish( void )
 
     /* Test serialization and deserialization of a QoS 1 PUBLISH. */
     publishInfo.qos = MQTTQoS1;
-
+    /* Mark the publish as duplicate. */
+    publishInfo.dup = true;
     status = MQTT_GetPublishPacketSize( &publishInfo, &remainingLength, &packetSize );
     TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
     TEST_ASSERT_GREATER_OR_EQUAL( packetSize, bufferSize );
@@ -1546,6 +1547,7 @@ void test_MQTT_DeserializePublish( void )
     mqttPacketInfo.pRemainingData = &buffer[ 2 ];
     status = MQTT_DeserializePublish( &mqttPacketInfo, &packetIdentifier, &publishInfo );
     TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
+    TEST_ASSERT_TRUE( publishInfo.dup );
 
     /* QoS 2 PUBLISH. */
     publishInfo.qos = MQTTQoS2;

--- a/libraries/standard/mqtt/utest/mqtt_state_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_state_utest.c
@@ -160,8 +160,8 @@ void test_MQTT_ReserveState_compactRecords( void )
      * Add an element will try to compact the array and the resulting state
      * should be - 1 1 1 1 1 1 1 1 1 1. */
     fillRecord( mqttContext.outgoingPublishRecords, PACKET_ID2 + 1, MQTTQoS2, MQTTPubRelSend );
-    /* Clear record at index 3. */
-    ( void ) memset( &mqttContext.outgoingPublishRecords[ 3 ], 0x00, sizeof( MQTTPubAckInfo_t ) );
+    /* Invalid record at index 3. */
+    mqttContext.outgoingPublishRecords[ 3 ].packetId = MQTT_PACKET_ID_INVALID;
     status = MQTT_ReserveState( &mqttContext, PACKET_ID, MQTTQoS1 );
     TEST_ASSERT_EQUAL( MQTTSuccess, status );
     /* The new record should be added to the end. */
@@ -179,12 +179,12 @@ void test_MQTT_ReserveState_compactRecords( void )
      * Add an element will skip to compact the array and the resulting state
      * should be - 1 0 1 0 1 0 1 0 1 0. */
     fillRecord( mqttContext.outgoingPublishRecords, PACKET_ID2 + 1, MQTTQoS2, MQTTPubRelSend );
-    /* Clear record at alternate indexes starting from 1. */
-    ( void ) memset( &mqttContext.outgoingPublishRecords[ 1 ], 0x00, sizeof( MQTTPubAckInfo_t ) );
-    ( void ) memset( &mqttContext.outgoingPublishRecords[ 3 ], 0x00, sizeof( MQTTPubAckInfo_t ) );
-    ( void ) memset( &mqttContext.outgoingPublishRecords[ 5 ], 0x00, sizeof( MQTTPubAckInfo_t ) );
-    ( void ) memset( &mqttContext.outgoingPublishRecords[ 7 ], 0x00, sizeof( MQTTPubAckInfo_t ) );
-    ( void ) memset( &mqttContext.outgoingPublishRecords[ 9 ], 0x00, sizeof( MQTTPubAckInfo_t ) );
+    /* Invalidate record at alternate indexes starting from 1. */
+    mqttContext.outgoingPublishRecords[ 1 ].packetId = MQTT_PACKET_ID_INVALID;
+    mqttContext.outgoingPublishRecords[ 3 ].packetId = MQTT_PACKET_ID_INVALID;
+    mqttContext.outgoingPublishRecords[ 5 ].packetId = MQTT_PACKET_ID_INVALID;
+    mqttContext.outgoingPublishRecords[ 7 ].packetId = MQTT_PACKET_ID_INVALID;
+    mqttContext.outgoingPublishRecords[ 9 ].packetId = MQTT_PACKET_ID_INVALID;
     status = MQTT_ReserveState( &mqttContext, PACKET_ID, MQTTQoS1 );
     TEST_ASSERT_EQUAL( MQTTSuccess, status );
     /* The new record should be added to the end. */
@@ -200,10 +200,10 @@ void test_MQTT_ReserveState_compactRecords( void )
     status = MQTT_ReserveState( &mqttContext, PACKET_ID2, MQTTQoS1 );
     TEST_ASSERT_EQUAL( MQTTSuccess, status );
     validateRecordAt( mqttContext.outgoingPublishRecords, 6, PACKET_ID2, MQTTQoS1, MQTTPublishSend );
-    /* Remaining records should be cleared. */
-    validateRecordAt( mqttContext.outgoingPublishRecords, 7, MQTT_PACKET_ID_INVALID, MQTTQoS0, MQTTStateNull );
-    validateRecordAt( mqttContext.outgoingPublishRecords, 8, MQTT_PACKET_ID_INVALID, MQTTQoS0, MQTTStateNull );
-    validateRecordAt( mqttContext.outgoingPublishRecords, 9, MQTT_PACKET_ID_INVALID, MQTTQoS0, MQTTStateNull );
+    /* Remaining records should be invalid. */
+    TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, mqttContext.outgoingPublishRecords[ 7 ].packetId );
+    TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, mqttContext.outgoingPublishRecords[ 8 ].packetId );
+    TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, mqttContext.outgoingPublishRecords[ 9 ].packetId );
 
     /* Free spots only in the beginning.
      * Pre condition - 0 0 0 0 0 1 1 1 1 1.
@@ -219,10 +219,10 @@ void test_MQTT_ReserveState_compactRecords( void )
     TEST_ASSERT_EQUAL( MQTTSuccess, status );
     validateRecordAt( mqttContext.outgoingPublishRecords, 5, PACKET_ID2, MQTTQoS1, MQTTPublishSend );
     /* Remaining records should be cleared. */
-    validateRecordAt( mqttContext.outgoingPublishRecords, 6, MQTT_PACKET_ID_INVALID, MQTTQoS0, MQTTStateNull );
-    validateRecordAt( mqttContext.outgoingPublishRecords, 7, MQTT_PACKET_ID_INVALID, MQTTQoS0, MQTTStateNull );
-    validateRecordAt( mqttContext.outgoingPublishRecords, 8, MQTT_PACKET_ID_INVALID, MQTTQoS0, MQTTStateNull );
-    validateRecordAt( mqttContext.outgoingPublishRecords, 9, MQTT_PACKET_ID_INVALID, MQTTQoS0, MQTTStateNull );
+    TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, mqttContext.outgoingPublishRecords[ 6 ].packetId );
+    TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, mqttContext.outgoingPublishRecords[ 7 ].packetId );
+    TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, mqttContext.outgoingPublishRecords[ 8 ].packetId );
+    TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, mqttContext.outgoingPublishRecords[ 9 ].packetId );
 
     /* Fragmented array.
      * Pre condition - 1 0 0 1 1 1 1 0 0 1.
@@ -230,17 +230,17 @@ void test_MQTT_ReserveState_compactRecords( void )
      * should be - 1 1 1 1 1 1 1 0 0 0. */
     fillRecord( mqttContext.outgoingPublishRecords, PACKET_ID2 + 1, MQTTQoS2, MQTTPubRelSend );
     /* Clear record at index 1,2,7 and 8. */
-    ( void ) memset( &mqttContext.outgoingPublishRecords[ 1 ], 0x00, sizeof( MQTTPubAckInfo_t ) );
-    ( void ) memset( &mqttContext.outgoingPublishRecords[ 2 ], 0x00, sizeof( MQTTPubAckInfo_t ) );
-    ( void ) memset( &mqttContext.outgoingPublishRecords[ 7 ], 0x00, sizeof( MQTTPubAckInfo_t ) );
-    ( void ) memset( &mqttContext.outgoingPublishRecords[ 8 ], 0x00, sizeof( MQTTPubAckInfo_t ) );
+    mqttContext.outgoingPublishRecords[ 1 ].packetId = MQTT_PACKET_ID_INVALID;
+    mqttContext.outgoingPublishRecords[ 2 ].packetId = MQTT_PACKET_ID_INVALID;
+    mqttContext.outgoingPublishRecords[ 7 ].packetId = MQTT_PACKET_ID_INVALID;
+    mqttContext.outgoingPublishRecords[ 8 ].packetId = MQTT_PACKET_ID_INVALID;
     status = MQTT_ReserveState( &mqttContext, PACKET_ID2, MQTTQoS1 );
     TEST_ASSERT_EQUAL( MQTTSuccess, status );
     validateRecordAt( mqttContext.outgoingPublishRecords, 6, PACKET_ID2, MQTTQoS1, MQTTPublishSend );
     /* Remaining records should be cleared. */
-    validateRecordAt( mqttContext.outgoingPublishRecords, 7, MQTT_PACKET_ID_INVALID, MQTTQoS0, MQTTStateNull );
-    validateRecordAt( mqttContext.outgoingPublishRecords, 8, MQTT_PACKET_ID_INVALID, MQTTQoS0, MQTTStateNull );
-    validateRecordAt( mqttContext.outgoingPublishRecords, 9, MQTT_PACKET_ID_INVALID, MQTTQoS0, MQTTStateNull );
+    TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, mqttContext.outgoingPublishRecords[ 7 ].packetId );
+    TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, mqttContext.outgoingPublishRecords[ 8 ].packetId );
+    TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, mqttContext.outgoingPublishRecords[ 9 ].packetId );
 
     /* Fragmented array.
      * Pre condition - 1 0 0 0 0 0 0 0 0 1.
@@ -540,11 +540,8 @@ void test_MQTT_UpdateStateAck( void )
     TEST_ASSERT_EQUAL( MQTTSuccess, status );
     TEST_ASSERT_EQUAL( MQTTPublishDone, state );
 
-    /* Test for deletion. After deletion of record at index 0, record at index 1 should be
-     * shifted left. */
-    TEST_ASSERT_EQUAL( MQTTStateNull, mqttContext.outgoingPublishRecords[ 0 ].publishState );
-    TEST_ASSERT_EQUAL( 0, mqttContext.outgoingPublishRecords[ 0 ].packetId );
-    TEST_ASSERT_EQUAL( MQTTQoS0, mqttContext.outgoingPublishRecords[ 0 ].qos );
+    /* Test for deletion. */
+    TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, mqttContext.outgoingPublishRecords[ 0 ].packetId );
     /* Send PUBACK for incoming publish. */
     operation = MQTT_SEND;
     addToRecord( mqttContext.incomingPublishRecords, 0, PACKET_ID, MQTTQoS1, MQTTPubAckSend );
@@ -611,10 +608,8 @@ void test_MQTT_UpdateStateAck( void )
     TEST_ASSERT_EQUAL( PACKET_ID, mqttContext.outgoingPublishRecords[ 2 ].packetId );
     TEST_ASSERT_EQUAL( MQTTQoS2, mqttContext.outgoingPublishRecords[ 2 ].qos );
     TEST_ASSERT_EQUAL( MQTTPubRelSend, mqttContext.outgoingPublishRecords[ 2 ].publishState );
-    /* Record at the current index will be cleared. */
+    /* Record at the current index will be marked as onvalid. */
     TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, mqttContext.outgoingPublishRecords[ 0 ].packetId );
-    TEST_ASSERT_EQUAL( MQTTQoS0, mqttContext.outgoingPublishRecords[ 0 ].qos );
-    TEST_ASSERT_EQUAL( MQTTStateNull, mqttContext.outgoingPublishRecords[ 0 ].publishState );
 
     /* Incoming. */
     addToRecord( mqttContext.incomingPublishRecords, 0, PACKET_ID, MQTTQoS2, MQTTPubRecSend );
@@ -662,16 +657,16 @@ void test_MQTT_AckToResend( void )
     const size_t index4 = index3 + 2;
 
     /* Invalid parameters. */
-    packetId = MQTT_AckToResend( NULL, &cursor, &state );
+    packetId = MQTT_PubrelToResend( NULL, &cursor, &state );
     TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, packetId );
-    packetId = MQTT_AckToResend( &mqttContext, NULL, &state );
+    packetId = MQTT_PubrelToResend( &mqttContext, NULL, &state );
     TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, packetId );
-    packetId = MQTT_AckToResend( &mqttContext, &cursor, NULL );
+    packetId = MQTT_PubrelToResend( &mqttContext, &cursor, NULL );
     TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, packetId );
 
     /* No packet exists. */
     cursor = MQTT_STATE_CURSOR_INITIALIZER;
-    packetId = MQTT_AckToResend( &mqttContext, &cursor, &state );
+    packetId = MQTT_PubrelToResend( &mqttContext, &cursor, &state );
     TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, packetId );
     TEST_ASSERT_EQUAL( MQTTStateNull, state );
     TEST_ASSERT_EQUAL( MQTT_STATE_ARRAY_MAX_COUNT, cursor );
@@ -680,7 +675,7 @@ void test_MQTT_AckToResend( void )
     cursor = MQTT_STATE_CURSOR_INITIALIZER;
     addToRecord( mqttContext.outgoingPublishRecords, index, PACKET_ID3, MQTTQoS2, MQTTPubRelPending );
     addToRecord( mqttContext.outgoingPublishRecords, index2, PACKET_ID4, MQTTQoS2, MQTTPubCompSend );
-    packetId = MQTT_AckToResend( &mqttContext, &cursor, &state );
+    packetId = MQTT_PubrelToResend( &mqttContext, &cursor, &state );
     TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, packetId );
     TEST_ASSERT_EQUAL( MQTTStateNull, state );
     TEST_ASSERT_EQUAL( MQTT_STATE_ARRAY_MAX_COUNT, cursor );
@@ -688,21 +683,21 @@ void test_MQTT_AckToResend( void )
     /* Add a record in #MQTTPubCompPending state. */
     cursor = MQTT_STATE_CURSOR_INITIALIZER;
     addToRecord( mqttContext.outgoingPublishRecords, index3, PACKET_ID, MQTTQoS2, MQTTPubCompPending );
-    packetId = MQTT_AckToResend( &mqttContext, &cursor, &state );
+    packetId = MQTT_PubrelToResend( &mqttContext, &cursor, &state );
     TEST_ASSERT_EQUAL( PACKET_ID, packetId );
     TEST_ASSERT_EQUAL( index3 + 1, cursor );
     TEST_ASSERT_EQUAL( MQTTPubRelSend, state );
 
     /* Add another record in #MQTTPubCompPending state. */
     addToRecord( mqttContext.outgoingPublishRecords, index4, PACKET_ID2, MQTTQoS2, MQTTPubCompPending );
-    packetId = MQTT_AckToResend( &mqttContext, &cursor, &state );
+    packetId = MQTT_PubrelToResend( &mqttContext, &cursor, &state );
     TEST_ASSERT_EQUAL( PACKET_ID2, packetId );
     TEST_ASSERT_EQUAL( index4 + 1, cursor );
     TEST_ASSERT_EQUAL( MQTTPubRelSend, state );
 
     /* Add another record in #MQTTPubRelSend state. */
     addToRecord( mqttContext.outgoingPublishRecords, index4 + 1, PACKET_ID2 + 1, MQTTQoS2, MQTTPubRelSend );
-    packetId = MQTT_AckToResend( &mqttContext, &cursor, &state );
+    packetId = MQTT_PubrelToResend( &mqttContext, &cursor, &state );
     TEST_ASSERT_EQUAL( PACKET_ID2 + 1, packetId );
     TEST_ASSERT_EQUAL( index4 + 2, cursor );
     TEST_ASSERT_EQUAL( MQTTPubRelSend, state );
@@ -711,14 +706,14 @@ void test_MQTT_AckToResend( void )
     resetPublishRecords( &mqttContext );
     cursor = MQTT_STATE_CURSOR_INITIALIZER;
     addToRecord( mqttContext.outgoingPublishRecords, index3, PACKET_ID, MQTTQoS2, MQTTPubRelSend );
-    packetId = MQTT_AckToResend( &mqttContext, &cursor, &state );
+    packetId = MQTT_PubrelToResend( &mqttContext, &cursor, &state );
     TEST_ASSERT_EQUAL( PACKET_ID, packetId );
     TEST_ASSERT_EQUAL( index3 + 1, cursor );
     TEST_ASSERT_EQUAL( MQTTPubRelSend, state );
 
     /* Further search should be return no valid packets. */
     state = MQTTStateNull;
-    packetId = MQTT_AckToResend( &mqttContext, &cursor, &state );
+    packetId = MQTT_PubrelToResend( &mqttContext, &cursor, &state );
     TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, packetId );
     TEST_ASSERT_EQUAL( MQTTStateNull, state );
     TEST_ASSERT_EQUAL( MQTT_STATE_ARRAY_MAX_COUNT, cursor );

--- a/libraries/standard/mqtt/utest/mqtt_state_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_state_utest.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include "unity.h"
 
 #include "mqtt_state.h"
@@ -68,12 +69,28 @@ static void fillRecord( MQTTPubAckInfo_t * records,
     }
 }
 
+static void validateRecordAt( MQTTPubAckInfo_t * records,
+                              size_t index,
+                              uint16_t packetId,
+                              MQTTQoS_t qos,
+                              MQTTPublishState_t state )
+{
+    TEST_ASSERT_EQUAL( packetId, records[ index ].packetId );
+    TEST_ASSERT_EQUAL( qos, records[ index ].qos );
+    TEST_ASSERT_EQUAL( state, records[ index ].publishState );
+}
+
 /* ========================================================================== */
 
 void test_MQTT_ReserveState( void )
 {
     MQTTContext_t mqttContext = { 0 };
     MQTTStatus_t status;
+    const uint16_t PACKET_ID = 1;
+    const uint16_t PACKET_ID2 = 2;
+    const uint16_t PACKET_ID3 = 3;
+    const size_t index = 0;
+    const size_t index2 = MQTT_STATE_ARRAY_MAX_COUNT / 2;
 
     /* QoS 0 returns success. */
     TEST_ASSERT_EQUAL( MQTTSuccess, MQTT_ReserveState( NULL, MQTT_PACKET_ID_INVALID, MQTTQoS0 ) );
@@ -81,32 +98,164 @@ void test_MQTT_ReserveState( void )
     /* Test for bad parameters */
     status = MQTT_ReserveState( &mqttContext, MQTT_PACKET_ID_INVALID, MQTTQoS1 );
     TEST_ASSERT_EQUAL( MQTTBadParameter, status );
-    status = MQTT_ReserveState( NULL, 1, MQTTQoS1 );
+    status = MQTT_ReserveState( NULL, PACKET_ID, MQTTQoS1 );
     TEST_ASSERT_EQUAL( MQTTBadParameter, status );
 
     /* Test for collisions. */
-    mqttContext.outgoingPublishRecords[ 1 ].packetId = 1;
+    mqttContext.outgoingPublishRecords[ 1 ].packetId = PACKET_ID;
     mqttContext.outgoingPublishRecords[ 1 ].qos = MQTTQoS1;
     mqttContext.outgoingPublishRecords[ 1 ].publishState = MQTTPublishSend;
 
-    status = MQTT_ReserveState( &mqttContext, 1, MQTTQoS1 );
+    status = MQTT_ReserveState( &mqttContext, PACKET_ID, MQTTQoS1 );
     TEST_ASSERT_EQUAL( MQTTStateCollision, status );
 
     /* Test for no memory. */
     fillRecord( mqttContext.outgoingPublishRecords, 2, MQTTQoS1, MQTTPublishSend );
-    status = MQTT_ReserveState( &mqttContext, 1, MQTTQoS1 );
+    status = MQTT_ReserveState( &mqttContext, PACKET_ID, MQTTQoS1 );
     TEST_ASSERT_EQUAL( MQTTNoMemory, status );
 
     /* Success. */
     resetPublishRecords( &mqttContext );
-    status = MQTT_ReserveState( &mqttContext, 1, MQTTQoS1 );
+    status = MQTT_ReserveState( &mqttContext, PACKET_ID, MQTTQoS1 );
     TEST_ASSERT_EQUAL( MQTTSuccess, status );
     /* Reserve uses first available entry. */
-    TEST_ASSERT_EQUAL( 1, mqttContext.outgoingPublishRecords[ 0 ].packetId );
-    TEST_ASSERT_EQUAL( MQTTQoS1, mqttContext.outgoingPublishRecords[ 0 ].qos );
-    TEST_ASSERT_EQUAL( MQTTPublishSend, mqttContext.outgoingPublishRecords[ 0 ].publishState );
+    TEST_ASSERT_EQUAL( PACKET_ID, mqttContext.outgoingPublishRecords[ index ].packetId );
+    TEST_ASSERT_EQUAL( MQTTQoS1, mqttContext.outgoingPublishRecords[ index ].qos );
+    TEST_ASSERT_EQUAL( MQTTPublishSend, mqttContext.outgoingPublishRecords[ index ].publishState );
+
+    /* Success.
+     * Add record after the highest non empty index.
+     * Already an entry exists at index 0. Adding 1 more entry at index 5.
+     * The new index used should be 6. */
+    addToRecord( mqttContext.outgoingPublishRecords, index2, PACKET_ID2, MQTTQoS2, MQTTPubRelSend );
+    status = MQTT_ReserveState( &mqttContext, PACKET_ID3, MQTTQoS1 );
+    TEST_ASSERT_EQUAL( MQTTSuccess, status );
+    TEST_ASSERT_EQUAL( PACKET_ID3, mqttContext.outgoingPublishRecords[ index2 + 1 ].packetId );
+    TEST_ASSERT_EQUAL( MQTTQoS1, mqttContext.outgoingPublishRecords[ index2 + 1 ].qos );
+    TEST_ASSERT_EQUAL( MQTTPublishSend, mqttContext.outgoingPublishRecords[ index2 + 1 ].publishState );
 }
 
+void test_MQTT_ReserveState_compactRecords( void )
+{
+    MQTTContext_t mqttContext = { 0 };
+    MQTTStatus_t status;
+    const uint16_t PACKET_ID = 1;
+    const uint16_t PACKET_ID2 = 2;
+
+    /* Consider the state of the array with 2 states. 1 indicates a non empty
+     * spot and 0 an empty spot. Size of the array is 10.
+     * Pre condition - 0 0 0 0 0 0 0 0 0 1.
+     * Add an element will try to compact the array and the resulting state
+     * should be - 1 1 0 0 0 0 0 0 0 0. */
+    addToRecord( mqttContext.outgoingPublishRecords, MQTT_STATE_ARRAY_MAX_COUNT - 1, PACKET_ID, MQTTQoS1, MQTTPubRelSend );
+    status = MQTT_ReserveState( &mqttContext, PACKET_ID2, MQTTQoS1 );
+    TEST_ASSERT_EQUAL( MQTTSuccess, status );
+    /* The existing record should be at index 0. */
+    validateRecordAt( mqttContext.outgoingPublishRecords, 0, PACKET_ID, MQTTQoS1, MQTTPubRelSend );
+    /* New record should be added to index 1. */
+    validateRecordAt( mqttContext.outgoingPublishRecords, 1, PACKET_ID2, MQTTQoS1, MQTTPublishSend );
+
+    /* One free spot.
+     * Pre condition - 1 1 1 0 1 1 1 1 1 1.
+     * Add an element will try to compact the array and the resulting state
+     * should be - 1 1 1 1 1 1 1 1 1 1. */
+    fillRecord( mqttContext.outgoingPublishRecords, PACKET_ID2 + 1, MQTTQoS2, MQTTPubRelSend );
+    /* Clear record at index 3. */
+    ( void ) memset( &mqttContext.outgoingPublishRecords[ 3 ], 0x00, sizeof( MQTTPubAckInfo_t ) );
+    status = MQTT_ReserveState( &mqttContext, PACKET_ID, MQTTQoS1 );
+    TEST_ASSERT_EQUAL( MQTTSuccess, status );
+    /* The new record should be added to the end. */
+    validateRecordAt( mqttContext.outgoingPublishRecords,
+                      MQTT_STATE_ARRAY_MAX_COUNT - 1,
+                      PACKET_ID,
+                      MQTTQoS1,
+                      MQTTPublishSend );
+    /* Any new add should result in no memory error. */
+    status = MQTT_ReserveState( &mqttContext, PACKET_ID2, MQTTQoS1 );
+    TEST_ASSERT_EQUAL( MQTTNoMemory, status );
+
+    /* Alternate free spots.
+     * Pre condition - 1 0 1 0 1 0 1 0 1 0.
+     * Add an element will skip to compact the array and the resulting state
+     * should be - 1 0 1 0 1 0 1 0 1 0. */
+    fillRecord( mqttContext.outgoingPublishRecords, PACKET_ID2 + 1, MQTTQoS2, MQTTPubRelSend );
+    /* Clear record at alternate indexes starting from 1. */
+    ( void ) memset( &mqttContext.outgoingPublishRecords[ 1 ], 0x00, sizeof( MQTTPubAckInfo_t ) );
+    ( void ) memset( &mqttContext.outgoingPublishRecords[ 3 ], 0x00, sizeof( MQTTPubAckInfo_t ) );
+    ( void ) memset( &mqttContext.outgoingPublishRecords[ 5 ], 0x00, sizeof( MQTTPubAckInfo_t ) );
+    ( void ) memset( &mqttContext.outgoingPublishRecords[ 7 ], 0x00, sizeof( MQTTPubAckInfo_t ) );
+    ( void ) memset( &mqttContext.outgoingPublishRecords[ 9 ], 0x00, sizeof( MQTTPubAckInfo_t ) );
+    status = MQTT_ReserveState( &mqttContext, PACKET_ID, MQTTQoS1 );
+    TEST_ASSERT_EQUAL( MQTTSuccess, status );
+    /* The new record should be added to the end. */
+    validateRecordAt( mqttContext.outgoingPublishRecords,
+                      MQTT_STATE_ARRAY_MAX_COUNT - 1,
+                      PACKET_ID,
+                      MQTTQoS1,
+                      MQTTPublishSend );
+
+    /* Array is in state 1 0 1 0 1 0 1 0 1 1.
+     * Adding one more element should result in array in state
+     * 1 1 1 1 1 1 1 0 0 0. */
+    status = MQTT_ReserveState( &mqttContext, PACKET_ID2, MQTTQoS1 );
+    TEST_ASSERT_EQUAL( MQTTSuccess, status );
+    validateRecordAt( mqttContext.outgoingPublishRecords, 6, PACKET_ID2, MQTTQoS1, MQTTPublishSend );
+    /* Remaining records should be cleared. */
+    validateRecordAt( mqttContext.outgoingPublishRecords, 7, MQTT_PACKET_ID_INVALID, MQTTQoS0, MQTTStateNull );
+    validateRecordAt( mqttContext.outgoingPublishRecords, 8, MQTT_PACKET_ID_INVALID, MQTTQoS0, MQTTStateNull );
+    validateRecordAt( mqttContext.outgoingPublishRecords, 9, MQTT_PACKET_ID_INVALID, MQTTQoS0, MQTTStateNull );
+
+    /* Free spots only in the beginning.
+     * Pre condition - 0 0 0 0 0 1 1 1 1 1.
+     * Add an element will compact the array and the resulting state
+     * should be - 1 1 1 1 1 1 0 0 0 0. */
+    fillRecord( mqttContext.outgoingPublishRecords, PACKET_ID2 + 1, MQTTQoS2, MQTTPubRelSend );
+    /* Clear record from 0 to 4. */
+    ( void ) memset( &mqttContext.outgoingPublishRecords[ 0 ], 0x00, 5 * sizeof( MQTTPubAckInfo_t ) );
+
+    /* Adding one element should result in array in state
+     * 1 1 1 1 1 1 0 0 0 0. */
+    status = MQTT_ReserveState( &mqttContext, PACKET_ID2, MQTTQoS1 );
+    TEST_ASSERT_EQUAL( MQTTSuccess, status );
+    validateRecordAt( mqttContext.outgoingPublishRecords, 5, PACKET_ID2, MQTTQoS1, MQTTPublishSend );
+    /* Remaining records should be cleared. */
+    validateRecordAt( mqttContext.outgoingPublishRecords, 6, MQTT_PACKET_ID_INVALID, MQTTQoS0, MQTTStateNull );
+    validateRecordAt( mqttContext.outgoingPublishRecords, 7, MQTT_PACKET_ID_INVALID, MQTTQoS0, MQTTStateNull );
+    validateRecordAt( mqttContext.outgoingPublishRecords, 8, MQTT_PACKET_ID_INVALID, MQTTQoS0, MQTTStateNull );
+    validateRecordAt( mqttContext.outgoingPublishRecords, 9, MQTT_PACKET_ID_INVALID, MQTTQoS0, MQTTStateNull );
+
+    /* Fragmented array.
+     * Pre condition - 1 0 0 1 1 1 1 0 0 1.
+     * Add an element will compact the array and the resulting state
+     * should be - 1 1 1 1 1 1 1 0 0 0. */
+    fillRecord( mqttContext.outgoingPublishRecords, PACKET_ID2 + 1, MQTTQoS2, MQTTPubRelSend );
+    /* Clear record at index 1,2,7 and 8. */
+    ( void ) memset( &mqttContext.outgoingPublishRecords[ 1 ], 0x00, sizeof( MQTTPubAckInfo_t ) );
+    ( void ) memset( &mqttContext.outgoingPublishRecords[ 2 ], 0x00, sizeof( MQTTPubAckInfo_t ) );
+    ( void ) memset( &mqttContext.outgoingPublishRecords[ 7 ], 0x00, sizeof( MQTTPubAckInfo_t ) );
+    ( void ) memset( &mqttContext.outgoingPublishRecords[ 8 ], 0x00, sizeof( MQTTPubAckInfo_t ) );
+    status = MQTT_ReserveState( &mqttContext, PACKET_ID2, MQTTQoS1 );
+    TEST_ASSERT_EQUAL( MQTTSuccess, status );
+    validateRecordAt( mqttContext.outgoingPublishRecords, 6, PACKET_ID2, MQTTQoS1, MQTTPublishSend );
+    /* Remaining records should be cleared. */
+    validateRecordAt( mqttContext.outgoingPublishRecords, 7, MQTT_PACKET_ID_INVALID, MQTTQoS0, MQTTStateNull );
+    validateRecordAt( mqttContext.outgoingPublishRecords, 8, MQTT_PACKET_ID_INVALID, MQTTQoS0, MQTTStateNull );
+    validateRecordAt( mqttContext.outgoingPublishRecords, 9, MQTT_PACKET_ID_INVALID, MQTTQoS0, MQTTStateNull );
+
+    /* Fragmented array.
+     * Pre condition - 1 0 0 0 0 0 0 0 0 1.
+     * Add an element will compact the array and the resulting state
+     * should be - 1 1 1 0 0 0 0 0 0 0. */
+    resetPublishRecords( &mqttContext );
+    addToRecord( mqttContext.outgoingPublishRecords, 0, PACKET_ID, MQTTQoS2, MQTTPubRecPending );
+    addToRecord( mqttContext.outgoingPublishRecords, 9, PACKET_ID2 + 1, MQTTQoS2, MQTTPubCompPending );
+    status = MQTT_ReserveState( &mqttContext, PACKET_ID2, MQTTQoS1 );
+    TEST_ASSERT_EQUAL( MQTTSuccess, status );
+    validateRecordAt( mqttContext.outgoingPublishRecords, 2, PACKET_ID2, MQTTQoS1, MQTTPublishSend );
+    /* Validate existing records. */
+    validateRecordAt( mqttContext.outgoingPublishRecords, 0, PACKET_ID, MQTTQoS2, MQTTPubRecPending );
+    validateRecordAt( mqttContext.outgoingPublishRecords, 1, PACKET_ID2 + 1, MQTTQoS2, MQTTPubCompPending );
+}
 /* ========================================================================== */
 
 void test_MQTT_CalculateStatePublish( void )
@@ -162,10 +311,10 @@ void test_MQTT_UpdateStatePublish( void )
     status = MQTT_UpdateStatePublish( &mqttContext, PACKET_ID, operation, qos, &state );
     TEST_ASSERT_EQUAL( MQTTBadParameter, status );
 
-    /* Publish resend when in state MQTTPubAckPending. */
-    addToRecord( mqttContext.outgoingPublishRecords, 0, PACKET_ID, MQTTQoS1, MQTTPubAckPending );
+    /* Invalid state transition. */
+    addToRecord( mqttContext.outgoingPublishRecords, 0, PACKET_ID, MQTTQoS1, MQTTPubRelPending );
     status = MQTT_UpdateStatePublish( &mqttContext, PACKET_ID, operation, qos, &state );
-    TEST_ASSERT_EQUAL( MQTTSuccess, status );
+    TEST_ASSERT_EQUAL( MQTTIllegalState, status );
 
     /* Invalid QoS. */
     operation = MQTT_SEND;
@@ -338,12 +487,29 @@ void test_MQTT_UpdateStateAck( void )
     TEST_ASSERT_EQUAL( MQTTBadParameter, status );
     /* No matching record found. */
     status = MQTT_UpdateStateAck( &mqttContext, PACKET_ID, ack, operation, &state );
-    TEST_ASSERT_EQUAL( MQTTStateNotPresent, status );
+    TEST_ASSERT_EQUAL( MQTTRecordNotPresent, status );
     /* Invalid packet ID. */
     status = MQTT_UpdateStateAck( &mqttContext, 0, ack, operation, &state );
-    TEST_ASSERT_EQUAL( MQTTStateNotPresent, status );
+    TEST_ASSERT_EQUAL( MQTTRecordNotPresent, status );
 
-    /* Invalid transition. */
+    /* Invalid transitions. */
+    /* Invalid transition from #MQTTPubRelPending. */
+    addToRecord( mqttContext.outgoingPublishRecords, 0, PACKET_ID, MQTTQoS2, MQTTPubRelPending );
+    ack = MQTTPubrel;
+    operation = MQTT_SEND;
+    status = MQTT_UpdateStateAck( &mqttContext, PACKET_ID, ack, operation, &state );
+    TEST_ASSERT_EQUAL( MQTTIllegalState, status );
+    /* Invalid transition from #MQTTPubCompSend. */
+    addToRecord( mqttContext.outgoingPublishRecords, 0, PACKET_ID, MQTTQoS2, MQTTPubCompSend );
+    status = MQTT_UpdateStateAck( &mqttContext, PACKET_ID, ack, operation, &state );
+    TEST_ASSERT_EQUAL( MQTTIllegalState, status );
+    /* Invalid transition from #MQTTPubCompPending. */
+    addToRecord( mqttContext.outgoingPublishRecords, 0, PACKET_ID, MQTTQoS2, MQTTPubCompPending );
+    ack = MQTTPubrec;
+    operation = MQTT_RECEIVE;
+    status = MQTT_UpdateStateAck( &mqttContext, PACKET_ID, ack, operation, &state );
+    TEST_ASSERT_EQUAL( MQTTIllegalState, status );
+    /* Invalid transition from #MQTTPubRecPending. */
     addToRecord( mqttContext.outgoingPublishRecords, 0, PACKET_ID, MQTTQoS2, MQTTPubRecPending );
     ack = MQTTPubcomp;
     status = MQTT_UpdateStateAck( &mqttContext, 1, ack, operation, &state );
@@ -351,7 +517,7 @@ void test_MQTT_UpdateStateAck( void )
 
     /* Invalid ack type. */
     status = MQTT_UpdateStateAck( &mqttContext, 1, MQTTPubcomp + 1, operation, &state );
-    TEST_ASSERT_EQUAL( MQTTStateNotPresent, status );
+    TEST_ASSERT_EQUAL( MQTTRecordNotPresent, status );
 
     /* Invalid current state. */
     addToRecord( mqttContext.outgoingPublishRecords, 0, PACKET_ID, MQTTQoS2, MQTTPublishDone );
@@ -368,8 +534,6 @@ void test_MQTT_UpdateStateAck( void )
 
     /* QoS 1, receive PUBACK for outgoing publish. */
     addToRecord( mqttContext.outgoingPublishRecords, 0, PACKET_ID, MQTTQoS1, MQTTPubAckPending );
-    /* Add another record to test shifting records when deleting. */
-    addToRecord( mqttContext.outgoingPublishRecords, 1, PACKET_ID + 1, MQTTQoS2, MQTTPublishSend );
     operation = MQTT_RECEIVE;
     ack = MQTTPuback;
     status = MQTT_UpdateStateAck( &mqttContext, PACKET_ID, ack, operation, &state );
@@ -378,9 +542,9 @@ void test_MQTT_UpdateStateAck( void )
 
     /* Test for deletion. After deletion of record at index 0, record at index 1 should be
      * shifted left. */
-    TEST_ASSERT_EQUAL( MQTTPublishSend, mqttContext.outgoingPublishRecords[ 0 ].publishState );
-    TEST_ASSERT_EQUAL( PACKET_ID + 1, mqttContext.outgoingPublishRecords[ 0 ].packetId );
-    TEST_ASSERT_EQUAL( MQTTQoS2, mqttContext.outgoingPublishRecords[ 0 ].qos );
+    TEST_ASSERT_EQUAL( MQTTStateNull, mqttContext.outgoingPublishRecords[ 0 ].publishState );
+    TEST_ASSERT_EQUAL( 0, mqttContext.outgoingPublishRecords[ 0 ].packetId );
+    TEST_ASSERT_EQUAL( MQTTQoS0, mqttContext.outgoingPublishRecords[ 0 ].qos );
     /* Send PUBACK for incoming publish. */
     operation = MQTT_SEND;
     addToRecord( mqttContext.incomingPublishRecords, 0, PACKET_ID, MQTTQoS1, MQTTPubAckSend );
@@ -420,7 +584,7 @@ void test_MQTT_UpdateStateAck( void )
     resetPublishRecords( &mqttContext );
     state = MQTTStateNull;
     status = MQTT_UpdateStateAck( &mqttContext, PACKET_ID, ack, operation, &state );
-    TEST_ASSERT_EQUAL( MQTTStateNotPresent, status );
+    TEST_ASSERT_EQUAL( MQTTRecordNotPresent, status );
     TEST_ASSERT_EQUAL( MQTTStateNull, state );
 
     /* QoS 2, PUBREC. */
@@ -431,6 +595,33 @@ void test_MQTT_UpdateStateAck( void )
     status = MQTT_UpdateStateAck( &mqttContext, PACKET_ID, ack, operation, &state );
     TEST_ASSERT_EQUAL( MQTTSuccess, status );
     TEST_ASSERT_EQUAL( MQTTPubRelSend, state );
+
+    /* Receiving a PUBREC will move the record to the end.
+     * In this case, only one record exists, no moving is required. */
+    TEST_ASSERT_EQUAL( PACKET_ID, mqttContext.outgoingPublishRecords[ 0 ].packetId );
+    TEST_ASSERT_EQUAL( MQTTQoS2, mqttContext.outgoingPublishRecords[ 0 ].qos );
+    TEST_ASSERT_EQUAL( MQTTPubRelSend, mqttContext.outgoingPublishRecords[ 0 ].publishState );
+
+    /* Outgoing.
+     * Test if the record moves to the end of the records when PUBREC is
+     * received. */
+    resetPublishRecords( &mqttContext );
+    addToRecord( mqttContext.outgoingPublishRecords, 0, PACKET_ID, MQTTQoS2, MQTTPubRecPending );
+    addToRecord( mqttContext.outgoingPublishRecords, 1, PACKET_ID + 1, MQTTQoS2, MQTTPubRelSend );
+    status = MQTT_UpdateStateAck( &mqttContext, PACKET_ID, ack, operation, &state );
+    TEST_ASSERT_EQUAL( MQTTSuccess, status );
+    TEST_ASSERT_EQUAL( MQTTPubRelSend, state );
+
+    /* Receiving a PUBREC will move the record to the end.
+     * In this case, the record wil be moved to index 2. */
+    TEST_ASSERT_EQUAL( PACKET_ID, mqttContext.outgoingPublishRecords[ 2 ].packetId );
+    TEST_ASSERT_EQUAL( MQTTQoS2, mqttContext.outgoingPublishRecords[ 2 ].qos );
+    TEST_ASSERT_EQUAL( MQTTPubRelSend, mqttContext.outgoingPublishRecords[ 2 ].publishState );
+    /* Record at the current index will be cleared. */
+    TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, mqttContext.outgoingPublishRecords[ 0 ].packetId );
+    TEST_ASSERT_EQUAL( MQTTQoS0, mqttContext.outgoingPublishRecords[ 0 ].qos );
+    TEST_ASSERT_EQUAL( MQTTStateNull, mqttContext.outgoingPublishRecords[ 0 ].publishState );
+
     /* Incoming. */
     addToRecord( mqttContext.incomingPublishRecords, 0, PACKET_ID, MQTTQoS2, MQTTPubRecSend );
     operation = MQTT_SEND;
@@ -457,61 +648,12 @@ void test_MQTT_UpdateStateAck( void )
     status = MQTT_UpdateStateAck( &mqttContext, PACKET_ID, ack, operation, &state );
     TEST_ASSERT_EQUAL( MQTTSuccess, status );
     TEST_ASSERT_EQUAL( MQTTPublishDone, state );
+
     /* Incoming. A PUBCOMP is send even when no record exists. This happens when PUBREL
      * is received when there is no state record exists. */
     resetPublishRecords( &mqttContext );
     status = MQTT_UpdateStateAck( &mqttContext, PACKET_ID, ack, operation, &state );
-    TEST_ASSERT_EQUAL( MQTTStateNotPresent, status );
-}
-
-/* ========================================================================== */
-
-void test_MQTT_StateSelect( void )
-{
-    MQTTContext_t mqttContext = { 0 };
-    MQTTStateCursor_t outgoingCursor = MQTT_STATE_CURSOR_INITIALIZER;
-    MQTTStateCursor_t incomingCursor = MQTT_STATE_CURSOR_INITIALIZER;
-    MQTTPublishState_t search = MQTTPublishSend;
-    uint16_t packetId;
-    const uint16_t PACKET_ID = 1;
-    const uint16_t PACKET_ID2 = 2;
-    const size_t index = MQTT_STATE_ARRAY_MAX_COUNT / 2;
-    const size_t secondIndex = index + 2;
-
-    /* Invalid parameters. */
-    packetId = MQTT_StateSelect( NULL, MQTTPublishSend, &outgoingCursor );
-    TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, packetId );
-    packetId = MQTT_StateSelect( NULL, MQTTPubAckSend, &incomingCursor );
-    TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, packetId );
-    packetId = MQTT_StateSelect( &mqttContext, search, NULL );
-    TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, packetId );
-    packetId = MQTT_StateSelect( &mqttContext, MQTTStateNull, &outgoingCursor );
-    TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, packetId );
-
-    /* Incoming. */
-    search = MQTTPubAckSend;
-    addToRecord( mqttContext.incomingPublishRecords, index, PACKET_ID, MQTTQoS1, search );
-    packetId = MQTT_StateSelect( &mqttContext, search, &incomingCursor );
-    TEST_ASSERT_EQUAL( PACKET_ID, packetId );
-    TEST_ASSERT_EQUAL( index + 1, incomingCursor );
-
-    /* Outgoing. */
-    search = MQTTPublishSend;
-    addToRecord( mqttContext.outgoingPublishRecords, index, PACKET_ID, MQTTQoS1, search );
-    packetId = MQTT_StateSelect( &mqttContext, search, &outgoingCursor );
-    TEST_ASSERT_EQUAL( PACKET_ID, packetId );
-    TEST_ASSERT_EQUAL( index + 1, outgoingCursor );
-
-    /* Test if second one can be found. */
-    addToRecord( mqttContext.outgoingPublishRecords, secondIndex, PACKET_ID2, MQTTQoS2, search );
-    packetId = MQTT_StateSelect( &mqttContext, search, &outgoingCursor );
-    TEST_ASSERT_EQUAL( PACKET_ID2, packetId );
-    TEST_ASSERT_EQUAL( secondIndex + 1, outgoingCursor );
-
-    /* Test if end of loop reached. */
-    packetId = MQTT_StateSelect( &mqttContext, search, &outgoingCursor );
-    TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, packetId );
-    TEST_ASSERT_EQUAL( MQTT_STATE_ARRAY_MAX_COUNT, outgoingCursor );
+    TEST_ASSERT_EQUAL( MQTTRecordNotPresent, status );
 }
 
 /* ========================================================================== */
@@ -524,10 +666,12 @@ void test_MQTT_AckToResend( void )
     uint16_t packetId;
     const uint16_t PACKET_ID = 1;
     const uint16_t PACKET_ID2 = 2;
-    const uint16_t PACKET_ID3 = 10;
-    const uint16_t PACKET_ID4 = 11;
-    const size_t index = MQTT_STATE_ARRAY_MAX_COUNT / 2;
-    const size_t secondIndex = index + 2;
+    const uint16_t PACKET_ID3 = 3;
+    const uint16_t PACKET_ID4 = 4;
+    const size_t index = 0;
+    const size_t index2 = 1;
+    const size_t index3 = MQTT_STATE_ARRAY_MAX_COUNT / 2;
+    const size_t index4 = index3 + 2;
 
     /* Invalid parameters. */
     packetId = MQTT_AckToResend( NULL, &cursor, &state );
@@ -546,8 +690,8 @@ void test_MQTT_AckToResend( void )
 
     /* No packet exists in state #MQTTPubCompPending or #MQTTPubCompPending states. */
     cursor = MQTT_STATE_CURSOR_INITIALIZER;
-    addToRecord( mqttContext.outgoingPublishRecords, 0, PACKET_ID3, MQTTQoS2, MQTTPubRelPending );
-    addToRecord( mqttContext.outgoingPublishRecords, 1, PACKET_ID3, MQTTQoS2, MQTTPubCompSend );
+    addToRecord( mqttContext.outgoingPublishRecords, index, PACKET_ID3, MQTTQoS2, MQTTPubRelPending );
+    addToRecord( mqttContext.outgoingPublishRecords, index2, PACKET_ID4, MQTTQoS2, MQTTPubCompSend );
     packetId = MQTT_AckToResend( &mqttContext, &cursor, &state );
     TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, packetId );
     TEST_ASSERT_EQUAL( MQTTStateNull, state );
@@ -555,34 +699,103 @@ void test_MQTT_AckToResend( void )
 
     /* Add a record in #MQTTPubCompPending state. */
     cursor = MQTT_STATE_CURSOR_INITIALIZER;
-    addToRecord( mqttContext.outgoingPublishRecords, index, PACKET_ID, MQTTQoS2, MQTTPubCompPending );
+    addToRecord( mqttContext.outgoingPublishRecords, index3, PACKET_ID, MQTTQoS2, MQTTPubCompPending );
     packetId = MQTT_AckToResend( &mqttContext, &cursor, &state );
     TEST_ASSERT_EQUAL( PACKET_ID, packetId );
-    TEST_ASSERT_EQUAL( index + 1, cursor );
+    TEST_ASSERT_EQUAL( index3 + 1, cursor );
     TEST_ASSERT_EQUAL( MQTTPubRelSend, state );
 
     /* Add another record in #MQTTPubCompPending state. */
-    addToRecord( mqttContext.outgoingPublishRecords, secondIndex, PACKET_ID2, MQTTQoS2, MQTTPubCompPending );
+    addToRecord( mqttContext.outgoingPublishRecords, index4, PACKET_ID2, MQTTQoS2, MQTTPubCompPending );
     packetId = MQTT_AckToResend( &mqttContext, &cursor, &state );
     TEST_ASSERT_EQUAL( PACKET_ID2, packetId );
-    TEST_ASSERT_EQUAL( secondIndex + 1, cursor );
+    TEST_ASSERT_EQUAL( index4 + 1, cursor );
     TEST_ASSERT_EQUAL( MQTTPubRelSend, state );
 
     /* Add another record in #MQTTPubRelSend state. */
-    addToRecord( mqttContext.outgoingPublishRecords, secondIndex + 1, PACKET_ID2 + 1, MQTTQoS2, MQTTPubRelSend );
+    addToRecord( mqttContext.outgoingPublishRecords, index4 + 1, PACKET_ID2 + 1, MQTTQoS2, MQTTPubRelSend );
     packetId = MQTT_AckToResend( &mqttContext, &cursor, &state );
     TEST_ASSERT_EQUAL( PACKET_ID2 + 1, packetId );
-    TEST_ASSERT_EQUAL( secondIndex + 2, cursor );
+    TEST_ASSERT_EQUAL( index4 + 2, cursor );
     TEST_ASSERT_EQUAL( MQTTPubRelSend, state );
 
     /* Only one record in #MQTTPubRelSend state. */
     resetPublishRecords( &mqttContext );
     cursor = MQTT_STATE_CURSOR_INITIALIZER;
-    addToRecord( mqttContext.outgoingPublishRecords, index, PACKET_ID, MQTTQoS2, MQTTPubRelSend );
+    addToRecord( mqttContext.outgoingPublishRecords, index3, PACKET_ID, MQTTQoS2, MQTTPubRelSend );
     packetId = MQTT_AckToResend( &mqttContext, &cursor, &state );
     TEST_ASSERT_EQUAL( PACKET_ID, packetId );
-    TEST_ASSERT_EQUAL( index + 1, cursor );
+    TEST_ASSERT_EQUAL( index3 + 1, cursor );
     TEST_ASSERT_EQUAL( MQTTPubRelSend, state );
+
+    /* Further search should be return no valid packets. */
+    state = MQTTStateNull;
+    packetId = MQTT_AckToResend( &mqttContext, &cursor, &state );
+    TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, packetId );
+    TEST_ASSERT_EQUAL( MQTTStateNull, state );
+    TEST_ASSERT_EQUAL( MQTT_STATE_ARRAY_MAX_COUNT, cursor );
+}
+
+void test_MQTT_PublishToResend( void )
+{
+    MQTTContext_t mqttContext = { 0 };
+    MQTTStateCursor_t cursor = MQTT_STATE_CURSOR_INITIALIZER;
+    MQTTPublishState_t state = MQTTStateNull;
+    uint16_t packetId;
+    const uint16_t PACKET_ID = 1;
+    const uint16_t PACKET_ID2 = 2;
+    const uint16_t PACKET_ID3 = 3;
+    const uint16_t PACKET_ID4 = 4;
+    const size_t index = 0;
+    const size_t index2 = 1;
+    const size_t index3 = MQTT_STATE_ARRAY_MAX_COUNT / 2;
+    const size_t index4 = index3 + 2;
+
+
+    /* Invalid parameters. */
+    packetId = MQTT_PublishToResend( NULL, &cursor );
+    TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, packetId );
+    packetId = MQTT_PublishToResend( &mqttContext, NULL );
+    TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, packetId );
+
+    /* No packet exists. */
+    cursor = MQTT_STATE_CURSOR_INITIALIZER;
+    packetId = MQTT_PublishToResend( &mqttContext, &cursor );
+    TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, packetId );
+    TEST_ASSERT_EQUAL( MQTT_STATE_ARRAY_MAX_COUNT, cursor );
+
+    /* No packet exists in state #MQTTPublishSend, #MQTTPubAckPending and
+     * #MQTTPubRecPending states. */
+    cursor = MQTT_STATE_CURSOR_INITIALIZER;
+    addToRecord( mqttContext.outgoingPublishRecords, index, PACKET_ID3, MQTTQoS2, MQTTPubCompPending );
+    addToRecord( mqttContext.outgoingPublishRecords, index2, PACKET_ID4, MQTTQoS2, MQTTPubRelSend );
+    packetId = MQTT_PublishToResend( &mqttContext, &cursor );
+    TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, packetId );
+    TEST_ASSERT_EQUAL( MQTT_STATE_ARRAY_MAX_COUNT, cursor );
+
+    /* Add a record in #MQTTPublishSend state. */
+    cursor = MQTT_STATE_CURSOR_INITIALIZER;
+    addToRecord( mqttContext.outgoingPublishRecords, index3, PACKET_ID, MQTTQoS2, MQTTPublishSend );
+    packetId = MQTT_PublishToResend( &mqttContext, &cursor );
+    TEST_ASSERT_EQUAL( PACKET_ID, packetId );
+    TEST_ASSERT_EQUAL( index3 + 1, cursor );
+
+    /* Add another record in #MQTTPubAckPending state. */
+    addToRecord( mqttContext.outgoingPublishRecords, index4, PACKET_ID2, MQTTQoS1, MQTTPubAckPending );
+    packetId = MQTT_PublishToResend( &mqttContext, &cursor );
+    TEST_ASSERT_EQUAL( PACKET_ID2, packetId );
+    TEST_ASSERT_EQUAL( index4 + 1, cursor );
+
+    /* Add another record in #MQTTPubRecPending state. */
+    addToRecord( mqttContext.outgoingPublishRecords, index4 + 1, PACKET_ID2 + 1, MQTTQoS2, MQTTPubRecPending );
+    packetId = MQTT_PublishToResend( &mqttContext, &cursor );
+    TEST_ASSERT_EQUAL( PACKET_ID2 + 1, packetId );
+    TEST_ASSERT_EQUAL( index4 + 2, cursor );
+
+    /* Further search should find no packets. */
+    packetId = MQTT_PublishToResend( &mqttContext, &cursor );
+    TEST_ASSERT_EQUAL( MQTT_PACKET_ID_INVALID, packetId );
+    TEST_ASSERT_EQUAL( MQTT_STATE_ARRAY_MAX_COUNT, cursor );
 }
 
 /* ========================================================================== */

--- a/libraries/standard/mqtt/utest/mqtt_state_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_state_utest.c
@@ -487,10 +487,10 @@ void test_MQTT_UpdateStateAck( void )
     TEST_ASSERT_EQUAL( MQTTBadParameter, status );
     /* No matching record found. */
     status = MQTT_UpdateStateAck( &mqttContext, PACKET_ID, ack, operation, &state );
-    TEST_ASSERT_EQUAL( MQTTRecordNotPresent, status );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, status );
     /* Invalid packet ID. */
     status = MQTT_UpdateStateAck( &mqttContext, 0, ack, operation, &state );
-    TEST_ASSERT_EQUAL( MQTTRecordNotPresent, status );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, status );
 
     /* Invalid transitions. */
     /* Invalid transition from #MQTTPubRelPending. */
@@ -517,7 +517,7 @@ void test_MQTT_UpdateStateAck( void )
 
     /* Invalid ack type. */
     status = MQTT_UpdateStateAck( &mqttContext, 1, MQTTPubcomp + 1, operation, &state );
-    TEST_ASSERT_EQUAL( MQTTRecordNotPresent, status );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, status );
 
     /* Invalid current state. */
     addToRecord( mqttContext.outgoingPublishRecords, 0, PACKET_ID, MQTTQoS2, MQTTPublishDone );
@@ -580,12 +580,6 @@ void test_MQTT_UpdateStateAck( void )
     status = MQTT_UpdateStateAck( &mqttContext, PACKET_ID, ack, operation, &state );
     TEST_ASSERT_EQUAL( MQTTSuccess, status );
     TEST_ASSERT_EQUAL( MQTTPubCompSend, state );
-    /* Incoming. PUBREL is received when record is not present. */
-    resetPublishRecords( &mqttContext );
-    state = MQTTStateNull;
-    status = MQTT_UpdateStateAck( &mqttContext, PACKET_ID, ack, operation, &state );
-    TEST_ASSERT_EQUAL( MQTTRecordNotPresent, status );
-    TEST_ASSERT_EQUAL( MQTTStateNull, state );
 
     /* QoS 2, PUBREC. */
     /* Outgoing. */
@@ -613,7 +607,7 @@ void test_MQTT_UpdateStateAck( void )
     TEST_ASSERT_EQUAL( MQTTPubRelSend, state );
 
     /* Receiving a PUBREC will move the record to the end.
-     * In this case, the record wil be moved to index 2. */
+    * In this case, the record wil be moved to index 2. */
     TEST_ASSERT_EQUAL( PACKET_ID, mqttContext.outgoingPublishRecords[ 2 ].packetId );
     TEST_ASSERT_EQUAL( MQTTQoS2, mqttContext.outgoingPublishRecords[ 2 ].qos );
     TEST_ASSERT_EQUAL( MQTTPubRelSend, mqttContext.outgoingPublishRecords[ 2 ].publishState );
@@ -648,12 +642,6 @@ void test_MQTT_UpdateStateAck( void )
     status = MQTT_UpdateStateAck( &mqttContext, PACKET_ID, ack, operation, &state );
     TEST_ASSERT_EQUAL( MQTTSuccess, status );
     TEST_ASSERT_EQUAL( MQTTPublishDone, state );
-
-    /* Incoming. A PUBCOMP is send even when no record exists. This happens when PUBREL
-     * is received when there is no state record exists. */
-    resetPublishRecords( &mqttContext );
-    status = MQTT_UpdateStateAck( &mqttContext, PACKET_ID, ack, operation, &state );
-    TEST_ASSERT_EQUAL( MQTTRecordNotPresent, status );
 }
 
 /* ========================================================================== */

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -835,7 +835,7 @@ void test_MQTT_Connect_resendPendingAcks( void )
     MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
     MQTT_DeserializeAck_ReturnThruPtr_pSessionPresent( &sessionPresent );
     /* No packets to resend. */
-    MQTT_AckToResend_ExpectAnyArgsAndReturn( MQTT_PACKET_TYPE_INVALID );
+    MQTT_PubrelToResend_ExpectAnyArgsAndReturn( MQTT_PACKET_TYPE_INVALID );
     status = MQTT_Connect( &mqttContext, &connectInfo, NULL, timeout, &sessionPresent );
     TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
     TEST_ASSERT_EQUAL_INT( MQTTConnected, mqttContext.connectStatus );
@@ -845,11 +845,11 @@ void test_MQTT_Connect_resendPendingAcks( void )
     MQTT_GetIncomingPacketTypeAndLength_ReturnThruPtr_pIncomingPacket( &incomingPacket );
     MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
     MQTT_DeserializeAck_ReturnThruPtr_pSessionPresent( &sessionPresent );
-    MQTT_AckToResend_ExpectAnyArgsAndReturn( packetIdentifier );
-    MQTT_AckToResend_ReturnThruPtr_pState( &pubRelState );
+    MQTT_PubrelToResend_ExpectAnyArgsAndReturn( packetIdentifier );
+    MQTT_PubrelToResend_ReturnThruPtr_pState( &pubRelState );
     /* Serialize Ack failure. */
     MQTT_SerializeAck_ExpectAnyArgsAndReturn( MQTTBadParameter );
-    MQTT_AckToResend_ExpectAnyArgsAndReturn( MQTT_PACKET_TYPE_INVALID );
+    MQTT_PubrelToResend_ExpectAnyArgsAndReturn( MQTT_PACKET_TYPE_INVALID );
     status = MQTT_Connect( &mqttContext, &connectInfo, NULL, timeout, &sessionPresent );
     TEST_ASSERT_EQUAL_INT( MQTTSendFailed, status );
     TEST_ASSERT_EQUAL_INT( MQTTConnected, mqttContext.connectStatus );
@@ -860,13 +860,13 @@ void test_MQTT_Connect_resendPendingAcks( void )
     MQTT_GetIncomingPacketTypeAndLength_ReturnThruPtr_pIncomingPacket( &incomingPacket );
     MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
     MQTT_DeserializeAck_ReturnThruPtr_pSessionPresent( &sessionPresent );
-    MQTT_AckToResend_ExpectAnyArgsAndReturn( packetIdentifier );
-    MQTT_AckToResend_ReturnThruPtr_pState( &pubRelState );
+    MQTT_PubrelToResend_ExpectAnyArgsAndReturn( packetIdentifier );
+    MQTT_PubrelToResend_ReturnThruPtr_pState( &pubRelState );
     /* Serialize Ack successful. */
     MQTT_SerializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
     MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTSuccess );
     /* Query for any remaining packets pending to ack. */
-    MQTT_AckToResend_ExpectAnyArgsAndReturn( MQTT_PACKET_ID_INVALID );
+    MQTT_PubrelToResend_ExpectAnyArgsAndReturn( MQTT_PACKET_ID_INVALID );
     status = MQTT_Connect( &mqttContext, &connectInfo, NULL, timeout, &sessionPresent );
     TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
     TEST_ASSERT_EQUAL_INT( MQTTConnected, mqttContext.connectStatus );
@@ -878,18 +878,18 @@ void test_MQTT_Connect_resendPendingAcks( void )
     MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
     MQTT_DeserializeAck_ReturnThruPtr_pSessionPresent( &sessionPresent );
     /* First packet. */
-    MQTT_AckToResend_ExpectAnyArgsAndReturn( packetIdentifier );
-    MQTT_AckToResend_ReturnThruPtr_pState( &pubRelState );
+    MQTT_PubrelToResend_ExpectAnyArgsAndReturn( packetIdentifier );
+    MQTT_PubrelToResend_ReturnThruPtr_pState( &pubRelState );
     /* Serialize Ack successful. */
     MQTT_SerializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
     MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTSuccess );
     /* Second packet. */
-    MQTT_AckToResend_ExpectAnyArgsAndReturn( packetIdentifier + 1 );
-    MQTT_AckToResend_ReturnThruPtr_pState( &pubRelState );
+    MQTT_PubrelToResend_ExpectAnyArgsAndReturn( packetIdentifier + 1 );
+    MQTT_PubrelToResend_ReturnThruPtr_pState( &pubRelState );
     /* Serialize Ack failed. */
     MQTT_SerializeAck_ExpectAnyArgsAndReturn( MQTTBadParameter );
     /* Query for any remaining packets pending to ack. */
-    MQTT_AckToResend_ExpectAnyArgsAndReturn( packetIdentifier + 2 );
+    MQTT_PubrelToResend_ExpectAnyArgsAndReturn( packetIdentifier + 2 );
     status = MQTT_Connect( &mqttContext, &connectInfo, NULL, timeout, &sessionPresent );
     TEST_ASSERT_EQUAL_INT( MQTTSendFailed, status );
     TEST_ASSERT_EQUAL_INT( MQTTConnected, mqttContext.connectStatus );
@@ -901,19 +901,19 @@ void test_MQTT_Connect_resendPendingAcks( void )
     MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
     MQTT_DeserializeAck_ReturnThruPtr_pSessionPresent( &sessionPresent );
     /* First packet. */
-    MQTT_AckToResend_ExpectAnyArgsAndReturn( packetIdentifier );
-    MQTT_AckToResend_ReturnThruPtr_pState( &pubRelState );
+    MQTT_PubrelToResend_ExpectAnyArgsAndReturn( packetIdentifier );
+    MQTT_PubrelToResend_ReturnThruPtr_pState( &pubRelState );
     /* Serialize Ack successful. */
     MQTT_SerializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
     MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTSuccess );
     /* Second packet. */
-    MQTT_AckToResend_ExpectAnyArgsAndReturn( packetIdentifier + 1 );
-    MQTT_AckToResend_ReturnThruPtr_pState( &pubRelState );
+    MQTT_PubrelToResend_ExpectAnyArgsAndReturn( packetIdentifier + 1 );
+    MQTT_PubrelToResend_ReturnThruPtr_pState( &pubRelState );
     /* Serialize Ack successful. */
     MQTT_SerializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
     MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTSuccess );
     /* Query for any remaining packets pending to ack. */
-    MQTT_AckToResend_ExpectAnyArgsAndReturn( MQTT_PACKET_ID_INVALID );
+    MQTT_PubrelToResend_ExpectAnyArgsAndReturn( MQTT_PACKET_ID_INVALID );
     status = MQTT_Connect( &mqttContext, &connectInfo, NULL, timeout, &sessionPresent );
     TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
     TEST_ASSERT_EQUAL_INT( MQTTConnected, mqttContext.connectStatus );

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -464,6 +464,12 @@ static void expectProcessLoopCalls( MQTTContext_t * const pContext,
 
                 case MQTTStateCollision:
                     expectMoreCalls = pPubInfo->dup;
+
+                    if( pPubInfo->dup == true )
+                    {
+                        MQTT_CalculateStatePublish_ExpectAnyArgsAndReturn( stateAfterDeserialize );
+                    }
+
                     break;
 
                 default:
@@ -1251,7 +1257,7 @@ void test_MQTT_ProcessLoop_handleIncomingPublish_Happy_Paths( void )
      * expectProcessLoopCalls will take on the following parameters:
      * incomingPublish=true, stateAfterDeserialize=MQTTPubAckSend,
      * updateStateStatus=MQTTStateCollision and pPubInfo is passed with
-     * dup flag set. The event callback should be invoked. */
+     * dup flag set. The event callback should not be invoked. */
     currentPacketType = MQTT_PACKET_TYPE_PUBLISH;
     pubInfo.dup = true;
     pubInfo.qos = MQTTQoS1;
@@ -1259,7 +1265,7 @@ void test_MQTT_ProcessLoop_handleIncomingPublish_Happy_Paths( void )
     expectProcessLoopCalls( &context, MQTTSuccess, MQTTPubAckSend,
                             MQTTStateCollision, MQTTSuccess, MQTTPublishDone,
                             MQTTSuccess, true, &pubInfo );
-    TEST_ASSERT_TRUE( isEventCallbackInvoked );
+    TEST_ASSERT_FALSE( isEventCallbackInvoked );
 
     /* Duplicate QoS2 publish received.
      * expectProcessLoopCalls will take on the following parameters:


### PR DESCRIPTION
*Description of changes:*
Handling the resend and receive of duplicate packets when an MQTT session is reestablished.

These are the cases that is handled in this PR,

When a session is reestablished,
Outgoing publishes:

Resend PUBLISHes for which and ack is not received(PUBACK and PUBREC).
Resend PUBRELs for PUBLISHes for which PUBCOMP was not received.
Incoming publishes:

Handle duplicate QoS1 and QoS2 PUBLISHes
Handle duplicate PUBRELs.

This change also handles the message ordering requirement in MQTT3.1.1 spec while re sending publishes and PUBRELs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
