### PR TITLE
Small checks for MQTT_GetPacketId and MQTT_GetIncomingPacketTypeAndLength

### DIFF
--- a/libraries/standard/mqtt/include/mqtt_lightweight.h
+++ b/libraries/standard/mqtt/include/mqtt_lightweight.h
@@ -508,13 +508,14 @@ MQTTStatus_t MQTT_DeserializeAck( const MQTTPacketInfo_t * pIncomingPacket,
                                   bool * pSessionPresent );
 
 /**
- * @brief Extract MQTT packet type and length from incoming packet.
+ * @brief Extract the MQTT packet type and length from incoming packet.
  *
  * @param[in] readFunc Transport layer read function pointer.
- * @param[out] pIncomingPacket Pointer to MQTTPacketInfo_t structure.
+ * @param[out] pIncomingPacket Pointer to MQTTPacketInfo_t structure. This is
  * where type, remaining length and packet identifier are stored.
  *
- * @return #MQTTSuccess on successful extraction of type and length,
+ * @return #MQTTBadParameter if @p pIncomingPacket is invalid,
+ * #MQTTSuccess on successful extraction of type and length,
  * #MQTTRecvFailed on transport receive failure,
  * #MQTTBadResponse if an invalid packet is read, and
  * #MQTTNoDataAvailable if there is nothing to read.

--- a/libraries/standard/mqtt/include/mqtt_lightweight.h
+++ b/libraries/standard/mqtt/include/mqtt_lightweight.h
@@ -514,8 +514,8 @@ MQTTStatus_t MQTT_DeserializeAck( const MQTTPacketInfo_t * pIncomingPacket,
  * @param[out] pIncomingPacket Pointer to MQTTPacketInfo_t structure. This is
  * where type, remaining length and packet identifier are stored.
  *
- * @return #MQTTBadParameter if @p pIncomingPacket is invalid,
- * #MQTTSuccess on successful extraction of type and length,
+ * @return #MQTTSuccess on successful extraction of type and length,
+ * #MQTTBadParameter if @p pIncomingPacket is invalid,
  * #MQTTRecvFailed on transport receive failure,
  * #MQTTBadResponse if an invalid packet is read, and
  * #MQTTNoDataAvailable if there is nothing to read.

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -1468,9 +1468,12 @@ uint16_t MQTT_GetPacketId( MQTTContext_t * pContext )
     if( pContext != NULL )
     {
         packetId = pContext->nextPacketId;
-        pContext->nextPacketId++;
 
-        if( pContext->nextPacketId == 0U )
+        if( pContext->nextPacketId == UINT16_MAX )
+        {
+            pContext->nextPacketId = 1;
+        }
+        else
         {
             pContext->nextPacketId++;
         }

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -2077,13 +2077,20 @@ MQTTStatus_t MQTT_GetIncomingPacketTypeAndLength( MQTTTransportRecvFunc_t readFu
             status = MQTTBadResponse;
         }
     }
-    else if( ( bytesReceived == 0 ) && ( status == MQTTSuccess ) )
+    else if( ( status != MQTTBadParameter ) && ( bytesReceived == 0 ) )
     {
         status = MQTTNoDataAvailable;
     }
-    else
+
+    /* If the input packet was valid, then any other number of bytes received is
+     * a failure. */
+    else if( status != MQTTBadParameter )
     {
         status = MQTTRecvFailed;
+    }
+    else
+    {
+        /* Empty else MISRA 15.7 */
     }
 
     return status;

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -242,11 +242,11 @@ static void serializeConnectPacket( const MQTTConnectInfo_t * pConnectInfo,
                                     const MQTTFixedBuffer_t * pBuffer );
 
 /**
- * @brief Extract MQTT packet type and length from incoming packet.
+ * @brief Extract the MQTT packet type and length from incoming packet.
  *
  * @param[in] readFunc Transport layer read function pointer.
  * @param[out] pIncomingPacket Pointer to MQTTPacketInfo_t structure.
- * where type, remaining length and packet identifier are stored.
+ * This is where type, remaining length and packet identifier are stored.
  *
  * @return #MQTTSuccess on successful extraction of type and length,
  * #MQTTRecvFailed on transport receive failure,

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -1577,6 +1577,11 @@ void test_MQTT_GetIncomingPacketTypeAndLength( void )
     /* Dummy network context - pointer to pointer to a buffer. */
     NetworkContext_t networkContext = ( NetworkContext_t ) &bufPtr;
 
+    /* Test a NULL pIncomingPacket parameter. */
+    status = MQTT_GetIncomingPacketTypeAndLength( mockReceive, networkContext, NULL );
+    TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
+
+    /* Test a typical happy path case for a CONN ACK packet. */ 
     buffer[ 0 ] = 0x20; /* CONN ACK */
     buffer[ 1 ] = 0x02; /* Remaining length. */
 


### PR DESCRIPTION
*Description of changes:*

- Intentionally check for integer overflow in MQTT_GetPacketId. This helps with alleviating flags in bound checking tools and any unwanted behavior that might result from simply just allowing overflow and handling it after.
- Add NULL parameter check for public function MQTT_GetIncomingPacketTypeAndLength
- Add unit tests for the last bullet point.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
