### PR TITLE
Fix test MQTT_Init_Happy_path

### DIFF
--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -494,6 +494,7 @@ void test_MQTT_Init_Happy_Path( void )
     MQTTApplicationCallbacks_t callbacks;
 
     setupCallbacks( &callbacks );
+    setupTransportInterface( &transport );
 
     mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );


### PR DESCRIPTION
*Description of changes:*
The transport interface in the test was not initialized, causing it to fail on some systems and succeed on others (due to having garbage non-NULL data)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
