### PR TITLE
Bugfix for system test failure of Fleet Provisioning tests

### DIFF
--- a/libraries/aws/provisioning/test/system/aws_iot_tests_provisioning_system.c
+++ b/libraries/aws/provisioning/test/system/aws_iot_tests_provisioning_system.c
@@ -564,7 +564,7 @@ TEST( Provisioning_System, CreateCertFromCsrNominalCase )
     status = AwsIotProvisioning_CreateCertificateFromCsr( _mqttConnection,
                                                           IOT_MQTT_QOS_1,
                                                           AWS_IOT_TEST_PROVISIONING_CSR_PEM,
-                                                          sizeof( AWS_IOT_TEST_PROVISIONING_CSR_PEM ),
+                                                          strlen( AWS_IOT_TEST_PROVISIONING_CSR_PEM ),
                                                           AWS_IOT_TEST_PROVISIONING_TIMEOUT,
                                                           &callbackInfo );
 
@@ -704,7 +704,7 @@ TEST( Provisioning_System, RegisterThingWithCertFromCsrNominalCase )
     status = AwsIotProvisioning_CreateCertificateFromCsr( _mqttConnection,
                                                           IOT_MQTT_QOS_1,
                                                           AWS_IOT_TEST_PROVISIONING_CSR_PEM,
-                                                          sizeof( AWS_IOT_TEST_PROVISIONING_CSR_PEM ),
+                                                          strlen( AWS_IOT_TEST_PROVISIONING_CSR_PEM ),
                                                           AWS_IOT_TEST_PROVISIONING_TIMEOUT,
                                                           &certFromCsrCallback );
 


### PR DESCRIPTION
Fixes failure in CI test calls to `AwsIotProvisioning_CreateCertificateFromCsr` from incorrect string size calculation of CSR string.

*Description of changes:*
Fix bug by using `strlen` instead of `sizeof` for string literal size calculation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
