### PR TITLE
Add overflow and null parameters checks to MQTT_GetConnectPacketSize and others

### DIFF
--- a/libraries/standard/http/utest/http_config.h
+++ b/libraries/standard/http/utest/http_config.h
@@ -16,7 +16,7 @@
 
 /* Configure name and log level for the HTTP library. */
 #define LIBRARY_LOG_NAME     "HTTP"
-#define LIBRARY_LOG_LEVEL    LOG_DEBUG
+#define LIBRARY_LOG_LEVEL    LOG_NONE
 
 #include "logging_stack.h"
 

--- a/libraries/standard/mqtt/include/mqtt_lightweight.h
+++ b/libraries/standard/mqtt/include/mqtt_lightweight.h
@@ -263,6 +263,14 @@ struct MQTTPacketInfo
 /**
  * @brief Get the size and Remaining Length of an MQTT CONNECT packet.
  *
+ * This function must be called before #MQTT_SerializeConnect in order to verify
+ * the size of the MQTT CONNECT packet that is generated from
+ * #MQTTConnectInfo_t and optional #MQTTPublishInfo_t. The parameters
+ * @p pConnectInfo , @p pWillInfo , and @p pRemainingLength are valid only if
+ * this function returns #MQTTSuccess.
+ * @p pPacketSize returned is used to verify the size of a #MQTTFixedBuffer_t
+ * that will hold the MQTT CONNECT packet.
+ *
  * @param[in] pConnectInfo MQTT CONNECT packet parameters.
  * @param[in] pWillInfo Last Will and Testament. Pass NULL if not used.
  * @param[out] pRemainingLength The Remaining Length of the MQTT CONNECT packet.
@@ -277,11 +285,18 @@ MQTTStatus_t MQTT_GetConnectPacketSize( const MQTTConnectInfo_t * pConnectInfo,
                                         size_t * pPacketSize );
 
 /**
- * @brief Serialize an MQTT CONNECT packet in the given buffer.
+ * @brief Serialize an MQTT CONNECT packet in the given fixed buffer @p pBuffer.
+ *
+ * #MQTT_GetConnectPacketSize should be called with @p pConnectInfo and
+ * @p pWillInfo before invoking this routine.
+ * The @p remainingLength was calculated from the parameters in @p pConnectInfo
+ * and @p pWillInfo using function #MQTT_GetConnectPacketSize. @p pConnectInfo,
+ * @p pWillInfo , and @p remainingLength are valid only if
+ * #MQTT_GetConnectPacketSize returned #MQTTSuccess.
  *
  * @param[in] pConnectInfo MQTT CONNECT packet parameters.
  * @param[in] pWillInfo Last Will and Testament. Pass NULL if not used.
- * @param[in] remainingLength Remaining Length provided by #MQTT_GetConnectPacketSize.
+ * @param[in] remainingLength Remaining length provided by #MQTT_GetConnectPacketSize.
  * @param[out] pBuffer Buffer for packet serialization.
  *
  * @return #MQTTNoMemory if pBuffer is too small to hold the MQTT packet;
@@ -509,6 +524,10 @@ MQTTStatus_t MQTT_DeserializeAck( const MQTTPacketInfo_t * pIncomingPacket,
 
 /**
  * @brief Extract the MQTT packet type and length from incoming packet.
+ *
+ * This function must be called for every incoming packet to retrieve the
+ * #MQTTPacketInfo_t.type and #MQTTPacketInfo_t.remainingLength. A
+ * #MQTTPacketInfo_t is not valid until this routine has been invoked.
  *
  * @param[in] readFunc Transport layer read function pointer.
  * @param[out] pIncomingPacket Pointer to MQTTPacketInfo_t structure. This is

--- a/libraries/standard/mqtt/include/mqtt_lightweight.h
+++ b/libraries/standard/mqtt/include/mqtt_lightweight.h
@@ -306,7 +306,7 @@ MQTTStatus_t MQTT_GetConnectPacketSize( const MQTTConnectInfo_t * pConnectInfo,
 MQTTStatus_t MQTT_SerializeConnect( const MQTTConnectInfo_t * pConnectInfo,
                                     const MQTTPublishInfo_t * pWillInfo,
                                     size_t remainingLength,
-                                    const MQTTFixedBuffer_t * pBuffer );
+                                    MQTTFixedBuffer_t * pBuffer );
 
 /**
  * @brief Get packet size and Remaining Length of an MQTT SUBSCRIBE packet.

--- a/libraries/standard/mqtt/include/mqtt_lightweight.h
+++ b/libraries/standard/mqtt/include/mqtt_lightweight.h
@@ -297,7 +297,7 @@ MQTTStatus_t MQTT_GetConnectPacketSize( const MQTTConnectInfo_t * pConnectInfo,
  * @param[in] pConnectInfo MQTT CONNECT packet parameters.
  * @param[in] pWillInfo Last Will and Testament. Pass NULL if not used.
  * @param[in] remainingLength Remaining Length provided by #MQTT_GetConnectPacketSize.
- * @param[out] pBuffer Buffer for packet serialization.
+ * @param[out] pFixedBuffer Buffer for packet serialization.
  *
  * @return #MQTTNoMemory if pBuffer is too small to hold the MQTT packet;
  * #MQTTBadParameter if invalid parameters are passed;
@@ -306,7 +306,7 @@ MQTTStatus_t MQTT_GetConnectPacketSize( const MQTTConnectInfo_t * pConnectInfo,
 MQTTStatus_t MQTT_SerializeConnect( const MQTTConnectInfo_t * pConnectInfo,
                                     const MQTTPublishInfo_t * pWillInfo,
                                     size_t remainingLength,
-                                    const MQTTFixedBuffer_t * pBuffer );
+                                    const MQTTFixedBuffer_t * pFixedBuffer );
 
 /**
  * @brief Get packet size and Remaining Length of an MQTT SUBSCRIBE packet.

--- a/libraries/standard/mqtt/include/mqtt_lightweight.h
+++ b/libraries/standard/mqtt/include/mqtt_lightweight.h
@@ -296,7 +296,7 @@ MQTTStatus_t MQTT_GetConnectPacketSize( const MQTTConnectInfo_t * pConnectInfo,
  *
  * @param[in] pConnectInfo MQTT CONNECT packet parameters.
  * @param[in] pWillInfo Last Will and Testament. Pass NULL if not used.
- * @param[in] remainingLength Remaining length provided by #MQTT_GetConnectPacketSize.
+ * @param[in] remainingLength Remaining Length provided by #MQTT_GetConnectPacketSize.
  * @param[out] pBuffer Buffer for packet serialization.
  *
  * @return #MQTTNoMemory if pBuffer is too small to hold the MQTT packet;

--- a/libraries/standard/mqtt/include/mqtt_lightweight.h
+++ b/libraries/standard/mqtt/include/mqtt_lightweight.h
@@ -306,7 +306,7 @@ MQTTStatus_t MQTT_GetConnectPacketSize( const MQTTConnectInfo_t * pConnectInfo,
 MQTTStatus_t MQTT_SerializeConnect( const MQTTConnectInfo_t * pConnectInfo,
                                     const MQTTPublishInfo_t * pWillInfo,
                                     size_t remainingLength,
-                                    MQTTFixedBuffer_t * pBuffer );
+                                    const MQTTFixedBuffer_t * pBuffer );
 
 /**
  * @brief Get packet size and Remaining Length of an MQTT SUBSCRIBE packet.

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -1863,6 +1863,8 @@ uint16_t MQTT_GetPacketId( MQTTContext_t * pContext )
     {
         packetId = pContext->nextPacketId;
 
+        /* A packet ID of zero is not a valid packet ID. When the max ID
+         * is reached the next one should start 1. */
         if( pContext->nextPacketId == ( uint16_t ) UINT16_MAX )
         {
             pContext->nextPacketId = 1;

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -1864,7 +1864,7 @@ uint16_t MQTT_GetPacketId( MQTTContext_t * pContext )
         packetId = pContext->nextPacketId;
 
         /* A packet ID of zero is not a valid packet ID. When the max ID
-         * is reached the next one should start 1. */
+         * is reached the next one should start at 1. */
         if( pContext->nextPacketId == ( uint16_t ) UINT16_MAX )
         {
             pContext->nextPacketId = 1;

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -1399,7 +1399,7 @@ MQTTStatus_t MQTT_GetConnectPacketSize( const MQTTConnectInfo_t * pConnectInfo,
         connectPacketSize += 1U + remainingLengthEncodedSize( connectPacketSize );
 
         /* The connectPacketSize calculated from this function's parameters is
-         * gauranteed to be less than the maximum MQTT CONNECT packet size, which
+         * guaranteed to be less than the maximum MQTT CONNECT packet size, which
          * is 327700. If the maximum client identifier length, the maximum will
          * message topic length, the maximum will topic payload length, the
          * maximum username length, and the maximum password length are all present
@@ -1430,24 +1430,24 @@ MQTTStatus_t MQTT_GetConnectPacketSize( const MQTTConnectInfo_t * pConnectInfo,
 MQTTStatus_t MQTT_SerializeConnect( const MQTTConnectInfo_t * pConnectInfo,
                                     const MQTTPublishInfo_t * pWillInfo,
                                     size_t remainingLength,
-                                    const MQTTFixedBuffer_t * pBuffer )
+                                    const MQTTFixedBuffer_t * pFixedBuffer )
 {
     MQTTStatus_t status = MQTTSuccess;
     size_t connectPacketSize = 0;
 
     /* Validate arguments. */
-    if( ( pConnectInfo == NULL ) || ( pBuffer == NULL ) )
+    if( ( pConnectInfo == NULL ) || ( pFixedBuffer == NULL ) )
     {
         LogError( ( "Argument cannot be NULL: pConnectInfo=%p, "
-                    "pBuffer=%p.",
+                    "pFixedBuffer=%p.",
                     pConnectInfo,
-                    pBuffer ) );
+                    pFixedBuffer ) );
         status = MQTTBadParameter;
     }
     /* A buffer must be configured for serialization. */
-    else if( pBuffer->pBuffer == NULL )
+    else if( pFixedBuffer->pBuffer == NULL )
     {
-        LogError( ( "Argument cannot be NULL: pBuffer->pBuffer is NULL." ) );
+        LogError( ( "Argument cannot be NULL: pFixedBuffer->pBuffer is NULL." ) );
         status = MQTTBadParameter;
     }
     else if( ( pWillInfo != NULL ) && ( pWillInfo->pTopicName == NULL ) )
@@ -1463,11 +1463,11 @@ MQTTStatus_t MQTT_SerializeConnect( const MQTTConnectInfo_t * pConnectInfo,
         connectPacketSize = remainingLength + remainingLengthEncodedSize( remainingLength ) + 1U;
 
         /* Check that the full packet size fits within the given buffer. */
-        if( connectPacketSize > pBuffer->size )
+        if( connectPacketSize > pFixedBuffer->size )
         {
             LogError( ( "Buffer size of %lu is not sufficient to hold "
                         "serialized CONNECT packet of size of %lu.",
-                        pBuffer->size,
+                        pFixedBuffer->size,
                         connectPacketSize ) );
             status = MQTTNoMemory;
         }
@@ -1476,7 +1476,7 @@ MQTTStatus_t MQTT_SerializeConnect( const MQTTConnectInfo_t * pConnectInfo,
             serializeConnectPacket( pConnectInfo,
                                     pWillInfo,
                                     remainingLength,
-                                    pBuffer );
+                                    pFixedBuffer );
         }
     }
 

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -1430,7 +1430,7 @@ MQTTStatus_t MQTT_GetConnectPacketSize( const MQTTConnectInfo_t * pConnectInfo,
 MQTTStatus_t MQTT_SerializeConnect( const MQTTConnectInfo_t * pConnectInfo,
                                     const MQTTPublishInfo_t * pWillInfo,
                                     size_t remainingLength,
-                                    MQTTFixedBuffer_t * pBuffer )
+                                    const MQTTFixedBuffer_t * pBuffer )
 {
     MQTTStatus_t status = MQTTSuccess;
     size_t connectPacketSize = 0;

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -1398,6 +1398,22 @@ MQTTStatus_t MQTT_GetConnectPacketSize( const MQTTConnectInfo_t * pConnectInfo,
          * the "Remaining Length" field plus 1 byte for the "Packet Type" field. */
         connectPacketSize += 1U + remainingLengthEncodedSize( connectPacketSize );
 
+        /* The connectPacketSize calculated from this function's parameters is 
+         * gauranteed to be less than the maximum MQTT CONNECT packet size, which
+         * is 327700. If the maximum client identifier length, the maximum will 
+         * message topic length, the maximum will topic payload length, the 
+         * maximum username length, and the maximum password length are all present
+         * in the MQTT CONNECT packet, the total size will be calculated to be 
+         * 327699:
+         * (variable length header)10 + 
+         * (maximum client identifier length) 65535 + (encoded length) 2 + 
+         * (maximum will message topic name length) 65535 + (encoded length)2 + 
+         * (maximum will message payload length) 65535 + 2 + 
+         * (maximum username length) 65535 + (encoded length) 2 + 
+         * (maximum password length) 65535 + (encoded length) 2 + 
+         * (packet type field length) 1 + 
+         * (CONNECT packet encoded length) 3 = 327699 */
+
         *pRemainingLength = remainingLength;
         *pPacketSize = connectPacketSize;
 

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -1398,20 +1398,20 @@ MQTTStatus_t MQTT_GetConnectPacketSize( const MQTTConnectInfo_t * pConnectInfo,
          * the "Remaining Length" field plus 1 byte for the "Packet Type" field. */
         connectPacketSize += 1U + remainingLengthEncodedSize( connectPacketSize );
 
-        /* The connectPacketSize calculated from this function's parameters is 
+        /* The connectPacketSize calculated from this function's parameters is
          * gauranteed to be less than the maximum MQTT CONNECT packet size, which
-         * is 327700. If the maximum client identifier length, the maximum will 
-         * message topic length, the maximum will topic payload length, the 
+         * is 327700. If the maximum client identifier length, the maximum will
+         * message topic length, the maximum will topic payload length, the
          * maximum username length, and the maximum password length are all present
-         * in the MQTT CONNECT packet, the total size will be calculated to be 
+         * in the MQTT CONNECT packet, the total size will be calculated to be
          * 327699:
-         * (variable length header)10 + 
-         * (maximum client identifier length) 65535 + (encoded length) 2 + 
-         * (maximum will message topic name length) 65535 + (encoded length)2 + 
-         * (maximum will message payload length) 65535 + 2 + 
-         * (maximum username length) 65535 + (encoded length) 2 + 
-         * (maximum password length) 65535 + (encoded length) 2 + 
-         * (packet type field length) 1 + 
+         * (variable length header)10 +
+         * (maximum client identifier length) 65535 + (encoded length) 2 +
+         * (maximum will message topic name length) 65535 + (encoded length)2 +
+         * (maximum will message payload length) 65535 + 2 +
+         * (maximum username length) 65535 + (encoded length) 2 +
+         * (maximum password length) 65535 + (encoded length) 2 +
+         * (packet type field length) 1 +
          * (CONNECT packet encoded length) 3 = 327699 */
 
         *pRemainingLength = remainingLength;
@@ -1430,7 +1430,7 @@ MQTTStatus_t MQTT_GetConnectPacketSize( const MQTTConnectInfo_t * pConnectInfo,
 MQTTStatus_t MQTT_SerializeConnect( const MQTTConnectInfo_t * pConnectInfo,
                                     const MQTTPublishInfo_t * pWillInfo,
                                     size_t remainingLength,
-                                    const MQTTFixedBuffer_t * pBuffer )
+                                    MQTTFixedBuffer_t * pBuffer )
 {
     MQTTStatus_t status = MQTTSuccess;
     size_t connectPacketSize = 0;
@@ -1458,7 +1458,7 @@ MQTTStatus_t MQTT_SerializeConnect( const MQTTConnectInfo_t * pConnectInfo,
     else
     {
         /* Calculate CONNECT packet size. Overflow in in this addition is not checked
-         * because it is part of the API contract to call MQTT_SerializeConnect()
+         * because it is part of the API contract to call Mqtt_GetConnectPacketSize()
          * before this function. */
         connectPacketSize = remainingLength + remainingLengthEncodedSize( remainingLength ) + 1U;
 
@@ -2167,7 +2167,7 @@ MQTTStatus_t MQTT_GetIncomingPacketTypeAndLength( MQTTTransportRecvFunc_t readFu
     {
         LogError( ( "A single byte was not read from the transport: "
                     "transportStatus=%d",
-                    status ) );
+                    bytesReceived ) );
         status = MQTTRecvFailed;
     }
     else

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -1445,7 +1445,7 @@ MQTTStatus_t MQTT_SerializeConnect( const MQTTConnectInfo_t * pConnectInfo,
         status = MQTTBadParameter;
     }
     /* A buffer must be configured for serialization. */
-    else if( ( pBuffer != NULL ) && ( pBuffer->pBuffer == NULL ) )
+    else if( pBuffer->pBuffer == NULL )
     {
         LogError( ( "Argument cannot be NULL: pBuffer->pBuffer is NULL." ) );
         status = MQTTBadParameter;

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -1354,7 +1354,7 @@ MQTTStatus_t MQTT_GetConnectPacketSize( const MQTTConnectInfo_t * pConnectInfo,
         LogError( ( "Mqtt_GetConnectPacketSize() client identifier must be set." ) );
         status = MQTTBadParameter;
     }
-    else if( ( pWillInfo != NULL ) && ( pWillInfo->payloadLength > UINT16_MAX ) )
+    else if( ( pWillInfo != NULL ) && ( pWillInfo->payloadLength > ( size_t ) UINT16_MAX ) )
     {
         /* The MQTTPublishInfo_t is reused for the will message. The payload
          * length for any other message could be larger than 65,535, but

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -424,7 +424,7 @@ void test_MQTT_GetConnectPacketSize( void )
     status = MQTT_GetConnectPacketSize( &connectInfo, NULL, &remainingLength, &packetSize );
     TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
 
-    /* Test a will message payload length beyond 16 bits. */
+    /* Test a will message payload length that is too large. */
     memset( ( void * ) &connectInfo, 0x0, sizeof( connectInfo ) );
     connectInfo.pClientIdentifier = CLIENT_IDENTIFIER;
     connectInfo.clientIdentifierLength = UINT16_MAX;
@@ -434,6 +434,7 @@ void test_MQTT_GetConnectPacketSize( void )
     connectInfo.userNameLength = UINT16_MAX;
     willInfo.pTopicName = TEST_TOPIC_NAME;
     willInfo.topicNameLength = UINT16_MAX;
+    /* A valid will message payload is less than the maximum 16 bit integer. */
     willInfo.payloadLength = UINT16_MAX + 2;
     status = MQTT_GetConnectPacketSize( &connectInfo, &willInfo, &remainingLength, &packetSize );
     TEST_ASSERT_EQUAL( MQTTBadParameter, status );

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -1452,6 +1452,8 @@ void test_MQTT_DeserializePublish( void )
 
     const uint16_t PACKET_ID = 1;
 
+    memset( ( void * ) &mqttPacketInfo, 0x00, sizeof( mqttPacketInfo ) );
+
     /* Verify parameters. */
     status = MQTT_DeserializePublish( NULL, &packetIdentifier, &publishInfo );
     TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
@@ -1460,7 +1462,9 @@ void test_MQTT_DeserializePublish( void )
     status = MQTT_DeserializePublish( &mqttPacketInfo, &packetIdentifier, NULL );
     TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
 
-    memset( ( void * ) &mqttPacketInfo, 0x00, sizeof( mqttPacketInfo ) );
+    mqttPacketInfo.type = MQTT_PACKET_TYPE_PUBLISH;
+    status = MQTT_DeserializePublish( &mqttPacketInfo, &packetIdentifier, &publishInfo );
+    TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
 
     /* Bad Packet Type. */
     mqttPacketInfo.type = 0x01;
@@ -1583,7 +1587,7 @@ void test_MQTT_GetIncomingPacketTypeAndLength( void )
     status = MQTT_GetIncomingPacketTypeAndLength( mockReceive, networkContext, NULL );
     TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
 
-    /* Test a typical happy path case for a CONN ACK packet. */ 
+    /* Test a typical happy path case for a CONN ACK packet. */
     buffer[ 0 ] = 0x20; /* CONN ACK */
     buffer[ 1 ] = 0x02; /* Remaining length. */
 

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -424,7 +424,7 @@ void test_MQTT_GetConnectPacketSize( void )
     status = MQTT_GetConnectPacketSize( &connectInfo, NULL, &remainingLength, &packetSize );
     TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
 
-    /* Test that the will message lengths are beyond 16 bits. */
+    /* Test a will message payload length beyond 16 bits. */
     memset( ( void * ) &connectInfo, 0x0, sizeof( connectInfo ) );
     connectInfo.pClientIdentifier = CLIENT_IDENTIFIER;
     connectInfo.clientIdentifierLength = UINT16_MAX;

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -424,7 +424,7 @@ void test_MQTT_GetConnectPacketSize( void )
     status = MQTT_GetConnectPacketSize( &connectInfo, NULL, &remainingLength, &packetSize );
     TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
 
-    /* Connect packet too large. */
+    /* Test that the will message lengths are beyond 16 bits. */
     memset( ( void * ) &connectInfo, 0x0, sizeof( connectInfo ) );
     connectInfo.pClientIdentifier = CLIENT_IDENTIFIER;
     connectInfo.clientIdentifierLength = UINT16_MAX;
@@ -502,11 +502,22 @@ void test_MQTT_SerializeConnect( void )
     status = MQTT_SerializeConnect( &connectInfo, NULL, 120, &fixedBuffer );
     TEST_ASSERT_EQUAL_INT( MQTTNoMemory, status );
 
-    /* Good case succeeds */
-    /* Calculate packet size. */
+    /* Create a good connection info. */
     memset( ( void * ) &connectInfo, 0x0, sizeof( connectInfo ) );
     connectInfo.pClientIdentifier = "TEST";
     connectInfo.clientIdentifierLength = 4;
+
+    /* Inject a invalid fixed buffer test with a good connectInfo. */
+    memset( ( void * ) &fixedBuffer, 0x0, sizeof( fixedBuffer ) );
+    status = MQTT_SerializeConnect( &connectInfo, NULL, remainingLength, &fixedBuffer );
+    TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
+
+    /* Good case succeeds. */
+    /* Set the fixedBuffer properly for the rest of the succeeding test. */
+    fixedBuffer.pBuffer = &buffer[ BUFFER_PADDING_LENGTH ];
+    fixedBuffer.size = bufferSize;
+
+    /* Calculate a good packet size. */
     status = MQTT_GetConnectPacketSize( &connectInfo, NULL, &remainingLength, &packetSize );
     TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
     /* Make sure buffer has enough space */


### PR DESCRIPTION
*Description of changes:*
- Add parameter check for will message payload length in MQTT_GetConnectPacketSize()
- Add documentation about the necessity of MQTT_GetConnectPacketSize()
- Add missing private static function documentation for consistency
- Add documentation about starting over the packet ID at 1.
- Add more parameter checks to MQTT_SerializeConnect()
- Add unit tests for changes.
- Disable logging in the HTTP Client unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
