### PR TITLE
Update license information for Mbed TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,5 @@ Existing ports (which may be used as examples) are present in `ports`. A blank t
 ## License
 
 This library is licensed under the [MIT License](LICENSE).
+
+This repository uses Mbed TLS under Apache 2.0

--- a/third_party/mbedtls/iot_config_mbedtls.h
+++ b/third_party/mbedtls/iot_config_mbedtls.h
@@ -41,7 +41,7 @@
  *
  *  **********
  *
- *  This file is part of mbed TLS (https://tls.mbed.org)
+ *  This repository uses Mbed TLS under Apache 2.0
  */
 
 /* This file configures the mbed TLS library built with this SDK. */


### PR DESCRIPTION
Updated the root README.md and the header file of the Mbed TLS config file to include information on the license being used. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
