### PR TITLE
Fix for PINGRESP Deserializing

### DIFF
--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -1992,7 +1992,11 @@ MQTTStatus_t MQTT_DeserializeAck( const MQTTPacketInfo_t * pIncomingPacket,
         LogError( ( "pSessionPresent cannot be NULL for CONNACK packet." ) );
         status = MQTTBadParameter;
     }
-    else if( pIncomingPacket->pRemainingData == NULL )
+
+    /* Pointer for remaining data cannot be NULL for packets other
+     * than PINGRESP. */
+    else if( ( pIncomingPacket->pRemainingData == NULL ) &&
+             ( pIncomingPacket->type != MQTT_PACKET_TYPE_PINGRESP ) )
     {
         LogError( ( "Remaining data of incoming packet is NULL." ) );
         status = MQTTBadParameter;

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -1354,13 +1354,15 @@ void test_MQTT_DeserializeAck_pingresp( void )
     uint8_t buffer[ 10 ] = { 0 };
 
     /* Bad remaining length. */
+    ( void ) memset( ( void * ) &mqttPacketInfo, 0x00, sizeof( mqttPacketInfo ) );
     mqttPacketInfo.type = MQTT_PACKET_TYPE_PINGRESP;
     mqttPacketInfo.remainingLength = MQTT_PACKET_PINGRESP_REMAINING_LENGTH + 1;
     status = MQTT_DeserializeAck( &mqttPacketInfo, &packetIdentifier, &sessionPresent );
     TEST_ASSERT_EQUAL_INT( MQTTBadResponse, status );
 
-    /* Process a valid PINGRESP. */
+    /* Process a valid PINGRESP with remaining data buffer NULL. */
     mqttPacketInfo.remainingLength = MQTT_PACKET_PINGRESP_REMAINING_LENGTH;
+    mqttPacketInfo.pRemainingData = NULL;
     status = MQTT_DeserializeAck( &mqttPacketInfo, NULL, NULL );
     TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
 

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -1351,7 +1351,6 @@ void test_MQTT_DeserializeAck_pingresp( void )
     uint16_t packetIdentifier;
     bool sessionPresent;
     MQTTStatus_t status = MQTTSuccess;
-    uint8_t buffer[ 10 ] = { 0 };
 
     /* Bad remaining length. */
     ( void ) memset( ( void * ) &mqttPacketInfo, 0x00, sizeof( mqttPacketInfo ) );
@@ -1360,15 +1359,9 @@ void test_MQTT_DeserializeAck_pingresp( void )
     status = MQTT_DeserializeAck( &mqttPacketInfo, &packetIdentifier, &sessionPresent );
     TEST_ASSERT_EQUAL_INT( MQTTBadResponse, status );
 
-    /* Process a valid PINGRESP with remaining data buffer NULL. */
+    /* Process a valid PINGRESP. */
     mqttPacketInfo.remainingLength = MQTT_PACKET_PINGRESP_REMAINING_LENGTH;
     mqttPacketInfo.pRemainingData = NULL;
-    status = MQTT_DeserializeAck( &mqttPacketInfo, NULL, NULL );
-    TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
-
-    /* Process a valid PINGRESP with remaining data buffer non-NULL. */
-    mqttPacketInfo.remainingLength = MQTT_PACKET_PINGRESP_REMAINING_LENGTH;
-    mqttPacketInfo.pRemainingData = buffer;
     status = MQTT_DeserializeAck( &mqttPacketInfo, NULL, NULL );
     TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
 }

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -1355,13 +1355,18 @@ void test_MQTT_DeserializeAck_pingresp( void )
 
     /* Bad remaining length. */
     mqttPacketInfo.type = MQTT_PACKET_TYPE_PINGRESP;
-    mqttPacketInfo.pRemainingData = buffer;
     mqttPacketInfo.remainingLength = MQTT_PACKET_PINGRESP_REMAINING_LENGTH + 1;
     status = MQTT_DeserializeAck( &mqttPacketInfo, &packetIdentifier, &sessionPresent );
     TEST_ASSERT_EQUAL_INT( MQTTBadResponse, status );
 
     /* Process a valid PINGRESP. */
     mqttPacketInfo.remainingLength = MQTT_PACKET_PINGRESP_REMAINING_LENGTH;
+    status = MQTT_DeserializeAck( &mqttPacketInfo, NULL, NULL );
+    TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
+
+    /* Process a valid PINGRESP with remaining data buffer non-NULL. */
+    mqttPacketInfo.remainingLength = MQTT_PACKET_PINGRESP_REMAINING_LENGTH;
+    mqttPacketInfo.pRemainingData = buffer;
     status = MQTT_DeserializeAck( &mqttPacketInfo, NULL, NULL );
     TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
 }
@@ -1583,7 +1588,7 @@ void test_MQTT_GetIncomingPacketTypeAndLength( void )
     status = MQTT_GetIncomingPacketTypeAndLength( mockReceive, networkContext, NULL );
     TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
 
-    /* Test a typical happy path case for a CONN ACK packet. */ 
+    /* Test a typical happy path case for a CONN ACK packet. */
     buffer[ 0 ] = 0x20; /* CONN ACK */
     buffer[ 1 ] = 0x02; /* Remaining length. */
 


### PR DESCRIPTION
*Description of changes:*
A NULL check for pointer to remaining data is not required for PINGRESP. PINGRESP doesn't have any remaining data to point to as per MQTT 3.1.1 spec. A NULL for buffer should be valid in this case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
