### PR TITLE
Fix build of mqtt_demo_plaintext when logging configured at warning v…

### DIFF
--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
@@ -489,8 +489,7 @@ static int connectToServerWithBackoffRetries( int * pTcpSocket )
 
         if( status == EXIT_FAILURE )
         {
-            LogWarn( ( "Connection to the broker failed. Retrying connection with backoff and jitter.",
-                       ( reconnectParams.reconnectTimeoutSec > MAX_RECONNECT_TIMEOUT_SECONDS ) ? MAX_RECONNECT_TIMEOUT_SECONDS : reconnectParams.reconnectTimeoutSec ) );
+            LogWarn( ( "Connection to the broker failed. Retrying connection with backoff and jitter." ) );
             backoffSuccess = Transport_ReconnectBackoffAndSleep( &reconnectParams );
         }
 


### PR DESCRIPTION
Fix build issue of `mqtt_demo_plaintext ` introduced in #1043 

*Background:*
The `reconnectTimeoutSec ` member was removed from the struct in #1043 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
