### PR TITLE
Fix return type of unsubscribeFromTopic in MQTT demos

### DIFF
--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -305,7 +305,7 @@ static int subscribeToTopic( MQTTContext_t * pMqttContext );
  * @return EXIT_SUCCESS if UNSUBSCRIBE was successfully sent;
  * EXIT_FAILURE otherwise.
  */
-static MQTTStatus_t unsubscribeFromTopic( MQTTContext_t * pMqttContext );
+static int unsubscribeFromTopic( MQTTContext_t * pMqttContext );
 
 /**
  * @brief Sends an MQTT PUBLISH to #MQTT_EXAMPLE_TOPIC defined at
@@ -807,7 +807,7 @@ static int subscribeToTopic( MQTTContext_t * pMqttContext )
 
 /*-----------------------------------------------------------*/
 
-static MQTTStatus_t unsubscribeFromTopic( MQTTContext_t * pMqttContext )
+static int unsubscribeFromTopic( MQTTContext_t * pMqttContext )
 {
     int returnStatus = EXIT_SUCCESS;
     MQTTStatus_t mqttStatus;

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -339,7 +339,7 @@ static int subscribeToTopic( MQTTContext_t * pMqttContext );
  * @return EXIT_SUCCESS if UNSUBSCRIBE was successfully sent;
  * EXIT_FAILURE otherwise.
  */
-static MQTTStatus_t unsubscribeFromTopic( MQTTContext_t * pMqttContext );
+static int unsubscribeFromTopic( MQTTContext_t * pMqttContext );
 
 /**
  * @brief Sends an MQTT PUBLISH to #MQTT_EXAMPLE_TOPIC defined at
@@ -836,7 +836,7 @@ static int subscribeToTopic( MQTTContext_t * pMqttContext )
 
 /*-----------------------------------------------------------*/
 
-static MQTTStatus_t unsubscribeFromTopic( MQTTContext_t * pMqttContext )
+static int unsubscribeFromTopic( MQTTContext_t * pMqttContext )
 {
     int returnStatus = EXIT_SUCCESS;
     MQTTStatus_t mqttStatus;

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
@@ -260,7 +260,7 @@ static int subscribeToTopic( MQTTContext_t * pMqttContext );
  * @return EXIT_SUCCESS if UNSUBSCRIBE was successfully sent;
  * EXIT_FAILURE otherwise.
  */
-static MQTTStatus_t unsubscribeFromTopic( MQTTContext_t * pMqttContext );
+static int unsubscribeFromTopic( MQTTContext_t * pMqttContext );
 
 /**
  * @brief Sends an MQTT PUBLISH to #MQTT_EXAMPLE_TOPIC defined at
@@ -573,7 +573,7 @@ static int subscribeToTopic( MQTTContext_t * pMqttContext )
 
 /*-----------------------------------------------------------*/
 
-static MQTTStatus_t unsubscribeFromTopic( MQTTContext_t * pMqttContext )
+static int unsubscribeFromTopic( MQTTContext_t * pMqttContext )
 {
     int returnStatus = EXIT_SUCCESS;
     MQTTStatus_t mqttStatus;


### PR DESCRIPTION
Return type of unsubscribeFromTopic needs to be changed to int from MQTTStatus_t

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
