### PR TITLE
Fix straggling lexicon words in mqtt and fixed spelling of retrieve.

### DIFF
--- a/libraries/standard/mqtt/lexicon.txt
+++ b/libraries/standard/mqtt/lexicon.txt
@@ -5,6 +5,7 @@ addrecord
 api
 app
 aws
+bool
 bufferlength
 bytesreceived
 bytestoread
@@ -14,6 +15,7 @@ bytestosend
 bytestowrite
 ca
 calculatestatepublish
+cb
 cbmc
 cleansession
 cmock
@@ -64,6 +66,7 @@ init
 int
 iot
 isn
+lsb
 lwt
 malloc
 managekeepalive
@@ -213,6 +216,7 @@ tcpsocket
 testcase
 timeoutms
 tls
+topicFilterLength
 uint
 un
 unsuback

--- a/platform/posix/transport/src/sockets_posix.c
+++ b/platform/posix/transport/src/sockets_posix.c
@@ -103,7 +103,7 @@ static SocketStatus_t attemptConnection( struct addrinfo * pListHead,
  *
  * @return #SOCKETS_API_ERROR, #SOCKETS_INSUFFICIENT_MEMORY, #SOCKETS_INVALID_PARAMETER on error.
  */
-static SocketStatus_t retreiveError( void );
+static SocketStatus_t retrieveError( void );
 
 /*-----------------------------------------------------------*/
 
@@ -262,7 +262,7 @@ static SocketStatus_t attemptConnection( struct addrinfo * pListHead,
 }
 /*-----------------------------------------------------------*/
 
-static SocketStatus_t retreiveError( void )
+static SocketStatus_t retrieveError( void )
 {
     SocketStatus_t returnStatus = SOCKETS_API_ERROR;
 
@@ -385,7 +385,7 @@ SocketStatus_t Sockets_Connect( int * pTcpSocket,
         if( setTimeoutStatus < 0 )
         {
             LogError( ( "Setting socket send timeout failed." ) );
-            returnStatus = retreiveError();
+            returnStatus = retrieveError();
         }
     }
 
@@ -404,7 +404,7 @@ SocketStatus_t Sockets_Connect( int * pTcpSocket,
         if( setTimeoutStatus < 0 )
         {
             LogError( ( "Setting socket receive timeout failed." ) );
-            returnStatus = retreiveError();
+            returnStatus = retrieveError();
         }
     }
 


### PR DESCRIPTION
Add bool, cb, lsb, and topicFilterLength to the mqtt lexicon.
Fix non-comment spelling of retrieve in function platform sockets file. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
