### PR TITLE
Fix/http build warnings

### DIFF
--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -533,6 +533,9 @@ static int httpParserOnMessageBeginCallback( http_parser * pHttpParser )
     HTTPParsingContext_t * pParsingContext = NULL;
     HTTPResponse_t * pResponse = NULL;
 
+    /* Disable unused variable warning. */
+    ( void ) pResponse;
+
     assert( pHttpParser != NULL );
     assert( pHttpParser->data != NULL );
 
@@ -655,6 +658,9 @@ static int httpParserOnHeaderValueCallback( http_parser * pHttpParser,
 {
     HTTPParsingContext_t * pParsingContext = NULL;
     HTTPResponse_t * pResponse = NULL;
+
+    /* Disable unused variable warning. */
+    ( void ) pResponse;
 
     assert( pHttpParser != NULL );
     assert( pHttpParser->data != NULL );

--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -1011,6 +1011,9 @@ static HTTPStatus_t parseHttpResponse( HTTPParsingContext_t * pParsingContext,
     http_parser_settings parserSettings = { 0 };
     size_t bytesParsed = 0u;
 
+    /* Disable unused variable warning. */
+    ( void ) bytesParsed;
+
     assert( pParsingContext != NULL );
     assert( pResponse != NULL );
     assert( isHeadResponse <= 1 );
@@ -2091,6 +2094,8 @@ static int findHeaderOnHeaderCompleteCallback( http_parser * pHttpParser )
 
     /* Disable unused parameter warning. */
     ( void ) pHttpParser;
+    /* Disable unused variable warning. */
+    ( void ) pContext;
 
     assert( pHttpParser != NULL );
 


### PR DESCRIPTION
Fix unused variable warnings in `http_client.c` file for **Release** build with `-Wall -Werror -Wextra` flags


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
