### PR TITLE
Fix typo in job's status strings.

### DIFF
--- a/include/aws_iot_jobs_types.h
+++ b/include/aws_iot_jobs_types.h
@@ -54,7 +54,7 @@ typedef enum {
 extern const char *JOB_EXECUTION_QUEUED_STR;
 extern const char *JOB_EXECUTION_IN_PROGRESS_STR;
 extern const char *JOB_EXECUTION_FAILED_STR;
-extern const char *JOB_EXECUTION_SUCCESS_STR;
+extern const char *JOB_EXECUTION_SUCCEEDED_STR;
 extern const char *JOB_EXECUTION_CANCELED_STR;
 extern const char *JOB_EXECUTION_REJECTED_STR;
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-iot-device-sdk-embedded-C/issues/1063
*Description of changes:*
Fix typo in extern declaration

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
