### PR TITLE
Update mqtt.c send and recv functions to handle more bytes and expected.

### DIFF
--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -1594,20 +1594,16 @@ static HTTPStatus_t sendHttpData( const TransportInterface_t * pTransport,
                                             pIndex,
                                             bytesRemaining );
 
+        /* It is a bug in the application's transport send implementation if
+         * more bytes than expected are sent. */
+        assert( transportStatus <= (int32_t)bytesRemaining );
+
         /* A transport status of less than zero is an error. */
         if( transportStatus < 0 )
         {
             LogError( ( "Failed to send HTTP data: Transport send()"
                         " returned error: TransportStatus=%d",
                         transportStatus ) );
-            returnStatus = HTTP_NETWORK_ERROR;
-        }
-        else if( ( size_t ) transportStatus > bytesRemaining )
-        {
-            LogError( ( "Failed to send HTTP data: Transport send() wrote more data "
-                        "than what was expected: BytesSent=%d, BytesRemaining=%lu",
-                        transportStatus,
-                        bytesRemaining ) );
             returnStatus = HTTP_NETWORK_ERROR;
         }
         else
@@ -1738,23 +1734,16 @@ static HTTPStatus_t receiveHttpData( const TransportInterface_t * pTransport,
                                         pBuffer,
                                         bufferLen );
 
+    /* It is a bug in the application's transport receive implementation if
+     * more bytes than expected are received. */
+    assert( transportStatus <= (int32_t)bufferLen );
+
     /* A transport status of less than zero is an error. */
     if( transportStatus < 0 )
     {
         LogError( ( "Failed to receive HTTP data: Transport recv() "
                     "returned error: TransportStatus=%d",
                     transportStatus ) );
-        returnStatus = HTTP_NETWORK_ERROR;
-    }
-    else if( ( size_t ) transportStatus > bufferLen )
-    {
-        /* There is a bug in the transport recv if more bytes are reported
-         * to have been read than the bytes asked for. */
-        LogError( ( "Failed to receive HTTP data: Transport recv() "
-                    " read more bytes than requested: BytesReceived=%d, "
-                    "BytesRequested=%lu",
-                    transportStatus,
-                    ( unsigned long ) bufferLen ) );
         returnStatus = HTTP_NETWORK_ERROR;
     }
     else if( transportStatus > 0 )

--- a/libraries/standard/http/utest/http_send_utest.c
+++ b/libraries/standard/http/utest/http_send_utest.c
@@ -303,18 +303,6 @@ static int32_t transportSendLessThanBytesToWrite( NetworkContext_t * pNetworkCon
     return retVal;
 }
 
-/* Application transport send that writes more bytes than expected. */
-static int32_t transportSendMoreThanBytesToWrite( NetworkContext_t * pNetworkContext,
-                                                  const void * pBuffer,
-                                                  size_t bytesToWrite )
-{
-    ( void ) pNetworkContext;
-    ( void ) pBuffer;
-
-    return( bytesToWrite + 1 );
-}
-
-
 /* Application transport receive interface that sends the bytes specified in
  * firstPartBytes on the first call, then sends the rest of the response in the
  * second call. The response to send is set in pNetworkData and the current
@@ -367,17 +355,6 @@ static int32_t transportRecvNetworkError( NetworkContext_t * pNetworkContext,
     ( void ) bytesToRead;
 
     return -1;
-}
-
-/* Application transport receive that returns more bytes read than expected. */
-static int32_t transportRecvMoreThanBytesToRead( NetworkContext_t * pNetworkContext,
-                                                 void * pBuffer,
-                                                 size_t bytesToRead )
-{
-    ( void ) pNetworkContext;
-    ( void ) pBuffer;
-
-    return( bytesToRead + 1 );
 }
 
 /* Mocked http_parser_execute callback that sets the internal http_errno. */
@@ -1251,46 +1228,6 @@ void test_HTTPClient_Send_network_error_response( void )
     http_parser_init_Ignore();
 
     transportInterface.recv = transportRecvNetworkError;
-    returnStatus = HTTPClient_Send( &transportInterface,
-                                    &requestHeaders,
-                                    NULL,
-                                    0,
-                                    &response,
-                                    0 );
-    TEST_ASSERT_EQUAL( HTTP_NETWORK_ERROR, returnStatus );
-}
-
-/*-----------------------------------------------------------*/
-
-/* Test when more bytes are received than expected, when receiving a response
- * from the network. */
-void test_HTTPClient_Send_recv_too_many_bytes( void )
-{
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
-
-    http_parser_init_Ignore();
-
-    transportInterface.recv = transportRecvMoreThanBytesToRead;
-    returnStatus = HTTPClient_Send( &transportInterface,
-                                    &requestHeaders,
-                                    NULL,
-                                    0,
-                                    &response,
-                                    0 );
-    TEST_ASSERT_EQUAL( HTTP_NETWORK_ERROR, returnStatus );
-}
-
-/*-----------------------------------------------------------*/
-
-/* Test when more bytes are sent than expected, when sending data
- * over the socket. */
-void test_HTTPClient_Send_send_too_many_bytes( void )
-{
-    HTTPStatus_t returnStatus = HTTP_SUCCESS;
-
-    http_parser_init_Ignore();
-
-    transportInterface.send = transportSendMoreThanBytesToWrite;
     returnStatus = HTTPClient_Send( &transportInterface,
                                     &requestHeaders,
                                     NULL,

--- a/libraries/standard/mqtt/cbmc/stubs/network_interface_stubs.c
+++ b/libraries/standard/mqtt/cbmc/stubs/network_interface_stubs.c
@@ -38,6 +38,7 @@ int32_t NetworkInterfaceReceiveStub( NetworkContext_t * pNetworkContext,
      * int32_t value returned from the application defined network receive
      * implementation. */
     int32_t bytesOrError;
+    __CPROVER_assume( bytesOrError <= bytesToRecv );
 
     return bytesOrError;
 }

--- a/libraries/standard/mqtt/include/mqtt.h
+++ b/libraries/standard/mqtt/include/mqtt.h
@@ -44,8 +44,23 @@ typedef struct MQTTPubAckInfo             MQTTPubAckInfo_t;
 struct MQTTContext;
 typedef struct MQTTContext                MQTTContext_t;
 
+/**
+ * @brief Application provided callback to retrieve the current time in
+ * milliseconds.
+ *
+ * @return The current time in milliseconds.
+ */
 typedef uint32_t (* MQTTGetCurrentTimeFunc_t )( void );
 
+/**
+ * @brief Application callback for receiving incoming publishes and incoming
+ * acks.
+ *
+ * @param[in] pContext Initialized MQTT context.
+ * @param[in] pPacketInfo Information on the type of incoming MQTT packet.
+ * @param[in] packetIdentifier Packet identifier of incoming PUBLISH packet.
+ * @param[in] pPublishInfo Incoming PUBLISH packet parameters.
+ */
 typedef void (* MQTTEventCallback_t )( MQTTContext_t * pContext,
                                        MQTTPacketInfo_t * pPacketInfo,
                                        uint16_t packetIdentifier,

--- a/libraries/standard/mqtt/lexicon.txt
+++ b/libraries/standard/mqtt/lexicon.txt
@@ -7,6 +7,7 @@ app
 aws
 bool
 bufferlength
+bytesorerror
 bytesreceived
 bytestoread
 bytestoreceive
@@ -110,6 +111,7 @@ mqttsuccess
 msb
 networkbuffer
 networkcontext
+networkinterfacesendstub
 newstate
 nextpacketid
 noninfringement

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -337,10 +337,14 @@ static int32_t sendPacket( MQTTContext_t * pContext,
         else if( ( size_t ) bytesSent > bytesRemaining )
         {
             LogError( ( "Transport send returned more bytes than expected: "
-                        "BytesExpected=%lu, BytesReceived=%d",
+                        "BytesExpected=%lu, BytesReceived=%d.",
                         bytesRemaining,
                         bytesSent ) );
             sendError = true;
+
+            /* In this error condition, the total amount of bytes sent is
+             * not saved. The returned value from this function will be less
+             * than bytesToSend, which will be seen as an error. */
         }
         else
         {
@@ -439,7 +443,7 @@ static int32_t recvExact( const MQTTContext_t * pContext,
 
         if( bytesRecvd < 0 )
         {
-            LogError( ( "Network error while receiving packet: ReturnCode=%d",
+            LogError( ( "Network error while receiving packet: ReturnCode=%d.",
                         bytesRecvd ) );
             totalBytesRecvd = bytesRecvd;
             receiveError = true;
@@ -447,15 +451,14 @@ static int32_t recvExact( const MQTTContext_t * pContext,
         else if( bytesRecvd > ( int32_t ) bytesRemaining )
         {
             LogError( ( "Transport receive returned more bytes than expected: "
-                        "BytesExpected=%lu, BytesReceived=%d",
+                        "BytesExpected=%lu, BytesReceived=%d.",
                         bytesRemaining,
                         bytesRecvd ) );
             receiveError = true;
 
-            /* Do not save this returned error in the total amount of bytes
-             * received to pass back to the caller. The returned value from this
-             * function will be less than bytesToRecv, which will be seen as an
-             * error. */
+            /* In this error condition, the total amount of bytes received is
+             * not saved. The returned value from this function will be less
+             * than bytesToRecv, which will be seen as an error. */
         }
         else
         {
@@ -463,7 +466,7 @@ static int32_t recvExact( const MQTTContext_t * pContext,
             totalBytesRecvd += ( int32_t ) bytesRecvd;
             pIndex += bytesRecvd;
             LogDebug( ( "BytesReceived=%d, BytesRemaining=%lu, "
-                        "TotalBytesReceived=%d",
+                        "TotalBytesReceived=%d.",
                         bytesRecvd,
                         bytesRemaining,
                         totalBytesRecvd ) );
@@ -566,7 +569,7 @@ static MQTTStatus_t receivePacket( const MQTTContext_t * pContext,
     {
         LogError( ( "Incoming packet will be dumped: "
                     "Packet length exceeds network buffer size."
-                    "PacketSize=%lu, NetworkBufferSize=%lu",
+                    "PacketSize=%lu, NetworkBufferSize=%lu.",
                     incomingPacket.remainingLength,
                     pContext->networkBuffer.size ) );
         status = discardPacket( pContext,
@@ -737,7 +740,7 @@ static MQTTStatus_t handleIncomingPublish( MQTTContext_t * pContext,
     assert( pIncomingPacket != NULL );
 
     status = MQTT_DeserializePublish( pIncomingPacket, &packetIdentifier, &publishInfo );
-    LogInfo( ( "De-serialized incoming PUBLISH packet: DeserializerResult=%d", status ) );
+    LogInfo( ( "De-serialized incoming PUBLISH packet: DeserializerResult=%d.", status ) );
 
     if( status == MQTTSuccess )
     {

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -328,23 +328,15 @@ static int32_t sendPacket( MQTTContext_t * pContext,
                                                        pIndex,
                                                        bytesRemaining );
 
+        /* It is a bug in the application's transport send implementation if
+         * more bytes than expected are sent. */
+        assert( bytesSent <= ( int32_t ) bytesRemaining );
+
         if( bytesSent <= 0 )
         {
             LogError( ( "Transport send failed. Error code=%d.", bytesSent ) );
             totalBytesSent = bytesSent;
             sendError = true;
-        }
-        else if( ( size_t ) bytesSent > bytesRemaining )
-        {
-            LogError( ( "Transport send returned more bytes than expected: "
-                        "BytesExpected=%lu, BytesReceived=%d.",
-                        bytesRemaining,
-                        bytesSent ) );
-            sendError = true;
-
-            /* In this error condition, the total amount of bytes sent is
-             * not saved. The returned value from this function will be less
-             * than bytesToSend, which will be seen as an error. */
         }
         else
         {
@@ -441,24 +433,16 @@ static int32_t recvExact( const MQTTContext_t * pContext,
                                pIndex,
                                bytesRemaining );
 
+        /* It is a bug in the application's transport receive implementation if
+         * more bytes than expected are received. */
+        assert( bytesRecvd <= ( int32_t ) bytesRemaining );
+
         if( bytesRecvd < 0 )
         {
             LogError( ( "Network error while receiving packet: ReturnCode=%d.",
                         bytesRecvd ) );
             totalBytesRecvd = bytesRecvd;
             receiveError = true;
-        }
-        else if( bytesRecvd > ( int32_t ) bytesRemaining )
-        {
-            LogError( ( "Transport receive returned more bytes than expected: "
-                        "BytesExpected=%lu, BytesReceived=%d.",
-                        bytesRemaining,
-                        bytesRecvd ) );
-            receiveError = true;
-
-            /* In this error condition, the total amount of bytes received is
-             * not saved. The returned value from this function will be less
-             * than bytesToRecv, which will be seen as an error. */
         }
         else
         {

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -41,11 +41,6 @@
     #define MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT    ( 5U )
 #endif
 
-/**
- * @brief A return code indicating an error from the transport interface.
- */
-#define TRANSPORT_ERROR    ( -1 )
-
 /*-----------------------------------------------------------*/
 
 /**
@@ -55,7 +50,7 @@
  * @brief param[in] pBufferToSend Buffer to be sent to network.
  * @brief param[in] bytesToSend Number of bytes to be sent.
  *
- * @return Total number of bytes sent; -1 if there is an error.
+ * @return Total number of bytes sent, or negative number on network error.
  */
 static int32_t sendPacket( MQTTContext_t * pContext,
                            const uint8_t * pBufferToSend,
@@ -316,6 +311,7 @@ static int32_t sendPacket( MQTTContext_t * pContext,
     size_t bytesRemaining = bytesToSend;
     int32_t totalBytesSent = 0, bytesSent;
     uint32_t sendTime = 0U;
+    bool sendError = false;
 
     assert( pContext != NULL );
     assert( pContext->callbacks.getTime != NULL );
@@ -326,33 +322,41 @@ static int32_t sendPacket( MQTTContext_t * pContext,
     sendTime = pContext->callbacks.getTime();
 
     /* Loop until the entire packet is sent. */
-    while( bytesRemaining > 0UL )
+    while( ( bytesRemaining > 0UL ) && ( sendError == false ) )
     {
         bytesSent = pContext->transportInterface.send( pContext->transportInterface.pNetworkContext,
                                                        pIndex,
                                                        bytesRemaining );
 
-        if( bytesSent > 0 )
+        if( bytesSent <= 0 )
+        {
+            LogError( ( "Transport send failed. Error code=%d.", bytesSent ) );
+            totalBytesSent = bytesSent;
+            sendError = true;
+        }
+        else if( ( size_t ) bytesSent > bytesRemaining )
+        {
+            LogError( ( "Transport send returned more bytes than expected: "
+                        "BytesExpected=%lu, BytesReceived=%d",
+                        bytesRemaining,
+                        bytesSent ) );
+            sendError = true;
+        }
+        else
         {
             bytesRemaining -= ( size_t ) bytesSent;
             totalBytesSent += bytesSent;
             pIndex += bytesSent;
-            LogDebug( ( "Bytes sent=%d, bytes remaining=%lu,"
-                        "total bytes sent=%d.",
+            LogDebug( ( "BytesSent=%d, BytesRemaining=%lu,"
+                        " TotalBytesSent=%d.",
                         bytesSent,
                         bytesRemaining,
                         totalBytesSent ) );
         }
-        else
-        {
-            LogError( ( "Transport send failed. Error code=%d.", bytesSent ) );
-            totalBytesSent = TRANSPORT_ERROR;
-            break;
-        }
     }
 
     /* Update time of last transmission if the entire packet is successfully sent. */
-    if( totalBytesSent > 0 )
+    if( bytesRemaining == 0U )
     {
         pContext->lastPacketTime = sendTime;
         LogDebug( ( "Successfully sent packet at time %u.",
@@ -433,18 +437,36 @@ static int32_t recvExact( const MQTTContext_t * pContext,
                                pIndex,
                                bytesRemaining );
 
-        if( bytesRecvd >= 0 )
-        {
-            bytesRemaining -= ( size_t ) bytesRecvd;
-            totalBytesRecvd += ( int32_t ) bytesRecvd;
-            pIndex += bytesRecvd;
-        }
-        else
+        if( bytesRecvd < 0 )
         {
             LogError( ( "Network error while receiving packet: ReturnCode=%d",
                         bytesRecvd ) );
             totalBytesRecvd = bytesRecvd;
             receiveError = true;
+        }
+        else if( bytesRecvd > ( int32_t ) bytesRemaining )
+        {
+            LogError( ( "Transport receive returned more bytes than expected: "
+                        "BytesExpected=%lu, BytesReceived=%d",
+                        bytesRemaining,
+                        bytesRecvd ) );
+            receiveError = true;
+
+            /* Do not save this returned error in the total amount of bytes
+             * received to pass back to the caller. The returned value from this
+             * function will be less than bytesToRecv, which will be seen as an
+             * error. */
+        }
+        else
+        {
+            bytesRemaining -= ( size_t ) bytesRecvd;
+            totalBytesRecvd += ( int32_t ) bytesRecvd;
+            pIndex += bytesRecvd;
+            LogDebug( ( "BytesReceived=%d, BytesRemaining=%lu, "
+                        "TotalBytesReceived=%d",
+                        bytesRecvd,
+                        bytesRemaining,
+                        totalBytesRecvd ) );
         }
 
         elapsedTimeMs = calculateElapsedTime( getTimeStampMs(), entryTimeMs );
@@ -538,6 +560,7 @@ static MQTTStatus_t receivePacket( const MQTTContext_t * pContext,
     size_t bytesToReceive = 0U;
 
     assert( pContext != NULL );
+    assert( pContext->networkBuffer.pBuffer != NULL );
 
     if( incomingPacket.remainingLength > pContext->networkBuffer.size )
     {
@@ -965,9 +988,17 @@ static MQTTStatus_t receiveSingleIteration( MQTTContext_t * pContext,
     }
     else
     {
-        /* Receive packet. Remaining time is recalculated before calling this
-         * function. */
-        status = receivePacket( pContext, incomingPacket, remainingTimeMs );
+        if( pContext->networkBuffer.pBuffer != NULL )
+        {
+            /* Receive packet. Remaining time is recalculated before calling this
+             * function. */
+            status = receivePacket( pContext, incomingPacket, remainingTimeMs );
+        }
+        else
+        {
+            LogError( ( "The MQTT context's networkBuffer must not be NULL." ) );
+            status = MQTTBadParameter;
+        }
     }
 
     /* Handle received packet. If no data was read then this will not execute. */
@@ -1051,7 +1082,7 @@ static MQTTStatus_t sendPublish( MQTTContext_t * pContext,
                             pContext->networkBuffer.pBuffer,
                             headerSize );
 
-    if( bytesSent < 0 )
+    if( ( bytesSent < 0 ) || ( ( size_t ) bytesSent != headerSize ) )
     {
         LogError( ( "Transport send failed for PUBLISH header." ) );
         status = MQTTSendFailed;
@@ -1066,7 +1097,7 @@ static MQTTStatus_t sendPublish( MQTTContext_t * pContext,
                                 pPublishInfo->pPayload,
                                 pPublishInfo->payloadLength );
 
-        if( bytesSent < 0 )
+        if( ( bytesSent < 0 ) || ( ( size_t ) bytesSent != pPublishInfo->payloadLength ) )
         {
             LogError( ( "Transport send failed for PUBLISH payload." ) );
             status = MQTTSendFailed;
@@ -1398,7 +1429,7 @@ MQTTStatus_t MQTT_Connect( MQTTContext_t * pContext,
                                 pContext->networkBuffer.pBuffer,
                                 packetSize );
 
-        if( bytesSent < 0 )
+        if( ( bytesSent < 0 ) || ( ( size_t ) bytesSent != packetSize ) )
         {
             LogError( ( "Transport send failed for CONNECT packet." ) );
             status = MQTTSendFailed;
@@ -1486,7 +1517,7 @@ MQTTStatus_t MQTT_Subscribe( MQTTContext_t * pContext,
                                 pContext->networkBuffer.pBuffer,
                                 packetSize );
 
-        if( bytesSent < 0 )
+        if( ( bytesSent < 0 ) || ( ( size_t ) bytesSent != packetSize ) )
         {
             LogError( ( "Transport send failed for SUBSCRIBE packet." ) );
             status = MQTTSendFailed;
@@ -1618,7 +1649,8 @@ MQTTStatus_t MQTT_Ping( MQTTContext_t * pContext )
                                 pContext->networkBuffer.pBuffer,
                                 packetSize );
 
-        if( bytesSent < 0 )
+        /* It is an error to not send the entire PINGREQ packet. */
+        if( ( bytesSent < 0 ) || ( ( size_t ) bytesSent != packetSize ) )
         {
             LogError( ( "Transport send failed for PINGREQ packet." ) );
             status = MQTTSendFailed;
@@ -1680,7 +1712,7 @@ MQTTStatus_t MQTT_Unsubscribe( MQTTContext_t * pContext,
                                 pContext->networkBuffer.pBuffer,
                                 packetSize );
 
-        if( bytesSent < 0 )
+        if( ( bytesSent < 0 ) || ( ( size_t ) bytesSent != packetSize ) )
         {
             LogError( ( "Transport send failed for UNSUBSCRIBE packet." ) );
             status = MQTTSendFailed;
@@ -1730,7 +1762,7 @@ MQTTStatus_t MQTT_Disconnect( MQTTContext_t * pContext )
                                 pContext->networkBuffer.pBuffer,
                                 packetSize );
 
-        if( bytesSent < 0 )
+        if( ( bytesSent < 0 ) || ( ( size_t ) bytesSent != packetSize ) )
         {
             LogError( ( "Transport send failed for DISCONNECT packet." ) );
             status = MQTTSendFailed;

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -496,7 +496,7 @@ static void serializePublishCommon( const MQTTPublishInfo_t * pPublishInfo,
     /* Packet Id should be non zero for QoS1 and QoS2. */
     assert( ( pPublishInfo->qos == MQTTQoS0 ) || ( packetIdentifier != 0U ) );
     /* Duplicate flag should be set only for Qos1 or Qos2. */
-    assert( ( pPublishInfo->dup == false ) || ( pPublishInfo->qos != MQTTQoS0 ) );
+    assert( ( pPublishInfo->dup != true ) || ( pPublishInfo->qos != MQTTQoS0 ) );
 
     /* Get the start address of the buffer. */
     pIndex = pFixedBuffer->pBuffer;

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -655,7 +655,7 @@ static bool incomingPacketValid( uint8_t packetType )
 
         /* Any other packet type is invalid. */
         default:
-            LogWarn( ( "Incoming packet invalid: Packet type=%u",
+            LogWarn( ( "Incoming packet invalid: Packet type=%u.",
                        packetType ) );
             break;
     }
@@ -1381,7 +1381,7 @@ MQTTStatus_t MQTT_GetConnectPacketSize( const MQTTConnectInfo_t * pConnectInfo,
          * By bounding the payloadLength of the will message, the CONNECT
          * packet will never be larger than 327699 bytes. */
         LogError( ( "The Will Message length must not exceed %d. "
-                    "pWillInfo->payloadLength=%lu",
+                    "pWillInfo->payloadLength=%lu.",
                     UINT16_MAX,
                     pWillInfo->payloadLength ) );
         status = MQTTBadParameter;
@@ -2227,7 +2227,7 @@ MQTTStatus_t MQTT_GetIncomingPacketTypeAndLength( TransportRecv_t readFunc,
         }
         else
         {
-            LogError( ( "Incoming packet invalid: Packet type=%u",
+            LogError( ( "Incoming packet invalid: Packet type=%u.",
                         pIncomingPacket->type ) );
             status = MQTTBadResponse;
         }
@@ -2243,7 +2243,7 @@ MQTTStatus_t MQTT_GetIncomingPacketTypeAndLength( TransportRecv_t readFunc,
     else if( status != MQTTBadParameter )
     {
         LogError( ( "A single byte was not read from the transport: "
-                    "transportStatus=%d",
+                    "transportStatus=%d.",
                     bytesReceived ) );
         status = MQTTRecvFailed;
     }

--- a/libraries/standard/mqtt/src/mqtt_state.c
+++ b/libraries/standard/mqtt/src/mqtt_state.c
@@ -525,7 +525,7 @@ static MQTTStatus_t addRecord( MQTTPubAckInfo_t * records,
             if( records[ index ].packetId == packetId )
             {
                 /* Collision. */
-                LogError( ( "Collision when adding PacketID=%u at index=%u",
+                LogError( ( "Collision when adding PacketID=%u at index=%u.",
                             packetId,
                             index ) );
 

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -257,20 +257,6 @@ static int32_t transportSendFailure( NetworkContext_t * pNetworkContext,
 }
 
 /**
- * @brief Mocked transport send that fails because more than bytesToWrite is
- * returned.
- */
-static int32_t transportSendFailureTooManyBytes( NetworkContext_t * pNetworkContext,
-                                                 const void * pBuffer,
-                                                 size_t bytesToWrite )
-{
-    ( void ) pNetworkContext;
-    ( void ) pBuffer;
-    ( void ) bytesToWrite;
-    return bytesToWrite + 1;
-}
-
-/**
  * @brief Mocked transport send that succeeds then fails.
  */
 static int32_t transportSendSucceedThenFail( NetworkContext_t * pNetworkContext,
@@ -286,29 +272,6 @@ static int32_t transportSendSucceedThenFail( NetworkContext_t * pNetworkContext,
     if( counter++ )
     {
         retVal = -1;
-        counter = 0;
-    }
-
-    return retVal;
-}
-
-/**
- * @brief Mocked transport send that succeeds then fails with sending more bytes
- * than expected.
- */
-static int32_t transportSendSucceedThenFailTooManyBytes( NetworkContext_t * pNetworkContext,
-                                                         const void * pMessage,
-                                                         size_t bytesToSend )
-{
-    int32_t retVal = bytesToSend;
-    static int counter = 0;
-
-    ( void ) pNetworkContext;
-    ( void ) pMessage;
-
-    if( counter++ )
-    {
-        retVal = bytesToSend + 1;
         counter = 0;
     }
 
@@ -344,20 +307,6 @@ static int32_t transportRecvFailure( NetworkContext_t * pNetworkContext,
     ( void ) pBuffer;
     ( void ) bytesToRead;
     return -1;
-}
-
-/**
- * @brief Mocked transport receive that fails because more than bytesToRead is
- * returned.
- */
-static int32_t transportRecvFailureTooManyBytes( NetworkContext_t * pNetworkContext,
-                                                 void * pBuffer,
-                                                 size_t bytesToRead )
-{
-    ( void ) pNetworkContext;
-    ( void ) pBuffer;
-    ( void ) bytesToRead;
-    return bytesToRead + 1;
 }
 
 /**
@@ -710,15 +659,6 @@ void test_MQTT_Connect_sendConnect( void )
     status = MQTT_Connect( &mqttContext, &connectInfo, NULL, timeout, &sessionPresent );
     TEST_ASSERT_EQUAL_INT( MQTTSendFailed, status );
 
-    mqttContext.transportInterface.send = transportSendFailureTooManyBytes;
-    MQTT_GetConnectPacketSize_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_GetConnectPacketSize_IgnoreArg_pPacketSize();
-    MQTT_GetConnectPacketSize_IgnoreArg_pRemainingLength();
-    MQTT_GetConnectPacketSize_ReturnThruPtr_pPacketSize( &packetSize );
-    MQTT_GetConnectPacketSize_ReturnThruPtr_pRemainingLength( &remainingLength );
-    status = MQTT_Connect( &mqttContext, &connectInfo, NULL, timeout, &sessionPresent );
-    TEST_ASSERT_EQUAL_INT( MQTTSendFailed, status );
-
     /* Send the CONNECT successfully. This provides branch coverage for sendPacket. */
     mqttContext.transportInterface.send = transportSendSuccess;
     MQTT_GetConnectPacketSize_ExpectAnyArgsAndReturn( MQTTSuccess );
@@ -779,17 +719,6 @@ void test_MQTT_Connect_receiveConnack( void )
     incomingPacket.remainingLength = 2;
     timeout = 2;
     mqttContext.transportInterface.recv = transportRecvFailure;
-    MQTT_GetIncomingPacketTypeAndLength_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_GetIncomingPacketTypeAndLength_ReturnThruPtr_pIncomingPacket( &incomingPacket );
-    status = MQTT_Connect( &mqttContext, &connectInfo, NULL, timeout, &sessionPresent );
-    TEST_ASSERT_EQUAL_INT( MQTTRecvFailed, status );
-
-    /* Test a transport receive failure again, but with receiving more bytes
-     * expected. */
-    incomingPacket.type = MQTT_PACKET_TYPE_CONNACK;
-    incomingPacket.remainingLength = 2;
-    timeout = 2;
-    mqttContext.transportInterface.recv = transportRecvFailureTooManyBytes;
     MQTT_GetIncomingPacketTypeAndLength_ExpectAnyArgsAndReturn( MQTTSuccess );
     MQTT_GetIncomingPacketTypeAndLength_ReturnThruPtr_pIncomingPacket( &incomingPacket );
     status = MQTT_Connect( &mqttContext, &connectInfo, NULL, timeout, &sessionPresent );
@@ -1260,26 +1189,9 @@ void test_MQTT_Publish( void )
     status = MQTT_Publish( &mqttContext, &publishInfo, 0 );
     TEST_ASSERT_EQUAL_INT( MQTTSendFailed, status );
 
-    /* Test send again with more bytes than expected returned. */
-    mqttContext.transportInterface.send = transportSendFailureTooManyBytes;
-    headerSize = 1;
-    MQTT_SerializePublishHeader_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_SerializePublishHeader_ReturnThruPtr_pHeaderSize( &headerSize );
-    status = MQTT_Publish( &mqttContext, &publishInfo, 0 );
-    TEST_ASSERT_EQUAL_INT( MQTTSendFailed, status );
-
     /* We want to test the first call to sendPacket within sendPublish succeeding,
      * and the second one failing. */
     mqttContext.transportInterface.send = transportSendSucceedThenFail;
-    MQTT_SerializePublishHeader_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_SerializePublishHeader_ReturnThruPtr_pHeaderSize( &headerSize );
-    publishInfo.pPayload = "Test";
-    publishInfo.payloadLength = 4;
-    status = MQTT_Publish( &mqttContext, &publishInfo, 0 );
-    TEST_ASSERT_EQUAL_INT( MQTTSendFailed, status );
-
-    /* Test again failing when more bytes than expected are sent. */
-    mqttContext.transportInterface.send = transportSendSucceedThenFailTooManyBytes;
     MQTT_SerializePublishHeader_ExpectAnyArgsAndReturn( MQTTSuccess );
     MQTT_SerializePublishHeader_ReturnThruPtr_pHeaderSize( &headerSize );
     publishInfo.pPayload = "Test";
@@ -1375,14 +1287,6 @@ void test_MQTT_Disconnect( void )
     TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
 
     /* Send failure with network error. */
-    MQTT_GetDisconnectPacketSize_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_GetDisconnectPacketSize_ReturnThruPtr_pPacketSize( &disconnectSize );
-    MQTT_SerializeDisconnect_ExpectAnyArgsAndReturn( MQTTSuccess );
-    status = MQTT_Disconnect( &mqttContext );
-    TEST_ASSERT_EQUAL( MQTTSendFailed, status );
-
-    /* Send failure with more bytes than expected. */
-    mqttContext.transportInterface.send = transportSendFailureTooManyBytes;
     MQTT_GetDisconnectPacketSize_ExpectAnyArgsAndReturn( MQTTSuccess );
     MQTT_GetDisconnectPacketSize_ReturnThruPtr_pPacketSize( &disconnectSize );
     MQTT_SerializeDisconnect_ExpectAnyArgsAndReturn( MQTTSuccess );
@@ -2075,17 +1979,6 @@ void test_MQTT_Subscribe_error_paths( void )
     /* Expect the above calls when running MQTT_Subscribe. */
     mqttStatus = MQTT_Subscribe( &context, &subscribeInfo, 1, MQTT_FIRST_VALID_PACKET_ID );
     TEST_ASSERT_EQUAL( MQTTSendFailed, mqttStatus );
-
-    /* Test a failure is returned when receiving too many bytes from transport
-     * send. */
-    context.transportInterface.send = transportSendFailureTooManyBytes;
-    MQTT_GetSubscribePacketSize_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_GetSubscribePacketSize_ReturnThruPtr_pPacketSize( &packetSize );
-    MQTT_GetSubscribePacketSize_ReturnThruPtr_pRemainingLength( &remainingLength );
-    MQTT_SerializeSubscribe_ExpectAnyArgsAndReturn( MQTTSuccess );
-    /* Expect the above calls when running MQTT_Subscribe. */
-    mqttStatus = MQTT_Subscribe( &context, &subscribeInfo, 1, MQTT_FIRST_VALID_PACKET_ID );
-    TEST_ASSERT_EQUAL( MQTTSendFailed, mqttStatus );
 }
 
 /* ========================================================================== */
@@ -2186,17 +2079,6 @@ void test_MQTT_Unsubscribe_error_path( void )
     /* Expect the above calls when running MQTT_Unsubscribe. */
     mqttStatus = MQTT_Unsubscribe( &context, &subscribeInfo, 1, MQTT_FIRST_VALID_PACKET_ID );
     TEST_ASSERT_EQUAL( MQTTSendFailed, mqttStatus );
-
-    /* Test that MQTTSendFailed is returned when receiving too many bytes from
-     * the transport send. */
-    context.transportInterface.send = transportSendFailureTooManyBytes;
-    MQTT_GetUnsubscribePacketSize_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_GetUnsubscribePacketSize_ReturnThruPtr_pPacketSize( &packetSize );
-    MQTT_GetUnsubscribePacketSize_ReturnThruPtr_pRemainingLength( &remainingLength );
-    MQTT_SerializeUnsubscribe_ExpectAnyArgsAndReturn( MQTTSuccess );
-    /* Expect the above calls when running MQTT_Unsubscribe. */
-    mqttStatus = MQTT_Unsubscribe( &context, &subscribeInfo, 1, MQTT_FIRST_VALID_PACKET_ID );
-    TEST_ASSERT_EQUAL( MQTTSendFailed, mqttStatus );
 }
 
 /* ========================================================================== */
@@ -2278,21 +2160,6 @@ void test_MQTT_Ping_error_path( void )
     /* Expect the above calls when running MQTT_Ping. */
     mqttStatus = MQTT_Ping( &context );
     TEST_ASSERT_EQUAL( MQTTSendFailed, mqttStatus );
-
-    /* Test more bytes than expected are received from sending the PING packet. */
-    transport.send = transportSendFailureTooManyBytes;
-
-    /* Initialize context. */
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
-    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
-    /* Verify MQTTSendFailed is propagated when transport interface returns an error. */
-    MQTT_GetPingreqPacketSize_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_GetPingreqPacketSize_ReturnThruPtr_pPacketSize( &pingreqSize );
-    MQTT_SerializePingreq_ExpectAnyArgsAndReturn( MQTTSuccess );
-    /* Expect the above calls when running MQTT_Ping. */
-    mqttStatus = MQTT_Ping( &context );
-    TEST_ASSERT_EQUAL( MQTTSendFailed, mqttStatus );
-
 
     /* Initialize context. */
     mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );


### PR DESCRIPTION
- Add some documentation to application callbacks.
- Update recvExact and sendPacket to handle the case of the transport layer returning more bytes than expected.
- Add unit tests for changes.
- Fix MISRA flags left in mqtt_lightweight.c and straggling pFixedBuffer variables.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
