### PR TITLE
Exclude mutual auth demo from default targets if no credentials provided

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -7,6 +7,34 @@ if( NOT DEFINED PLATFORM_NAME )
     endif()
 endif()
 
+# This function will add a demo target to the list of default targets
+# if all AWS Credentials are defined.
+function(check_aws_credentials demo_name)
+    if(AWS_IOT_ENDPOINT AND CLIENT_CERT_PATH AND CLIENT_PRIVATE_KEY_PATH)
+        target_compile_definitions(
+            ${demo_name} PRIVATE
+                AWS_IOT_ENDPOINT="${AWS_IOT_ENDPOINT}"
+                CLIENT_CERT_PATH="${CLIENT_CERT_PATH}"
+                CLIENT_PRIVATE_KEY_PATH="${CLIENT_PRIVATE_KEY_PATH}"
+        )
+        set(CMAKE_REQUIRED_DEFINITIONS -DAWS_IOT_ENDPOINT -DCLIENT_CERT_PATH -DCLIENT_PRIVATE_KEY_PATH)
+    endif()
+
+    set(FILES_TO_CHECK "demo_config.h")
+    list(APPEND CMAKE_REQUIRED_INCLUDES "${CMAKE_CURRENT_LIST_DIR};${LOGGING_INCLUDE_DIRS}")
+    unset(HAVE_AWS_ENDPOINT CACHE)
+    unset(HAVE_CLIENT_CERT CACHE)
+    unset(HAVE_PRIVATE_KEY CACHE)
+    check_symbol_exists(AWS_IOT_ENDPOINT ${FILES_TO_CHECK} HAVE_AWS_ENDPOINT)
+    check_symbol_exists(CLIENT_CERT_PATH ${FILES_TO_CHECK} HAVE_CLIENT_CERT)
+    check_symbol_exists(CLIENT_PRIVATE_KEY_PATH ${FILES_TO_CHECK} HAVE_PRIVATE_KEY)
+    
+    if(NOT(HAVE_AWS_ENDPOINT AND HAVE_CLIENT_CERT AND HAVE_PRIVATE_KEY))
+        message("To run ${demo_name}, define AWS_IOT_ENDPOINT, CLIENT_CERT_PATH, CLIENT_PRIVATE_KEY_PATH in demos/${demo_name}/demo_config.h.")
+        set_target_properties(${demo_name} PROPERTIES EXCLUDE_FROM_ALL true)
+    endif()
+endfunction()
+
 # Include each subdirectory that has a CMakeLists.txt file in it
 file(GLOB demo_dirs "${DEMOS_DIR}/*/*")
 foreach(demo_dir IN LISTS demo_dirs)
@@ -15,10 +43,3 @@ foreach(demo_dir IN LISTS demo_dirs)
         add_subdirectory(${demo_dir})
     endif()
 endforeach()
-
-# Replace macro definition if defined
-if(AWS_IOT_ENDPOINT AND CLIENT_CERT_PATH AND CLIENT_PRIVATE_KEY_PATH)
-    set_target_properties(http_demo_mutual_auth mqtt_demo_mutual_auth 
-                            PROPERTIES COMPILE_DEFINITIONS 
-                            "AWS_IOT_ENDPOINT;CLIENT_CERT_PATH;CLIENT_PRIVATE_KEY_PATH")
-endif()

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -30,7 +30,7 @@ function(check_aws_credentials demo_name)
     check_symbol_exists(CLIENT_PRIVATE_KEY_PATH ${FILES_TO_CHECK} HAVE_PRIVATE_KEY)
     
     if(NOT(HAVE_AWS_ENDPOINT AND HAVE_CLIENT_CERT AND HAVE_PRIVATE_KEY))
-        message("To run ${demo_name}, define AWS_IOT_ENDPOINT, CLIENT_CERT_PATH, CLIENT_PRIVATE_KEY_PATH in demos/${demo_name}/demo_config.h.")
+        message("To run ${demo_name}, define AWS_IOT_ENDPOINT, CLIENT_CERT_PATH, CLIENT_PRIVATE_KEY_PATH in ${demo_name}/demo_config.h.")
         set_target_properties(${demo_name} PROPERTIES EXCLUDE_FROM_ALL true)
     endif()
 endfunction()

--- a/demos/http/http_demo_mutual_auth/CMakeLists.txt
+++ b/demos/http/http_demo_mutual_auth/CMakeLists.txt
@@ -2,26 +2,11 @@ include(CheckSymbolExists)
 
 set( DEMO_NAME "http_demo_mutual_auth" )
 
-# Check if all required macros needed to run this demo are defined
-list(APPEND CMAKE_REQUIRED_INCLUDES "${CMAKE_CURRENT_LIST_DIR};${LOGGING_INCLUDE_DIRS}")
-if(AWS_IOT_ENDPOINT AND CLIENT_CERT_PATH AND CLIENT_PRIVATE_KEY_PATH)
-    set(CMAKE_REQUIRED_DEFINITIONS -DAWS_IOT_ENDPOINT -DCLIENT_CERT_PATH -DCLIENT_PRIVATE_KEY_PATH)
-endif()
-unset(HAVE_AWS_ENDPOINT CACHE)
-unset(HAVE_CLIENT_CERT CACHE)
-unset(HAVE_PRIVATE_KEY CACHE)
-set(FILES_TO_CHECK "demo_config.h")
-check_symbol_exists(AWS_IOT_ENDPOINT ${FILES_TO_CHECK} HAVE_AWS_ENDPOINT)
-check_symbol_exists(CLIENT_CERT_PATH ${FILES_TO_CHECK} HAVE_CLIENT_CERT)
-check_symbol_exists(CLIENT_PRIVATE_KEY_PATH ${FILES_TO_CHECK} HAVE_PRIVATE_KEY)
-if(NOT(HAVE_AWS_ENDPOINT AND HAVE_CLIENT_CERT AND HAVE_PRIVATE_KEY))
-    message("To run ${DEMO_NAME}, define AWS_IOT_ENDPOINT, CLIENT_CERT_PATH, CLIENT_PRIVATE_KEY_PATH in demos/${DEMO_NAME}/demo_config.h.")
-    message("After doing this, rebuild using cmake ..")
-    return()
-endif()
-
 # Demo target.
 add_executable(${DEMO_NAME})
+
+# Add to default target if all required macros needed to run this demo are defined
+check_aws_credentials(${DEMO_NAME})
 
 target_sources(
     ${DEMO_NAME}

--- a/demos/mqtt/mqtt_demo_mutual_auth/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_mutual_auth/CMakeLists.txt
@@ -2,26 +2,11 @@ include(CheckSymbolExists)
 
 set( DEMO_NAME "mqtt_demo_mutual_auth" )
 
-# Check if all required macros needed to run this demo are defined
-list(APPEND CMAKE_REQUIRED_INCLUDES "${CMAKE_CURRENT_LIST_DIR};${LOGGING_INCLUDE_DIRS}")
-if(AWS_IOT_ENDPOINT AND CLIENT_CERT_PATH AND CLIENT_PRIVATE_KEY_PATH)
-    set(CMAKE_REQUIRED_DEFINITIONS -DAWS_IOT_ENDPOINT -DCLIENT_CERT_PATH -DCLIENT_PRIVATE_KEY_PATH)
-endif()
-unset(HAVE_AWS_ENDPOINT CACHE)
-unset(HAVE_CLIENT_CERT CACHE)
-unset(HAVE_PRIVATE_KEY CACHE)
-set(FILES_TO_CHECK "demo_config.h")
-check_symbol_exists(AWS_IOT_ENDPOINT ${FILES_TO_CHECK} HAVE_AWS_ENDPOINT)
-check_symbol_exists(CLIENT_CERT_PATH ${FILES_TO_CHECK} HAVE_CLIENT_CERT)
-check_symbol_exists(CLIENT_PRIVATE_KEY_PATH ${FILES_TO_CHECK} HAVE_PRIVATE_KEY)
-if(NOT(HAVE_AWS_ENDPOINT AND HAVE_CLIENT_CERT AND HAVE_PRIVATE_KEY))
-    message("To run ${DEMO_NAME}, define AWS_IOT_ENDPOINT, CLIENT_CERT_PATH, CLIENT_PRIVATE_KEY_PATH in demos/${DEMO_NAME}/demo_config.h")
-    message("After doing this, rebuild using cmake ..")
-    return()
-endif()
-
 # Demo target.
 add_executable(${DEMO_NAME})
+
+# Add to default target if all required macros needed to run this demo are defined
+check_aws_credentials(${DEMO_NAME})
 
 target_sources(
     ${DEMO_NAME}


### PR DESCRIPTION
It used to be that the mutual auth demos were not added as a target when no credentials are provided. Now, we simply remove it from the ALL target so that `make` will no longer build the mutual auth demos. However, a user can always see the mutual auth targets through `make help`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
