### PR TITLE
Update MQTT_Init API function to accept parameters by value

### DIFF
--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -686,7 +686,7 @@ static int establishMqttSession( MQTTContext_t * pMqttContext,
     callbacks.getTime = Clock_GetTimeMs;
 
     /* Initialize MQTT library. */
-    mqttStatus = MQTT_Init( pMqttContext, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( pMqttContext, transport, callbacks, networkBuffer );
 
     if( mqttStatus != MQTTSuccess )
     {

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -715,7 +715,7 @@ static int establishMqttSession( MQTTContext_t * pMqttContext,
     callbacks.getTime = Clock_GetTimeMs;
 
     /* Initialize MQTT library. */
-    mqttStatus = MQTT_Init( pMqttContext, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( pMqttContext, transport, callbacks, networkBuffer );
 
     if( mqttStatus != MQTTSuccess )
     {

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
@@ -452,7 +452,7 @@ static int establishMqttSession( MQTTContext_t * pMqttContext,
     callbacks.getTime = Clock_GetTimeMs;
 
     /* Initialize MQTT library. */
-    mqttStatus = MQTT_Init( pMqttContext, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( pMqttContext, transport, callbacks, networkBuffer );
 
     if( mqttStatus != MQTTSuccess )
     {

--- a/libraries/standard/mqtt/include/mqtt.h
+++ b/libraries/standard/mqtt/include/mqtt.h
@@ -142,17 +142,17 @@ struct MQTTContext
  * will ensure all time based functions will run for a single iteration.
  *
  * @brief param[in] pContext The context to initialize.
- * @brief param[in] pTransportInterface The transport interface to use with the context.
- * @brief param[in] pCallbacks Callbacks to use with the context.
- * @brief param[in] pNetworkBuffer Network buffer provided for the context.
+ * @brief param[in] transportInterface The transport interface to use with the context.
+ * @brief param[in] callbacks Callbacks to use with the context.
+ * @brief param[in] networkBuffer Network buffer provided for the context.
  *
  * @return #MQTTBadParameter if invalid parameters are passed;
  * #MQTTSuccess otherwise.
  */
 MQTTStatus_t MQTT_Init( MQTTContext_t * pContext,
-                        const TransportInterface_t * pTransportInterface,
-                        const MQTTApplicationCallbacks_t * pCallbacks,
-                        const MQTTFixedBuffer_t * pNetworkBuffer );
+                        TransportInterface_t transportInterface,
+                        MQTTApplicationCallbacks_t callbacks,
+                        MQTTFixedBuffer_t networkBuffer );
 
 /**
  * @brief Establish an MQTT session.

--- a/libraries/standard/mqtt/integration-test/mqtt_system_test.c
+++ b/libraries/standard/mqtt/integration-test/mqtt_system_test.c
@@ -57,99 +57,99 @@
 /**
  * @brief A valid starting packet ID per MQTT spec. Start from 1.
  */
-#define MQTT_FIRST_VALID_PACKET_ID          ( 1 )
+#define MQTT_FIRST_VALID_PACKET_ID           ( 1 )
 
 /**
  * @brief A PINGREQ packet is always 2 bytes in size, defined by MQTT 3.1.1 spec.
  */
-#define MQTT_PACKET_PINGREQ_SIZE            ( 2U )
+#define MQTT_PACKET_PINGREQ_SIZE             ( 2U )
 
 /**
  * @brief A packet type not handled by MQTT_ProcessLoop.
  */
-#define MQTT_PACKET_TYPE_INVALID            ( 0U )
+#define MQTT_PACKET_TYPE_INVALID             ( 0U )
 
 /**
  * @brief Number of milliseconds in a second.
  */
-#define MQTT_ONE_SECOND_TO_MS               ( 1000U )
+#define MQTT_ONE_SECOND_TO_MS                ( 1000U )
 
 /**
  * @brief Length of the MQTT network buffer.
  */
-#define MQTT_TEST_BUFFER_LENGTH             ( 128 )
+#define MQTT_TEST_BUFFER_LENGTH              ( 128 )
 
 /**
  * @brief Sample length of remaining serialized data.
  */
-#define MQTT_SAMPLE_REMAINING_LENGTH        ( 64 )
+#define MQTT_SAMPLE_REMAINING_LENGTH         ( 64 )
 
 /**
  * @brief Subtract this value from max value of global entry time
  * for the timer overflow test.
  */
-#define MQTT_OVERFLOW_OFFSET                ( 3 )
+#define MQTT_OVERFLOW_OFFSET                 ( 3 )
 
 /**
  * @brief Sample topic filter to subscribe to.
  */
-#define TEST_MQTT_TOPIC                     "/iot/integration/test"
+#define TEST_MQTT_TOPIC                      "/iot/integration/test"
 
 /**
  * @brief Length of sample topic filter.
  */
-#define TEST_MQTT_TOPIC_LENGTH              ( sizeof( TEST_MQTT_TOPIC ) - 1 )
+#define TEST_MQTT_TOPIC_LENGTH               ( sizeof( TEST_MQTT_TOPIC ) - 1 )
 
 /**
  * @brief Sample topic filter to subscribe to.
  */
-#define TEST_MQTT_LWT_TOPIC                 "/iot/integration/test/lwt"
+#define TEST_MQTT_LWT_TOPIC                  "/iot/integration/test/lwt"
 
 /**
  * @brief Length of sample topic filter.
  */
-#define TEST_MQTT_LWT_TOPIC_LENGTH          ( sizeof( TEST_MQTT_LWT_TOPIC ) - 1 )
+#define TEST_MQTT_LWT_TOPIC_LENGTH           ( sizeof( TEST_MQTT_LWT_TOPIC ) - 1 )
 
 /**
  * @brief Size of the network buffer for MQTT packets.
  */
-#define NETWORK_BUFFER_SIZE                 ( 1024U )
+#define NETWORK_BUFFER_SIZE                  ( 1024U )
 
 /**
  * @brief Client identifier for MQTT session in the tests.
  */
-#define TEST_CLIENT_IDENTIFIER              "MQTT-Test"
+#define TEST_CLIENT_IDENTIFIER               "MQTT-Test"
 
 /**
  * @brief Length of the client identifier.
  */
-#define TEST_CLIENT_IDENTIFIER_LENGTH       ( sizeof( TEST_CLIENT_IDENTIFIER ) - 1u )
+#define TEST_CLIENT_IDENTIFIER_LENGTH        ( sizeof( TEST_CLIENT_IDENTIFIER ) - 1u )
 
 /**
  * @brief Client identifier for use in LWT tests.
  */
-#define TEST_CLIENT_IDENTIFIER_LWT          "MQTT-Test-LWT"
+#define TEST_CLIENT_IDENTIFIER_LWT           "MQTT-Test-LWT"
 
 /**
  * @brief Length of LWT client identifier.
  */
-#define TEST_CLIENT_IDENTIFIER_LWT_LENGTH   ( sizeof( TEST_CLIENT_IDENTIFIER_LWT ) - 1u )
+#define TEST_CLIENT_IDENTIFIER_LWT_LENGTH    ( sizeof( TEST_CLIENT_IDENTIFIER_LWT ) - 1u )
 
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
-#define TRANSPORT_SEND_RECV_TIMEOUT_MS      ( 200U )
+#define TRANSPORT_SEND_RECV_TIMEOUT_MS       ( 200U )
 
 /**
  * @brief Timeout for receiving CONNACK packet in milli seconds.
  */
-#define CONNACK_RECV_TIMEOUT_MS             ( 1000U )
+#define CONNACK_RECV_TIMEOUT_MS              ( 1000U )
 
 /**
  * @brief Time interval in seconds at which an MQTT PINGREQ need to be sent to
  * broker.
  */
-#define MQTT_KEEP_ALIVE_INTERVAL_SECONDS    ( 5U )
+#define MQTT_KEEP_ALIVE_INTERVAL_SECONDS     ( 5U )
 
 /**
  * @brief Timeout for MQTT_ProcessLoop() function in milliseconds.
@@ -157,12 +157,12 @@
  * PUBLISH message and ack responses for QoS 1 and QoS 2 communications
  * with the broker.
  */
-#define MQTT_PROCESS_LOOP_TIMEOUT_MS        ( 700U )
+#define MQTT_PROCESS_LOOP_TIMEOUT_MS         ( 700U )
 
 /**
  * @brief The MQTT message published in this example.
  */
-#define MQTT_EXAMPLE_MESSAGE                "Hello World!"
+#define MQTT_EXAMPLE_MESSAGE                 "Hello World!"
 
 /**
  * @brief Packet Identifier generated when Subscribe request was sent to the broker;
@@ -321,9 +321,9 @@ static void establishMqttSession( MQTTContext_t * pContext,
 
     /* Initialize MQTT library. */
     TEST_ASSERT_EQUAL( MQTTSuccess, MQTT_Init( pContext,
-                                               &transport,
-                                               &callbacks,
-                                               &networkBuffer ) );
+                                               transport,
+                                               callbacks,
+                                               networkBuffer ) );
 
     /* Establish MQTT session with a CONNECT packet. */
 
@@ -836,6 +836,7 @@ void test_MQTT_ProcessLoop_KeepAlive( void )
 {
     uint32_t connectPacketTime = context.lastPacketTime;
     uint32_t elapsedTime = 0;
+
     TEST_ASSERT_EQUAL( 0, context.pingReqSendTimeMs );
 
     /* Sleep until control packet needs to be sent. */

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -1312,34 +1312,26 @@ static MQTTStatus_t validatePublishParams( const MQTTContext_t * pContext,
 /*-----------------------------------------------------------*/
 
 MQTTStatus_t MQTT_Init( MQTTContext_t * pContext,
-                        const TransportInterface_t * pTransportInterface,
-                        const MQTTApplicationCallbacks_t * pCallbacks,
-                        const MQTTFixedBuffer_t * pNetworkBuffer )
+                        TransportInterface_t transportInterface,
+                        MQTTApplicationCallbacks_t callbacks,
+                        MQTTFixedBuffer_t networkBuffer )
 {
     MQTTStatus_t status = MQTTSuccess;
 
     /* Validate arguments. */
-    if( ( pContext == NULL ) || ( pTransportInterface == NULL ) ||
-        ( pCallbacks == NULL ) || ( pNetworkBuffer == NULL ) )
+    if( pContext == NULL )
     {
-        LogError( ( "Argument cannot be NULL: pContext=%p, "
-                    "pTransportInterface=%p, "
-                    "pCallbacks=%p, "
-                    "pNetworkBuffer=%p.",
-                    pContext,
-                    pTransportInterface,
-                    pCallbacks,
-                    pNetworkBuffer ) );
+        LogError( ( "pContext argument cannot be NULL" ) );
         status = MQTTBadParameter;
     }
-    else if( ( pCallbacks->getTime == NULL ) || ( pCallbacks->appCallback == NULL ) ||
-             ( pTransportInterface->recv == NULL ) || ( pTransportInterface->send == NULL ) )
+    else if( ( callbacks.getTime == NULL ) || ( callbacks.appCallback == NULL ) ||
+             ( transportInterface.recv == NULL ) || ( transportInterface.send == NULL ) )
     {
         LogError( ( "Functions cannot be NULL: getTime=%p, appCallback=%p, recv=%p, send=%p.",
-                    pCallbacks->getTime,
-                    pCallbacks->appCallback,
-                    pTransportInterface->recv,
-                    pTransportInterface->send ) );
+                    callbacks.getTime,
+                    callbacks.appCallback,
+                    transportInterface.recv,
+                    transportInterface.send ) );
         status = MQTTBadParameter;
     }
     else
@@ -1347,9 +1339,9 @@ MQTTStatus_t MQTT_Init( MQTTContext_t * pContext,
         ( void ) memset( pContext, 0x00, sizeof( MQTTContext_t ) );
 
         pContext->connectStatus = MQTTNotConnected;
-        pContext->transportInterface = *pTransportInterface;
-        pContext->callbacks = *pCallbacks;
-        pContext->networkBuffer = *pNetworkBuffer;
+        pContext->transportInterface = transportInterface;
+        pContext->callbacks = callbacks;
+        pContext->networkBuffer = networkBuffer;
 
         /* Zero is not a valid packet ID per MQTT spec. Start from 1. */
         pContext->nextPacketId = 1;

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -537,7 +537,7 @@ void test_MQTT_Init_Happy_Path( void )
     setupTransportInterface( &transport );
     setupNetworkBuffer( &networkBuffer );
 
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     TEST_ASSERT_EQUAL( MQTTNotConnected, context.connectStatus );
     TEST_ASSERT_EQUAL( MQTT_FIRST_VALID_PACKET_ID, context.nextPacketId );
@@ -562,36 +562,27 @@ void test_MQTT_Init_Invalid_Params( void )
     setupTransportInterface( &transport );
 
     /* Check that MQTTBadParameter is returned if any NULL parameters are passed. */
-    mqttStatus = MQTT_Init( NULL, &transport, &callbacks, &networkBuffer );
-    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
-
-    mqttStatus = MQTT_Init( &context, NULL, &callbacks, &networkBuffer );
-    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
-
-    mqttStatus = MQTT_Init( &context, &transport, NULL, &networkBuffer );
-    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
-
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, NULL );
+    mqttStatus = MQTT_Init( NULL, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
 
     /* Test if NULL is passed for any callbacks. */
     callbacks.getTime = NULL;
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
 
     callbacks.appCallback = NULL;
     callbacks.getTime = getTime;
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
 
     callbacks.appCallback = eventCallback;
     transport.recv = NULL;
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
 
     transport.recv = transportRecvSuccess;
     transport.send = NULL;
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
 }
 
@@ -617,7 +608,7 @@ void test_MQTT_Connect_sendConnect( void )
     setupNetworkBuffer( &networkBuffer );
 
     memset( ( void * ) &mqttContext, 0x0, sizeof( mqttContext ) );
-    MQTT_Init( &mqttContext, &transport, &callbacks, &networkBuffer );
+    MQTT_Init( &mqttContext, transport, callbacks, networkBuffer );
 
     /* Check parameters */
     status = MQTT_Connect( NULL, &connectInfo, NULL, timeout, &sessionPresent );
@@ -693,7 +684,7 @@ void test_MQTT_Connect_receiveConnack( void )
     transport.recv = transportRecvFailure;
 
     memset( ( void * ) &mqttContext, 0x0, sizeof( mqttContext ) );
-    MQTT_Init( &mqttContext, &transport, &callbacks, &networkBuffer );
+    MQTT_Init( &mqttContext, transport, callbacks, networkBuffer );
 
     /* Everything before receiving the CONNACK should succeed. */
     MQTT_SerializeConnect_IgnoreAndReturn( MQTTSuccess );
@@ -766,7 +757,7 @@ void test_MQTT_Connect_receiveConnack_retries( void )
     transport.recv = transportRecvFailure;
 
     memset( ( void * ) &mqttContext, 0x0, sizeof( mqttContext ) );
-    MQTT_Init( &mqttContext, &transport, &callbacks, &networkBuffer );
+    MQTT_Init( &mqttContext, transport, callbacks, networkBuffer );
 
     /* Everything before receiving the CONNACK should succeed. */
     MQTT_SerializeConnect_IgnoreAndReturn( MQTTSuccess );
@@ -828,7 +819,7 @@ void test_MQTT_Connect_partial_receive()
     transport.recv = transportRecvOneByte;
 
     memset( ( void * ) &mqttContext, 0x0, sizeof( mqttContext ) );
-    MQTT_Init( &mqttContext, &transport, &callbacks, &networkBuffer );
+    MQTT_Init( &mqttContext, transport, callbacks, networkBuffer );
 
     /* Everything before receiving the CONNACK should succeed. */
     MQTT_SerializeConnect_IgnoreAndReturn( MQTTSuccess );
@@ -905,7 +896,7 @@ void test_MQTT_Connect_resendPendingAcks( void )
 
     memset( ( void * ) &mqttContext, 0x0, sizeof( mqttContext ) );
     memset( ( void * ) &connectInfo, 0x00, sizeof( connectInfo ) );
-    MQTT_Init( &mqttContext, &transport, &callbacks, &networkBuffer );
+    MQTT_Init( &mqttContext, transport, callbacks, networkBuffer );
 
     MQTT_SerializeConnect_IgnoreAndReturn( MQTTSuccess );
     MQTT_GetConnectPacketSize_IgnoreAndReturn( MQTTSuccess );
@@ -1037,7 +1028,7 @@ void test_MQTT_Connect_happy_path()
     setupNetworkBuffer( &networkBuffer );
 
     memset( ( void * ) &mqttContext, 0x0, sizeof( mqttContext ) );
-    MQTT_Init( &mqttContext, &transport, &callbacks, &networkBuffer );
+    MQTT_Init( &mqttContext, transport, callbacks, networkBuffer );
     connectInfo.keepAliveSeconds = MQTT_SAMPLE_KEEPALIVE_INTERVAL_S;
 
     MQTT_SerializeConnect_IgnoreAndReturn( MQTTSuccess );
@@ -1154,7 +1145,7 @@ void test_MQTT_Publish( void )
 
     memset( ( void * ) &mqttContext, 0x0, sizeof( mqttContext ) );
     memset( ( void * ) &publishInfo, 0x0, sizeof( publishInfo ) );
-    MQTT_Init( &mqttContext, &transport, &callbacks, &networkBuffer );
+    MQTT_Init( &mqttContext, transport, callbacks, networkBuffer );
 
     /* Verify parameters. */
     status = MQTT_Publish( NULL, &publishInfo, PACKET_ID );
@@ -1279,7 +1270,7 @@ void test_MQTT_Disconnect( void )
     transport.send = transportSendFailure;
 
     memset( ( void * ) &mqttContext, 0x0, sizeof( mqttContext ) );
-    MQTT_Init( &mqttContext, &transport, &callbacks, &networkBuffer );
+    MQTT_Init( &mqttContext, transport, callbacks, networkBuffer );
     mqttContext.connectStatus = MQTTConnected;
 
     /* Verify parameters. */
@@ -1323,7 +1314,7 @@ void test_MQTT_GetPacketId( void )
     setupCallbacks( &callbacks );
     setupNetworkBuffer( &networkBuffer );
     memset( ( void * ) &mqttContext, 0x0, sizeof( mqttContext ) );
-    MQTT_Init( &mqttContext, &transport, &callbacks, &networkBuffer );
+    MQTT_Init( &mqttContext, transport, callbacks, networkBuffer );
 
     /* Verify parameters. */
     packetId = MQTT_GetPacketId( NULL );
@@ -1356,7 +1347,7 @@ void test_MQTT_ProcessLoop_Invalid_Params( void )
 
     setupTransportInterface( &transport );
     setupCallbacks( &callbacks );
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
 
     /* Get time function cannot be NULL. */
@@ -1390,7 +1381,7 @@ void test_MQTT_ProcessLoop_handleIncomingPublish_Happy_Paths( void )
     setupCallbacks( &callbacks );
     setupNetworkBuffer( &networkBuffer );
 
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
 
     modifyIncomingPacketStatus = MQTTSuccess;
@@ -1469,7 +1460,7 @@ void test_MQTT_ProcessLoop_handleIncomingPublish_Error_Paths( void )
     setupCallbacks( &callbacks );
     setupNetworkBuffer( &networkBuffer );
 
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
 
     modifyIncomingPacketStatus = MQTTSuccess;
@@ -1521,7 +1512,7 @@ void test_MQTT_ProcessLoop_handleIncomingAck_Happy_Paths( void )
     setupCallbacks( &callbacks );
     setupNetworkBuffer( &networkBuffer );
 
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
 
     modifyIncomingPacketStatus = MQTTSuccess;
@@ -1599,7 +1590,7 @@ void test_MQTT_ProcessLoop_handleIncomingAck_Error_Paths( void )
     setupCallbacks( &callbacks );
     setupNetworkBuffer( &networkBuffer );
 
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
 
     modifyIncomingPacketStatus = MQTTSuccess;
@@ -1667,7 +1658,7 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Happy_Paths( void )
     globalEntryTime = MQTT_ONE_SECOND_TO_MS;
 
     /* Coverage for the branch path where keep alive interval is 0. */
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     context.waitingForPingResp = false;
     context.keepAliveIntervalSec = 0;
@@ -1677,7 +1668,7 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Happy_Paths( void )
 
     /* Coverage for the branch path where keep alive interval is greater than 0,
      * and the interval has expired. */
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     context.waitingForPingResp = true;
     context.keepAliveIntervalSec = MQTT_SAMPLE_KEEPALIVE_INTERVAL_S;
@@ -1687,7 +1678,7 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Happy_Paths( void )
                             MQTTSuccess, false, NULL );
 
     /* Coverage for the branch path where PINGRESP timeout interval hasn't expired. */
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     context.waitingForPingResp = true;
     context.keepAliveIntervalSec = MQTT_SAMPLE_KEEPALIVE_INTERVAL_S;
@@ -1699,7 +1690,7 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Happy_Paths( void )
                             MQTTSuccess, false, NULL );
 
     /* Coverage for the branch path where a PINGRESP hasn't been sent out yet. */
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     context.waitingForPingResp = false;
     context.keepAliveIntervalSec = MQTT_SAMPLE_KEEPALIVE_INTERVAL_S;
@@ -1729,7 +1720,7 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Error_Paths( void )
     globalEntryTime = MQTT_ONE_SECOND_TO_MS;
 
     /* Coverage for the branch path where PING timeout interval hasn't expired. */
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     context.lastPacketTime = 0;
     context.keepAliveIntervalSec = MQTT_SAMPLE_KEEPALIVE_INTERVAL_S;
@@ -1754,7 +1745,7 @@ void test_MQTT_ProcessLoop_Receive_Failed( void )
     setupTransportInterface( &transport );
     setupCallbacks( &callbacks );
 
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
 
     MQTT_GetIncomingPacketTypeAndLength_ExpectAnyArgsAndReturn( MQTTRecvFailed );
@@ -1791,7 +1782,7 @@ void test_MQTT_ProcessLoop_Timer_Overflow( void )
     globalEntryTime = UINT32_MAX - MQTT_OVERFLOW_OFFSET;
     expectedFinalTime = MQTT_TIMER_CALLS_PER_ITERATION * numIterations - MQTT_OVERFLOW_OFFSET;
 
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
 
     /* Verify that we run the expected number of iterations despite overflowing. */
@@ -1832,7 +1823,7 @@ void test_MQTT_ReceiveLoop( void )
     setupTransportInterface( &transport );
     setupCallbacks( &callbacks );
 
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
 
     /* Verify that a NULL Context returns an error. */
@@ -1932,7 +1923,7 @@ void test_MQTT_Subscribe_happy_path( void )
     setupSubscriptionInfo( &subscribeInfo );
 
     /* Initialize context. */
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     /* Verify MQTTSuccess is returned with the following mocks. */
     MQTT_GetSubscribePacketSize_ExpectAnyArgsAndReturn( MQTTSuccess );
@@ -1969,7 +1960,7 @@ void test_MQTT_Subscribe_error_paths( void )
     transport.recv = transportRecvFailure;
 
     /* Initialize context. */
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     /* Verify MQTTSendFailed is propagated when transport interface returns an error. */
     MQTT_GetSubscribePacketSize_ExpectAnyArgsAndReturn( MQTTSuccess );
@@ -2032,7 +2023,7 @@ void test_MQTT_Unsubscribe_happy_path( void )
     setupSubscriptionInfo( &subscribeInfo );
 
     /* Initialize context. */
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     /* Verify MQTTSuccess is returned with the following mocks. */
     MQTT_GetUnsubscribePacketSize_ExpectAnyArgsAndReturn( MQTTSuccess );
@@ -2069,7 +2060,7 @@ void test_MQTT_Unsubscribe_error_path( void )
     transport.recv = transportRecvFailure;
 
     /* Initialize context. */
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     /* Verify MQTTSendFailed is propagated when transport interface returns an error. */
     MQTT_GetUnsubscribePacketSize_ExpectAnyArgsAndReturn( MQTTSuccess );
@@ -2114,7 +2105,7 @@ void test_MQTT_Ping_happy_path( void )
     setupNetworkBuffer( &networkBuffer );
 
     /* Initialize context. */
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     /* Verify MQTTSuccess is returned. */
     MQTT_GetPingreqPacketSize_ExpectAnyArgsAndReturn( MQTTSuccess );
@@ -2151,7 +2142,7 @@ void test_MQTT_Ping_error_path( void )
     transport.recv = transportRecvFailure;
 
     /* Initialize context. */
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     /* Verify MQTTSendFailed is propagated when transport interface returns an error. */
     MQTT_GetPingreqPacketSize_ExpectAnyArgsAndReturn( MQTTSuccess );
@@ -2162,7 +2153,7 @@ void test_MQTT_Ping_error_path( void )
     TEST_ASSERT_EQUAL( MQTTSendFailed, mqttStatus );
 
     /* Initialize context. */
-    mqttStatus = MQTT_Init( &context, &transport, &callbacks, &networkBuffer );
+    mqttStatus = MQTT_Init( &context, transport, callbacks, networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     /* Verify MQTTBadParameter is propagated when getting PINGREQ packet size fails. */
     MQTT_GetPingreqPacketSize_ExpectAnyArgsAndReturn( MQTTBadParameter );


### PR DESCRIPTION
Improve `MQTT_Init` API signature by passing input parameters by value instead of by pointers.
**Reason**: Passing by pointer usually gives the opinion of either:
- An output parameter
- An object who memory value will be stored by a state object 
In `MQTT_Init` function, the input parameters' values are _copied_ in the internal implementation of the function. There is no need to pass the parameters by pointer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
