### PR TITLE
mqtt.c updates in sendPacket(), asserting on developer bugs, and payload length of zero.

### DIFF
--- a/libraries/standard/http/lexicon.txt
+++ b/libraries/standard/http/lexicon.txt
@@ -6,6 +6,7 @@ api
 ascii
 br
 bufferlen
+bytesremaining
 cbmc
 chunked
 com
@@ -134,6 +135,7 @@ statuscode
 strchr
 sublicense
 totalreceived
+transportstatus
 txt
 uri
 utest

--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -1594,10 +1594,6 @@ static HTTPStatus_t sendHttpData( const TransportInterface_t * pTransport,
                                             pIndex,
                                             bytesRemaining );
 
-        /* It is a bug in the application's transport send implementation if
-         * more bytes than expected are sent. */
-        assert( transportStatus <= (int32_t)bytesRemaining );
-
         /* A transport status of less than zero is an error. */
         if( transportStatus < 0 )
         {
@@ -1608,6 +1604,10 @@ static HTTPStatus_t sendHttpData( const TransportInterface_t * pTransport,
         }
         else
         {
+            /* It is a bug in the application's transport send implementation if
+             * more bytes than expected are sent. */
+            assert( ( size_t ) transportStatus <= bytesRemaining );
+
             bytesRemaining -= ( size_t ) transportStatus;
             pIndex += transportStatus;
             LogDebug( ( "Sent HTTP data over the transport: "
@@ -1734,10 +1734,6 @@ static HTTPStatus_t receiveHttpData( const TransportInterface_t * pTransport,
                                         pBuffer,
                                         bufferLen );
 
-    /* It is a bug in the application's transport receive implementation if
-     * more bytes than expected are received. */
-    assert( transportStatus <= (int32_t)bufferLen );
-
     /* A transport status of less than zero is an error. */
     if( transportStatus < 0 )
     {
@@ -1748,6 +1744,10 @@ static HTTPStatus_t receiveHttpData( const TransportInterface_t * pTransport,
     }
     else if( transportStatus > 0 )
     {
+        /* It is a bug in the application's transport receive implementation if
+         * more bytes than expected are received. */
+        assert( ( size_t ) transportStatus <= bufferLen );
+
         /* Some or all of the specified data was received. */
         *pBytesReceived = ( size_t ) ( transportStatus );
         LogDebug( ( "Received data from the transport: BytesReceived=%d",

--- a/libraries/standard/http/src/http_client.c
+++ b/libraries/standard/http/src/http_client.c
@@ -1605,7 +1605,9 @@ static HTTPStatus_t sendHttpData( const TransportInterface_t * pTransport,
         else
         {
             /* It is a bug in the application's transport send implementation if
-             * more bytes than expected are sent. */
+             * more bytes than expected are sent. To avoid a possible overflow
+             * in converting bytesRemaining from unsigned to signed, this assert
+             * must exist after the check for transportStatus being negative. */
             assert( ( size_t ) transportStatus <= bytesRemaining );
 
             bytesRemaining -= ( size_t ) transportStatus;
@@ -1745,7 +1747,9 @@ static HTTPStatus_t receiveHttpData( const TransportInterface_t * pTransport,
     else if( transportStatus > 0 )
     {
         /* It is a bug in the application's transport receive implementation if
-         * more bytes than expected are received. */
+         * more bytes than expected are received. To avoid a possible overflow
+         * in converting bytesRemaining from unsigned to signed, this assert
+         * must exist after the check for transportStatus being negative. */
         assert( ( size_t ) transportStatus <= bufferLen );
 
         /* Some or all of the specified data was received. */

--- a/libraries/standard/mqtt/include/mqtt.h
+++ b/libraries/standard/mqtt/include/mqtt.h
@@ -175,7 +175,7 @@ MQTTStatus_t MQTT_Init( MQTTContext_t * pContext,
  * Testament is not used.
  * @param[in] timeoutMs Maximum time in milliseconds to wait for a CONNACK packet.
  * A zero timeout makes use of the retries for receiving CONNACK as configured with
- * #MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT .
+ * #MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT.
  * @param[out] pSessionPresent Whether a previous session was present.
  * Only relevant if not establishing a clean session.
  *

--- a/libraries/standard/mqtt/lexicon.txt
+++ b/libraries/standard/mqtt/lexicon.txt
@@ -9,6 +9,9 @@ bool
 bufferlength
 bytesorerror
 bytesreceived
+bytesrecvd
+bytesremaining
+bytessent
 bytestoread
 bytestoreceive
 bytestorecv

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -450,7 +450,7 @@ static int32_t recvExact( const MQTTContext_t * pContext,
              * more bytes than expected are received. */
             assert( ( size_t ) bytesRecvd <= bytesRemaining );
 
-            bytesRemaining -= bytesRecvd;
+            bytesRemaining -= ( size_t ) bytesRecvd;
             totalBytesRecvd += ( int32_t ) bytesRecvd;
             pIndex += bytesRecvd;
             LogDebug( ( "BytesReceived=%d, BytesRemaining=%lu, "
@@ -1080,7 +1080,7 @@ static MQTTStatus_t sendPublish( MQTTContext_t * pContext,
 
         /* Send Payload if there is one to send. It is valid for a PUBLISH
          * Packet to contain a zero length payload.*/
-        if( pPublishInfo->payloadLength > 0 )
+        if( pPublishInfo->payloadLength > 0U )
         {
             bytesSent = sendPacket( pContext,
                                     pPublishInfo->pPayload,

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -1068,7 +1068,7 @@ static MQTTStatus_t sendPublish( MQTTContext_t * pContext,
                             pContext->networkBuffer.pBuffer,
                             headerSize );
 
-    if( ( bytesSent < 0 ) || ( ( size_t ) bytesSent != headerSize ) )
+    if( bytesSent < 0 )
     {
         LogError( ( "Transport send failed for PUBLISH header." ) );
         status = MQTTSendFailed;
@@ -1086,7 +1086,7 @@ static MQTTStatus_t sendPublish( MQTTContext_t * pContext,
                                     pPublishInfo->pPayload,
                                     pPublishInfo->payloadLength );
 
-            if( ( bytesSent < 0 ) || ( ( size_t ) bytesSent != pPublishInfo->payloadLength ) )
+            if( bytesSent < 0 )
             {
                 LogError( ( "Transport send failed for PUBLISH payload." ) );
                 status = MQTTSendFailed;
@@ -1096,6 +1096,10 @@ static MQTTStatus_t sendPublish( MQTTContext_t * pContext,
                 LogDebug( ( "Sent %d bytes of PUBLISH payload.",
                             bytesSent ) );
             }
+        }
+        else
+        {
+            LogDebug( "PUSHLISH payload was not sent. Payload length was zero." );
         }
     }
 
@@ -1427,7 +1431,7 @@ MQTTStatus_t MQTT_Connect( MQTTContext_t * pContext,
                                 pContext->networkBuffer.pBuffer,
                                 packetSize );
 
-        if( ( bytesSent < 0 ) || ( ( size_t ) bytesSent != packetSize ) )
+        if( bytesSent < 0 )
         {
             LogError( ( "Transport send failed for CONNECT packet." ) );
             status = MQTTSendFailed;
@@ -1515,7 +1519,7 @@ MQTTStatus_t MQTT_Subscribe( MQTTContext_t * pContext,
                                 pContext->networkBuffer.pBuffer,
                                 packetSize );
 
-        if( ( bytesSent < 0 ) || ( ( size_t ) bytesSent != packetSize ) )
+        if( bytesSent < 0 )
         {
             LogError( ( "Transport send failed for SUBSCRIBE packet." ) );
             status = MQTTSendFailed;
@@ -1648,7 +1652,7 @@ MQTTStatus_t MQTT_Ping( MQTTContext_t * pContext )
                                 packetSize );
 
         /* It is an error to not send the entire PINGREQ packet. */
-        if( ( bytesSent < 0 ) || ( ( size_t ) bytesSent != packetSize ) )
+        if( bytesSent < 0 )
         {
             LogError( ( "Transport send failed for PINGREQ packet." ) );
             status = MQTTSendFailed;
@@ -1710,7 +1714,7 @@ MQTTStatus_t MQTT_Unsubscribe( MQTTContext_t * pContext,
                                 pContext->networkBuffer.pBuffer,
                                 packetSize );
 
-        if( ( bytesSent < 0 ) || ( ( size_t ) bytesSent != packetSize ) )
+        if( bytesSent < 0 )
         {
             LogError( ( "Transport send failed for UNSUBSCRIBE packet." ) );
             status = MQTTSendFailed;
@@ -1760,7 +1764,7 @@ MQTTStatus_t MQTT_Disconnect( MQTTContext_t * pContext )
                                 pContext->networkBuffer.pBuffer,
                                 packetSize );
 
-        if( ( bytesSent < 0 ) || ( ( size_t ) bytesSent != packetSize ) )
+        if( bytesSent < 0 )
         {
             LogError( ( "Transport send failed for DISCONNECT packet." ) );
             status = MQTTSendFailed;

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -1086,7 +1086,7 @@ static MQTTStatus_t sendPublish( MQTTContext_t * pContext,
                                     pPublishInfo->pPayload,
                                     pPublishInfo->payloadLength );
 
-            if( bytesSent <= 0 )
+            if( bytesSent < 0 )
             {
                 LogError( ( "Transport send failed for PUBLISH payload." ) );
                 status = MQTTSendFailed;

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -354,7 +354,7 @@ static int32_t sendPacket( MQTTContext_t * pContext,
     }
 
     /* Update time of last transmission if the entire packet is successfully sent. */
-    if( bytesRemaining == 0U )
+    if( totalBytesSent > 0 )
     {
         pContext->lastPacketTime = sendTime;
         LogDebug( ( "Successfully sent packet at time %u.",

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -451,7 +451,7 @@ static int32_t recvExact( const MQTTContext_t * pContext,
             /* It is a bug in the application's transport receive implementation
              * if more bytes than expected are received. To avoid a possible
              * overflow in converting bytesRemaining from unsigned to signed,
-             * this assert must exist after the check for bytesSent being
+             * this assert must exist after the check for bytesRecvd being
              * negative. */
             assert( ( size_t ) bytesRecvd <= bytesRemaining );
 

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -330,7 +330,7 @@ static int32_t sendPacket( MQTTContext_t * pContext,
                                                        pIndex,
                                                        bytesRemaining );
 
-        if( bytesSent <= 0 )
+        if( bytesSent < 0 )
         {
             LogError( ( "Transport send failed. Error code=%d.", bytesSent ) );
             totalBytesSent = bytesSent;
@@ -1086,7 +1086,7 @@ static MQTTStatus_t sendPublish( MQTTContext_t * pContext,
                                     pPublishInfo->pPayload,
                                     pPublishInfo->payloadLength );
 
-            if( bytesSent < 0 )
+            if( bytesSent <= 0 )
             {
                 LogError( ( "Transport send failed for PUBLISH payload." ) );
                 status = MQTTSendFailed;

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -339,7 +339,9 @@ static int32_t sendPacket( MQTTContext_t * pContext,
         else
         {
             /* It is a bug in the application's transport send implementation if
-             * more bytes than expected are sent. */
+             * more bytes than expected are sent. To avoid a possible overflow
+             * in converting bytesRemaining from unsigned to signed, this assert
+             * must exist after the check for bytesSent being negative. */
             assert( ( size_t ) bytesSent <= bytesRemaining );
 
             bytesRemaining -= ( size_t ) bytesSent;
@@ -446,8 +448,11 @@ static int32_t recvExact( const MQTTContext_t * pContext,
         }
         else
         {
-            /* It is a bug in the application's transport receive implementation if
-             * more bytes than expected are received. */
+            /* It is a bug in the application's transport receive implementation
+             * if more bytes than expected are received. To avoid a possible
+             * overflow in converting bytesRemaining from unsigned to signed,
+             * this assert must exist after the check for bytesSent being
+             * negative. */
             assert( ( size_t ) bytesRecvd <= bytesRemaining );
 
             bytesRemaining -= ( size_t ) bytesRecvd;
@@ -1099,7 +1104,7 @@ static MQTTStatus_t sendPublish( MQTTContext_t * pContext,
         }
         else
         {
-            LogDebug( "PUSHLISH payload was not sent. Payload length was zero." );
+            LogDebug( "PUBLISH payload was not sent. Payload length was zero." );
         }
     }
 

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -1164,6 +1164,10 @@ void test_MQTT_Publish( void )
     publishInfo.qos = MQTTQoS1;
     status = MQTT_Publish( &mqttContext, &publishInfo, 0 );
     TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
+    publishInfo.payloadLength = 1;
+    publishInfo.pPayload = NULL;
+    status = MQTT_Publish( &mqttContext, &publishInfo, PACKET_ID );
+    memset( ( void * ) &publishInfo, 0x0, sizeof( publishInfo ) );
 
     /* Bad Parameter when getting packet size. */
     publishInfo.qos = MQTTQoS0;
@@ -1204,6 +1208,17 @@ void test_MQTT_Publish( void )
     MQTT_SerializePublishHeader_ReturnThruPtr_pHeaderSize( &headerSize );
     status = MQTT_Publish( &mqttContext, &publishInfo, 0 );
     TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
+
+    /* Test that sending a publish without a payload succeeds. */
+    publishInfo.pPayload = NULL;
+    publishInfo.payloadLength = 0;
+    MQTT_SerializePublishHeader_ExpectAnyArgsAndReturn( MQTTSuccess );
+    MQTT_SerializePublishHeader_ReturnThruPtr_pHeaderSize( &headerSize );
+    status = MQTT_Publish( &mqttContext, &publishInfo, 0 );
+    TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
+    /* Restore the test payload and length. */
+    publishInfo.pPayload = "Test";
+    publishInfo.payloadLength = 4;
 
     /* Now for non zero QoS, which uses state engine. */
     publishInfo.qos = MQTTQoS2;

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -1167,6 +1167,7 @@ void test_MQTT_Publish( void )
     publishInfo.payloadLength = 1;
     publishInfo.pPayload = NULL;
     status = MQTT_Publish( &mqttContext, &publishInfo, PACKET_ID );
+    TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
     memset( ( void * ) &publishInfo, 0x0, sizeof( publishInfo ) );
 
     /* Bad Parameter when getting packet size. */


### PR DESCRIPTION
- Move assert on bug in the transport rx/tx to after checking for a negative returned. This is done to avoid overflow on the signed to unsigned conversion.
- Delete check for the sendPacket return not equal to the total amount to send. sendPacket() returns only the full amount to send OR a negative return code.
- Check for a payload length of zero for a publish. When the payload length is zero, then the payload buffer is allowed to be NULL. Added unit tests for this case.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
