### PR TITLE
Return suback when server refuses subscription

### DIFF
--- a/demos/lexicon.txt
+++ b/demos/lexicon.txt
@@ -58,7 +58,7 @@ packetidtoresend
 param
 pathlen
 pbuffer
-pdeserialized
+pdeserializedinfo
 pem
 pfixedbuffer
 pincomingpacket

--- a/demos/lexicon.txt
+++ b/demos/lexicon.txt
@@ -58,6 +58,7 @@ packetidtoresend
 param
 pathlen
 pbuffer
+pdeserialized
 pem
 pfixedbuffer
 pincomingpacket

--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -248,14 +248,11 @@ static void handleIncomingPublish( MQTTPublishInfo_t * pPublishInfo,
  *
  * @param[in] pMqttContext MQTT context pointer.
  * @param[in] pPacketInfo Packet Info pointer for the incoming packet.
- * @param[in] packetIdentifier Packet identifier of the incoming packet.
- * @param[in] pPublishInfo Deserialized publish info pointer for the incoming
- * packet.
+ * @param[in] pDeserialized Deserialized information from the incoming packet.
  */
 static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           uint16_t packetIdentifier,
-                           MQTTPublishInfo_t * pPublishInfo );
+                           MQTTDeserializedInfo_t * pDeserialized );
 
 /**
  * @brief Sends an MQTT CONNECT packet over the already connected TCP socket.
@@ -604,20 +601,24 @@ static void handleIncomingPublish( MQTTPublishInfo_t * pPublishInfo,
 
 static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           uint16_t packetIdentifier,
-                           MQTTPublishInfo_t * pPublishInfo )
+                           MQTTDeserializedInfo_t * pDeserialized )
 {
+    uint16_t packetIdentifier;
+
     assert( pMqttContext != NULL );
     assert( pPacketInfo != NULL );
+    assert( pDeserialized != NULL );
+
+    packetIdentifier = pDeserialized->packetIdentifier;
 
     /* Handle incoming publish. The lower 4 bits of the publish packet
      * type is used for the dup, QoS, and retain flags. Hence masking
      * out the lower bits to check if the packet is publish. */
     if( ( pPacketInfo->type & 0xF0U ) == MQTT_PACKET_TYPE_PUBLISH )
     {
-        assert( pPublishInfo != NULL );
+        assert( pDeserialized->pPublishInfo != NULL );
         /* Handle incoming publish. */
-        handleIncomingPublish( pPublishInfo, packetIdentifier );
+        handleIncomingPublish( pDeserialized->pPublishInfo, packetIdentifier );
     }
     else
     {

--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -248,11 +248,11 @@ static void handleIncomingPublish( MQTTPublishInfo_t * pPublishInfo,
  *
  * @param[in] pMqttContext MQTT context pointer.
  * @param[in] pPacketInfo Packet Info pointer for the incoming packet.
- * @param[in] pDeserialized Deserialized information from the incoming packet.
+ * @param[in] pDeserializedInfo Deserialized information from the incoming packet.
  */
 static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           MQTTDeserializedInfo_t * pDeserialized );
+                           MQTTDeserializedInfo_t * pDeserializedInfo );
 
 /**
  * @brief Sends an MQTT CONNECT packet over the already connected TCP socket.
@@ -601,24 +601,24 @@ static void handleIncomingPublish( MQTTPublishInfo_t * pPublishInfo,
 
 static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           MQTTDeserializedInfo_t * pDeserialized )
+                           MQTTDeserializedInfo_t * pDeserializedInfo )
 {
     uint16_t packetIdentifier;
 
     assert( pMqttContext != NULL );
     assert( pPacketInfo != NULL );
-    assert( pDeserialized != NULL );
+    assert( pDeserializedInfo != NULL );
 
-    packetIdentifier = pDeserialized->packetIdentifier;
+    packetIdentifier = pDeserializedInfo->packetIdentifier;
 
     /* Handle incoming publish. The lower 4 bits of the publish packet
      * type is used for the dup, QoS, and retain flags. Hence masking
      * out the lower bits to check if the packet is publish. */
     if( ( pPacketInfo->type & 0xF0U ) == MQTT_PACKET_TYPE_PUBLISH )
     {
-        assert( pDeserialized->pPublishInfo != NULL );
+        assert( pDeserializedInfo->pPublishInfo != NULL );
         /* Handle incoming publish. */
-        handleIncomingPublish( pDeserialized->pPublishInfo, packetIdentifier );
+        handleIncomingPublish( pDeserializedInfo->pPublishInfo, packetIdentifier );
     }
     else
     {

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -282,11 +282,11 @@ static void handleIncomingPublish( MQTTPublishInfo_t * pPublishInfo,
  *
  * @param[in] pMqttContext MQTT context pointer.
  * @param[in] pPacketInfo Packet Info pointer for the incoming packet.
- * @param[in] pDeserialized Deserialized information from the incoming packet.
+ * @param[in] pDeserializedInfo Deserialized information from the incoming packet.
  */
 static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           MQTTDeserializedInfo_t * pDeserialized );
+                           MQTTDeserializedInfo_t * pDeserializedInfo );
 
 /**
  * @brief Sends an MQTT CONNECT packet over the already connected TCP socket.
@@ -646,24 +646,24 @@ static void handleIncomingPublish( MQTTPublishInfo_t * pPublishInfo,
 
 static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           MQTTDeserializedInfo_t * pDeserialized )
+                           MQTTDeserializedInfo_t * pDeserializedInfo )
 {
     uint16_t packetIdentifier;
 
     assert( pMqttContext != NULL );
     assert( pPacketInfo != NULL );
-    assert( pDeserialized != NULL );
+    assert( pDeserializedInfo != NULL );
 
-    packetIdentifier = pDeserialized->packetIdentifier;
+    packetIdentifier = pDeserializedInfo->packetIdentifier;
 
     /* Handle incoming publish. The lower 4 bits of the publish packet
      * type is used for the dup, QoS, and retain flags. Hence masking
      * out the lower bits to check if the packet is publish. */
     if( ( pPacketInfo->type & 0xF0U ) == MQTT_PACKET_TYPE_PUBLISH )
     {
-        assert( pDeserialized->pPublishInfo != NULL );
+        assert( pDeserializedInfo->pPublishInfo != NULL );
         /* Handle incoming publish. */
-        handleIncomingPublish( pDeserialized->pPublishInfo, packetIdentifier );
+        handleIncomingPublish( pDeserializedInfo->pPublishInfo, packetIdentifier );
     }
     else
     {

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -282,14 +282,11 @@ static void handleIncomingPublish( MQTTPublishInfo_t * pPublishInfo,
  *
  * @param[in] pMqttContext MQTT context pointer.
  * @param[in] pPacketInfo Packet Info pointer for the incoming packet.
- * @param[in] packetIdentifier Packet identifier of the incoming packet.
- * @param[in] pPublishInfo Deserialized publish info pointer for the incoming
- * packet.
+ * @param[in] pDeserialized Deserialized information from the incoming packet.
  */
 static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           uint16_t packetIdentifier,
-                           MQTTPublishInfo_t * pPublishInfo );
+                           MQTTDeserializedInfo_t * pDeserialized );
 
 /**
  * @brief Sends an MQTT CONNECT packet over the already connected TCP socket.
@@ -649,20 +646,24 @@ static void handleIncomingPublish( MQTTPublishInfo_t * pPublishInfo,
 
 static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           uint16_t packetIdentifier,
-                           MQTTPublishInfo_t * pPublishInfo )
+                           MQTTDeserializedInfo_t * pDeserialized )
 {
+    uint16_t packetIdentifier;
+
     assert( pMqttContext != NULL );
     assert( pPacketInfo != NULL );
+    assert( pDeserialized != NULL );
+
+    packetIdentifier = pDeserialized->packetIdentifier;
 
     /* Handle incoming publish. The lower 4 bits of the publish packet
      * type is used for the dup, QoS, and retain flags. Hence masking
      * out the lower bits to check if the packet is publish. */
     if( ( pPacketInfo->type & 0xF0U ) == MQTT_PACKET_TYPE_PUBLISH )
     {
-        assert( pPublishInfo != NULL );
+        assert( pDeserialized->pPublishInfo != NULL );
         /* Handle incoming publish. */
-        handleIncomingPublish( pPublishInfo, packetIdentifier );
+        handleIncomingPublish( pDeserialized->pPublishInfo, packetIdentifier );
     }
     else
     {

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
@@ -209,14 +209,11 @@ static void handleIncomingPublish( MQTTPublishInfo_t * pPublishInfo,
  *
  * @param[in] pMqttContext MQTT context pointer.
  * @param[in] pPacketInfo Packet Info pointer for the incoming packet.
- * @param[in] packetIdentifier Packet identifier of the incoming packet.
- * @param[in] pPublishInfo Deserialized publish info pointer for the incoming
- * packet.
+ * @param[in] pDeserialized Deserialized information from the incoming packet.
  */
 static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           uint16_t packetIdentifier,
-                           MQTTPublishInfo_t * pPublishInfo );
+                           MQTTDeserializedInfo_t * pDeserialized );
 
 /**
  * @brief Sends an MQTT CONNECT packet over the already connected TCP socket.
@@ -364,20 +361,24 @@ static void handleIncomingPublish( MQTTPublishInfo_t * pPublishInfo,
 
 static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           uint16_t packetIdentifier,
-                           MQTTPublishInfo_t * pPublishInfo )
+                           MQTTDeserializedInfo_t * pDeserialized )
 {
+    uint16_t packetIdentifier;
+
     assert( pMqttContext != NULL );
     assert( pPacketInfo != NULL );
+    assert( pDeserialized != NULL );
+
+    packetIdentifier = pDeserialized->packetIdentifier;
 
     /* Handle incoming publish. The lower 4 bits of the publish packet
      * type is used for the dup, QoS, and retain flags. Hence masking
      * out the lower bits to check if the packet is publish. */
     if( ( pPacketInfo->type & 0xF0U ) == MQTT_PACKET_TYPE_PUBLISH )
     {
-        assert( pPublishInfo != NULL );
+        assert( pDeserialized->pPublishInfo != NULL );
         /* Handle incoming publish. */
-        handleIncomingPublish( pPublishInfo, packetIdentifier );
+        handleIncomingPublish( pDeserialized->pPublishInfo, packetIdentifier );
     }
     else
     {

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
@@ -209,11 +209,11 @@ static void handleIncomingPublish( MQTTPublishInfo_t * pPublishInfo,
  *
  * @param[in] pMqttContext MQTT context pointer.
  * @param[in] pPacketInfo Packet Info pointer for the incoming packet.
- * @param[in] pDeserialized Deserialized information from the incoming packet.
+ * @param[in] pDeserializedInfo Deserialized information from the incoming packet.
  */
 static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           MQTTDeserializedInfo_t * pDeserialized );
+                           MQTTDeserializedInfo_t * pDeserializedInfo );
 
 /**
  * @brief Sends an MQTT CONNECT packet over the already connected TCP socket.
@@ -361,24 +361,24 @@ static void handleIncomingPublish( MQTTPublishInfo_t * pPublishInfo,
 
 static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           MQTTDeserializedInfo_t * pDeserialized )
+                           MQTTDeserializedInfo_t * pDeserializedInfo )
 {
     uint16_t packetIdentifier;
 
     assert( pMqttContext != NULL );
     assert( pPacketInfo != NULL );
-    assert( pDeserialized != NULL );
+    assert( pDeserializedInfo != NULL );
 
-    packetIdentifier = pDeserialized->packetIdentifier;
+    packetIdentifier = pDeserializedInfo->packetIdentifier;
 
     /* Handle incoming publish. The lower 4 bits of the publish packet
      * type is used for the dup, QoS, and retain flags. Hence masking
      * out the lower bits to check if the packet is publish. */
     if( ( pPacketInfo->type & 0xF0U ) == MQTT_PACKET_TYPE_PUBLISH )
     {
-        assert( pDeserialized->pPublishInfo != NULL );
+        assert( pDeserializedInfo->pPublishInfo != NULL );
         /* Handle incoming publish. */
-        handleIncomingPublish( pDeserialized->pPublishInfo, packetIdentifier );
+        handleIncomingPublish( pDeserializedInfo->pPublishInfo, packetIdentifier );
     }
     else
     {

--- a/libraries/standard/mqtt/cbmc/include/event_callback_stub.h
+++ b/libraries/standard/mqtt/cbmc/include/event_callback_stub.h
@@ -35,10 +35,10 @@
  *
  * @param[in] pContext Initialized MQTT context.
  * @param[in] pPacketInfo Information on the type of incoming MQTT packet.
- * @param[in] pDeserialized Deserialized information from incoming packet.
+ * @param[in] pDeserializedInfo Deserialized information from incoming packet.
  */
 void EventCallbackStub( MQTTContext_t * pContext,
                         MQTTPacketInfo_t * pPacketInfo,
-                        MQTTDeserializedInfo_t * pDeserialized );
+                        MQTTDeserializedInfo_t * pDeserializedInfo );
 
 #endif /* ifndef EVENT_CALLBACK_STUB_H_ */

--- a/libraries/standard/mqtt/cbmc/include/event_callback_stub.h
+++ b/libraries/standard/mqtt/cbmc/include/event_callback_stub.h
@@ -35,12 +35,10 @@
  *
  * @param[in] pContext Initialized MQTT context.
  * @param[in] pPacketInfo Information on the type of incoming MQTT packet.
- * @param[in] packetIdentifier Packet identifier of incoming PUBLISH packet.
- * @param[in] pPublishInfo Incoming PUBLISH packet parameters.
+ * @param[in] pDeserialized Deserialized information from incoming packet.
  */
 void EventCallbackStub( MQTTContext_t * pContext,
                         MQTTPacketInfo_t * pPacketInfo,
-                        uint16_t packetIdentifier,
-                        MQTTPublishInfo_t * pPublishInfo );
+                        MQTTDeserializedInfo_t * pDeserialized );
 
 #endif /* ifndef EVENT_CALLBACK_STUB_H_ */

--- a/libraries/standard/mqtt/cbmc/stubs/event_callback_stub.c
+++ b/libraries/standard/mqtt/cbmc/stubs/event_callback_stub.c
@@ -23,12 +23,12 @@
 
 void EventCallbackStub( MQTTContext_t * pContext,
                         MQTTPacketInfo_t * pPacketInfo,
-                        MQTTDeserializedInfo_t * pDeserialized )
+                        MQTTDeserializedInfo_t * pDeserializedInfo )
 {
     __CPROVER_assert( pContext != NULL,
                       "EventCallbackStub pContext is not NULL" );
     __CPROVER_assert( pPacketInfo != NULL,
                       "EventCallbackStub pPacketInfo is not NULL" );
-    __CPROVER_assert( pDeserialized != NULL,
-                      "EventCallbackStub pDeserialized is not NULL" );
+    __CPROVER_assert( pDeserializedInfo != NULL,
+                      "EventCallbackStub pDeserializedInfo is not NULL" );
 }

--- a/libraries/standard/mqtt/cbmc/stubs/event_callback_stub.c
+++ b/libraries/standard/mqtt/cbmc/stubs/event_callback_stub.c
@@ -23,12 +23,12 @@
 
 void EventCallbackStub( MQTTContext_t * pContext,
                         MQTTPacketInfo_t * pPacketInfo,
-                        uint16_t packetIdentifier,
-                        MQTTPublishInfo_t * pPublishInfo )
+                        MQTTDeserializedInfo_t * pDeserialized )
 {
     __CPROVER_assert( pContext != NULL,
                       "EventCallbackStub pContext is not NULL" );
     __CPROVER_assert( pPacketInfo != NULL,
                       "EventCallbackStub pPacketInfo is not NULL" );
-    /* pPublishInfo will be NULL for an incoming ACK event. */
+    __CPROVER_assert( pDeserialized != NULL,
+                      "EventCallbackStub pDeserialized is not NULL" );
 }

--- a/libraries/standard/mqtt/include/mqtt.h
+++ b/libraries/standard/mqtt/include/mqtt.h
@@ -128,7 +128,7 @@ struct MQTTDeserializedInfo
 {
     uint16_t packetIdentifier;
     MQTTPublishInfo_t * pPublishInfo;
-    MQTTStatus_t status;
+    MQTTStatus_t deserializationResult;
 };
 
 /**

--- a/libraries/standard/mqtt/include/mqtt.h
+++ b/libraries/standard/mqtt/include/mqtt.h
@@ -56,6 +56,10 @@ typedef uint32_t (* MQTTGetCurrentTimeFunc_t )( void );
  * @brief Application callback for receiving incoming publishes and incoming
  * acks.
  *
+ * @note This callback will be called only if packets are deserialized with a
+ * result of #MQTTSuccess or #MQTTServerRefused. The latter can be obtained
+ * when deserializing a SUBACK, indicating a broker's rejection of a subscribe.
+ *
  * @param[in] pContext Initialized MQTT context.
  * @param[in] pPacketInfo Information on the type of incoming MQTT packet.
  * @param[in] pDeserialized Deserialized information from incoming packet.

--- a/libraries/standard/mqtt/include/mqtt.h
+++ b/libraries/standard/mqtt/include/mqtt.h
@@ -62,11 +62,11 @@ typedef uint32_t (* MQTTGetCurrentTimeFunc_t )( void );
  *
  * @param[in] pContext Initialized MQTT context.
  * @param[in] pPacketInfo Information on the type of incoming MQTT packet.
- * @param[in] pDeserialized Deserialized information from incoming packet.
+ * @param[in] pDeserializedInfo Deserialized information from incoming packet.
  */
 typedef void (* MQTTEventCallback_t )( MQTTContext_t * pContext,
                                        MQTTPacketInfo_t * pPacketInfo,
-                                       MQTTDeserializedInfo_t * pDeserialized );
+                                       MQTTDeserializedInfo_t * pDeserializedInfo );
 
 typedef enum MQTTConnectionStatus
 {

--- a/libraries/standard/mqtt/include/mqtt.h
+++ b/libraries/standard/mqtt/include/mqtt.h
@@ -36,10 +36,13 @@
 #define MQTT_PACKET_ID_INVALID    ( ( uint16_t ) 0U )
 
 struct MQTTPubAckInfo;
-typedef struct MQTTPubAckInfo   MQTTPubAckInfo_t;
+typedef struct MQTTPubAckInfo         MQTTPubAckInfo_t;
 
 struct MQTTContext;
-typedef struct MQTTContext      MQTTContext_t;
+typedef struct MQTTContext            MQTTContext_t;
+
+struct MQTTDeserializedInfo;
+typedef struct MQTTDeserializedInfo   MQTTDeserializedInfo_t;
 
 /**
  * @brief Application provided callback to retrieve the current time in
@@ -55,13 +58,11 @@ typedef uint32_t (* MQTTGetCurrentTimeFunc_t )( void );
  *
  * @param[in] pContext Initialized MQTT context.
  * @param[in] pPacketInfo Information on the type of incoming MQTT packet.
- * @param[in] packetIdentifier Packet identifier of incoming PUBLISH packet.
- * @param[in] pPublishInfo Incoming PUBLISH packet parameters.
+ * @param[in] pDeserialized Deserialized information from incoming packet.
  */
 typedef void (* MQTTEventCallback_t )( MQTTContext_t * pContext,
                                        MQTTPacketInfo_t * pPacketInfo,
-                                       uint16_t packetIdentifier,
-                                       MQTTPublishInfo_t * pPublishInfo );
+                                       MQTTDeserializedInfo_t * pDeserialized );
 
 typedef enum MQTTConnectionStatus
 {
@@ -121,6 +122,13 @@ struct MQTTContext
     uint32_t pingReqSendTimeMs;
     uint32_t pingRespTimeoutMs;
     bool waitingForPingResp;
+};
+
+struct MQTTDeserializedInfo
+{
+    uint16_t packetIdentifier;
+    MQTTPublishInfo_t * pPublishInfo;
+    MQTTStatus_t status;
 };
 
 /**

--- a/libraries/standard/mqtt/integration-test/mqtt_system_test.c
+++ b/libraries/standard/mqtt/integration-test/mqtt_system_test.c
@@ -300,11 +300,11 @@ static void handleAckEvents( MQTTPacketInfo_t * pPacketInfo,
  *
  * @param[in] pContext MQTT context pointer.
  * @param[in] pPacketInfo Packet Info pointer for the incoming packet.
- * @param[in] pDeserialized Deserialized information from the incoming packet.
+ * @param[in] pDeserializedInfo Deserialized information from the incoming packet.
  */
 static void eventCallback( MQTTContext_t * pContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           MQTTDeserializedInfo_t * pDeserialized );
+                           MQTTDeserializedInfo_t * pDeserializedInfo );
 
 /**
  * @brief Implementation of TransportSend_t interface that terminates the TLS
@@ -504,16 +504,16 @@ static void handleAckEvents( MQTTPacketInfo_t * pPacketInfo,
 
 static void eventCallback( MQTTContext_t * pContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           MQTTDeserializedInfo_t * pDeserialized )
+                           MQTTDeserializedInfo_t * pDeserializedInfo )
 {
     MQTTPublishInfo_t * pPublishInfo = NULL;
 
     assert( pContext != NULL );
     assert( pPacketInfo != NULL );
-    assert( pDeserialized != NULL );
+    assert( pDeserializedInfo != NULL );
 
-    TEST_ASSERT_EQUAL( MQTTSuccess, pDeserialized->deserializationResult );
-    pPublishInfo = pDeserialized->pPublishInfo;
+    TEST_ASSERT_EQUAL( MQTTSuccess, pDeserializedInfo->deserializationResult );
+    pPublishInfo = pDeserializedInfo->pPublishInfo;
 
     if( ( pPacketInfo->type == disconnectOnPacketType ) ||
         ( ( pPacketInfo->type & 0xF0U ) == disconnectOnPacketType ) )
@@ -554,7 +554,7 @@ static void eventCallback( MQTTContext_t * pContext,
         }
         else
         {
-            handleAckEvents( pPacketInfo, pDeserialized->packetIdentifier );
+            handleAckEvents( pPacketInfo, pDeserializedInfo->packetIdentifier );
         }
     }
 }

--- a/libraries/standard/mqtt/integration-test/mqtt_system_test.c
+++ b/libraries/standard/mqtt/integration-test/mqtt_system_test.c
@@ -512,7 +512,7 @@ static void eventCallback( MQTTContext_t * pContext,
     assert( pPacketInfo != NULL );
     assert( pDeserialized != NULL );
 
-    TEST_ASSERT_EQUAL( MQTTSuccess, pDeserialized->status );
+    TEST_ASSERT_EQUAL( MQTTSuccess, pDeserialized->deserializationResult );
     pPublishInfo = pDeserialized->pPublishInfo;
 
     if( ( pPacketInfo->type == disconnectOnPacketType ) ||

--- a/libraries/standard/mqtt/integration-test/mqtt_system_test.c
+++ b/libraries/standard/mqtt/integration-test/mqtt_system_test.c
@@ -300,14 +300,11 @@ static void handleAckEvents( MQTTPacketInfo_t * pPacketInfo,
  *
  * @param[in] pContext MQTT context pointer.
  * @param[in] pPacketInfo Packet Info pointer for the incoming packet.
- * @param[in] packetIdentifier Packet identifier of the incoming packet.
- * @param[in] pPublishInfo Deserialized publish info pointer for the incoming
- * packet.
+ * @param[in] pDeserialized Deserialized information from the incoming packet.
  */
 static void eventCallback( MQTTContext_t * pContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           uint16_t packetIdentifier,
-                           MQTTPublishInfo_t * pPublishInfo );
+                           MQTTDeserializedInfo_t * pDeserialized );
 
 /**
  * @brief Implementation of TransportSend_t interface that terminates the TLS
@@ -507,11 +504,16 @@ static void handleAckEvents( MQTTPacketInfo_t * pPacketInfo,
 
 static void eventCallback( MQTTContext_t * pContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           uint16_t packetIdentifier,
-                           MQTTPublishInfo_t * pPublishInfo )
+                           MQTTDeserializedInfo_t * pDeserialized )
 {
+    MQTTPublishInfo_t * pPublishInfo = NULL;
+
     assert( pContext != NULL );
     assert( pPacketInfo != NULL );
+    assert( pDeserialized != NULL );
+
+    TEST_ASSERT_EQUAL( MQTTSuccess, pDeserialized->status );
+    pPublishInfo = pDeserialized->pPublishInfo;
 
     if( ( pPacketInfo->type == disconnectOnPacketType ) ||
         ( ( pPacketInfo->type & 0xF0U ) == disconnectOnPacketType ) )
@@ -552,8 +554,7 @@ static void eventCallback( MQTTContext_t * pContext,
         }
         else
         {
-            handleAckEvents( pPacketInfo,
-                             packetIdentifier );
+            handleAckEvents( pPacketInfo, pDeserialized->packetIdentifier );
         }
     }
 }

--- a/libraries/standard/mqtt/lexicon.txt
+++ b/libraries/standard/mqtt/lexicon.txt
@@ -140,6 +140,7 @@ pconnectinfo
 pcontext
 pcurrentstate
 pcursor
+pdeserialized
 pdestination
 pem
 pfixedbuffer

--- a/libraries/standard/mqtt/lexicon.txt
+++ b/libraries/standard/mqtt/lexicon.txt
@@ -140,7 +140,7 @@ pconnectinfo
 pcontext
 pcurrentstate
 pcursor
-pdeserialized
+pdeserializedinfo
 pdestination
 pem
 pfixedbuffer

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -920,7 +920,7 @@ static MQTTStatus_t handleIncomingAck( MQTTContext_t * pContext,
 
         case MQTT_PACKET_TYPE_PINGRESP:
             status = MQTT_DeserializeAck( pIncomingPacket, &packetIdentifier, NULL );
-            invokeAppCallback = ( manageKeepAlive == true ) ? false : true;
+            invokeAppCallback = ( ( status == MQTTSuccess ) && ( manageKeepAlive == false ) ) ? true : false;
 
             if( ( status == MQTTSuccess ) && ( manageKeepAlive == true ) )
             {
@@ -933,7 +933,7 @@ static MQTTStatus_t handleIncomingAck( MQTTContext_t * pContext,
         case MQTT_PACKET_TYPE_UNSUBACK:
             /* Deserialize and give these to the app provided callback. */
             status = MQTT_DeserializeAck( pIncomingPacket, &packetIdentifier, NULL );
-            invokeAppCallback = true;
+            invokeAppCallback = ( ( status == MQTTSuccess ) || ( status == MQTTServerRefused ) ) ? true : false;
             break;
 
         default:
@@ -944,7 +944,7 @@ static MQTTStatus_t handleIncomingAck( MQTTContext_t * pContext,
             break;
     }
 
-    if( ( status == MQTTSuccess ) && ( invokeAppCallback == true ) )
+    if( invokeAppCallback == true )
     {
         appCallback( pContext, pIncomingPacket, packetIdentifier, NULL );
     }

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -964,6 +964,8 @@ static MQTTStatus_t handleIncomingAck( MQTTContext_t * pContext,
         deserializedInfo.packetIdentifier = packetIdentifier;
         deserializedInfo.deserializationResult = status;
         appCallback( pContext, pIncomingPacket, &deserializedInfo );
+        /* In case a SUBACK indicated refusal, reset the status to continue the loop. */
+        status = MQTTSuccess;
     }
 
     return status;

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -917,8 +917,6 @@ static MQTTStatus_t handleIncomingAck( MQTTContext_t * pContext,
     assert( pContext->appCallback != NULL );
 
     appCallback = pContext->appCallback;
-    /* We did not receive a publish. */
-    deserializedInfo.pPublishInfo = NULL;
 
     switch( pIncomingPacket->type )
     {
@@ -963,6 +961,7 @@ static MQTTStatus_t handleIncomingAck( MQTTContext_t * pContext,
         /* Set fields of deserialized struct. */
         deserializedInfo.packetIdentifier = packetIdentifier;
         deserializedInfo.deserializationResult = status;
+        deserializedInfo.pPublishInfo = NULL;
         appCallback( pContext, pIncomingPacket, &deserializedInfo );
         /* In case a SUBACK indicated refusal, reset the status to continue the loop. */
         status = MQTTSuccess;

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -960,7 +960,7 @@ static MQTTStatus_t readSubackStatus( size_t statusCount,
 
             case 0x80:
 
-                LogDebug( ( "Topic filter %lu refused.", ( unsigned long ) i ) );
+                LogWarn( ( "Topic filter %lu refused.", ( unsigned long ) i ) );
 
                 /* Application should remove subscription from the list */
                 status = MQTTServerRefused;

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -1538,6 +1538,15 @@ void test_MQTT_ProcessLoop_handleIncomingAck_Happy_Paths( void )
                             MQTTSuccess, MQTTSuccess, MQTTStateNull,
                             MQTTSuccess, false, NULL );
 
+    /* Verify that process loop is still successful when SUBACK indicates a
+     * server refusal. */
+    currentPacketType = MQTT_PACKET_TYPE_SUBACK;
+    isEventCallbackInvoked = false;
+    expectProcessLoopCalls( &context, MQTTServerRefused, MQTTStateNull,
+                            MQTTSuccess, MQTTSuccess, MQTTStateNull,
+                            MQTTSuccess, false, NULL );
+    TEST_ASSERT_TRUE( isEventCallbackInvoked );
+
     /* Mock the receiving of an UNSUBACK packet type and expect the appropriate
      * calls made from the process loop. */
     currentPacketType = MQTT_PACKET_TYPE_UNSUBACK;
@@ -1600,15 +1609,6 @@ void test_MQTT_ProcessLoop_handleIncomingAck_Error_Paths( void )
     expectProcessLoopCalls( &context, MQTTBadResponse, MQTTStateNull,
                             MQTTIllegalState, MQTTBadResponse, MQTTStateNull,
                             MQTTBadResponse, false, NULL );
-
-    /* Verify that MQTTServerRefused is propagated when SUBACK indicates a
-     * server refusal. */
-    currentPacketType = MQTT_PACKET_TYPE_SUBACK;
-    isEventCallbackInvoked = false;
-    expectProcessLoopCalls( &context, MQTTServerRefused, MQTTStateNull,
-                            MQTTIllegalState, MQTTBadResponse, MQTTStateNull,
-                            MQTTServerRefused, false, NULL );
-    TEST_ASSERT_TRUE( isEventCallbackInvoked );
 
     /* Verify that MQTTIllegalState is returned if MQTT_UpdateStateAck(...)
      * provides an unknown state such as MQTTStateNull to sendPublishAcks(...). */

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -187,15 +187,15 @@ static void setupNetworkBuffer( MQTTFixedBuffer_t * const pNetworkBuffer )
  *
  * @param[in] pContext MQTT context pointer.
  * @param[in] pPacketInfo Packet Info pointer for the incoming packet.
- * @param[in] pDeserialized Deserialized information from the incoming packet.
+ * @param[in] pDeserializedInfo Deserialized information from the incoming packet.
  */
 static void eventCallback( MQTTContext_t * pContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           MQTTDeserializedInfo_t * pDeserialized )
+                           MQTTDeserializedInfo_t * pDeserializedInfo )
 {
     ( void ) pContext;
     ( void ) pPacketInfo;
-    ( void ) pDeserialized;
+    ( void ) pDeserializedInfo;
 
     /* Update the global state to indicate that event callback is invoked. */
     isEventCallbackInvoked = true;

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -1605,6 +1605,15 @@ void test_MQTT_ProcessLoop_handleIncomingAck_Error_Paths( void )
                             MQTTIllegalState, MQTTBadResponse, MQTTStateNull,
                             MQTTBadResponse, false, NULL );
 
+    /* Verify that MQTTServerRefused is propagated when SUBACK indicates a
+     * server refusal. */
+    currentPacketType = MQTT_PACKET_TYPE_SUBACK;
+    isEventCallbackInvoked = false;
+    expectProcessLoopCalls( &context, MQTTServerRefused, MQTTStateNull,
+                            MQTTIllegalState, MQTTBadResponse, MQTTStateNull,
+                            MQTTServerRefused, false, NULL );
+    TEST_ASSERT_TRUE( isEventCallbackInvoked );
+
     /* Verify that MQTTIllegalState is returned if MQTT_UpdateStateAck(...)
      * provides an unknown state such as MQTTStateNull to sendPublishAcks(...). */
     currentPacketType = MQTT_PACKET_TYPE_PUBREC;

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -187,19 +187,15 @@ static void setupNetworkBuffer( MQTTFixedBuffer_t * const pNetworkBuffer )
  *
  * @param[in] pContext MQTT context pointer.
  * @param[in] pPacketInfo Packet Info pointer for the incoming packet.
- * @param[in] packetIdentifier Packet identifier of the incoming packet.
- * @param[in] pPublishInfo Deserialized publish info pointer for the incoming
- * packet.
+ * @param[in] pDeserialized Deserialized information from the incoming packet.
  */
 static void eventCallback( MQTTContext_t * pContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           uint16_t packetIdentifier,
-                           MQTTPublishInfo_t * pPublishInfo )
+                           MQTTDeserializedInfo_t * pDeserialized )
 {
     ( void ) pContext;
     ( void ) pPacketInfo;
-    ( void ) packetIdentifier;
-    ( void ) pPublishInfo;
+    ( void ) pDeserialized;
 
     /* Update the global state to indicate that event callback is invoked. */
     isEventCallbackInvoked = true;


### PR DESCRIPTION
*Description of changes:*
The application should be aware of when a subscription is refused by the broker. The app callback should be called when a suback is deserialized with the status `MQTTServerRefused`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
