### PR TITLE
Fix logging call in MQTT, Make hygiene improvement in logging stack

### DIFF
--- a/demos/logging-stack/logging_stack.h
+++ b/demos/logging-stack/logging_stack.h
@@ -37,7 +37,7 @@
 
 /* Metadata information to prepend to every log message. */
 #define LOG_METADATA_FORMAT    "[%s:%d] "
-#define LOG_METADATA_ARGS      __FILE__, __LINE__
+#define LOG_METADATA_ARGS      __FUNCTION__, __LINE__
 
 /* Common macro for all logging interface macros. */
 #if !defined( DISABLE_LOGGING )

--- a/libraries/standard/http/utest/http_config.h
+++ b/libraries/standard/http/utest/http_config.h
@@ -15,8 +15,13 @@
 #include "logging_levels.h"
 
 /* Configure name and log level for the HTTP library. */
-#define LIBRARY_LOG_NAME     "HTTP"
-#define LIBRARY_LOG_LEVEL    LOG_NONE
+#ifndef LIBRARY_LOG_NAME
+    #define LIBRARY_LOG_NAME    "HTTP"
+#endif
+
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
+#endif
 
 #include "logging_stack.h"
 

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -1109,7 +1109,7 @@ static MQTTStatus_t sendPublish( MQTTContext_t * pContext,
         }
         else
         {
-            LogDebug( "PUBLISH payload was not sent. Payload length was zero." );
+            LogDebug( ( "PUBLISH payload was not sent. Payload length was zero." ) );
         }
     }
 

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -1164,7 +1164,7 @@ static MQTTStatus_t deserializePublish( const MQTTPacketInfo_t * pIncomingPacket
             pPublishInfo->pPayload = pPacketIdentifierHigh + sizeof( uint16_t );
         }
 
-        LogDebug( ( "Payload length %hu.", pPublishInfo->payloadLength ) );
+        LogDebug( ( "Payload length %lu.", pPublishInfo->payloadLength ) );
     }
 
     return status;

--- a/libraries/standard/mqtt/utest/mqtt_config.h
+++ b/libraries/standard/mqtt/utest/mqtt_config.h
@@ -15,8 +15,13 @@
 #include "logging_levels.h"
 
 /* Configure name and log level for the MQTT library. */
-#define LIBRARY_LOG_NAME     "MQTT"
-#define LIBRARY_LOG_LEVEL    LOG_NONE
+#ifndef LIBRARY_LOG_NAME
+    #define LIBRARY_LOG_NAME    "MQTT"
+#endif
+
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
+#endif
 
 #include "logging_stack.h"
 


### PR DESCRIPTION
* **Fix logging call in MQTT library** causing build failure when logging verbosity is `Debug` level
* **Fix some warnings** related to warnings in MQTT and HTTP
* **Hygiene change**: Update metadata of log messages to print function name instead of absolute file path to improve readability of log messages

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
