### PR TITLE
Fix Seg Faults in MQTT demo from transport implementations

### DIFF
--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -1083,7 +1083,7 @@ int main( int argc,
           char ** argv )
 {
     int returnStatus = EXIT_SUCCESS;
-    NetworkContext_t networkContext;
+    NetworkContext_t networkContext = { 0 };
 
     ( void ) argc;
     ( void ) argv;

--- a/demos/mqtt/mqtt_demo_lightweight/mqtt_demo_lightweight.c
+++ b/demos/mqtt/mqtt_demo_lightweight/mqtt_demo_lightweight.c
@@ -779,7 +779,7 @@ int main( int argc,
     uint32_t timeDiff = 0;
     bool controlPacketSent = false;
     bool publishPacketSent = false;
-    NetworkContext_t networkContext;
+    NetworkContext_t networkContext = { 0 };
 
     ( void ) argc;
     ( void ) argv;

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -1112,7 +1112,7 @@ int main( int argc,
           char ** argv )
 {
     int returnStatus = EXIT_SUCCESS;
-    NetworkContext_t networkContext;
+    NetworkContext_t networkContext = { 0 };
 
     ( void ) argc;
     ( void ) argv;

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
@@ -809,7 +809,7 @@ int main( int argc,
           char ** argv )
 {
     int returnStatus = EXIT_SUCCESS;
-    NetworkContext_t networkContext;
+    NetworkContext_t networkContext = { 0 };
 
     ( void ) argc;
     ( void ) argv;

--- a/platform/posix/transport/src/sockets_posix.c
+++ b/platform/posix/transport/src/sockets_posix.c
@@ -130,11 +130,12 @@ static SocketStatus_t resolveHostName( const char * pHostName,
     /* Perform a DNS lookup on the given host name. */
     dnsStatus = getaddrinfo( pHostName, NULL, &hints, pListHead );
 
-    if( dnsStatus == -1 )
+    if( dnsStatus != 0 )
     {
-        LogError( ( "Could not resolve host %.*s.\n",
+        LogError( ( "Failed to resolve DNS: Hostname=%.*s, ErrorCode=%d.\n",
                     ( int32_t ) hostNameLength,
-                    pHostName ) );
+                    pHostName,
+                    dnsStatus ) );
         returnStatus = SOCKETS_DNS_FAILURE;
     }
 


### PR DESCRIPTION
Fix **Seg Faults** encountered in MQTT demos for 2 corner cases:
* DNS resolution failure when demo configured with incorrect hostname
* SSL connection failure when server is down


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
