### PR TITLE
Use MQTT_PublishToResend() in the basic_tls and mutual_auth demos

### DIFF
--- a/demos/lexicon.txt
+++ b/demos/lexicon.txt
@@ -31,6 +31,7 @@ developerguide
 doesn
 dup
 endif
+hashmap
 hasn
 html
 http
@@ -53,6 +54,7 @@ org
 outgoingpublishpackets
 packetid
 packetidentifier
+packetidtoresend
 param
 pathlen
 pbuffer

--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -511,7 +511,7 @@ static int handlePublishResend( MQTTContext_t * pMqttContext )
      * packetId key and PublishPacket_t values may be used instead. */
     packetIdToResend = MQTT_PublishToResend( pMqttContext, &cursor );
 
-    while( packetIdToResend != 0 )
+    while( packetIdToResend != MQTT_PACKET_ID_INVALID )
     {
         for( index = 0U; index < MAX_OUTGOING_PUBLISHES; index++ )
         {

--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -44,8 +44,9 @@
 /* Include Demo Config as the first non-system header. */
 #include "demo_config.h"
 
-/* MQTT API header. */
+/* MQTT API headers. */
 #include "mqtt.h"
+#include "mqtt_state.h"
 
 /* OpenSSL sockets transport implementation. */
 #include "openssl_posix.h"
@@ -497,39 +498,50 @@ static int handlePublishResend( MQTTContext_t * pMqttContext )
     int returnStatus = EXIT_SUCCESS;
     MQTTStatus_t mqttStatus = MQTTSuccess;
     uint8_t index = 0U;
+    MQTTStateCursor_t cursor = MQTT_STATE_CURSOR_INITIALIZER;
+    uint16_t packetIdToResend = 0;
 
+    assert( pMqttContext != NULL );
     assert( outgoingPublishPackets != NULL );
 
-    /* Resend all the QoS2 publishes still in the array. These are the
-     * publishes that hasn't received a PUBREC. When a PUBREC is
-     * received, the publish is removed from the array. */
-    for( index = 0U; index < MAX_OUTGOING_PUBLISHES; index++ )
+    /* For the sake of demonstrating how to use MQTT_PublishToResend(), the 
+     * outgoingPublishPackets array is iterated through for the next pending 
+     * publish packet to be resent. If the application requires increased 
+     * efficiency in the look up of the packetIdToResend, then a hashmap of 
+     * packetId key and PublishPacket_t values may be used instead. */
+    packetIdToResend = MQTT_PublishToResend( pMqttContext, &cursor);
+    while( packetIdToResend != 0 )
     {
-        if( outgoingPublishPackets[ index ].packetId != MQTT_PACKET_ID_INVALID )
+        for( index = 0U; index < MAX_OUTGOING_PUBLISHES; index++ )
         {
-            outgoingPublishPackets[ index ].pubInfo.dup = true;
-
-            LogInfo( ( "Sending duplicate PUBLISH with packet id %u.",
-                       outgoingPublishPackets[ index ].packetId ) );
-            mqttStatus = MQTT_Publish( pMqttContext,
-                                       &outgoingPublishPackets[ index ].pubInfo,
-                                       outgoingPublishPackets[ index ].packetId );
-
-            if( mqttStatus != MQTTSuccess )
+            if( outgoingPublishPackets[ index ].packetId == packetIdToResend )
             {
-                LogError( ( "Sending duplicate PUBLISH for packet id %u "
-                            " failed with status %u.",
-                            outgoingPublishPackets[ index ].packetId,
-                            mqttStatus ) );
-                returnStatus = EXIT_FAILURE;
-                break;
-            }
-            else
-            {
-                LogInfo( ( "Sent duplicate PUBLISH successfully for packet id %u.\n\n",
-                           outgoingPublishPackets[ index ].packetId ) );
+                outgoingPublishPackets[ index ].pubInfo.dup = true;
+
+                LogInfo( ( "Sending duplicate PUBLISH with packet id %u.",
+                        outgoingPublishPackets[ index ].packetId ) );
+                mqttStatus = MQTT_Publish( pMqttContext,
+                                        &outgoingPublishPackets[ index ].pubInfo,
+                                        outgoingPublishPackets[ index ].packetId );
+
+                if( mqttStatus != MQTTSuccess )
+                {
+                    LogError( ( "Sending duplicate PUBLISH for packet id %u "
+                                " failed with status %u.",
+                                outgoingPublishPackets[ index ].packetId,
+                                mqttStatus ) );
+                    returnStatus = EXIT_FAILURE;
+                    break;
+                }
+                else
+                {
+                    LogInfo( ( "Sent duplicate PUBLISH successfully for packet id %u.\n\n",
+                            outgoingPublishPackets[ index ].packetId ) );
+                }
             }
         }
+        /* Get the next packetID to be resent. */
+        packetIdToResend = MQTT_PublishToResend( pMqttContext, &cursor);
     }
 
     return returnStatus;

--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -516,6 +516,7 @@ static int handlePublishResend( MQTTContext_t * pMqttContext )
 
     while( packetIdToResend != MQTT_PACKET_ID_INVALID )
     {
+        foundPacketId = false;
         for( index = 0U; index < MAX_OUTGOING_PUBLISHES; index++ )
         {
             if( outgoingPublishPackets[ index ].packetId == packetIdToResend )

--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -57,8 +57,6 @@
 /* Clock for timer. */
 #include "clock.h"
 
-#include <signal.h>
-
 /**
  * These configuration settings are required to run the basic TLS demo.
  * Throw compilation error if the below configs are not defined.
@@ -1079,19 +1077,6 @@ static int subscribePublishLoop( NetworkContext_t * pNetworkContext )
     return returnStatus;
 }
 
-void handler(int sig) {
-  void *array[10];
-  size_t size;
-
-  // get void*'s for all entries on the stack
-  size = backtrace(array, 10);
-
-  // print out all the frames to stderr
-  fprintf(stderr, "Error: signal %d:\n", sig);
-  backtrace_symbols_fd(array, size, STDERR_FILENO);
-  exit(1);
-}
-
 /*-----------------------------------------------------------*/
 
 /**
@@ -1116,8 +1101,6 @@ int main( int argc,
 
     ( void ) argc;
     ( void ) argv;
-
-    signal(SIGSEGV, handler);
 
     for( ; ; )
     {

--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -499,7 +499,7 @@ static int handlePublishResend( MQTTContext_t * pMqttContext )
     MQTTStatus_t mqttStatus = MQTTSuccess;
     uint8_t index = 0U;
     MQTTStateCursor_t cursor = MQTT_STATE_CURSOR_INITIALIZER;
-    uint16_t packetIdToResend = 0;
+    uint16_t packetIdToResend = MQTT_PACKET_ID_INVALID;
 
     assert( pMqttContext != NULL );
     assert( outgoingPublishPackets != NULL );

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -51,6 +51,7 @@
 
 /* MQTT API header. */
 #include "mqtt.h"
+#include "mqtt_state.h"
 
 /* OpenSSL sockets transport implementation. */
 #include "openssl_posix.h"

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -550,12 +550,13 @@ static int handlePublishResend( MQTTContext_t * pMqttContext )
     assert( pMqttContext != NULL );
     assert( outgoingPublishPackets != NULL );
 
-    /* For the sake of demonstrating how to use MQTT_PublishToResend(), the 
-     * outgoingPublishPackets array is iterated through for the next pending 
-     * publish packet to be resent. If the application requires increased 
-     * efficiency in the look up of the packetIdToResend, then a hashmap of 
+    /* For the sake of demonstrating how to use MQTT_PublishToResend(), the
+     * outgoingPublishPackets array is iterated through for the next pending
+     * publish packet to be resent. If the application requires increased
+     * efficiency in the look up of the packetIdToResend, then a hashmap of
      * packetId key and PublishPacket_t values may be used instead. */
-    packetIdToResend = MQTT_PublishToResend( pMqttContext, &cursor);
+    packetIdToResend = MQTT_PublishToResend( pMqttContext, &cursor );
+
     while( packetIdToResend != 0 )
     {
         for( index = 0U; index < MAX_OUTGOING_PUBLISHES; index++ )
@@ -565,10 +566,10 @@ static int handlePublishResend( MQTTContext_t * pMqttContext )
                 outgoingPublishPackets[ index ].pubInfo.dup = true;
 
                 LogInfo( ( "Sending duplicate PUBLISH with packet id %u.",
-                        outgoingPublishPackets[ index ].packetId ) );
+                           outgoingPublishPackets[ index ].packetId ) );
                 mqttStatus = MQTT_Publish( pMqttContext,
-                                        &outgoingPublishPackets[ index ].pubInfo,
-                                        outgoingPublishPackets[ index ].packetId );
+                                           &outgoingPublishPackets[ index ].pubInfo,
+                                           outgoingPublishPackets[ index ].packetId );
 
                 if( mqttStatus != MQTTSuccess )
                 {
@@ -582,12 +583,13 @@ static int handlePublishResend( MQTTContext_t * pMqttContext )
                 else
                 {
                     LogInfo( ( "Sent duplicate PUBLISH successfully for packet id %u.\n\n",
-                            outgoingPublishPackets[ index ].packetId ) );
+                               outgoingPublishPackets[ index ].packetId ) );
                 }
             }
         }
+
         /* Get the next packetID to be resent. */
-        packetIdToResend = MQTT_PublishToResend( pMqttContext, &cursor);
+        packetIdToResend = MQTT_PublishToResend( pMqttContext, &cursor );
     }
 
     return returnStatus;

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -563,6 +563,7 @@ static int handlePublishResend( MQTTContext_t * pMqttContext )
 
     while( packetIdToResend != MQTT_PACKET_ID_INVALID )
     {
+        foundPacketId = false;
         for( index = 0U; index < MAX_OUTGOING_PUBLISHES; index++ )
         {
             if( outgoingPublishPackets[ index ].packetId == packetIdToResend )

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -49,7 +49,7 @@
 /* Include Demo Config as the first non-system header. */
 #include "demo_config.h"
 
-/* MQTT API header. */
+/* MQTT API headers. */
 #include "mqtt.h"
 #include "mqtt_state.h"
 

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -546,24 +546,28 @@ static int handlePublishResend( MQTTContext_t * pMqttContext )
     MQTTStatus_t mqttStatus = MQTTSuccess;
     uint8_t index = 0U;
     MQTTStateCursor_t cursor = MQTT_STATE_CURSOR_INITIALIZER;
-    uint16_t packetIdToResend = 0;
+    uint16_t packetIdToResend = MQTT_PACKET_ID_INVALID;
+    bool foundPacketId = false;
 
     assert( pMqttContext != NULL );
     assert( outgoingPublishPackets != NULL );
 
-    /* For the sake of demonstrating how to use MQTT_PublishToResend(), the
-     * outgoingPublishPackets array is iterated through for the next pending
-     * publish packet to be resent. If the application requires increased
-     * efficiency in the look up of the packetIdToResend, then a hashmap of
+    /* MQTT_PublishToResend() provides a packet ID of the next PUBLISH packet
+     * that should be resent. In accordance with the MQTT v3.1.1 spec,
+     * MQTT_PublishToResend() preserves the ordering of when the original
+     * PUBLISH packets were sent. The outgoingPublishPackets array is searched
+     * through for the associated packet ID. If the application requires
+     * increased efficiency in the look up of the packet ID, then a hashmap of
      * packetId key and PublishPacket_t values may be used instead. */
     packetIdToResend = MQTT_PublishToResend( pMqttContext, &cursor );
 
-    while( packetIdToResend != 0 )
+    while( packetIdToResend != MQTT_PACKET_ID_INVALID )
     {
         for( index = 0U; index < MAX_OUTGOING_PUBLISHES; index++ )
         {
             if( outgoingPublishPackets[ index ].packetId == packetIdToResend )
             {
+                foundPacketId = true;
                 outgoingPublishPackets[ index ].pubInfo.dup = true;
 
                 LogInfo( ( "Sending duplicate PUBLISH with packet id %u.",
@@ -589,8 +593,19 @@ static int handlePublishResend( MQTTContext_t * pMqttContext )
             }
         }
 
-        /* Get the next packetID to be resent. */
-        packetIdToResend = MQTT_PublishToResend( pMqttContext, &cursor );
+        if( foundPacketId == false )
+        {
+            LogError( ( "Packet id %u requires resend, but was not found in "
+                        "outgoingPublishPackets.",
+                        packetIdToResend ) );
+            returnStatus = EXIT_FAILURE;
+            break;
+        }
+        else
+        {
+            /* Get the next packetID to be resent. */
+            packetIdToResend = MQTT_PublishToResend( pMqttContext, &cursor );
+        }
     }
 
     return returnStatus;

--- a/tools/spell/README.md
+++ b/tools/spell/README.md
@@ -1,4 +1,4 @@
-# How to create a lexicon.txt for a new library.
+# Pre-requisites to running the spell check scripts
 
 1. In your GNU environment, install the *spell* and *getopt* programs. Use the following commands in Debian distributions, to install the packages (*getopt* is part of the `util-linux` package):
    ```shell
@@ -11,9 +11,20 @@
    export PATH=<CSDK_ROOT>/tools/spell:$PATH
    ```
 
+# How to create a lexicon.txt for a new library.
+
 1. Ensure there does not exist a file called "lexicon.txt" in your library's directory. Run the following command to create a lexicon.txt for your library:  
    ```shell
    find-unknown-comment-words -d <CSDK_ROOT>/libraries/<LIBRARY_TYPE>/<MY_LIBRARY_NAME> > <CSDK_ROOT>/libraries/<LIBRARY_TYPE>/<MY_LIBRARY_NAME>/lexicon.txt
    ```
 
-1. Check the contents of *<CSDK_ROOT>/libraries/<LIBRARY_TYPE>/<MY_LIBRARY_NAME>/lexicon.txt* for any misspelled words. Fix them in your library's source code and delete them from the lexicon.txt. 
+1. Check the contents of *<CSDK_ROOT>/libraries/<LIBRARY_TYPE>/<MY_LIBRARY_NAME>/lexicon.txt* for any misspelled words. Fix them in your library's source code and delete them from the lexicon.txt.
+
+# How to run for changes to an existing library.
+
+1. If there exists a lexicon.txt in the library's directory, run the following command:
+   ```shell
+   find-unknown-comment-words -d <CSDK_ROOT>/libraries/<LIBRARY_TYPE>/<MY_LIBRARY_NAME>
+   ```
+
+1. Add any non-dictionary correctly spelled words to *<CSDK_ROOT>/libraries/<LIBRARY_TYPE>/<MY_LIBRARY_NAME>/lexicon.txt*. Fix any misspelled words in your code comment change.


### PR DESCRIPTION
***Description of changes:***
For demonstration purposes MQTT_PublishToResend() is now used in the mqtt_basic_tls_demo and the mqtt_mutual_auth_demo. These demos use a Qos > 0. 

***Extra changes:***
Updated the README.md in tools/spell for clarity on how to use the scripts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
