### PR TITLE
[PR from CLI tool] Update OpenSSL transport implementation to fix integration test SegFault

### DIFF
--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -606,7 +606,11 @@ int32_t Openssl_Recv( NetworkContext_t * pNetworkContext,
     int32_t bytesReceived = 0;
     int sslError = 0;
 
-    if( pNetworkContext->pSsl != NULL )
+    if( pNetworkContext == NULL )
+    {
+        LogError( ( "Parameter check failed: pNetworkContext is NULL." ) );
+    }
+    else if( pNetworkContext->pSsl != NULL )
     {
         /* SSL read of data. */
         bytesReceived = ( int32_t ) SSL_read( pNetworkContext->pSsl,
@@ -620,7 +624,8 @@ int32_t Openssl_Recv( NetworkContext_t * pNetworkContext,
     }
 
     /* Handle error return status if transport read did not succeed. */
-    if( ( pNetworkContext->pSsl != NULL ) && ( bytesReceived <= 0 ) )
+    if( ( pNetworkContext != NULL ) && ( pNetworkContext->pSsl != NULL ) &&
+        ( bytesReceived <= 0 ) )
     {
         sslError = SSL_get_error( pNetworkContext->pSsl, bytesReceived );
 
@@ -647,7 +652,11 @@ int32_t Openssl_Send( NetworkContext_t * pNetworkContext,
     int32_t bytesSent = 0;
     int32_t sslError = 0;
 
-    if( pNetworkContext->pSsl != NULL )
+    if( pNetworkContext == NULL )
+    {
+        LogError( ( "Parameter check failed: pNetworkContext is NULL." ) );
+    }
+    else if( pNetworkContext->pSsl != NULL )
     {
         /* SSL write of data. */
         bytesSent = ( int32_t ) SSL_write( pNetworkContext->pSsl,

--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -613,7 +613,13 @@ int32_t Openssl_Recv( NetworkContext_t * pNetworkContext,
                                               pBuffer,
                                               bytesToRecv );
     }
+    else
+    {
+        LogError( ( "Failed to receive data over network: "
+                    "SSL object in network context is NULL." ) );
+    }
 
+    /* Handle error return status if transport read did not succeed. */
     if( ( pNetworkContext->pSsl != NULL ) && ( bytesReceived <= 0 ) )
     {
         sslError = SSL_get_error( pNetworkContext->pSsl, bytesReceived );
@@ -628,11 +634,6 @@ int32_t Openssl_Recv( NetworkContext_t * pNetworkContext,
             LogError( ( "Failed to receive data over network: SSL_read failed: "
                         "ErrorStatus=%s.", ERR_reason_error_string( sslError ) ) );
         }
-    }
-    else if( pNetworkContext->pSsl == NULL )
-    {
-        LogError( ( "Failed to receive data over network: "
-                    "SSL object in network context is NULL." ) );
     }
 
     return bytesReceived;

--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -632,7 +632,7 @@ int32_t Openssl_Recv( NetworkContext_t * pNetworkContext,
     else if( pNetworkContext->pSsl == NULL )
     {
         LogError( ( "Failed to receive data over network: "
-                    "Network context has invalid SSL object." ) );
+                    "SSL object in network context is NULL." ) );
     }
 
     return bytesReceived;
@@ -658,13 +658,13 @@ int32_t Openssl_Send( NetworkContext_t * pNetworkContext,
             sslError = SSL_get_error( pNetworkContext->pSsl, bytesSent );
 
             LogError( ( "Failed to send data over network: SSL_write of OpenSSL failed: "
-                        " ErrorStatus=%s.", ERR_reason_error_string( sslError ) ) );
+                        "ErrorStatus=%s.", ERR_reason_error_string( sslError ) ) );
         }
     }
     else
     {
         LogError( ( "Failed to send data over network: "
-                    "Network context has invalid SSL object." ) );
+                    "SSL object in network context is NULL." ) );
     }
 
     return bytesSent;

--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -581,7 +581,6 @@ OpensslStatus_t Openssl_Disconnect( NetworkContext_t * pNetworkContext )
         }
 
         SSL_free( pNetworkContext->pSsl );
-        pNetworkContext->pSsl = NULL;
     }
     else
     {
@@ -607,12 +606,15 @@ int32_t Openssl_Recv( NetworkContext_t * pNetworkContext,
     int32_t bytesReceived = 0;
     int sslError = 0;
 
-    /* SSL read of data. */
-    bytesReceived = ( int32_t ) SSL_read( pNetworkContext->pSsl,
-                                          pBuffer,
-                                          bytesToRecv );
+    if( pNetworkContext->pSsl != NULL )
+    {
+        /* SSL read of data. */
+        bytesReceived = ( int32_t ) SSL_read( pNetworkContext->pSsl,
+                                              pBuffer,
+                                              bytesToRecv );
+    }
 
-    if( bytesReceived <= 0 )
+    if( ( pNetworkContext->pSsl != NULL ) && ( bytesReceived <= 0 ) )
     {
         sslError = SSL_get_error( pNetworkContext->pSsl, bytesReceived );
 
@@ -623,9 +625,14 @@ int32_t Openssl_Recv( NetworkContext_t * pNetworkContext,
         }
         else
         {
-            LogError( ( "SSL_read of OpenSSL failed to receive data: "
-                        "status=%s.", ERR_reason_error_string( sslError ) ) );
+            LogError( ( "Failed to receive data over network: SSL_read failed: "
+                        "ErrorStatus=%s.", ERR_reason_error_string( sslError ) ) );
         }
+    }
+    else if( pNetworkContext->pSsl == NULL )
+    {
+        LogError( ( "Failed to receive data over network: "
+                    "Network context has invalid SSL object." ) );
     }
 
     return bytesReceived;
@@ -637,16 +644,27 @@ int32_t Openssl_Send( NetworkContext_t * pNetworkContext,
                       size_t bytesToSend )
 {
     int32_t bytesSent = 0;
+    int32_t sslError = 0;
 
-    /* SSL write of data. */
-    bytesSent = ( int32_t ) SSL_write( pNetworkContext->pSsl,
-                                       pBuffer,
-                                       bytesToSend );
-
-    if( bytesSent <= 0 )
+    if( pNetworkContext->pSsl != NULL )
     {
-        LogError( ( "SSL_write of OpenSSL failed to send data: "
-                    " status=%d.", bytesSent ) );
+        /* SSL write of data. */
+        bytesSent = ( int32_t ) SSL_write( pNetworkContext->pSsl,
+                                           pBuffer,
+                                           bytesToSend );
+
+        if( bytesSent <= 0 )
+        {
+            sslError = SSL_get_error( pNetworkContext->pSsl, bytesSent );
+
+            LogError( ( "Failed to send data over network: SSL_write of OpenSSL failed: "
+                        " ErrorStatus=%s.", ERR_reason_error_string( sslError ) ) );
+        }
+    }
+    else
+    {
+        LogError( ( "Failed to send data over network: "
+                    "Network context has invalid SSL object." ) );
     }
 
     return bytesSent;


### PR DESCRIPTION
### Issue
MQTT integration test undergoes Segmentation Fault when `MQTT_ProcessLoop` is called after `OpenSSL_Disconnect`.

### Cause
PR #1100 had updated implementation of `OpenSSL_Disconnect` to explicitly set the `NetworkContext_t.pSsl` member to be `NULL`. Thus, when `MQTT_ProcessLoop` is called after OpenSSL disconnection, the `OpenSSL_Send` function (called by the MQTT library) results in Segmentation Fault by calling `SSL_write` function with a `NULL` SSL object.

### Fix
Update `OpenSSL_Disconnect` (and `OpenSSL_Connect`) to not explicitly set the `NetworkContext_t.pSsl` member to `NULL` as `SSL_free` function call should suffice for clean up. Also, update the `OpenSSL_Read` and `OpenSSL_Send` functions to perform NULL check on the input SSL object before calling the OpenSSL read/write function.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
