### PR TITLE
[PR from CLI tool] Fix pointer logging warnings in MQTT library

### DIFF
--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -1055,8 +1055,8 @@ static MQTTStatus_t validateSubscribeUnsubscribeParams( const MQTTContext_t * pC
     {
         LogError( ( "Argument cannot be NULL: pContext=%p, "
                     "pSubscriptionList=%p.",
-                    pContext,
-                    pSubscriptionList ) );
+                    ( void * ) pContext,
+                    ( void * ) pSubscriptionList ) );
         status = MQTTBadParameter;
     }
     else if( subscriptionCount == 0UL )
@@ -1334,8 +1334,8 @@ static MQTTStatus_t validatePublishParams( const MQTTContext_t * pContext,
     {
         LogError( ( "Argument cannot be NULL: pContext=%p, "
                     "pPublishInfo=%p.",
-                    pContext,
-                    pPublishInfo ) );
+                    ( void * ) pContext,
+                    ( void * ) pPublishInfo ) );
         status = MQTTBadParameter;
     }
     else if( ( pPublishInfo->qos != MQTTQoS0 ) && ( packetId == 0U ) )
@@ -1377,20 +1377,29 @@ MQTTStatus_t MQTT_Init( MQTTContext_t * pContext,
         LogError( ( "Argument cannot be NULL: pContext=%p, "
                     "pTransportInterface=%p, "
                     "pNetworkBuffer=%p",
-                    pContext,
-                    pTransportInterface,
-                    pNetworkBuffer ) );
+                    ( void * ) pContext,
+                    ( void * ) pTransportInterface,
+                    ( void * ) pNetworkBuffer ) );
         status = MQTTBadParameter;
     }
-    else if( ( getTimeFunction == NULL ) || ( userCallback == NULL ) ||
-             ( pTransportInterface->recv == NULL ) || ( pTransportInterface->send == NULL ) )
+    else if( getTimeFunction == NULL )
     {
-        LogError( ( "Function pointers cannot be NULL: getTimeFunction=%p, userCallback=%p, "
-                    "transportRecv=%p, transportRecvSend=%p",
-                    getTimeFunction,
-                    userCallback,
-                    pTransportInterface->recv,
-                    pTransportInterface->send ) );
+        LogError( ( "Invalid parameter: getTimeFunction is NULL" ) );
+        status = MQTTBadParameter;
+    }
+    else if( userCallback == NULL )
+    {
+        LogError( ( "Invalid parameter: userCallback is NULL" ) );
+        status = MQTTBadParameter;
+    }
+    else if( pTransportInterface->recv == NULL )
+    {
+        LogError( ( "Invalid parameter: pTransportInterface->recv is NULL" ) );
+        status = MQTTBadParameter;
+    }
+    else if( pTransportInterface->send == NULL )
+    {
+        LogError( ( "Invalid parameter: pTransportInterface->send is NULL" ) );
         status = MQTTBadParameter;
     }
     else
@@ -1429,9 +1438,9 @@ MQTTStatus_t MQTT_Connect( MQTTContext_t * pContext,
     {
         LogError( ( "Argument cannot be NULL: pContext=%p, "
                     "pConnectInfo=%p, pSessionPresent=%p.",
-                    pContext,
-                    pConnectInfo,
-                    pSessionPresent ) );
+                    ( void * ) pContext,
+                    ( void * ) pConnectInfo,
+                    ( void * ) pSessionPresent ) );
         status = MQTTBadParameter;
     }
 

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -1042,8 +1042,8 @@ static MQTTStatus_t validateSubscriptionSerializeParams( const MQTTSubscribeInfo
     {
         LogError( ( "Argument cannot be NULL: pFixedBuffer=%p, "
                     "pSubscriptionList=%p.",
-                    pFixedBuffer,
-                    pSubscriptionList ) );
+                    ( void * ) pFixedBuffer,
+                    ( void * ) pSubscriptionList ) );
         status = MQTTBadParameter;
     }
     /* A buffer must be configured for serialization. */
@@ -1362,9 +1362,9 @@ MQTTStatus_t MQTT_GetConnectPacketSize( const MQTTConnectInfo_t * pConnectInfo,
     {
         LogError( ( "Argument cannot be NULL: pConnectInfo=%p, "
                     "pRemainingLength=%p, pPacketSize=%p.",
-                    pConnectInfo,
-                    pRemainingLength,
-                    pPacketSize ) );
+                    ( void * ) pConnectInfo,
+                    ( void * ) pRemainingLength,
+                    ( void * ) pPacketSize ) );
         status = MQTTBadParameter;
     }
     else if( ( pConnectInfo->clientIdentifierLength == 0U ) || ( pConnectInfo->pClientIdentifier == NULL ) )
@@ -1458,8 +1458,8 @@ MQTTStatus_t MQTT_SerializeConnect( const MQTTConnectInfo_t * pConnectInfo,
     {
         LogError( ( "Argument cannot be NULL: pConnectInfo=%p, "
                     "pFixedBuffer=%p.",
-                    pConnectInfo,
-                    pFixedBuffer ) );
+                    ( void * ) pConnectInfo,
+                    ( void * ) pFixedBuffer ) );
         status = MQTTBadParameter;
     }
     /* A buffer must be configured for serialization. */
@@ -1516,9 +1516,9 @@ MQTTStatus_t MQTT_GetSubscribePacketSize( const MQTTSubscribeInfo_t * pSubscript
     {
         LogError( ( "Argument cannot be NULL: pSubscriptionList=%p, "
                     "pRemainingLength=%p, pPacketSize=%p.",
-                    pSubscriptionList,
-                    pRemainingLength,
-                    pPacketSize ) );
+                    ( void * ) pSubscriptionList,
+                    ( void * ) pRemainingLength,
+                    ( void * ) pPacketSize ) );
         status = MQTTBadParameter;
     }
     else if( subscriptionCount == 0U )
@@ -1615,9 +1615,9 @@ MQTTStatus_t MQTT_GetUnsubscribePacketSize( const MQTTSubscribeInfo_t * pSubscri
     {
         LogError( ( "Argument cannot be NULL: pSubscriptionList=%p, "
                     "pRemainingLength=%p, pPacketSize=%p.",
-                    pSubscriptionList,
-                    pRemainingLength,
-                    pPacketSize ) );
+                    ( void * ) pSubscriptionList,
+                    ( void * ) pRemainingLength,
+                    ( void * ) pPacketSize ) );
         status = MQTTBadParameter;
     }
     else if( subscriptionCount == 0U )
@@ -1708,9 +1708,9 @@ MQTTStatus_t MQTT_GetPublishPacketSize( const MQTTPublishInfo_t * pPublishInfo,
     {
         LogError( ( "Argument cannot be NULL: pPublishInfo=%p, "
                     "pRemainingLength=%p, pPacketSize=%p.",
-                    pPublishInfo,
-                    pRemainingLength,
-                    pPacketSize ) );
+                    ( void * ) pPublishInfo,
+                    ( void * ) pRemainingLength,
+                    ( void * ) pPacketSize ) );
         status = MQTTBadParameter;
     }
     else if( ( pPublishInfo->pTopicName == NULL ) || ( pPublishInfo->topicNameLength == 0U ) )
@@ -1756,8 +1756,8 @@ MQTTStatus_t MQTT_SerializePublish( const MQTTPublishInfo_t * pPublishInfo,
     {
         LogError( ( "Argument cannot be NULL: pFixedBuffer=%p, "
                     "pPublishInfo=%p.",
-                    pFixedBuffer,
-                    pPublishInfo ) );
+                    ( void * ) pFixedBuffer,
+                    ( void * ) pPublishInfo ) );
         status = MQTTBadParameter;
     }
     /* A buffer must be configured for serialization. */
@@ -1841,9 +1841,9 @@ MQTTStatus_t MQTT_SerializePublishHeader( const MQTTPublishInfo_t * pPublishInfo
     {
         LogError( ( "Argument cannot be NULL: pFixedBuffer=%p, "
                     "pPublishInfo=%p, pHeaderSize=%p.",
-                    pFixedBuffer,
-                    pPublishInfo,
-                    pHeaderSize ) );
+                    ( void * ) pFixedBuffer,
+                    ( void * ) pPublishInfo,
+                    ( void * ) pHeaderSize ) );
         status = MQTTBadParameter;
     }
     /* A buffer must be configured for serialization. */
@@ -2088,9 +2088,9 @@ MQTTStatus_t MQTT_DeserializePublish( const MQTTPacketInfo_t * pIncomingPacket,
     {
         LogError( ( "Argument cannot be NULL: pIncomingPacket=%p, "
                     "pPacketId=%p, pPublishInfo=%p",
-                    pIncomingPacket,
-                    pPacketId,
-                    pPublishInfo ) );
+                    ( void * ) pIncomingPacket,
+                    ( void * ) pPacketId,
+                    ( void * ) pPublishInfo ) );
         status = MQTTBadParameter;
     }
     else if( ( pIncomingPacket->type & 0xF0U ) != MQTT_PACKET_TYPE_PUBLISH )

--- a/libraries/standard/mqtt/src/mqtt_state.c
+++ b/libraries/standard/mqtt/src/mqtt_state.c
@@ -852,8 +852,8 @@ MQTTStatus_t MQTT_UpdateStatePublish( MQTTContext_t * pMqttContext,
     if( ( pMqttContext == NULL ) || ( pNewState == NULL ) )
     {
         LogError( ( "Argument cannot be NULL: pMqttContext=%p, pNewState=%p",
-                    pMqttContext,
-                    pNewState ) );
+                    ( void * ) pMqttContext,
+                    ( void * ) pNewState ) );
 
         mqttStatus = MQTTBadParameter;
     }
@@ -928,8 +928,8 @@ MQTTStatus_t MQTT_UpdateStateAck( MQTTContext_t * pMqttContext,
     if( ( pMqttContext == NULL ) || ( pNewState == NULL ) )
     {
         LogError( ( "Argument cannot be NULL: pMqttContext=%p, pNewState=%p.",
-                    pMqttContext,
-                    pNewState ) );
+                    ( void * ) pMqttContext,
+                    ( void * ) pNewState ) );
     }
     else
     {
@@ -982,11 +982,11 @@ uint16_t MQTT_PubrelToResend( const MQTTContext_t * pMqttContext,
     /* Validate arguments. */
     if( ( pMqttContext == NULL ) || ( pCursor == NULL ) || ( pState == NULL ) )
     {
-        LogError( ( "Arguments cannot be NULL pMqttContext =%p, pCursor=%p"
+        LogError( ( "Arguments cannot be NULL pMqttContext=%p, pCursor=%p"
                     " pState=%p.",
-                    pMqttContext,
-                    pCursor,
-                    pState ) );
+                    ( void * ) pMqttContext,
+                    ( void * ) pCursor,
+                    ( void * ) pState ) );
     }
     else
     {
@@ -1018,8 +1018,8 @@ uint16_t MQTT_PublishToResend( const MQTTContext_t * pMqttContext,
     if( ( pMqttContext == NULL ) || ( pCursor == NULL ) )
     {
         LogError( ( "Arguments cannot be NULL pMqttContext =%p, pCursor=%p",
-                    pMqttContext,
-                    pCursor ) );
+                    ( void * ) pMqttContext,
+                    ( void * ) pCursor ) );
     }
     else
     {


### PR DESCRIPTION
Fix build warnings with `-Wall -Wextra` flags for pointer logging in MQTT files.

*Description of changes:*
* Use `(void *)` cast for logging non-function pointers
* Remove logging of function pointers as ISO C does not support `(void *)` cast of function pointers (Only POSIX does)


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
