### PR TITLE
Add metrics to the MQTT TLS Mutual Auth demo.

### DIFF
--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -514,6 +514,7 @@ static int handlePublishResend( MQTTContext_t * pMqttContext )
     while( packetIdToResend != MQTT_PACKET_ID_INVALID )
     {
         foundPacketId = false;
+
         for( index = 0U; index < MAX_OUTGOING_PUBLISHES; index++ )
         {
             if( outgoingPublishPackets[ index ].packetId == packetIdToResend )

--- a/demos/mqtt/mqtt_demo_mutual_auth/demo_config.h
+++ b/demos/mqtt/mqtt_demo_mutual_auth/demo_config.h
@@ -126,13 +126,13 @@
  * @brief The name of the operating system or SDK that the application is
  * running a part of.
  */
-#define OS_NAME                   "aws-iot-device-sdk-embedded-C"
+#define SDK_NAME                   "aws-iot-device-sdk-embedded-C"
 
 /**
  * @brief The version of the operating system or SDK that the application is
  * running a part of.
  */
-#define OS_VERSION                "4.0.0"
+#define SDK_VERSION                "4.0.0"
 
 /**
  * @brief The name of the hardware platform the application is running on.

--- a/demos/mqtt/mqtt_demo_mutual_auth/demo_config.h
+++ b/demos/mqtt/mqtt_demo_mutual_auth/demo_config.h
@@ -126,13 +126,13 @@
  * @brief The name of the operating system or SDK that the application is
  * running a part of.
  */
-#define SDK_NAME                   "aws-iot-device-sdk-embedded-C"
+#define SDK_NAME                  "aws-iot-device-sdk-embedded-C"
 
 /**
  * @brief The version of the operating system or SDK that the application is
  * running a part of.
  */
-#define SDK_VERSION                "4.0.0"
+#define SDK_VERSION               "4.0.0"
 
 /**
  * @brief The name of the hardware platform the application is running on.

--- a/demos/mqtt/mqtt_demo_mutual_auth/demo_config.h
+++ b/demos/mqtt/mqtt_demo_mutual_auth/demo_config.h
@@ -115,12 +115,29 @@
  *
  * No two clients may use the same client identifier simultaneously.
  */
-#define CLIENT_IDENTIFIER      "testclient"
+#define CLIENT_IDENTIFIER         "testclient"
 
 /**
  * @brief Size of the network buffer for MQTT packets.
  */
-#define NETWORK_BUFFER_SIZE    ( 1024U )
+#define NETWORK_BUFFER_SIZE       ( 1024U )
+
+/**
+ * @brief The name of the operating system or SDK that the application is
+ * running a part of.
+ */
+#define OS_NAME                   "aws-iot-embedded-c-sdk"
+
+/**
+ * @brief The version of the operating system or SDK that the application is
+ * running a part of.
+ */
+#define OS_VERSION                "4.0.0"
+
+/**
+ * @brief The name of the hardware platform the application is running on.
+ */
+#define HARDWARE_PLATFORM_NAME    "Posix"
 
 
 #endif /* ifndef DEMO_CONFIG_H_ */

--- a/demos/mqtt/mqtt_demo_mutual_auth/demo_config.h
+++ b/demos/mqtt/mqtt_demo_mutual_auth/demo_config.h
@@ -126,7 +126,7 @@
  * @brief The name of the operating system or SDK that the application is
  * running a part of.
  */
-#define OS_NAME                   "aws-iot-embedded-c-sdk"
+#define OS_NAME                   "aws-iot-device-sdk-embedded-C"
 
 /**
  * @brief The version of the operating system or SDK that the application is

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -93,12 +93,12 @@
     #define NETWORK_BUFFER_SIZE    ( 1024U )
 #endif
 
-#ifndef OS_NAME
-    #define OS_NAME    "aws-iot-device-sdk-embedded-C"
+#ifndef SDK_NAME
+    #define SDK_NAME    "aws-iot-device-sdk-embedded-C"
 #endif
 
-#ifndef OS_VERSION
-    #define OS_VERSION    "4.0.0"
+#ifndef SDK_VERSION
+    #define SDK_VERSION    "4.0.0"
 #endif
 
 #ifndef HARDWARE_PLATFORM_NAME
@@ -209,7 +209,7 @@
 /**
  * @brief The MQTT metrics string expected by AWS IoT.
  */
-#define METRICS_STRING                      "?SDK=" OS_NAME "&Version=" OS_VERSION "&Platform=" HARDWARE_PLATFORM_NAME
+#define METRICS_STRING                      "?SDK=" SDK_NAME "&Version=" SDK_VERSION "&Platform=" HARDWARE_PLATFORM_NAME
 
 /**
  * @brief The length of the MQTT metrics string expected by AWS IoT.

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -93,6 +93,18 @@
     #define NETWORK_BUFFER_SIZE    ( 1024U )
 #endif
 
+#ifndef OS_NAME
+    #define OS_NAME    "aws-iot-embedded-c-sdk"
+#endif
+
+#ifndef OS_VERSION
+    #define OS_VERSION    "4.0.0"
+#endif
+
+#ifndef HARDWARE_PLATFORM_NAME
+    #define HARDWARE_PLATFORM_NAME    "Posix"
+#endif
+
 /**
  * @brief Length of MQTT server host name.
  */
@@ -193,6 +205,16 @@
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
 #define TRANSPORT_SEND_RECV_TIMEOUT_MS      ( 100 )
+
+/**
+ * @brief The format of the MQTT metrics expected by AWS IoT.
+ */
+#define METRICS_FORMAT                      "?SDK=" OS_NAME "&Version=" OS_VERSION "&Platform=" HARDWARE_PLATFORM_NAME
+
+/**
+ * @brief The length of the MQTT metrics string expected by AWS IoT.
+ */
+#define METRICS_FORMAT_LENGTH               ( ( uint16_t ) ( sizeof( METRICS_FORMAT ) - 1 ) )
 
 /*-----------------------------------------------------------*/
 
@@ -561,6 +583,7 @@ static int handlePublishResend( MQTTContext_t * pMqttContext )
     while( packetIdToResend != MQTT_PACKET_ID_INVALID )
     {
         foundPacketId = false;
+
         for( index = 0U; index < MAX_OUTGOING_PUBLISHES; index++ )
         {
             if( outgoingPublishPackets[ index ].packetId == packetIdToResend )
@@ -772,9 +795,14 @@ static int establishMqttSession( MQTTContext_t * pMqttContext,
          * PINGREQ Packet. */
         connectInfo.keepAliveSeconds = MQTT_KEEP_ALIVE_INTERVAL_SECONDS;
 
-        /* Username and password for authentication. Not used in this demo. */
-        connectInfo.pUserName = NULL;
-        connectInfo.userNameLength = 0U;
+        /* The username field is populated with voluntary metrics to AWS IoT.
+         * The metrics collected by AWS IoT are the current operating system and
+         * its version. These metrics help AWS IoT improve security and provide
+         * better technical support. */
+        connectInfo.pUserName = METRICS_FORMAT;
+        connectInfo.userNameLength = METRICS_FORMAT_LENGTH;
+
+        /* Password for authentication is not used in this demo. */
         connectInfo.pPassword = NULL;
         connectInfo.passwordLength = 0U;
 

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -94,7 +94,7 @@
 #endif
 
 #ifndef OS_NAME
-    #define OS_NAME    "aws-iot-embedded-c-sdk"
+    #define OS_NAME    "aws-iot-device-sdk-embedded-C"
 #endif
 
 #ifndef OS_VERSION
@@ -207,14 +207,14 @@
 #define TRANSPORT_SEND_RECV_TIMEOUT_MS      ( 100 )
 
 /**
- * @brief The format of the MQTT metrics expected by AWS IoT.
+ * @brief The MQTT metrics string expected by AWS IoT.
  */
-#define METRICS_FORMAT                      "?SDK=" OS_NAME "&Version=" OS_VERSION "&Platform=" HARDWARE_PLATFORM_NAME
+#define METRICS_STRING                      "?SDK=" OS_NAME "&Version=" OS_VERSION "&Platform=" HARDWARE_PLATFORM_NAME
 
 /**
  * @brief The length of the MQTT metrics string expected by AWS IoT.
  */
-#define METRICS_FORMAT_LENGTH               ( ( uint16_t ) ( sizeof( METRICS_FORMAT ) - 1 ) )
+#define METRICS_STRING_LENGTH               ( ( uint16_t ) ( sizeof( METRICS_STRING ) - 1 ) )
 
 /*-----------------------------------------------------------*/
 
@@ -799,8 +799,8 @@ static int establishMqttSession( MQTTContext_t * pMqttContext,
          * The metrics collected by AWS IoT are the current operating system and
          * its version. These metrics help AWS IoT improve security and provide
          * better technical support. */
-        connectInfo.pUserName = METRICS_FORMAT;
-        connectInfo.userNameLength = METRICS_FORMAT_LENGTH;
+        connectInfo.pUserName = METRICS_STRING;
+        connectInfo.userNameLength = METRICS_STRING_LENGTH;
 
         /* Password for authentication is not used in this demo. */
         connectInfo.pPassword = NULL;

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -796,9 +796,9 @@ static int establishMqttSession( MQTTContext_t * pMqttContext,
         connectInfo.keepAliveSeconds = MQTT_KEEP_ALIVE_INTERVAL_SECONDS;
 
         /* The username field is populated with voluntary metrics to AWS IoT.
-         * The metrics collected by AWS IoT are the current operating system and
-         * its version. These metrics help AWS IoT improve security and provide
-         * better technical support. */
+         * The metrics collected by AWS IoT are the current operating system or
+         * SDK and its version. These metrics help AWS IoT improve security and
+         * provide better technical support. */
         connectInfo.pUserName = METRICS_STRING;
         connectInfo.userNameLength = METRICS_STRING_LENGTH;
 


### PR DESCRIPTION
*Description of changes:*
Add AWS IoT MQTT metrics for operating system, operating system version, and hardware platform to the MQTT TLS Mutual Auth demo.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
