### PR TITLE
Add macro to initialize ping response timeout

### DIFF
--- a/demos/lexicon.txt
+++ b/demos/lexicon.txt
@@ -49,6 +49,7 @@ methodlen
 milli
 mosquitto
 mqtt
+mqttkeepalivetimeout
 nameindex
 noninfringement
 openssl

--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_config.h
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_config.h
@@ -61,10 +61,11 @@
 #define MQTT_STATE_ARRAY_MAX_COUNT    ( 10U )
 
 /**
- * @brief Timeout for receiving a response to a PINGREQ.
+ * @brief Number of milliseconds to wait for a ping response to a ping
+ * request as part of the keep-alive mechanism.
  *
- * If the time expires without receiving a response to a PINGREQ, then
- * #MQTT_ProcessLoop() will return #MQTTKeepAliveTimeout.
+ * If a ping response is not received before this timeout, then
+ * #MQTT_ProcessLoop will return #MQTTKeepAliveTimeout.
  */
 #define MQTT_PINGRESP_TIMEOUT_MS      ( 500U )
 

--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_config.h
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_config.h
@@ -58,18 +58,14 @@
  * macro sets the limit on how many simultaneous PUBLISH states an MQTT
  * context maintains.
  */
-#define MQTT_STATE_ARRAY_MAX_COUNT          10U
+#define MQTT_STATE_ARRAY_MAX_COUNT    ( 10U )
 
 /**
- * @brief The maximum number of MQTT PUBLISH messages that may be pending
- * acknowledgement at any time.
+ * @brief Timeout for receiving a response to a PINGREQ.
  *
- * QoS 1 and 2 MQTT PUBLISHes require acknowledgement from the server before
- * they can be completed. While they are awaiting the acknowledgement, the
- * client must maintain information about their state. The value of this
- * macro sets the limit on how many simultaneous PUBLISH states an MQTT
- * context maintains.
+ * If the time expires without receiving a response to a PINGREQ, then
+ * #MQTT_ProcessLoop() will return #MQTTKeepAliveTimeout.
  */
-#define MQTT_MAX_QUEUED_PUBLISH_MESSAGES    10
+#define MQTT_PINGRESP_TIMEOUT_MS      ( 500U )
 
 #endif /* ifndef MQTT_CONFIG_H_ */

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_config.h
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_config.h
@@ -59,4 +59,12 @@
  */
 #define MQTT_STATE_ARRAY_MAX_COUNT    ( 10U )
 
+/**
+ * @brief Timeout for receiving a response to a PINGREQ.
+ *
+ * If the time expires without receiving a response to a PINGREQ, then
+ * #MQTT_ProcessLoop() will return #MQTTKeepAliveTimeout.
+ */
+#define MQTT_PINGRESP_TIMEOUT_MS      ( 500U )
+
 #endif /* ifndef MQTT_CONFIG_H_ */

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_config.h
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_config.h
@@ -60,10 +60,11 @@
 #define MQTT_STATE_ARRAY_MAX_COUNT    ( 10U )
 
 /**
- * @brief Timeout for receiving a response to a PINGREQ.
+ * @brief Number of milliseconds to wait for a ping response to a ping
+ * request as part of the keep-alive mechanism.
  *
- * If the time expires without receiving a response to a PINGREQ, then
- * #MQTT_ProcessLoop() will return #MQTTKeepAliveTimeout.
+ * If a ping response is not received before this timeout, then
+ * #MQTT_ProcessLoop will return #MQTTKeepAliveTimeout.
  */
 #define MQTT_PINGRESP_TIMEOUT_MS      ( 500U )
 

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_config.h
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_config.h
@@ -61,10 +61,11 @@
 #define MQTT_STATE_ARRAY_MAX_COUNT    10U
 
 /**
- * @brief Timeout for receiving a response to a PINGREQ.
+ * @brief Number of milliseconds to wait for a ping response to a ping
+ * request as part of the keep-alive mechanism.
  *
- * If the time expires without receiving a response to a PINGREQ, then
- * #MQTT_ProcessLoop() will return #MQTTKeepAliveTimeout.
+ * If a ping response is not received before this timeout, then
+ * #MQTT_ProcessLoop will return #MQTTKeepAliveTimeout.
  */
 #define MQTT_PINGRESP_TIMEOUT_MS      500U
 

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_config.h
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_config.h
@@ -60,4 +60,12 @@
  */
 #define MQTT_STATE_ARRAY_MAX_COUNT    10U
 
+/**
+ * @brief Timeout for receiving a response to a PINGREQ.
+ *
+ * If the time expires without receiving a response to a PINGREQ, then
+ * #MQTT_ProcessLoop() will return #MQTTKeepAliveTimeout.
+ */
+#define MQTT_PINGRESP_TIMEOUT_MS      500U
+
 #endif /* ifndef MQTT_CONFIG_H_ */

--- a/libraries/standard/mqtt/cbmc/include/mqtt_config.h
+++ b/libraries/standard/mqtt/cbmc/include/mqtt_config.h
@@ -55,11 +55,11 @@ struct NetworkContext
 #define MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT    ( 2U )
 
 /**
- * @brief Default timeout for receiving a response to a PINGREQ.
- * 
- * If the time expires without receiving a response to a PINGREQ, then 
+ * @brief Timeout for receiving a response to a PINGREQ.
+ *
+ * If the time expires without receiving a response to a PINGREQ, then
  * #MQTT_ProcessLoop() will return #MQTTKeepAliveTimeout.
  */
-#define MQTT_DEFAULT_PINGRESP_TIMEOUT_MS        ( 500U )
+#define MQTT_PINGRESP_TIMEOUT_MS                ( 500U )
 
 #endif /* ifndef MQTT_CONFIG_H_ */

--- a/libraries/standard/mqtt/cbmc/include/mqtt_config.h
+++ b/libraries/standard/mqtt/cbmc/include/mqtt_config.h
@@ -55,10 +55,11 @@ struct NetworkContext
 #define MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT    ( 2U )
 
 /**
- * @brief Timeout for receiving a response to a PINGREQ.
+ * @brief Number of milliseconds to wait for a ping response to a ping
+ * request as part of the keep-alive mechanism.
  *
- * If the time expires without receiving a response to a PINGREQ, then
- * #MQTT_ProcessLoop() will return #MQTTKeepAliveTimeout.
+ * If a ping response is not received before this timeout, then
+ * #MQTT_ProcessLoop will return #MQTTKeepAliveTimeout.
  */
 #define MQTT_PINGRESP_TIMEOUT_MS                ( 500U )
 

--- a/libraries/standard/mqtt/cbmc/include/mqtt_config.h
+++ b/libraries/standard/mqtt/cbmc/include/mqtt_config.h
@@ -54,4 +54,12 @@ struct NetworkContext
  */
 #define MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT    ( 2U )
 
+/**
+ * @brief Default timeout for receiving a response to a PINGREQ.
+ * 
+ * If the time expires without receiving a response to a PINGREQ, then 
+ * #MQTT_ProcessLoop() will return #MQTTKeepAliveTimeout.
+ */
+#define MQTT_DEFAULT_PINGRESP_TIMEOUT_MS        ( 500U )
+
 #endif /* ifndef MQTT_CONFIG_H_ */

--- a/libraries/standard/mqtt/include/mqtt.h
+++ b/libraries/standard/mqtt/include/mqtt.h
@@ -186,7 +186,6 @@ struct MQTTContext
     /* Keep alive members. */
     uint16_t keepAliveIntervalSec; /**< @brief Keep Alive interval. */
     uint32_t pingReqSendTimeMs;    /**< @brief Timestamp of the last sent PINGREQ. */
-    uint32_t pingRespTimeoutMs;    /**< @brief Timeout for waiting for a PINGRESP. */
     bool waitingForPingResp;       /**< @brief If the library is currently awaiting a PINGRESP. */
 };
 
@@ -379,7 +378,7 @@ MQTTStatus_t MQTT_Disconnect( MQTTContext_t * pContext );
  * #MQTTSendFailed if a network error occurs while sending an ACK or PINGREQ;
  * #MQTTBadResponse if an invalid packet is received;
  * #MQTTKeepAliveTimeout if the server has not sent a PINGRESP before
- * pContext->pingRespTimeoutMs milliseconds;
+ * #MQTT_PINGRESP_TIMEOUT_MS milliseconds;
  * #MQTTIllegalState if an incoming QoS 1/2 publish or ack causes an
  * invalid transition for the internal state machine;
  * #MQTTSuccess on success.

--- a/libraries/standard/mqtt/integration-test/mqtt_config.h
+++ b/libraries/standard/mqtt/integration-test/mqtt_config.h
@@ -61,10 +61,11 @@
 #define MQTT_STATE_ARRAY_MAX_COUNT    ( 10U )
 
 /**
- * @brief Timeout for receiving a response to a PINGREQ.
+ * @brief Number of milliseconds to wait for a ping response to a ping
+ * request as part of the keep-alive mechanism.
  *
- * If the time expires without receiving a response to a PINGREQ, then
- * #MQTT_ProcessLoop() will return #MQTTKeepAliveTimeout.
+ * If a ping response is not received before this timeout, then
+ * #MQTT_ProcessLoop will return #MQTTKeepAliveTimeout.
  */
 #define MQTT_PINGRESP_TIMEOUT_MS      ( 500U )
 

--- a/libraries/standard/mqtt/integration-test/mqtt_config.h
+++ b/libraries/standard/mqtt/integration-test/mqtt_config.h
@@ -72,4 +72,12 @@
  */
 #define MQTT_MAX_QUEUED_PUBLISH_MESSAGES    10
 
+/**
+ * @brief Default timeout for receiving a response to a PINGREQ.
+ * 
+ * If the time expires without receiving a response to a PINGREQ, then 
+ * #MQTT_ProcessLoop() will return #MQTTKeepAliveTimeout.
+ */
+#define MQTT_DEFAULT_PINGRESP_TIMEOUT_MS    500U
+
 #endif /* ifndef MQTT_CONFIG_H_ */

--- a/libraries/standard/mqtt/integration-test/mqtt_config.h
+++ b/libraries/standard/mqtt/integration-test/mqtt_config.h
@@ -73,11 +73,11 @@
 #define MQTT_MAX_QUEUED_PUBLISH_MESSAGES    10
 
 /**
- * @brief Default timeout for receiving a response to a PINGREQ.
- * 
- * If the time expires without receiving a response to a PINGREQ, then 
+ * @brief Timeout for receiving a response to a PINGREQ.
+ *
+ * If the time expires without receiving a response to a PINGREQ, then
  * #MQTT_ProcessLoop() will return #MQTTKeepAliveTimeout.
  */
-#define MQTT_DEFAULT_PINGRESP_TIMEOUT_MS    500U
+#define MQTT_PINGRESP_TIMEOUT_MS            500U
 
 #endif /* ifndef MQTT_CONFIG_H_ */

--- a/libraries/standard/mqtt/integration-test/mqtt_config.h
+++ b/libraries/standard/mqtt/integration-test/mqtt_config.h
@@ -58,19 +58,7 @@
  * macro sets the limit on how many simultaneous PUBLISH states an MQTT
  * context maintains.
  */
-#define MQTT_STATE_ARRAY_MAX_COUNT          10U
-
-/**
- * @brief The maximum number of MQTT PUBLISH messages that may be pending
- * acknowledgement at any time.
- *
- * QoS 1 and 2 MQTT PUBLISHes require acknowledgement from the server before
- * they can be completed. While they are awaiting the acknowledgement, the
- * client must maintain information about their state. The value of this
- * macro sets the limit on how many simultaneous PUBLISH states an MQTT
- * context maintains.
- */
-#define MQTT_MAX_QUEUED_PUBLISH_MESSAGES    10
+#define MQTT_STATE_ARRAY_MAX_COUNT    ( 10U )
 
 /**
  * @brief Timeout for receiving a response to a PINGREQ.
@@ -78,6 +66,6 @@
  * If the time expires without receiving a response to a PINGREQ, then
  * #MQTT_ProcessLoop() will return #MQTTKeepAliveTimeout.
  */
-#define MQTT_PINGRESP_TIMEOUT_MS            500U
+#define MQTT_PINGRESP_TIMEOUT_MS      ( 500U )
 
 #endif /* ifndef MQTT_CONFIG_H_ */

--- a/libraries/standard/mqtt/lexicon.txt
+++ b/libraries/standard/mqtt/lexicon.txt
@@ -160,7 +160,6 @@ pingreq
 pingreqsendtimems
 pingresp
 pingresps
-pingresptimeoutms
 pmessage
 pmqttcontext
 pnetworkbuffer

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -42,11 +42,11 @@
 #endif
 
 /**
- * @brief Default number of milliseconds to wait for a ping response.
+ * @brief Number of milliseconds to wait for a ping response.
  */
-#ifndef MQTT_DEFAULT_PINGRESP_TIMEOUT_MS
+#ifndef MQTT_PINGRESP_TIMEOUT_MS
     /* Wait 0.5 seconds by default for a ping response. */
-    #define MQTT_DEFAULT_PINGRESP_TIMEOUT_MS        ( 500U )
+    #define MQTT_PINGRESP_TIMEOUT_MS    ( 500U )
 #endif
 
 /*-----------------------------------------------------------*/
@@ -208,7 +208,7 @@ static MQTTStatus_t handleIncomingAck( MQTTContext_t * pContext,
  * #MQTTSendFailed if a network error occurs while sending an ACK or PINGREQ;
  * #MQTTBadResponse if an invalid packet is received;
  * #MQTTKeepAliveTimeout if the server has not sent a PINGRESP before
- * pContext->pingRespTimeoutMs milliseconds;
+ * #MQTT_PINGRESP_TIMEOUT_MS milliseconds;
  * #MQTTIllegalState if an incoming QoS 1/2 publish or ack causes an
  * invalid transition for the internal state machine;
  * #MQTTSuccess on success.
@@ -715,7 +715,7 @@ static MQTTStatus_t handleKeepAlive( MQTTContext_t * pContext )
         {
             /* Has time expired? */
             if( calculateElapsedTime( now, pContext->pingReqSendTimeMs ) >
-                pContext->pingRespTimeoutMs )
+                MQTT_PINGRESP_TIMEOUT_MS )
             {
                 status = MQTTKeepAliveTimeout;
             }
@@ -1419,9 +1419,6 @@ MQTTStatus_t MQTT_Init( MQTTContext_t * pContext,
         pContext->getTime = getTimeFunction;
         pContext->appCallback = userCallback;
         pContext->networkBuffer = *pNetworkBuffer;
-
-        /* Set ping response timeout for process loop. */
-        pContext->pingRespTimeoutMs = MQTT_DEFAULT_PINGRESP_TIMEOUT_MS;
 
         /* Zero is not a valid packet ID per MQTT spec. Start from 1. */
         pContext->nextPacketId = 1;

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -42,8 +42,8 @@
 #endif
 
 /**
- * @brief Number of milliseconds to wait for a ping response to a ping request
- * as part of the keep-alive mechanism.
+ * @brief Number of milliseconds to wait for a ping response to a ping
+ * request as part of the keep-alive mechanism.
  *
  * If a ping response is not received before this timeout, then
  * #MQTT_ProcessLoop will return #MQTTKeepAliveTimeout.

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -42,7 +42,11 @@
 #endif
 
 /**
- * @brief Number of milliseconds to wait for a ping response.
+ * @brief Number of milliseconds to wait for a ping response to a ping request
+ * as part of the keep-alive mechanism.
+ *
+ * If a ping response is not received before this timeout, then
+ * #MQTT_ProcessLoop will return #MQTTKeepAliveTimeout.
  */
 #ifndef MQTT_PINGRESP_TIMEOUT_MS
     /* Wait 0.5 seconds by default for a ping response. */

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -41,6 +41,14 @@
     #define MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT    ( 5U )
 #endif
 
+/**
+ * @brief Default number of milliseconds to wait for a ping response.
+ */
+#ifndef MQTT_DEFAULT_PINGRESP_TIMEOUT_MS
+    /* Wait 0.5 seconds by default for a ping response. */
+    #define MQTT_DEFAULT_PINGRESP_TIMEOUT_MS        ( 500U )
+#endif
+
 /*-----------------------------------------------------------*/
 
 /**
@@ -1411,6 +1419,9 @@ MQTTStatus_t MQTT_Init( MQTTContext_t * pContext,
         pContext->getTime = getTimeFunction;
         pContext->appCallback = userCallback;
         pContext->networkBuffer = *pNetworkBuffer;
+
+        /* Set ping response timeout for process loop. */
+        pContext->pingRespTimeoutMs = MQTT_DEFAULT_PINGRESP_TIMEOUT_MS;
 
         /* Zero is not a valid packet ID per MQTT spec. Start from 1. */
         pContext->nextPacketId = 1;

--- a/libraries/standard/mqtt/utest/mqtt_config.h
+++ b/libraries/standard/mqtt/utest/mqtt_config.h
@@ -56,10 +56,11 @@
 #define MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT    ( 2U )
 
 /**
- * @brief Timeout for receiving a response to a PINGREQ.
+ * @brief Number of milliseconds to wait for a ping response to a ping
+ * request as part of the keep-alive mechanism.
  *
- * If the time expires without receiving a response to a PINGREQ, then
- * #MQTT_ProcessLoop() will return #MQTTKeepAliveTimeout.
+ * If a ping response is not received before this timeout, then
+ * #MQTT_ProcessLoop will return #MQTTKeepAliveTimeout.
  */
 #define MQTT_PINGRESP_TIMEOUT_MS                ( 1000U )
 

--- a/libraries/standard/mqtt/utest/mqtt_config.h
+++ b/libraries/standard/mqtt/utest/mqtt_config.h
@@ -67,6 +67,14 @@
  */
 #define MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT    ( 2U )
 
+/**
+ * @brief Default timeout for receiving a response to a PINGREQ.
+ * 
+ * If the time expires without receiving a response to a PINGREQ, then 
+ * #MQTT_ProcessLoop() will return #MQTTKeepAliveTimeout.
+ */
+#define MQTT_DEFAULT_PINGRESP_TIMEOUT_MS        ( 500U )
+
 /* Set network context to double pointer to buffer (uint8_t**).  */
 struct NetworkContext
 {

--- a/libraries/standard/mqtt/utest/mqtt_config.h
+++ b/libraries/standard/mqtt/utest/mqtt_config.h
@@ -68,12 +68,12 @@
 #define MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT    ( 2U )
 
 /**
- * @brief Default timeout for receiving a response to a PINGREQ.
- * 
- * If the time expires without receiving a response to a PINGREQ, then 
+ * @brief Timeout for receiving a response to a PINGREQ.
+ *
+ * If the time expires without receiving a response to a PINGREQ, then
  * #MQTT_ProcessLoop() will return #MQTTKeepAliveTimeout.
  */
-#define MQTT_DEFAULT_PINGRESP_TIMEOUT_MS        ( 500U )
+#define MQTT_PINGRESP_TIMEOUT_MS                ( 1000U )
 
 /* Set network context to double pointer to buffer (uint8_t**).  */
 struct NetworkContext

--- a/libraries/standard/mqtt/utest/mqtt_config.h
+++ b/libraries/standard/mqtt/utest/mqtt_config.h
@@ -37,18 +37,6 @@
  * macro sets the limit on how many simultaneous PUBLISH states an MQTT
  * context maintains.
  */
-#define MQTT_MAX_QUEUED_PUBLISH_MESSAGES        10
-
-/**
- * @brief The maximum number of MQTT PUBLISH messages that may be pending
- * acknowledgement at any time.
- *
- * QoS 1 and 2 MQTT PUBLISHes require acknowledgement from the server before
- * they can be completed. While they are awaiting the acknowledgement, the
- * client must maintain information about their state. The value of this
- * macro sets the limit on how many simultaneous PUBLISH states an MQTT
- * context maintains.
- */
 #define MQTT_STATE_ARRAY_MAX_COUNT              10U
 
 /**

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -522,6 +522,7 @@ void test_MQTT_Init_Happy_Path( void )
     mqttStatus = MQTT_Init( &context, &transport, getTime, eventCallback, &networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     TEST_ASSERT_EQUAL( MQTTNotConnected, context.connectStatus );
+    TEST_ASSERT_EQUAL( MQTT_DEFAULT_PINGRESP_TIMEOUT_MS, context.pingRespTimeoutMs );
     TEST_ASSERT_EQUAL( MQTT_FIRST_VALID_PACKET_ID, context.nextPacketId );
     TEST_ASSERT_EQUAL_PTR( getTime, context.getTime );
     TEST_ASSERT_EQUAL_PTR( eventCallback, context.appCallback );
@@ -1696,11 +1697,13 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Error_Paths( void )
     modifyIncomingPacketStatus = MQTTNoDataAvailable;
     globalEntryTime = MQTT_ONE_SECOND_TO_MS;
 
-    /* Coverage for the branch path where PING timeout interval hasn't expired. */
+    /* Coverage for the branch path where PINGRESP timeout interval has expired. */
     mqttStatus = MQTT_Init( &context, &transport, getTime, eventCallback, &networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
-    context.lastPacketTime = 0;
     context.keepAliveIntervalSec = MQTT_SAMPLE_KEEPALIVE_INTERVAL_S;
+    context.lastPacketTime = 0;
+    context.pingReqSendTimeMs = 0;
+    context.pingRespTimeoutMs = MQTT_ONE_SECOND_TO_MS;
     context.waitingForPingResp = true;
     expectProcessLoopCalls( &context, MQTTStateNull, MQTTStateNull,
                             MQTTIllegalState, MQTTSuccess, MQTTStateNull,

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -522,7 +522,6 @@ void test_MQTT_Init_Happy_Path( void )
     mqttStatus = MQTT_Init( &context, &transport, getTime, eventCallback, &networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     TEST_ASSERT_EQUAL( MQTTNotConnected, context.connectStatus );
-    TEST_ASSERT_EQUAL( MQTT_DEFAULT_PINGRESP_TIMEOUT_MS, context.pingRespTimeoutMs );
     TEST_ASSERT_EQUAL( MQTT_FIRST_VALID_PACKET_ID, context.nextPacketId );
     TEST_ASSERT_EQUAL_PTR( getTime, context.getTime );
     TEST_ASSERT_EQUAL_PTR( eventCallback, context.appCallback );
@@ -1664,7 +1663,6 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Happy_Paths( void )
     context.keepAliveIntervalSec = MQTT_SAMPLE_KEEPALIVE_INTERVAL_S;
     context.lastPacketTime = 0;
     context.pingReqSendTimeMs = MQTT_ONE_SECOND_TO_MS;
-    context.pingRespTimeoutMs = MQTT_ONE_SECOND_TO_MS;
     expectProcessLoopCalls( &context, MQTTStateNull, MQTTStateNull,
                             MQTTIllegalState, MQTTSuccess, MQTTStateNull,
                             MQTTSuccess, false, NULL );
@@ -1703,7 +1701,6 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Error_Paths( void )
     context.keepAliveIntervalSec = MQTT_SAMPLE_KEEPALIVE_INTERVAL_S;
     context.lastPacketTime = 0;
     context.pingReqSendTimeMs = 0;
-    context.pingRespTimeoutMs = MQTT_ONE_SECOND_TO_MS;
     context.waitingForPingResp = true;
     expectProcessLoopCalls( &context, MQTTStateNull, MQTTStateNull,
                             MQTTIllegalState, MQTTSuccess, MQTTStateNull,


### PR DESCRIPTION
*Description of changes:*
The `pingRespTimeoutMs` field of MQTTContext_t is initialized to 0 in MQTT_Init(), which doesn't make sense. This adds a macro to give it default value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
