### PR TITLE
[PR from CLI tool] Remove unused enum value from subscription manager

### DIFF
--- a/demos/mqtt/subscription-manager/mqtt_subscription_manager.c
+++ b/demos/mqtt/subscription-manager/mqtt_subscription_manager.c
@@ -379,7 +379,7 @@ SubscriptionManagerStatus_t SubscriptionManager_RegisterCallback( const char * p
     assert( topicFilterLength != 0 );
     assert( callback != NULL );
 
-    SubscriptionManagerStatus_t returnStatus = SUBSCRIPTION_MANAGER_INVALID;
+    SubscriptionManagerStatus_t returnStatus;
     size_t availableIndex = MAX_SUBSCRIPTION_CALLBACK_RECORDS;
     bool recordExists = false;
     size_t index = 0u;

--- a/demos/mqtt/subscription-manager/mqtt_subscription_manager.h
+++ b/demos/mqtt/subscription-manager/mqtt_subscription_manager.h
@@ -59,8 +59,6 @@
 /* Enumeration type for return status value from Subscription Manager API. */
 typedef enum SubscriptionManagerStatus
 {
-    SUBSCRIPTION_MANAGER_INVALID = 0,
-
     /**
      * @brief Success return value from Subscription Manager API.
      */


### PR DESCRIPTION
Remove unused `SUBSCRIPTION_MANAGER_INVALID` enum value (that was intended to be a sentinel value) from the Subscription Manager API.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
