### PR TITLE
[PR from CLI tool] Address -Wunused-variable and -Wunused-parameter warnings in lightweight tests

### DIFF
--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -182,6 +182,11 @@ static int32_t mockReceiveNoData( NetworkContext_t * pNetworkContext,
                                   void * pBuffer,
                                   size_t bytesToRecv )
 {
+    /* Suppress unused parameter warning. */
+    ( void ) pNetworkContext;
+    ( void ) pBuffer;
+    ( void ) bytesToRecv;
+
     return 0;
 }
 
@@ -192,6 +197,11 @@ static int32_t mockReceiveFailure( NetworkContext_t * pNetworkContext,
                                    void * pBuffer,
                                    size_t bytesToRecv )
 {
+    /* Suppress unused parameter warning. */
+    ( void ) pNetworkContext;
+    ( void ) pBuffer;
+    ( void ) bytesToRecv;
+
     return -1;
 }
 
@@ -736,7 +746,6 @@ void test_MQTT_SerializeSubscribe( void )
     MQTTSubscribeInfo_t subscriptionList;
     size_t subscriptionCount = 1;
     size_t remainingLength = 0;
-    uint16_t packetIdentifier;
     uint8_t buffer[ 25 + 2 * BUFFER_PADDING_LENGTH ];
     size_t bufferSize = sizeof( buffer ) - 2 * BUFFER_PADDING_LENGTH;
     size_t packetSize = bufferSize;
@@ -845,7 +854,6 @@ void test_MQTT_SerializeUnsubscribe( void )
     MQTTSubscribeInfo_t subscriptionList;
     size_t subscriptionCount = 1;
     size_t remainingLength = 0;
-    uint16_t packetIdentifier;
     uint8_t buffer[ 25 + 2 * BUFFER_PADDING_LENGTH ];
     size_t bufferSize = sizeof( buffer ) - 2 * BUFFER_PADDING_LENGTH;
     size_t packetSize = bufferSize;
@@ -1011,8 +1019,6 @@ void test_MQTT_SerializePublish( void )
 {
     MQTTPublishInfo_t publishInfo;
     size_t remainingLength = 98;
-    uint16_t packetIdentifier;
-    uint8_t * pPacketIdentifierHigh;
     uint8_t buffer[ 200 + 2 * BUFFER_PADDING_LENGTH ];
     size_t bufferSize = sizeof( buffer ) - 2 * BUFFER_PADDING_LENGTH;
     size_t packetSize = bufferSize;
@@ -1525,7 +1531,6 @@ void test_MQTT_DeserializePublish( void )
 
     size_t remainingLength = 0;
     uint16_t packetIdentifier;
-    uint8_t * pPacketIdentifierHigh;
 
     fixedBuffer.pBuffer = buffer;
     fixedBuffer.size = bufferSize;
@@ -1761,8 +1766,6 @@ void test_MQTT_SerializePublishHeader( void )
 {
     MQTTPublishInfo_t publishInfo;
     size_t remainingLength = 0;
-    uint16_t packetIdentifier;
-    uint8_t * pPacketIdentifierHigh;
     uint8_t buffer[ 200 + 2 * BUFFER_PADDING_LENGTH ];
     uint8_t expectedPacket[ 200 ];
     uint8_t * pIterator;
@@ -2324,7 +2327,6 @@ void test_MQTT_SerializeDisconnect_Invalid_Params()
 void test_MQTT_SerializeDisconnect_Happy_Path()
 {
     MQTTStatus_t mqttStatus = MQTTSuccess;
-    size_t packetSize = 0;
     MQTTFixedBuffer_t networkBuffer;
 
     /* Fill structs to pass into methods to be tested. */


### PR DESCRIPTION
Address `-Wunused-variable` and `-Wunused-parameter` warnings in `mqtt_lightweight_utest.c` file