### PR TITLE
Add cbmc pointer primitive check flag and mqtt_lightweight.c small refactor

### DIFF
--- a/libraries/standard/http/cbmc/proofs/Makefile-project-defines
+++ b/libraries/standard/http/cbmc/proofs/Makefile-project-defines
@@ -27,3 +27,7 @@ INCLUDES += -I$(SRCDIR)/platform/include
 
 # Preprocessor definitions -D...
 DEFINES += -Dhttp_EXPORTS
+
+# Ensure that all assumptions are sound by checking that "all pointers
+# in pointer primitives are valid or null"
+CHECKFLAGS += --pointer-primitive-check

--- a/libraries/standard/mqtt/cbmc/proofs/Makefile-project-defines
+++ b/libraries/standard/mqtt/cbmc/proofs/Makefile-project-defines
@@ -26,3 +26,7 @@ INCLUDES += -I$(SRCDIR)/platform/include
 
 # Preprocessor definitions -D...
 DEFINES += -Dmqtt_EXPORTS
+
+# Ensure that all assumptions are sound by checking that "all pointers
+# in pointer primitives are valid or null"
+CHECKFLAGS += --pointer-primitive-check

--- a/libraries/standard/mqtt/cbmc/stubs/memcpy.c
+++ b/libraries/standard/mqtt/cbmc/stubs/memcpy.c
@@ -47,8 +47,10 @@
                    const void * src,
                    size_t n )
     {
-        __CPROVER_assert( __CPROVER_w_ok( dest, n ), "write" );
-        __CPROVER_assert( __CPROVER_r_ok( src, n ), "read" );
+        /* Per ANSI C specification, memcpy must be able to handle a copy length
+         * of zero. */
+        __CPROVER_assert( ( n == 0 ) || __CPROVER_w_ok( dest, n ), "write" );
+        __CPROVER_assert( ( n == 0 ) || __CPROVER_r_ok( src, n ), "read" );
         return dest;
     }
 #endif /* if __has_builtin( __builtin___memcpy_chk ) */

--- a/libraries/standard/mqtt/lexicon.txt
+++ b/libraries/standard/mqtt/lexicon.txt
@@ -2,6 +2,7 @@ ack
 acked
 acks
 addrecord
+ansi
 api
 app
 aws

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -1874,7 +1874,6 @@ MQTTStatus_t MQTT_SerializePublishHeader( const MQTTPublishInfo_t * pPublishInfo
          *                               + Length of encoded remaining length
          *                               + Remaining length
          *                               - Payload Length.
-         * Payload length will be subtracted after verifying pPublishInfo parameter.
          */
         packetSize = 1U + remainingLengthEncodedSize( remainingLength )
                      + remainingLength

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -1878,27 +1878,28 @@ MQTTStatus_t MQTT_SerializePublishHeader( const MQTTPublishInfo_t * pPublishInfo
         packetSize = 1U + remainingLengthEncodedSize( remainingLength )
                      + remainingLength
                      - pPublishInfo->payloadLength;
+    }
 
-        if( packetSize > pFixedBuffer->size )
-        {
-            LogError( ( "Buffer size of %lu is not sufficient to hold "
-                        "serialized PUBLISH header packet of size of %lu.",
-                        ( unsigned long ) pFixedBuffer->size,
-                        ( unsigned long ) ( packetSize - pPublishInfo->payloadLength ) ) );
-            status = MQTTNoMemory;
-        }
-        else
-        {
-            /* Serialize publish without copying the payload. */
-            serializePublishCommon( pPublishInfo,
-                                    remainingLength,
-                                    packetId,
-                                    pFixedBuffer,
-                                    false );
+    if( ( status == MQTTSuccess ) && ( packetSize > pFixedBuffer->size ) )
+    {
+        LogError( ( "Buffer size of %lu is not sufficient to hold "
+                    "serialized PUBLISH header packet of size of %lu.",
+                    ( unsigned long ) pFixedBuffer->size,
+                    ( unsigned long ) ( packetSize - pPublishInfo->payloadLength ) ) );
+        status = MQTTNoMemory;
+    }
 
-            /* Header size is the same as calculated packet size. */
-            *pHeaderSize = packetSize;
-        }
+    if( status == MQTTSuccess )
+    {
+        /* Serialize publish without copying the payload. */
+        serializePublishCommon( pPublishInfo,
+                                remainingLength,
+                                packetId,
+                                pFixedBuffer,
+                                false );
+
+        /* Header size is the same as calculated packet size. */
+        *pHeaderSize = packetSize;
     }
 
     return status;

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -1897,7 +1897,7 @@ MQTTStatus_t MQTT_SerializePublishHeader( const MQTTPublishInfo_t * pPublishInfo
                                     false );
 
             /* Header size is the same as calculated packet size. */
-            *pHeaderSize = ( packetSize - pPublishInfo->payloadLength );
+            *pHeaderSize = packetSize;
         }
     }
 

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -605,6 +605,23 @@ void test_MQTT_SerializeConnect( void )
     status = MQTT_SerializeConnect( &connectInfo, &willInfo, remainingLength, &fixedBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, status );
     checkBufferOverflow( buffer, sizeof( buffer ) );
+
+    /* Success right on the buffer boundary. */
+    connectInfo.pUserName = "USER";
+    connectInfo.userNameLength = 4;
+    /* Throwing in a possible valid zero length password. */
+    connectInfo.pPassword = "PASS";
+    connectInfo.passwordLength = 0;
+    status = MQTT_GetConnectPacketSize( &connectInfo, NULL, &remainingLength, &packetSize );
+    TEST_ASSERT_EQUAL( MQTTSuccess, status );
+    TEST_ASSERT_GREATER_OR_EQUAL( packetSize, bufferSize );
+    /* Set the fixed buffer to exactly the size of the packet. */
+    fixedBuffer.size = packetSize;
+    padAndResetBuffer( buffer, sizeof( buffer ) );
+    status = MQTT_SerializeConnect( &connectInfo, NULL, remainingLength, &fixedBuffer );
+    TEST_ASSERT_EQUAL( MQTTSuccess, status );
+    checkBufferOverflow( buffer, sizeof( buffer ) );
+
 }
 
 /* ========================================================================== */

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -621,7 +621,6 @@ void test_MQTT_SerializeConnect( void )
     status = MQTT_SerializeConnect( &connectInfo, NULL, remainingLength, &fixedBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, status );
     checkBufferOverflow( buffer, sizeof( buffer ) );
-
 }
 
 /* ========================================================================== */


### PR DESCRIPTION
*Description of changes:*
- This pull request updates the proof template submodule to include checks missing from continuous integration, and added a flag --pointer-primitive-check to the proofs to check the soundness of assumptions by checking that all pointers in pointer primitives are valid or null.

- Update validateSerializeSubscribeParams(), MQTT_SerializePublish(), and MQTT_SerializePublishHeader() to check the packet size against the fixed buffer AFTER the NULL parameter checks. When a NULL subscribeInfo or publishInfo, is passed into these functions, we don't care about the remaining length, so the remaining length should NOT immediately be used in a possible overflow causing arithmetic operation. This helps with the CBMC proof that passes in a NULL parameter for coverage, but an unbounded remaining length.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
