### PR TITLE
Fix Doxygen warnings for MQTT library documentation

### DIFF
--- a/libraries/standard/mqtt/include/mqtt.h
+++ b/libraries/standard/mqtt/include/mqtt.h
@@ -19,6 +19,10 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+/**
+ * @file mqtt.h
+ * @brief User-facing functions of the MQTT 3.1.1 library.
+ */
 #ifndef MQTT_H
 #define MQTT_H
 
@@ -34,15 +38,6 @@
  * Zero is an invalid packet identifier as per MQTT v3.1.1 spec.
  */
 #define MQTT_PACKET_ID_INVALID    ( ( uint16_t ) 0U )
-
-struct MQTTPubAckInfo;
-typedef struct MQTTPubAckInfo         MQTTPubAckInfo_t;
-
-struct MQTTContext;
-typedef struct MQTTContext            MQTTContext_t;
-
-struct MQTTDeserializedInfo;
-typedef struct MQTTDeserializedInfo   MQTTDeserializedInfo_t;
 
 /**
  * @brief Application provided callback to retrieve the current time in
@@ -109,12 +104,12 @@ typedef enum MQTTPubAckType
 /**
  * @brief An element of the state engine records for QoS 1/2 publishes.
  */
-struct MQTTPubAckInfo
+typedef struct MQTTPubAckInfo
 {
     uint16_t packetId;               /**< @brief The packet ID of the original PUBLISH. */
     MQTTQoS_t qos;                   /**< @brief The QoS of the original PUBLISH. */
     MQTTPublishState_t publishState; /**< @brief The current state of the publish process. */
-};
+} MQTTPubAckInfo_t;
 
 /**
  * @brief The status codes in the SUBACK response to a subscription request.
@@ -130,7 +125,7 @@ typedef enum MQTTSubAckStatus
 /**
  * @brief A struct representing an MQTT connection.
  */
-struct MQTTContext
+typedef struct MQTTContext
 {
     /**
      * @brief State engine records for outgoing publishes.
@@ -188,38 +183,41 @@ struct MQTTContext
     uint32_t pingReqSendTimeMs;    /**< @brief Timestamp of the last sent PINGREQ. */
     uint32_t pingRespTimeoutMs;    /**< @brief Timeout for waiting for a PINGRESP. */
     bool waitingForPingResp;       /**< @brief If the library is currently awaiting a PINGRESP. */
-};
+} MQTTContext_t;
 
 /**
  * @brief Struct to hold deserialized packet information for an #MQTTEventCallback_t
  * callback.
  */
-struct MQTTDeserializedInfo
+typedef struct MQTTDeserializedInfo
 {
     uint16_t packetIdentifier;          /**< @brief Packet ID of deserialized packet. */
     MQTTPublishInfo_t * pPublishInfo;   /**< @brief Pointer to deserialized publish info. */
     MQTTStatus_t deserializationResult; /**< @brief Return code of deserialization. */
-};
+} MQTTDeserializedInfo_t;
 
 /**
  * @brief Initialize an MQTT context.
  *
- * This function must be called on an MQTT context before any other function.
+ * This function must be called on a #MQTTContext_t before any other function.
  *
- * @note The getTime callback function must be defined. If there is no time
- * implementation, it is the responsibility of the application to provide a
- * dummy function to always return 0, and provide 0 timeouts for functions. This
- * will ensure all time based functions will run for a single iteration.
+ * @note The #MQTTGetCurrentTimeFunc_t callback function must be defined. If
+ * there is no time implementation, it is the responsibility of the application
+ * to provide a dummy function to always return 0, and provide 0 timeouts for
+ * functions. This will ensure all time based functions will run for a single
+ * iteration.
  *
  * @brief param[in] pContext The context to initialize.
- * @brief param[in] pTransportInterface The transport interface to use with the context.
- * @brief param[in] getTimeFunction The time utility function to use with the context.
- * @brief param[in] userCallback The user callback to use with the context to notify about
- * incoming packet events.
+ * @brief param[in] pTransportInterface The transport interface to use with the
+ * context.
+ * @brief param[in] getTimeFunction The time utility function to use with the
+ * context.
+ * @brief param[in] userCallback The user callback to use with the context to
+ * notify about incoming packet events.
  * @brief param[in] pNetworkBuffer Network buffer provided for the context.
  *
- * @return #MQTTBadParameter if invalid parameters are passed;
- * #MQTTSuccess otherwise.
+ * @return #MQTTBadParameter if invalid parameters are passed; #MQTTSuccess
+ * otherwise.
  */
 MQTTStatus_t MQTT_Init( MQTTContext_t * pContext,
                         const TransportInterface_t * pTransportInterface,
@@ -235,12 +233,12 @@ MQTTStatus_t MQTT_Init( MQTTContext_t * pContext,
  *
  * The maximum time this function waits for a CONNACK is decided in one of the
  * following ways:
- * 1. If #timeoutMs is greater than 0:
- *    #getTime is used to ensure that the function does not wait more than #timeoutMs
- *    for CONNACK.
- * 2. If #timeoutMs is 0:
- *    The network receive for CONNACK is retried up to the number of times configured
- *    by #MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT.
+ * 1. If @p timeoutMs is greater than 0:
+ *    #MQTTContext_t.getTime is used to ensure that the function does not wait
+ *    more than @p timeoutMs for CONNACK.
+ * 2. If @p timeoutMs is 0:
+ *    The network receive for CONNACK is retried up to the number of times
+ *    configured by #MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT.
  *
  * @param[in] pContext Initialized MQTT context.
  * @param[in] pConnectInfo MQTT CONNECT packet information.
@@ -258,7 +256,7 @@ MQTTStatus_t MQTT_Init( MQTTContext_t * pContext,
  * #MQTTSendFailed if transport send failed;
  * #MQTTRecvFailed if transport receive failed for CONNACK;
  * #MQTTNoDataAvailable if no data available to receive in transport until
- * the #timeoutMs for CONNACK;
+ * the @p timeoutMs for CONNACK;
  * #MQTTSuccess otherwise.
  *
  * @note This API may spend more time than provided in the timeoutMS parameters in
@@ -292,7 +290,7 @@ MQTTStatus_t MQTT_Connect( MQTTContext_t * pContext,
  * @param[in] pContext Initialized MQTT context.
  * @param[in] pSubscriptionList List of MQTT subscription info.
  * @param[in] subscriptionCount The number of elements in pSubscriptionList.
- * @param[in] packetId packet ID generated by #MQTT_GetPacketId.
+ * @param[in] packetId Packet ID generated by #MQTT_GetPacketId.
  *
  * @return #MQTTNoMemory if the #MQTTContext_t.networkBuffer is too small to
  * hold the MQTT packet;
@@ -429,7 +427,7 @@ uint16_t MQTT_GetPacketId( MQTTContext_t * pContext );
  *  - 0x01 - Success - Maximum QoS 1
  *  - 0x02 - Success - Maximum QoS 2
  *  - 0x80 - Failure
- * Refer to @ref MQTTSubAckStatus for the status codes.
+ * Refer to #MQTTSubAckStatus_t for the status codes.
  *
  * @param[in] pSubackPacket The SUBACK packet whose payload is to be parsed.
  * @param[out] pPayloadStart This is populated with the starting address

--- a/libraries/standard/mqtt/include/mqtt_lightweight.h
+++ b/libraries/standard/mqtt/include/mqtt_lightweight.h
@@ -19,11 +19,22 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+/**
+ * @file mqtt_lightweight.h
+ * @brief User-facing functions for serializing MQTT 3.1.1 packets. This header
+ * should be included for building a light-weight MQTT client bypassing the
+ * stateful CSDK MQTT library API in mqtt.h.
+ */
 #ifndef MQTT_LIGHTWEIGHT_H
 #define MQTT_LIGHTWEIGHT_H
 
 #include <stddef.h>
 #include <stdint.h>
+
+/**
+ * @cond DOXYGEN_IGNORE
+ * Doxygen should ignore this section.
+ */
 
 /* bool is defined in only C99+. */
 #if defined( __cplusplus ) || ( defined( __STDC_VERSION__ ) && ( __STDC_VERSION__ >= 199901L ) )
@@ -33,6 +44,7 @@
     #define false    ( int8_t ) 0
     #define true     ( int8_t ) 1
 #endif
+/** @endcond */
 
 /* Include config file before other headers. */
 #include "mqtt_config.h"
@@ -55,26 +67,10 @@
 #define MQTT_PACKET_TYPE_PINGRESP       ( ( uint8_t ) 0xD0U )  /**< @brief PINGRESP (server-to-client). */
 #define MQTT_PACKET_TYPE_DISCONNECT     ( ( uint8_t ) 0xE0U )  /**< @brief DISCONNECT (client-to-server). */
 
-
 /**
  * @brief The size of MQTT PUBACK, PUBREC, PUBREL, and PUBCOMP packets, per MQTT spec.
  */
 #define MQTT_PUBLISH_ACK_PACKET_SIZE    ( 4UL )
-
-struct MQTTFixedBuffer;
-typedef struct MQTTFixedBuffer     MQTTFixedBuffer_t;
-
-struct MQTTConnectInfo;
-typedef struct MQTTConnectInfo     MQTTConnectInfo_t;
-
-struct MQTTSubscribeInfo;
-typedef struct MQTTSubscribeInfo   MQTTSubscribeInfo_t;
-
-struct MqttPublishInfo;
-typedef struct MqttPublishInfo     MQTTPublishInfo_t;
-
-struct MQTTPacketInfo;
-typedef struct MQTTPacketInfo      MQTTPacketInfo_t;
 
 /**
  * @brief Return codes from MQTT functions.
@@ -110,16 +106,16 @@ typedef enum MQTTQoS
  * These buffers are not copied and must remain in scope for the duration of the
  * MQTT operation.
  */
-struct MQTTFixedBuffer
+typedef struct MQTTFixedBuffer
 {
     uint8_t * pBuffer; /**< @brief Pointer to buffer. */
     size_t size;       /**< @brief Size of buffer. */
-};
+} MQTTFixedBuffer_t;
 
 /**
  * @brief MQTT CONNECT packet parameters.
  */
-struct MQTTConnectInfo
+typedef struct MQTTConnectInfo
 {
     /**
      * @brief Whether to establish a new, clean session or resume a previous session.
@@ -160,12 +156,12 @@ struct MQTTConnectInfo
      * @brief Length of MQTT password. Set to 0 if not used.
      */
     uint16_t passwordLength;
-};
+} MQTTConnectInfo_t;
 
 /**
  * @brief MQTT SUBSCRIBE packet parameters.
  */
-struct MQTTSubscribeInfo
+typedef struct MQTTSubscribeInfo
 {
     /**
      * @brief Quality of Service for subscription.
@@ -181,12 +177,12 @@ struct MQTTSubscribeInfo
      * @brief Length of subscription topic filter.
      */
     uint16_t topicFilterLength;
-};
+} MQTTSubscribeInfo_t;
 
 /**
  * @brief MQTT PUBLISH packet parameters.
  */
-struct MqttPublishInfo
+typedef struct MQTTPublishInfo
 {
     /**
      * @brief Quality of Service for message.
@@ -222,12 +218,12 @@ struct MqttPublishInfo
      * @brief Message payload length.
      */
     size_t payloadLength;
-};
+} MQTTPublishInfo_t;
 
 /**
  * @brief MQTT incoming packet parameters.
  */
-struct MQTTPacketInfo
+typedef struct MQTTPacketInfo
 {
     /**
      * @brief Type of incoming MQTT packet.
@@ -243,7 +239,7 @@ struct MQTTPacketInfo
      * @brief Length of remaining serialized data.
      */
     size_t remainingLength;
-};
+} MQTTPacketInfo_t;
 
 /**
  * @brief Get the size and Remaining Length of an MQTT CONNECT packet.

--- a/libraries/standard/mqtt/include/mqtt_state.h
+++ b/libraries/standard/mqtt/include/mqtt_state.h
@@ -19,14 +19,25 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+/**
+ * @file mqtt_state.h
+ * @brief User-facing functions for keeping state of MQTT 3.1.1 packets.
+ */
 #ifndef MQTT_STATE_H
 #define MQTT_STATE_H
 
 #include "mqtt.h"
 
+/**
+ * @brief Initializer value for an #MQTTStateCursor_t, indicating a search
+ * should start at the beginning of a state record array
+ */
 #define MQTT_STATE_CURSOR_INITIALIZER    ( size_t ) 0
 
 /**
+ * @cond DOXYGEN_IGNORE
+ * Doxygen should ignore this section, this enum is private.
+ *
  * @brief Value indicating either send or receive.
  */
 typedef enum MQTTStateOperation
@@ -34,6 +45,7 @@ typedef enum MQTTStateOperation
     MQTT_SEND,
     MQTT_RECEIVE
 } MQTTStateOperation_t;
+/** @endcond */
 
 /**
  * @brief Cursor for iterating through state records.
@@ -41,6 +53,9 @@ typedef enum MQTTStateOperation
 typedef size_t MQTTStateCursor_t;
 
 /**
+ * @cond DOXYGEN_IGNORE
+ * Doxygen should ignore this section, this function is private.
+ *
  * @brief Reserve an entry for an outgoing QoS 1/2 publish.
  *
  * @param[in] pMqttContext Initialized MQTT context.
@@ -52,8 +67,12 @@ typedef size_t MQTTStateCursor_t;
 MQTTStatus_t MQTT_ReserveState( MQTTContext_t * pMqttContext,
                                 uint16_t packetId,
                                 MQTTQoS_t qos );
+/** @endcond */
 
 /**
+ * @cond DOXYGEN_IGNORE
+ * Doxygen should ignore this section, this function is private.
+ *
  * @brief Calculate the new state for a publish from its qos and operation type.
  *
  * @param[in] opType Send or Receive.
@@ -63,8 +82,12 @@ MQTTStatus_t MQTT_ReserveState( MQTTContext_t * pMqttContext,
  */
 MQTTPublishState_t MQTT_CalculateStatePublish( MQTTStateOperation_t opType,
                                                MQTTQoS_t qos );
+/** @endcond */
 
 /**
+ * @cond DOXYGEN_IGNORE
+ * Doxygen should ignore this section, this function is private.
+ *
  * @brief Update the state record for a PUBLISH packet.
  *
  * @param[in] pMqttContext Initialized MQTT context.
@@ -81,8 +104,12 @@ MQTTStatus_t MQTT_UpdateStatePublish( MQTTContext_t * pMqttContext,
                                       MQTTStateOperation_t opType,
                                       MQTTQoS_t qos,
                                       MQTTPublishState_t * pNewState );
+/** @endcond */
 
 /**
+ * @cond DOXYGEN_IGNORE
+ * Doxygen should ignore this section, this function is private.
+ *
  * @brief Calculate the state from a PUBACK, PUBREC, PUBREL, or PUBCOMP.
  *
  * @param[in] packetType PUBACK, PUBREC, PUBREL, or PUBCOMP.
@@ -94,8 +121,12 @@ MQTTStatus_t MQTT_UpdateStatePublish( MQTTContext_t * pMqttContext,
 MQTTPublishState_t MQTT_CalculateStateAck( MQTTPubAckType_t packetType,
                                            MQTTStateOperation_t opType,
                                            MQTTQoS_t qos );
+/** @endcond */
 
 /**
+ * @cond DOXYGEN_IGNORE
+ * Doxygen should ignore this section, this function is private.
+ *
  * @brief Update the state record for an ACKed publish.
  *
  * @param[in] pMqttContext Initialized MQTT context.
@@ -111,8 +142,12 @@ MQTTStatus_t MQTT_UpdateStateAck( MQTTContext_t * pMqttContext,
                                   MQTTPubAckType_t packetType,
                                   MQTTStateOperation_t opType,
                                   MQTTPublishState_t * pNewState );
+/** @endcond */
 
 /**
+ * @cond DOXYGEN_IGNORE
+ * Doxygen should ignore this section, this function is private.
+ *
  * @brief Get the packet ID of next pending PUBREL ack to be resent.
  *
  * This function will need to be called to get the packet for which a PUBREL
@@ -127,6 +162,7 @@ MQTTStatus_t MQTT_UpdateStateAck( MQTTContext_t * pMqttContext,
 uint16_t MQTT_PubrelToResend( const MQTTContext_t * pMqttContext,
                               MQTTStateCursor_t * pCursor,
                               MQTTPublishState_t * pState );
+/** @endcond */
 
 /**
  * @brief Get the packet ID of next pending publish to be resent.
@@ -143,6 +179,9 @@ uint16_t MQTT_PublishToResend( const MQTTContext_t * pMqttContext,
                                MQTTStateCursor_t * pCursor );
 
 /**
+ * @cond DOXYGEN_IGNORE
+ * Doxygen should ignore this section, this function is private.
+ *
  * @brief State to string conversion for state engine.
  *
  * @param[in] state The state to convert to a string.
@@ -150,5 +189,6 @@ uint16_t MQTT_PublishToResend( const MQTTContext_t * pMqttContext,
  * @return The string representation of the state.
  */
 const char * MQTT_State_strerror( MQTTPublishState_t state );
+/** @endcond */
 
 #endif /* ifndef MQTT_STATE_H */

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -19,6 +19,10 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+/**
+ * @file mqtt.c
+ * @brief Implements the user facing functions in mqtt.h.
+ */
 #include <string.h>
 #include <assert.h>
 
@@ -97,7 +101,7 @@ static int32_t recvExact( const MQTTContext_t * pContext,
 /**
  * @brief Discard a packet from the transport interface.
  *
- * @param[in] PContext MQTT Connection context.
+ * @param[in] pContext MQTT Connection context.
  * @param[in] remainingLength Remaining length of the packet to dump.
  * @param[in] timeoutMs Time remaining to discard the packet.
  *

--- a/libraries/standard/mqtt/src/mqtt_lightweight.c
+++ b/libraries/standard/mqtt/src/mqtt_lightweight.c
@@ -19,6 +19,10 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+/**
+ * @file mqtt_lightweight.c
+ * @brief Implements the user facing functions in mqtt_lightweight.h.
+ */
 #include <string.h>
 #include <assert.h>
 
@@ -58,7 +62,7 @@
  */
 #define MQTT_DISCONNECT_PACKET_SIZE                 ( 2UL )
 
-/*
+/**
  * @brief A PINGREQ packet is always 2 bytes in size, defined by MQTT 3.1.1 spec.
  */
 #define MQTT_PACKET_PINGREQ_SIZE                    ( 2U )
@@ -135,11 +139,13 @@
 
 /*-----------------------------------------------------------*/
 
-/* MQTT Subscription packet types. */
+/**
+ * @brief MQTT Subscription packet types.
+ */
 typedef enum MQTTSubscriptionType
 {
-    MQTT_SUBSCRIBE,
-    MQTT_UNSUBSCRIBE
+    MQTT_SUBSCRIBE,  /**< @brief The type is a SUBSCRIBE packet. */
+    MQTT_UNSUBSCRIBE /**< @brief The type is a UNSUBSCRIBE packet. */
 } MQTTSubscriptionType_t;
 
 /*-----------------------------------------------------------*/
@@ -147,9 +153,9 @@ typedef enum MQTTSubscriptionType
 /**
  * @brief Serializes MQTT PUBLISH packet into the buffer provided.
  *
- * This function serializes MQTT PUBLISH packet into #pFixedBuffer.pBuffer.
+ * This function serializes MQTT PUBLISH packet into #MQTTFixedBuffer_t.pBuffer.
  * Copy of the payload into the buffer is done as part of the serialization
- * only if #serializePayload is true.
+ * only if @p serializePayload is true.
  *
  * @brief param[in] pPublishInfo Publish information.
  * @brief param[in] remainingLength Remaining length of the PUBLISH packet.
@@ -237,16 +243,16 @@ static void serializeConnectPacket( const MQTTConnectInfo_t * pConnectInfo,
                                     const MQTTFixedBuffer_t * pFixedBuffer );
 
 /**
- * Prints the appropriate message for the CONNACK response code if logs are
- * enabled.
+ * @brief Prints the appropriate message for the CONNACK response code if logs
+ * are enabled.
  *
  * @param[in] responseCode MQTT standard CONNACK response code.
  */
 static void logConnackResponse( uint8_t responseCode );
 
 /**
- * Encodes the remaining length of the packet using the variable length encoding
- * scheme provided in the MQTT v3.1.1 specification.
+ * @brief Encodes the remaining length of the packet using the variable length
+ * encoding scheme provided in the MQTT v3.1.1 specification.
  *
  * @param[out] pDestination The destination buffer to store the encoded remaining
  * length.
@@ -258,7 +264,7 @@ static uint8_t * encodeRemainingLength( uint8_t * pDestination,
                                         size_t length );
 
 /**
- * Retrieve the size of the remaining length if it were to be encoded.
+ * @brief Retrieve the size of the remaining length if it were to be encoded.
  *
  * @param[in] length The remaining length to be encoded.
  *
@@ -267,7 +273,7 @@ static uint8_t * encodeRemainingLength( uint8_t * pDestination,
 static size_t remainingLengthEncodedSize( size_t length );
 
 /**
- * Encode a string whose size is at maximum 16 bits in length.
+ * @brief Encode a string whose size is at maximum 16 bits in length.
  *
  * @param[out] pDestination Destination buffer for the encoding.
  * @param[in] pSource The source string to encode.
@@ -280,8 +286,8 @@ static uint8_t * encodeString( uint8_t * pDestination,
                                uint16_t sourceLength );
 
 /**
- * Retrieves and decodes the Remaining Length from the network interface by
- * reading a single byte at a time.
+ * @brief Retrieves and decodes the Remaining Length from the network interface
+ * by reading a single byte at a time.
  *
  * @param[in] recvFunc Network interface receive function.
  * @param[in] pNetworkContext Network interface context to the receive function.
@@ -290,6 +296,133 @@ static uint8_t * encodeString( uint8_t * pDestination,
  */
 static size_t getRemainingLength( TransportRecv_t recvFunc,
                                   NetworkContext_t * pNetworkContext );
+
+/**
+ * @brief Check if an incoming packet type is valid.
+ *
+ * @param[in] packetType The packet type to check.
+ *
+ * @return `true` if the packet type is valid; `false` otherwise.
+ */
+static bool incomingPacketValid( uint8_t packetType );
+
+/**
+ * @brief Check the remaining length of an incoming PUBLISH packet against some
+ * value for QoS 0 or QoS 1 and 2.
+ *
+ * The remaining length for a QoS 1 and 2 packet will always be two greater than
+ * for a QoS 0.
+ *
+ * @param[in] remainingLength Remaining length of the PUBLISH packet.
+ * @param[in] qos The QoS of the PUBLISH.
+ * @param[in] qos0Minimum Minimum possible remaining length for a QoS 0 PUBLISH.
+ *
+ * @return #MQTTSuccess or #MQTTBadResponse.
+ */
+static MQTTStatus_t checkPublishRemainingLength( size_t remainingLength,
+                                                 MQTTQoS_t qos,
+                                                 size_t qos0Minimum );
+
+/**
+ * @brief Process incoming publish flags.
+ *
+ * @param[in] publishFlags Incoming publish flags.
+ * @param[in, out] pPublishInfo Pointer to #MQTTPublishInfo_t struct where
+ * output will be written.
+ *
+ * @return #MQTTSuccess, #MQTTBadResponse.
+ */
+static MQTTStatus_t processPublishFlags( uint8_t publishFlags,
+                                         MQTTPublishInfo_t * pPublishInfo );
+
+/**
+ * @brief Deserialize a CONNACK packet.
+ *
+ * Converts the packet from a stream of bytes to an #MQTTStatus_t.
+ *
+ * @param[in] pConnack Pointer to an MQTT packet struct representing a
+ * CONNACK.
+ * @param[out] pSessionPresent Whether a previous session was present.
+ *
+ * @return #MQTTSuccess if CONNACK specifies that CONNECT was accepted;
+ * #MQTTServerRefused if CONNACK specifies that CONNECT was rejected;
+ * #MQTTBadResponse if the CONNACK packet doesn't follow MQTT spec.
+ */
+static MQTTStatus_t deserializeConnack( const MQTTPacketInfo_t * pConnack,
+                                        bool * pSessionPresent );
+
+/**
+ * @brief Decode the status bytes of a SUBACK packet to a #MQTTStatus_t.
+ *
+ * @param[in] statusCount Number of status bytes in the SUBACK.
+ * @param[in] pStatusStart The first status byte in the SUBACK.
+ *
+ * @return #MQTTSuccess, #MQTTServerRefused, or #MQTTBadResponse.
+ */
+static MQTTStatus_t readSubackStatus( size_t statusCount,
+                                      const uint8_t * pStatusStart );
+
+/**
+ * @brief Deserialize a SUBACK packet.
+ *
+ * Converts the packet from a stream of bytes to an #MQTTStatus_t and extracts
+ * the packet identifier.
+ *
+ * @param[in] pSuback Pointer to an MQTT packet struct representing a SUBACK.
+ * @param[out] pPacketIdentifier Packet ID of the SUBACK.
+ *
+ * @return #MQTTSuccess if SUBACK is valid; #MQTTBadResponse if SUBACK packet
+ * doesn't follow the MQTT spec.
+ */
+static MQTTStatus_t deserializeSuback( const MQTTPacketInfo_t * pSuback,
+                                       uint16_t * pPacketIdentifier );
+
+/**
+ * @brief Deserialize a PUBLISH packet received from the server.
+ *
+ * Converts the packet from a stream of bytes to an #MQTTPublishInfo_t and
+ * extracts the packet identifier. Also prints out debug log messages about the
+ * packet.
+ *
+ * @param[in] pIncomingPacket Pointer to an MQTT packet struct representing a
+ * PUBLISH.
+ * @param[out] pPacketId Packet identifier of the PUBLISH.
+ * @param[out] pPublishInfo Pointer to #MQTTPublishInfo_t where write output is
+ * written.
+ *
+ * @return #MQTTSuccess if PUBLISH is valid; #MQTTBadResponse
+ * if the PUBLISH packet doesn't follow MQTT spec.
+ */
+static MQTTStatus_t deserializePublish( const MQTTPacketInfo_t * pIncomingPacket,
+                                        uint16_t * pPacketId,
+                                        MQTTPublishInfo_t * pPublishInfo );
+
+/**
+ * @brief Deserialize a UNSUBACK, PUBACK, PUBREC, PUBREL, or PUBCOMP packet.
+ *
+ * Converts the packet from a stream of bytes to an #MQTTStatus_t and extracts
+ * the packet identifier.
+ *
+ * @param[in] pAck Pointer to the MQTT packet structure representing the packet.
+ * @param[out] pPacketIdentifier Packet ID of the ack type packet.
+ *
+ * @return #MQTTSuccess if UNSUBACK, PUBACK, PUBREC, PUBREL, or PUBCOMP is valid;
+ * #MQTTBadResponse if the packet doesn't follow the MQTT spec.
+ */
+static MQTTStatus_t deserializeSimpleAck( const MQTTPacketInfo_t * pAck,
+                                          uint16_t * pPacketIdentifier );
+
+/**
+ * @brief Deserialize a PINGRESP packet.
+ *
+ * Converts the packet from a stream of bytes to an #MQTTStatus_t.
+ *
+ * @param[in] pPingresp Pointer to an MQTT packet struct representing a PINGRESP.
+ *
+ * @return #MQTTSuccess if PINGRESP is valid; #MQTTBadResponse if the PINGRESP
+ * packet doesn't follow MQTT spec.
+ */
+static MQTTStatus_t deserializePingresp( const MQTTPacketInfo_t * pPingresp );
 
 /*-----------------------------------------------------------*/
 

--- a/libraries/standard/mqtt/src/mqtt_state.c
+++ b/libraries/standard/mqtt/src/mqtt_state.c
@@ -19,6 +19,10 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+/**
+ * @file mqtt_state.c
+ * @brief Implements the user facing functions in mqtt_state.h.
+ */
 #include <assert.h>
 #include <string.h>
 #include "mqtt_state.h"
@@ -127,11 +131,11 @@ static void compactRecords( MQTTPubAckInfo_t * records,
  *
  * @param[in] records State record array.
  * @param[in] recordCount Length of record array.
- * @param[in] packetId, packet ID of new entry.
+ * @param[in] packetId Packet ID of new entry.
  * @param[in] qos QoS of new entry.
- * @param[in] publishState state of new entry.
+ * @param[in] publishState State of new entry.
  *
- * @return MQTTSuccess, MQTTNoMemory, MQTTStateCollision.
+ * @return #MQTTSuccess, #MQTTNoMemory, or #MQTTStateCollision.
  */
 static MQTTStatus_t addRecord( MQTTPubAckInfo_t * records,
                                size_t recordCount,
@@ -159,6 +163,8 @@ static void updateRecord( MQTTPubAckInfo_t * records,
  * @param[in] pMqttContext Initialized MQTT context.
  * @param[in] searchStates The states to search for in 2-byte bit map.
  * @param[in,out] pCursor Index at which to start searching.
+ *
+ * @return Packet ID of the outgoing publish.
  */
 static uint16_t stateSelect( const MQTTContext_t * pMqttContext,
                              uint16_t searchStates,
@@ -615,6 +621,10 @@ static uint16_t stateSelect( const MQTTContext_t * pMqttContext,
 
 /*-----------------------------------------------------------*/
 
+/**
+ * @cond DOXYGEN_IGNORE
+ * Doxygen should ignore this private function.
+ */
 MQTTPublishState_t MQTT_CalculateStateAck( MQTTPubAckType_t packetType,
                                            MQTTStateOperation_t opType,
                                            MQTTQoS_t qos )
@@ -661,6 +671,7 @@ MQTTPublishState_t MQTT_CalculateStateAck( MQTTPubAckType_t packetType,
 
     return calculatedState;
 }
+/** @endcond */
 
 /*-----------------------------------------------------------*/
 
@@ -779,6 +790,10 @@ static MQTTStatus_t updateStatePublish( MQTTContext_t * pMqttContext,
 
 /*-----------------------------------------------------------*/
 
+/**
+ * @cond DOXYGEN_IGNORE
+ * Doxygen should ignore this private function.
+ */
 MQTTStatus_t MQTT_ReserveState( MQTTContext_t * pMqttContext,
                                 uint16_t packetId,
                                 MQTTQoS_t qos )
@@ -805,9 +820,14 @@ MQTTStatus_t MQTT_ReserveState( MQTTContext_t * pMqttContext,
 
     return status;
 }
+/** @endcond */
 
 /*-----------------------------------------------------------*/
 
+/**
+ * @cond DOXYGEN_IGNORE
+ * Doxygen should ignore this private function.
+ */
 MQTTPublishState_t MQTT_CalculateStatePublish( MQTTStateOperation_t opType,
                                                MQTTQoS_t qos )
 {
@@ -834,9 +854,14 @@ MQTTPublishState_t MQTT_CalculateStatePublish( MQTTStateOperation_t opType,
 
     return calculatedState;
 }
+/** @endcond */
 
 /*-----------------------------------------------------------*/
 
+/**
+ * @cond DOXYGEN_IGNORE
+ * Doxygen should ignore this private function.
+ */
 MQTTStatus_t MQTT_UpdateStatePublish( MQTTContext_t * pMqttContext,
                                       uint16_t packetId,
                                       MQTTStateOperation_t opType,
@@ -908,9 +933,14 @@ MQTTStatus_t MQTT_UpdateStatePublish( MQTTContext_t * pMqttContext,
 
     return mqttStatus;
 }
+/** @endcond */
 
 /*-----------------------------------------------------------*/
 
+/**
+ * @cond DOXYGEN_IGNORE
+ * Doxygen should ignore this private function.
+ */
 MQTTStatus_t MQTT_UpdateStateAck( MQTTContext_t * pMqttContext,
                                   uint16_t packetId,
                                   MQTTPubAckType_t packetType,
@@ -969,9 +999,14 @@ MQTTStatus_t MQTT_UpdateStateAck( MQTTContext_t * pMqttContext,
 
     return status;
 }
+/** @endcond */
 
 /*-----------------------------------------------------------*/
 
+/**
+ * @cond DOXYGEN_IGNORE
+ * Doxygen should ignore this private function.
+ */
 uint16_t MQTT_PubrelToResend( const MQTTContext_t * pMqttContext,
                               MQTTStateCursor_t * pCursor,
                               MQTTPublishState_t * pState )
@@ -1005,6 +1040,7 @@ uint16_t MQTT_PubrelToResend( const MQTTContext_t * pMqttContext,
 
     return packetId;
 }
+/** @endcond */
 
 /*-----------------------------------------------------------*/
 
@@ -1038,6 +1074,10 @@ uint16_t MQTT_PublishToResend( const MQTTContext_t * pMqttContext,
 
 /*-----------------------------------------------------------*/
 
+/**
+ * @cond DOXYGEN_IGNORE
+ * Doxygen should ignore this private function.
+ */
 const char * MQTT_State_strerror( MQTTPublishState_t state )
 {
     const char * str = NULL;
@@ -1096,5 +1136,6 @@ const char * MQTT_State_strerror( MQTTPublishState_t state )
 
     return str;
 }
+/** @endcond */
 
 /*-----------------------------------------------------------*/

--- a/libraries/standard/mqtt/src/private/mqtt_internal.h
+++ b/libraries/standard/mqtt/src/private/mqtt_internal.h
@@ -1,9 +1,41 @@
+/*
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file mqtt_internal.h
+ * @brief Internal header of the MQTT library. This header should not be
+ * included in typical application code.
+ */
 #ifndef MQTT_INTERNAL_H_
 #define MQTT_INTERNAL_H_
 
 /* Include config file before other headers. */
 #include "mqtt_config.h"
 
+/**
+ * @cond DOXYGEN_IGNORE
+ * Doxygen should ignore this section.
+ *
+ * Configure logs for MQTT functions.
+ */
 #ifndef LogError
     #define LogError( message )
 #endif
@@ -19,5 +51,6 @@
 #ifndef LogDebug
     #define LogDebug( message )
 #endif
+/** @endcond */
 
 #endif /* ifndef MQTT_INTERNAL_H_ */


### PR DESCRIPTION
*Description of changes:*
- Fix warnings through the MQTT library files.
- Add \@file where missing so Doxygen will pick up the file.
- Add documentation for static functions in mqtt_lightweight.c (also a warning with static doc parsing on)
- Ignore private functions in mqtt_state.h.

Doxygen infrastructure and config files is a separate PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
