### PR TITLE
[PR from CLI tool] Allow connectivity configs in MQTT demo to be CLI overridden

### DIFF
--- a/demos/mqtt/mqtt_demo_basic_tls/demo_config.h
+++ b/demos/mqtt/mqtt_demo_basic_tls/demo_config.h
@@ -56,26 +56,30 @@
  * the instructions in https://mosquitto.org/ for running a Mosquitto broker
  * locally.
  */
-#define BROKER_ENDPOINT             "test.mosquitto.org"
+#ifndef BROKER_ENDPOINT
+    #define BROKER_ENDPOINT    "test.mosquitto.org"
+#endif
 
 /**
  * @brief Length of MQTT server host name.
  */
-#define BROKER_ENDPOINT_LENGTH      ( ( uint16_t ) ( sizeof( BROKER_ENDPOINT ) - 1 ) )
+#define BROKER_ENDPOINT_LENGTH    ( ( uint16_t ) ( sizeof( BROKER_ENDPOINT ) - 1 ) )
 
 /**
  * @brief MQTT server port number.
  *
  * In general, port 8883 is for secured MQTT connections.
  */
-#define BROKER_PORT                 ( 8883 )
+#define BROKER_PORT               ( 8883 )
 
 /**
  * @brief Path of the file containing the server's root CA certificate.
  *
  * This certificate should be PEM-encoded.
  */
-#define ROOT_CA_CERT_PATH           "certificates/mosquitto.org.crt"
+#ifndef ROOT_CA_CERT_PATH
+    #define ROOT_CA_CERT_PATH    "certificates/mosquitto.org.crt"
+#endif
 
 /**
  * @brief Length of path to server certificate.

--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -61,8 +61,11 @@
  * These configuration settings are required to run the basic TLS demo.
  * Throw compilation error if the below configs are not defined.
  */
+#ifndef BROKER_ENDPOINT
+    #error "Please define an MQTT broker endpoint, BROKER_ENDPOINT, in demo_config.h."
+#endif
 #ifndef ROOT_CA_CERT_PATH
-    #error "Please define path to Root CA certificate of the MQTT broker(ROOT_CA_CERT_PATH) in demo_config.h."
+    #error "Please define path to Root CA certificate of the MQTT broker, ROOT_CA_CERT_PATH, in demo_config.h."
 #endif
 #ifndef CLIENT_IDENTIFIER
     #error "Please define a unique CLIENT_IDENTIFIER."

--- a/demos/mqtt/mqtt_demo_lightweight/demo_config.h
+++ b/demos/mqtt/mqtt_demo_lightweight/demo_config.h
@@ -53,7 +53,9 @@
  * This demo uses the Mosquitto test server. This is a public MQTT server; do not
  * publish anything sensitive to this server.
  */
-#define BROKER_ENDPOINT           "test.mosquitto.org"
+#ifndef BROKER_ENDPOINT
+    #define BROKER_ENDPOINT    "test.mosquitto.org"
+#endif
 
 /**
  * @brief Length of MQTT server host name.

--- a/demos/mqtt/mqtt_demo_lightweight/mqtt_demo_lightweight.c
+++ b/demos/mqtt/mqtt_demo_lightweight/mqtt_demo_lightweight.c
@@ -55,6 +55,11 @@
 /* Reconnect parameters. */
 #include "transport_reconnect.h"
 
+/* Check that the broker endpoint is defined. */
+#ifndef BROKER_ENDPOINT
+    #error "Please define an MQTT broker endpoint, BROKER_ENDPOINT, in demo_config.h."
+#endif
+
 /* Check that client identifier is defined. */
 #ifndef CLIENT_IDENTIFIER
     #error "Please define a unique CLIENT_IDENTIFIER."

--- a/demos/mqtt/mqtt_demo_plaintext/demo_config.h
+++ b/demos/mqtt/mqtt_demo_plaintext/demo_config.h
@@ -53,7 +53,9 @@
  * This demo uses the Mosquitto test server. This is a public MQTT server; do not
  * publish anything sensitive to this server.
  */
-#define BROKER_ENDPOINT      "test.mosquitto.org"
+#ifndef BROKER_ENDPOINT
+    #define BROKER_ENDPOINT    "test.mosquitto.org"
+#endif
 
 /**
  * @brief MQTT server port number.

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
@@ -58,8 +58,11 @@
  * These configuration settings are required to run the plaintext demo.
  * Throw compilation error if the below configs are not defined.
  */
+#ifndef BROKER_ENDPOINT
+    #error "Please define an MQTT broker endpoint, BROKER_ENDPOINT, in demo_config.h."
+#endif
 #ifndef CLIENT_IDENTIFIER
-    #error "Please define a unique CLIENT_IDENTIFIER."
+    #error "Please define a unique CLIENT_IDENTIFIER in demo_config.h."
 #endif
 
 /**


### PR DESCRIPTION
Allow `BROKER_ENDPOINT` and `ROOT_CA_CERT_PATH` (only for basic TLS demo) to be specified through build command for CI.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
