### PR TITLE
Remove failing directory copy

### DIFF
--- a/libraries/standard/mqtt/integration-test/CMakeLists.txt
+++ b/libraries/standard/mqtt/integration-test/CMakeLists.txt
@@ -57,13 +57,3 @@ create_test(${stest_name}
             "${stest_dep_list}"
             "${test_include_directories}"
         )
-
-# Copy the certificates and client key to the binary directory.
-add_custom_command(
-    TARGET
-        ${stest_name}
-    POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-        "${CMAKE_CURRENT_LIST_DIR}/certificates"
-        "$<TARGET_FILE_DIR:${stest_name}>/certificates"
-)


### PR DESCRIPTION
*Description of changes:* When opting to not download certs (a recent change), the removed section fails because the certificate directory will not exist.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
