### PR TITLE
Change state status code and increase coverage

### DIFF
--- a/libraries/standard/mqtt/include/mqtt_state.h
+++ b/libraries/standard/mqtt/include/mqtt_state.h
@@ -135,7 +135,8 @@ MQTTPublishState_t MQTT_CalculateStateAck( MQTTPubAckType_t packetType,
  * @param[in] opType Send or Receive.
  * @param[out] pNewState Updated state of the publish.
  *
- * @return #MQTTBadParameter, #MQTTIllegalState, or #MQTTSuccess.
+ * @return #MQTTBadParameter, #MQTTBadResponse, #MQTTIllegalState, or
+ * #MQTTSuccess.
  */
 MQTTStatus_t MQTT_UpdateStateAck( MQTTContext_t * pMqttContext,
                                   uint16_t packetId,

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -1179,6 +1179,8 @@ static MQTTStatus_t handleIncomingAck( MQTTContext_t * pContext,
 
     appCallback = pContext->appCallback;
 
+    LogDebug( ( "Received packet of type %02x.", pIncomingPacket->type ) );
+
     switch( pIncomingPacket->type )
     {
         case MQTT_PACKET_TYPE_PUBACK:

--- a/libraries/standard/mqtt/src/mqtt_state.c
+++ b/libraries/standard/mqtt/src/mqtt_state.c
@@ -424,22 +424,17 @@ static size_t findInRecord( const MQTTPubAckInfo_t * records,
 {
     size_t index = 0;
 
+    assert( packetId != MQTT_PACKET_ID_INVALID );
+
     *pCurrentState = MQTTStateNull;
 
-    if( packetId == MQTT_PACKET_ID_INVALID )
+    for( index = 0; index < recordCount; index++ )
     {
-        index = recordCount;
-    }
-    else
-    {
-        for( index = 0; index < recordCount; index++ )
+        if( records[ index ].packetId == packetId )
         {
-            if( records[ index ].packetId == packetId )
-            {
-                *pQos = records[ index ].qos;
-                *pCurrentState = records[ index ].publishState;
-                break;
-            }
+            *pQos = records[ index ].qos;
+            *pCurrentState = records[ index ].publishState;
+            break;
         }
     }
 
@@ -964,7 +959,8 @@ MQTTStatus_t MQTT_UpdateStatePublish( MQTTContext_t * pMqttContext,
  * @param[in] opType Send or Receive.
  * @param[out] pNewState Updated state of the publish.
  *
- * @return #MQTTBadParameter, #MQTTIllegalState, or #MQTTSuccess.
+ * @return #MQTTBadParameter, #MQTTBadResponse, #MQTTIllegalState, or
+ * #MQTTSuccess.
  */
 MQTTStatus_t MQTT_UpdateStateAck( MQTTContext_t * pMqttContext,
                                   uint16_t packetId,
@@ -978,13 +974,24 @@ MQTTStatus_t MQTT_UpdateStateAck( MQTTContext_t * pMqttContext,
     MQTTQoS_t qos = MQTTQoS0;
     size_t recordIndex = MQTT_STATE_ARRAY_MAX_COUNT;
     MQTTPubAckInfo_t * records = NULL;
-    MQTTStatus_t status = MQTTBadParameter;
+    MQTTStatus_t status = MQTTBadResponse;
 
     if( ( pMqttContext == NULL ) || ( pNewState == NULL ) )
     {
         LogError( ( "Argument cannot be NULL: pMqttContext=%p, pNewState=%p.",
                     ( void * ) pMqttContext,
                     ( void * ) pNewState ) );
+        status = MQTTBadParameter;
+    }
+    else if( packetId == MQTT_PACKET_ID_INVALID )
+    {
+        LogError( ( "Packet ID must be nonzero." ) );
+        status = MQTTBadParameter;
+    }
+    else if( packetType > MQTTPubcomp )
+    {
+        LogError( ( "Invalid packet type." ) );
+        status = MQTTBadParameter;
     }
     else
     {
@@ -1019,7 +1026,7 @@ MQTTStatus_t MQTT_UpdateStateAck( MQTTContext_t * pMqttContext,
     }
     else
     {
-        LogError( ( "No matching record found for publish %u.", packetId ) );
+        LogError( ( "No matching record found for publish ID %u.", packetId ) );
     }
 
     return status;

--- a/libraries/standard/mqtt/utest/mqtt_state_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_state_utest.c
@@ -487,12 +487,12 @@ void test_MQTT_UpdateStateAck( void )
     TEST_ASSERT_EQUAL( MQTTBadParameter, status );
     status = MQTT_UpdateStateAck( &mqttContext, PACKET_ID, ack, operation, NULL );
     TEST_ASSERT_EQUAL( MQTTBadParameter, status );
-    /* No matching record found. */
-    status = MQTT_UpdateStateAck( &mqttContext, PACKET_ID, ack, operation, &state );
-    TEST_ASSERT_EQUAL( MQTTBadParameter, status );
     /* Invalid packet ID. */
     status = MQTT_UpdateStateAck( &mqttContext, 0, ack, operation, &state );
     TEST_ASSERT_EQUAL( MQTTBadParameter, status );
+    /* No matching record found. */
+    status = MQTT_UpdateStateAck( &mqttContext, PACKET_ID, ack, operation, &state );
+    TEST_ASSERT_EQUAL( MQTTBadResponse, status );
 
     /* Invalid transitions. */
     /* Invalid transition from #MQTTPubRelPending. */

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -2209,6 +2209,16 @@ void test_MQTT_MatchTopic_ExactMatch( void )
                                                      MQTT_SAMPLE_TOPIC_FILTER_LENGTH,
                                                      &matchResult ) );
     TEST_ASSERT_EQUAL( false, matchResult );
+
+    /* Test for match at end with no wildcards. */
+    pTopicName = "/test/match/";
+    pTopicFilter = "/test/match/a";
+    TEST_ASSERT_EQUAL( MQTTSuccess, MQTT_MatchTopic( pTopicName,
+                                                     strlen( pTopicName ),
+                                                     pTopicFilter,
+                                                     strlen( pTopicFilter ),
+                                                     &matchResult ) );
+    TEST_ASSERT_EQUAL( false, matchResult );
 }
 
 /**


### PR DESCRIPTION
*Description of changes:*
Changes the status code returned by the state engine from bad parameter to bad response if an unexpected packet is received. Also adds some debug logs to aid in debugging unexpected packets received from the network, and increases test coverage to 100%.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
