### PR TITLE
Update proof for HTTPClient_ReadHeader to pass double pointer

### DIFF
--- a/libraries/standard/http/cbmc/proofs/HTTPClient_ReadHeader/HTTPClient_ReadHeader_harness.c
+++ b/libraries/standard/http/cbmc/proofs/HTTPClient_ReadHeader/HTTPClient_ReadHeader_harness.c
@@ -32,7 +32,7 @@ void harness()
 {
     HTTPResponse_t * pResponse;
     char * pField;
-    char * pValue;
+    char ** pValue;
     size_t fieldLen;
     size_t valueLen;
 
@@ -42,7 +42,7 @@ void harness()
 
     /* Initialize and make assumptions for header value. */
     __CPROVER_assume( valueLen < CBMC_MAX_OBJECT_SIZE );
-    pValue = mallocCanFail( valueLen );
+    pValue = mallocCanFail( sizeof( char * ) );
 
     /* Initialize and make assumptions for response object. */
     pResponse = allocateHttpResponse( NULL );

--- a/libraries/standard/http/cbmc/sources/http_cbmc_state.c
+++ b/libraries/standard/http/cbmc/sources/http_cbmc_state.c
@@ -90,7 +90,7 @@ HTTPResponse_t * allocateHttpResponse( HTTPResponse_t * pResponse )
 
         pResponse->pBuffer = mallocCanFail( pResponse->bufferLen );
 
-        __CPROVER_assume( headerOffset < pResponse->headersLen );
+        __CPROVER_assume( headerOffset <= pResponse->headersLen );
         pResponse->pHeaders = nondet_bool() ? NULL :
                               pResponse->pBuffer + headerOffset;
 


### PR DESCRIPTION
I mistakenly used a regular pointer even though the parameter requires a double pointer. Although a pointer to a pointer can carry the same values as a regular pointer, so that's probably why CBMC didn't flag this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
