### PR TITLE
Add code examples for new and state API functions

### DIFF
--- a/libraries/standard/mqtt/include/mqtt.h
+++ b/libraries/standard/mqtt/include/mqtt.h
@@ -742,7 +742,7 @@ MQTTStatus_t MQTT_MatchTopic( const char * pTopicName,
  * MQTTSubscribeInfo_t pSubscribes[ NUMBER_OF_SUBSCRIPTIONS ];
  *
  * // MQTT_GetSubAckStatusCodes is intended to be used from the application
- * // callback that is called by the library in the process/receive loop.
+ * // callback that is called by the library in MQTT_ProcessLoop or MQTT_ReceiveLoop.
  * void eventCallback(
  *      MQTTContext_t * pContext,
  *      MQTTPacketInfo_t * pPacketInfo,

--- a/libraries/standard/mqtt/include/mqtt.h
+++ b/libraries/standard/mqtt/include/mqtt.h
@@ -767,8 +767,8 @@ MQTTStatus_t MQTT_MatchTopic( const char * pTopicName,
  *
  *          for( int i = 0; i < numCodes; i++ )
  *          {
- *              // The only failure code is 0x80.
- *              if( pCodes[ i ] == 0x80 )
+ *              // The only failure code is 0x80 = MQTTSubAckFailure.
+ *              if( pCodes[ i ] == MQTTSubAckFailure )
  *              {
  *                  // The subscription failed, we may want to retry the
  *                  // subscription in pSubscribes[ i ] outside of this callback.

--- a/libraries/standard/mqtt/include/mqtt.h
+++ b/libraries/standard/mqtt/include/mqtt.h
@@ -681,6 +681,27 @@ uint16_t MQTT_GetPacketId( MQTTContext_t * pContext );
  * @return Returns one of the following:
  * - #MQTTBadParameter, if any of the input parameters is invalid.
  * - #MQTTSuccess, if the matching operation was performed.
+ *
+ * <b>Example</b>
+ * @code{c}
+ *
+ * // Variables used in this example.
+ * const char * pTopic = "topic/match/1";
+ * const char * pFilter = "topic/#";
+ * MQTTStatus_t status = MQTTSuccess;
+ * bool match = false;
+ *
+ * status = MQTT_MatchTopic( pTopic, strlen( pTopic ), pFilter, strlen( pFilter ), &match );
+ * // Our parameters were valid, so this will return success.
+ * assert( status == MQTTSuccess );
+ *
+ * // For this specific example, we already know this value is true. This
+ * // check is placed here as an example for use with variable topic names.
+ * if( match )
+ * {
+ *      // Application can decide what to do with the matching topic name.
+ * }
+ * @endcode
  */
 MQTTStatus_t MQTT_MatchTopic( const char * pTopicName,
                               const uint16_t topicNameLength,
@@ -712,6 +733,63 @@ MQTTStatus_t MQTT_MatchTopic( const char * pTopicName,
  * @return Returns one of the following:
  * - #MQTTBadParameter if the input SUBACK packet is invalid.
  * - #MQTTSuccess if parsing the payload was successful.
+ *
+ * <b>Example</b>
+ * @code{c}
+ *
+ * // Global variable used in this example.
+ * // This is assumed to be the subscription list in the original SUBSCRIBE packet.
+ * MQTTSubscribeInfo_t pSubscribes[ NUMBER_OF_SUBSCRIPTIONS ];
+ *
+ * // MQTT_GetSubAckStatusCodes is intended to be used from the application
+ * // callback that is called by the library in the process/receive loop.
+ * void eventCallback(
+ *      MQTTContext_t * pContext,
+ *      MQTTPacketInfo_t * pPacketInfo,
+ *      MQTTDeserializedInfo_t * pDeserializedInfo
+ * )
+ * {
+ *      MQTTStatus_t status = MQTTSuccess;
+ *      uint8_t * pCodes;
+ *      size_t numCodes;
+ *
+ *      if( pPacketInfo->type == MQTT_PACKET_TYPE_SUBACK )
+ *      {
+ *          status = MQTT_GetSubAckStatusCodes( pPacketInfo, &pCodes, &numCodes );
+ *
+ *          // Since the pointers to the payload and payload size are not NULL, and
+ *          // we use the packet info struct passed to the app callback (verified
+ *          // to be valid by the library), this function must return success.
+ *          assert( status == MQTTSuccess );
+ *          // The server must send a response code for each topic filter in the
+ *          // original SUBSCRIBE packet.
+ *          assert( numCodes == NUMBER_OF_SUBSCRIPTIONS );
+ *
+ *          for( int i = 0; i < numCodes; i++ )
+ *          {
+ *              // The only failure code is 0x80.
+ *              if( pCodes[ i ] == 0x80 )
+ *              {
+ *                  // The subscription failed, we may want to retry the
+ *                  // subscription in pSubscribes[ i ] outside of this callback.
+ *              }
+ *              else
+ *              {
+ *                  // The subscription was granted, but the maximum QoS may be
+ *                  // lower than what was requested. We can verify the granted QoS.
+ *                  if( pSubscribes[ i ].qos != pCodes[ i ] )
+ *                  {
+ *                      LogWarn( (
+ *                          "Requested QoS %u, but granted QoS %u for %s",
+ *                          pSubscribes[ i ].qos, pCodes[ i ], pSubscribes[ i ].pTopicFilter
+ *                      ) );
+ *                  }
+ *              }
+ *          }
+ *      }
+ *      // Handle other packet types.
+ * }
+ * @endcode
  */
 MQTTStatus_t MQTT_GetSubAckStatusCodes( const MQTTPacketInfo_t * pSubackPacket,
                                         uint8_t ** pPayloadStart,

--- a/libraries/standard/mqtt/include/mqtt_state.h
+++ b/libraries/standard/mqtt/include/mqtt_state.h
@@ -203,7 +203,7 @@ uint16_t MQTT_PubrelToResend( const MQTTContext_t * pMqttContext,
  * connectInfo.keepAliveSeconds = 60;
  * // Optional connect parameters are not relevant to this example.
  *
- * // Create MQTT connection. Use 100 milliseconds as a timeout.
+ * // Create an MQTT connection. Use 100 milliseconds as a timeout.
  * status = MQTT_Connect( pContext, &connectInfo, NULL, 100, &sessionPresent );
  *
  * if( status == MQTTSuccess )

--- a/libraries/standard/mqtt/include/mqtt_state.h
+++ b/libraries/standard/mqtt/include/mqtt_state.h
@@ -177,6 +177,61 @@ uint16_t MQTT_PubrelToResend( const MQTTContext_t * pMqttContext,
  *
  * @param[in] pMqttContext Initialized MQTT context.
  * @param[in,out] pCursor Index at which to start searching.
+ *
+ * <b>Example</b>
+ * @code{c}
+ *
+ * // For this example assume this function returns an outgoing unacknowledged
+ * // QoS 1 or 2 publish from its packet identifier.
+ * MQTTPublishInfo_t * getPublish( uint16_t packetID );
+ *
+ * // Variables used in this example.
+ * MQTTStatus_t status;
+ * MQTTStateCursor_t cursor = MQTT_STATE_CURSOR_INITIALIZER;
+ * bool sessionPresent;
+ * uint16_t packetID;
+ * MQTTPublishInfo_t * pResendPublish = NULL;
+ * MQTTConnectInfo_t connectInfo = { 0 };
+ *
+ * // This is assumed to have been initialized before the call to MQTT_Connect().
+ * MQTTContext_t * pContext;
+ *
+ * // Set clean session to false to attempt session resumption.
+ * connectInfo.cleanSession = false;
+ * connectInfo.pClientIdentifier = "someClientID";
+ * connectInfo.clientIdentifierLength = strlen( connectInfo.pClientIdentifier );
+ * connectInfo.keepAliveSeconds = 60;
+ * // Optional connect parameters are not relevant to this example.
+ *
+ * // Create MQTT connection. Use 100 milliseconds as a timeout.
+ * status = MQTT_Connect( pContext, &connectInfo, NULL, 100, &sessionPresent );
+ *
+ * if( status == MQTTSuccess )
+ * {
+ *      if( sessionPresent )
+ *      {
+ *          // Loop while packet ID is nonzero.
+ *          while( packetID = MQTT_PublishToResend( pContext, &cursor ) )
+ *          {
+ *              // Assume this function will succeed.
+ *              pResendPublish = getPublish( packetID );
+ *              // Set DUP flag.
+ *              pResendPublish->dup = true;
+ *              status = MQTT_Publish( pContext, pResendPublish, packetID );
+ *
+ *              if( status != MQTTSuccess )
+ *              {
+ *                  // Application can decide how to handle a failure.
+ *              }
+ *          }
+ *      }
+ *      else
+ *      {
+ *          // The broker did not resume a session, so we can clean up the
+ *          // list of outgoing publishes.
+ *      }
+ * }
+ * @endcode
  */
 uint16_t MQTT_PublishToResend( const MQTTContext_t * pMqttContext,
                                MQTTStateCursor_t * pCursor );

--- a/libraries/standard/mqtt/include/mqtt_state.h
+++ b/libraries/standard/mqtt/include/mqtt_state.h
@@ -211,7 +211,7 @@ uint16_t MQTT_PubrelToResend( const MQTTContext_t * pMqttContext,
  *      if( sessionPresent )
  *      {
  *          // Loop while packet ID is nonzero.
- *          while( packetID = MQTT_PublishToResend( pContext, &cursor ) )
+ *          while( ( packetID = MQTT_PublishToResend( pContext, &cursor ) ) != 0 )
  *          {
  *              // Assume this function will succeed.
  *              pResendPublish = getPublish( packetID );

--- a/libraries/standard/mqtt/lexicon.txt
+++ b/libraries/standard/mqtt/lexicon.txt
@@ -67,6 +67,7 @@ getincomingpackettypeandlength
 getnewpacketid
 getpacketid
 getpingreqpacketsize
+getpublish
 getpublishpacketsize
 getsubscribepacketsize
 gettime
@@ -97,6 +98,7 @@ keepalivems
 keepaliveseconds
 lastpackettime
 linux
+logwarn
 lsb
 lwt
 malloc
@@ -162,6 +164,7 @@ networksend
 newstate
 nextpacketid
 noninfringement
+numcodes
 openssl
 optype
 org
@@ -177,6 +180,7 @@ pbuffer
 pbuffertosend
 pcallbacks
 pclientidentifier
+pcodes
 pconnack
 pconnectinfo
 pcontext
@@ -186,6 +190,7 @@ pdeserialized
 pdeserializedinfo
 pdestination
 pem
+pfilter
 pfilterindex
 pfixedbuffer
 pheadersize
@@ -219,6 +224,7 @@ pqos
 pre
 premainingdata
 premaininglength
+presendpublish
 processloop
 psessionpresent
 psource
@@ -227,7 +233,9 @@ pstatusstart
 psuback
 psubackpacket
 psubscribeinfo
+psubscribes
 psubscriptionlist
+ptopic
 ptopicfilter
 ptopicname
 ptr


### PR DESCRIPTION
*Description of changes:*
Adds doxygen code examples for `MQTT_PublishToResend`, `MQTT_MatchTopic`, and `MQTT_GetSubAckStatusCodes`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
