### PR TITLE
Fix flaky behavior of LWT test

### DIFF
--- a/libraries/standard/mqtt/integration-test/mqtt_system_test.c
+++ b/libraries/standard/mqtt/integration-test/mqtt_system_test.c
@@ -513,6 +513,9 @@ static void eventCallback( MQTTContext_t * pContext,
     assert( pPacketInfo != NULL );
     assert( pDeserializedInfo != NULL );
 
+    /* Suppress unused parameter warning when asserts are disabled in build. */
+    ( void ) pContext;
+
     TEST_ASSERT_EQUAL( MQTTSuccess, pDeserializedInfo->deserializationResult );
     pPublishInfo = pDeserializedInfo->pPublishInfo;
 
@@ -970,6 +973,11 @@ void test_MQTT_Connect_LWT( void )
     /* Subscribe to LWT Topic. */
     TEST_ASSERT_EQUAL( MQTTSuccess, subscribeToTopic(
                            &context, TEST_MQTT_LWT_TOPIC, MQTTQoS0 ) );
+
+    /* Wait for the SUBACK response from the broker for the subscribe request. */
+    TEST_ASSERT_EQUAL( MQTTSuccess,
+                       MQTT_ProcessLoop( &context, MQTT_PROCESS_LOOP_TIMEOUT_MS ) );
+    TEST_ASSERT_TRUE( receivedSubAck );
 
     /* Abruptly terminate TCP connection. */
     ( void ) Openssl_Disconnect( &secondNetworkContext );


### PR DESCRIPTION
### Problem
The LWT integration test showed flaky behavior in nightly jobs with intermittent failures.

### Cause
The test uses 2 MQTT connections, one that subscribes to the LWT topic, and one that represents the connection whose network connection is broker for the broker to publish to LWT topic.
There was a race condition between the connection subscribing to the LWT topic and broker recognizing the network disconnection of the other connection, thereby, causing the subsription request to be completed after the broker publishes the LWT topic in the runs when the test failed.

### Fix
Add an extra call to `MQTT_ProcessLoop` to ensure that SUBACK (for subscription to LWT topic) is received before network is disconnected  


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
