### PR TITLE
Clear old records for clean sessions

### DIFF
--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -281,7 +281,7 @@ static MQTTStatus_t receiveConnack( const MQTTContext_t * pContext,
  * clears existing state records for a clean session.
  *
  * @param[in] pContext Initialized MQTT context.
- * @param[in] sessionPresent Session present flag from the MQTT broker.
+ * @param[in] sessionPresent Session present flag received from the MQTT broker.
  *
  * @return #MQTTSendFailed if transport send during resend failed;
  * #MQTTSuccess otherwise.
@@ -1590,6 +1590,7 @@ static MQTTStatus_t handleSessionResumption( MQTTContext_t * pContext,
     }
     else
     {
+        /* Clear any existing records if a new session is established. */
         ( void ) memset( pContext->outgoingPublishRecords,
                          0x00,
                          sizeof( pContext->outgoingPublishRecords ) );

--- a/libraries/standard/mqtt/src/mqtt.c
+++ b/libraries/standard/mqtt/src/mqtt.c
@@ -1567,15 +1567,14 @@ static MQTTStatus_t handleSessionResumption( MQTTContext_t * pContext,
                                              bool sessionPresent )
 {
     MQTTStatus_t status = MQTTSuccess;
+    MQTTStateCursor_t cursor = MQTT_STATE_CURSOR_INITIALIZER;
+    uint16_t packetId = MQTT_PACKET_ID_INVALID;
+    MQTTPublishState_t state = MQTTStateNull;
 
     assert( pContext != NULL );
 
     if( sessionPresent == true )
     {
-        MQTTStateCursor_t cursor = MQTT_STATE_CURSOR_INITIALIZER;
-        uint16_t packetId = MQTT_PACKET_ID_INVALID;
-        MQTTPublishState_t state = MQTTStateNull;
-
         /* Get the next packet ID for which a PUBREL need to be resent. */
         packetId = MQTT_PubrelToResend( pContext, &cursor, &state );
 

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -1034,7 +1034,8 @@ void test_MQTT_Connect_happy_path()
     mqttContext.keepAliveIntervalSec = 0;
     connectInfo.cleanSession = true;
     sessionPresentExpected = false;
-    /* Populate some state records to make sure they are cleared. */
+    /* Populate some state records to make sure they are cleared since a clean session
+     * will be established. */
     mqttContext.outgoingPublishRecords[ 0 ].packetId = 1;
     mqttContext.outgoingPublishRecords[ 0 ].qos = MQTTQoS2;
     mqttContext.outgoingPublishRecords[ 0 ].publishState = MQTTPublishSend;


### PR DESCRIPTION
*Description of changes:*
Currently, `MQTT_Connect` does not clear records for a clean session, nor when the CONNACK's session present flag is set to false by the broker. Clients are required by the MQTT spec to discard state for clean sessions, and not clearing state when session present is false could lead to the state records being cluttered with dead publishes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
