### PR TITLE
Add unit tests for sockets wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,34 +65,36 @@ if(DEFINED ENV{PWD})
     endif()
 endif()
 
-# Check if the CMock source directory exists.
-if( NOT EXISTS ${3RDPARTY_DIR}/CMock/src )
-# Attempt to clone CMock.
-if( ${BUILD_CLONE_SUBMODULES} )
-    find_package( Git REQUIRED )
+if(${BUILD_TESTS})
+    # Check if the CMock source directory exists.
+    if( NOT EXISTS ${3RDPARTY_DIR}/CMock/src )
+    # Attempt to clone CMock.
+    if( ${BUILD_CLONE_SUBMODULES} )
+        find_package( Git REQUIRED )
 
-    message( "Cloning submodule CMock." )
-    execute_process( COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive libraries/3rdparty/CMock
-                     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-                     RESULT_VARIABLE CMOCK_CLONE_RESULT )
+        message( "Cloning submodule CMock." )
+        execute_process( COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive libraries/3rdparty/CMock
+                        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+                        RESULT_VARIABLE CMOCK_CLONE_RESULT )
 
-    if( NOT ${CMOCK_CLONE_RESULT} STREQUAL "0" )
-        message( FATAL_ERROR "Failed to clone CMock submodule." )
+        if( NOT ${CMOCK_CLONE_RESULT} STREQUAL "0" )
+            message( FATAL_ERROR "Failed to clone CMock submodule." )
+        endif()
+        else()
+            message( FATAL_ERROR "The required submodule CMock does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
+        endif()
     endif()
-else()
-    message( FATAL_ERROR "The required submodule CMock does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
-endif()
-endif()
 
-include("${ROOT_DIR}/tools/cmock/create_test.cmake")
+    include("${ROOT_DIR}/tools/cmock/create_test.cmake")
 
-include_directories("${3RDPARTY_DIR}/CMock/vendor/unity/src/"
-                "${3RDPARTY_DIR}/CMock/vendor/unity/extras/fixture/src"
-                "${3RDPARTY_DIR}/CMock/vendor/unity/extras/memory/src"
-                "${3RDPARTY_DIR}/CMock/src"
-    )
-link_directories("${CMAKE_BINARY_DIR}/lib"
-    )
+    include_directories("${3RDPARTY_DIR}/CMock/vendor/unity/src/"
+                    "${3RDPARTY_DIR}/CMock/vendor/unity/extras/fixture/src"
+                    "${3RDPARTY_DIR}/CMock/vendor/unity/extras/memory/src"
+                    "${3RDPARTY_DIR}/CMock/src"
+        )
+    link_directories("${CMAKE_BINARY_DIR}/lib"
+        )
+endif()
 
 # Add libraries.
 add_subdirectory( libraries )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,24 +65,34 @@ if(DEFINED ENV{PWD})
     endif()
 endif()
 
+# Add libraries.
+add_subdirectory( libraries )
+
+# Add platform.
+add_subdirectory( platform )
+
+# Build the demos.
+add_subdirectory( demos )
+
+# Build the tests if flag enabled.
 if(${BUILD_TESTS})
-    # Check if the CMock source directory exists.
-    if( NOT EXISTS ${3RDPARTY_DIR}/CMock/src )
-    # Attempt to clone CMock.
-    if( ${BUILD_CLONE_SUBMODULES} )
-        find_package( Git REQUIRED )
+    # Check if the CMock source directory exists.	
+    if( NOT EXISTS ${3RDPARTY_DIR}/CMock/src )	
+        # Attempt to clone CMock.	
+        if( ${BUILD_CLONE_SUBMODULES} )	
+            find_package( Git REQUIRED )	
 
-        message( "Cloning submodule CMock." )
-        execute_process( COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive libraries/3rdparty/CMock
-                        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-                        RESULT_VARIABLE CMOCK_CLONE_RESULT )
+            message( "Cloning submodule CMock." )	
+            execute_process( COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive libraries/3rdparty/CMock	
+                                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}	
+                                RESULT_VARIABLE CMOCK_CLONE_RESULT )	
 
-        if( NOT ${CMOCK_CLONE_RESULT} STREQUAL "0" )
-            message( FATAL_ERROR "Failed to clone CMock submodule." )
-        endif()
-        else()
-            message( FATAL_ERROR "The required submodule CMock does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
-        endif()
+            if( NOT ${CMOCK_CLONE_RESULT} STREQUAL "0" )	
+                message( FATAL_ERROR "Failed to clone CMock submodule." )	
+            endif()	
+        else()	
+            message( FATAL_ERROR "The required submodule CMock does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )	
+        endif()	
     endif()
 
     include("${ROOT_DIR}/tools/cmock/create_test.cmake")
@@ -109,14 +119,3 @@ if(${BUILD_TESTS})
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )
 endif()
-
-# Add libraries.
-add_subdirectory( libraries )
-
-# Add platform.
-add_subdirectory( platform )
-
-# Build the demos.
-add_subdirectory( demos )
-
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,15 +65,6 @@ if(DEFINED ENV{PWD})
     endif()
 endif()
 
-# Add libraries.
-add_subdirectory( libraries )
-
-# Add platform.
-add_subdirectory( platform )
-
-# Build the demos.
-add_subdirectory( demos )
-
 # Build the tests if flag enabled.
 if(${BUILD_TESTS})
     # Check if the CMock source directory exists.	
@@ -119,3 +110,12 @@ if(${BUILD_TESTS})
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )
 endif()
+
+# Add libraries.
+add_subdirectory( libraries )
+
+# Add platform.
+add_subdirectory( platform )
+
+# Build the demos.
+add_subdirectory( demos )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,35 @@ if(DEFINED ENV{PWD})
     endif()
 endif()
 
+# Check if the CMock source directory exists.
+if( NOT EXISTS ${3RDPARTY_DIR}/CMock/src )
+# Attempt to clone CMock.
+if( ${BUILD_CLONE_SUBMODULES} )
+    find_package( Git REQUIRED )
+
+    message( "Cloning submodule CMock." )
+    execute_process( COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive libraries/3rdparty/CMock
+                     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+                     RESULT_VARIABLE CMOCK_CLONE_RESULT )
+
+    if( NOT ${CMOCK_CLONE_RESULT} STREQUAL "0" )
+        message( FATAL_ERROR "Failed to clone CMock submodule." )
+    endif()
+else()
+    message( FATAL_ERROR "The required submodule CMock does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
+endif()
+endif()
+
+include("${ROOT_DIR}/tools/cmock/create_test.cmake")
+
+include_directories("${3RDPARTY_DIR}/CMock/vendor/unity/src/"
+                "${3RDPARTY_DIR}/CMock/vendor/unity/extras/fixture/src"
+                "${3RDPARTY_DIR}/CMock/vendor/unity/extras/memory/src"
+                "${3RDPARTY_DIR}/CMock/src"
+    )
+link_directories("${CMAKE_BINARY_DIR}/lib"
+    )
+
 # Add libraries.
 add_subdirectory( libraries )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,20 @@ if(${BUILD_TESTS})
         )
     link_directories("${CMAKE_BINARY_DIR}/lib"
         )
+
+    # Create a list for each unit test target
+    set(utest_targets 
+            http_utest mqtt_utest 
+            mqtt_lightweight_utest mqtt_state_utest 
+            http_send_utest sockets_utest)
+
+    # Add a target for running coverage on tests.
+    add_custom_target(coverage
+        COMMAND ${CMAKE_COMMAND} -DROOT_DIR=${ROOT_DIR}
+        -P ${CMAKE_SOURCE_DIR}/tools/cmock/coverage.cmake
+        DEPENDS cmock unity ${utest_targets}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
 endif()
 
 # Add libraries.

--- a/libraries/3rdparty/CMakeLists.txt
+++ b/libraries/3rdparty/CMakeLists.txt
@@ -1,28 +1,29 @@
-# Build Configuration for CMock and Unity libraries.
-add_library(cmock STATIC
+if(${BUILD_TESTS})
+    add_library(cmock STATIC
         "${ROOT_DIR}/libraries/3rdparty/CMock/src/cmock.c"
-        )
+    )
 
-set_target_properties(cmock PROPERTIES
+    set_target_properties(cmock PROPERTIES
         ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
         POSITION_INDEPENDENT_CODE ON
         COMPILE_FLAGS "-Og"
-        )
+    )
 
-add_library(unity STATIC
+    add_library(unity STATIC
         "${3RDPARTY_DIR}/CMock/vendor/unity/src/unity.c"
         "${3RDPARTY_DIR}/CMock/vendor/unity/extras/fixture/src/unity_fixture.c"
         "${3RDPARTY_DIR}/CMock/vendor/unity/extras/memory/src/unity_memory.c"
-        )
-set_target_properties(unity PROPERTIES
+    )
+    set_target_properties(unity PROPERTIES
         ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
         POSITION_INDEPENDENT_CODE ON
-        )
+    )
 
-target_include_directories(cmock PUBLIC
+    target_include_directories(cmock PUBLIC
         ${ROOT_DIR}/libraries/3rdparty/CMock/src
         ${ROOT_DIR}/libraries/3rdparty/CMock/vendor/unity/src/
         ${ROOT_DIR}/libraries/3rdparty/CMock/examples
-        )
+    )
 
-target_link_libraries(cmock unity)
+    target_link_libraries(cmock unity)
+endif()

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -1,41 +1,12 @@
 # Configuration for CMock if testing is enabled.
 if( ${BUILD_TESTS} )
-    # Check if the CMock source directory exists.
-    if( NOT EXISTS ${3RDPARTY_DIR}/CMock/src )
-        # Attempt to clone CMock.
-        if( ${BUILD_CLONE_SUBMODULES} )
-            find_package( Git REQUIRED )
-
-            message( "Cloning submodule CMock." )
-            execute_process( COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive libraries/3rdparty/CMock
-                             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-                             RESULT_VARIABLE CMOCK_CLONE_RESULT )
-
-            if( NOT ${CMOCK_CLONE_RESULT} STREQUAL "0" )
-                message( FATAL_ERROR "Failed to clone CMock submodule." )
-            endif()
-        else()
-            message( FATAL_ERROR "The required submodule CMock does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
-        endif()
-    endif()
-
-    include("${ROOT_DIR}/tools/cmock/create_test.cmake")
-
-    include_directories("${3RDPARTY_DIR}/CMock/vendor/unity/src/"
-                        "${3RDPARTY_DIR}/CMock/vendor/unity/extras/fixture/src"
-                        "${3RDPARTY_DIR}/CMock/vendor/unity/extras/memory/src"
-                        "${3RDPARTY_DIR}/CMock/src"
-            )
-    link_directories("${CMAKE_BINARY_DIR}/lib"
-            )
-
     # Include the 3rdparty CMakeLists.txt for CMock build configuration.
     add_subdirectory(${3RDPARTY_DIR})
 
     # Add a target for running coverage on tests.
     add_custom_target(coverage
         COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/tools/cmock/coverage.cmake
-        DEPENDS cmock unity http_utest mqtt_utest mqtt_lightweight_utest mqtt_state_utest http_send_utest
+        DEPENDS cmock unity http_utest mqtt_utest mqtt_lightweight_utest mqtt_state_utest http_send_utest sockets_utest
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )
 endif()

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -1,23 +1,3 @@
-# Configuration for CMock if testing is enabled.
-if( ${BUILD_TESTS} )
-    
-    # Include the 3rdparty CMakeLists.txt for CMock build configuration.
-    add_subdirectory(${3RDPARTY_DIR})
-
-    # Create a list for each unit test target
-    set(utest_targets 
-            http_utest mqtt_utest 
-            mqtt_lightweight_utest mqtt_state_utest 
-            http_send_utest sockets_utest)
-
-    # Add a target for running coverage on tests.
-    add_custom_target(coverage
-        COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/tools/cmock/coverage.cmake
-        DEPENDS cmock unity ${utest_targets}
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    )
-endif()
-
 # Add all modules.
 file(GLOB standard_modules "${MODULES_DIR}/standard/*")
 file(GLOB aws_modules "${MODULES_DIR}/aws/*")
@@ -27,3 +7,4 @@ foreach(module IN LISTS standard_modules aws_modules)
     endif()
 endforeach()
 
+add_subdirectory(${3RDPARTY_DIR})

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -1,16 +1,23 @@
 # Configuration for CMock if testing is enabled.
 if( ${BUILD_TESTS} )
+    
     # Include the 3rdparty CMakeLists.txt for CMock build configuration.
     add_subdirectory(${3RDPARTY_DIR})
+
+    # Create a list for each unit test target
+    set(utest_targets 
+            http_utest mqtt_utest 
+            mqtt_lightweight_utest mqtt_state_utest 
+            http_send_utest sockets_utest)
 
     # Add a target for running coverage on tests.
     add_custom_target(coverage
         COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/tools/cmock/coverage.cmake
-        DEPENDS cmock unity http_utest mqtt_utest mqtt_lightweight_utest mqtt_state_utest http_send_utest sockets_utest
+        DEPENDS cmock unity ${utest_targets}
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )
 endif()
-            
+
 # Add all modules.
 file(GLOB standard_modules "${MODULES_DIR}/standard/*")
 file(GLOB aws_modules "${MODULES_DIR}/aws/*")

--- a/platform/lexicon.txt
+++ b/platform/lexicon.txt
@@ -12,9 +12,11 @@ coverity
 cwd
 dns
 endif
+enums
 errno
 errornumber
 fclose
+fd
 filelabel
 filepath
 filepaths
@@ -31,6 +33,7 @@ ifndef
 implemenation
 ip
 inc
+int
 iot
 ip
 logpath
@@ -87,3 +90,4 @@ tcpsocket
 timespec
 tls
 transportinterface
+unistd

--- a/platform/posix/transport/CMakeLists.txt
+++ b/platform/posix/transport/CMakeLists.txt
@@ -54,3 +54,7 @@ target_include_directories( transport_reconnect_posix
                               PUBLIC 
                                 ${COMMON_TRANSPORT_INCLUDE_PUBLIC_DIRS}
                                 ${LOGGING_INCLUDE_DIRS} )
+
+if(BUILD_TESTS)
+  add_subdirectory(utest)
+endif()

--- a/platform/posix/transport/CMakeLists.txt
+++ b/platform/posix/transport/CMakeLists.txt
@@ -10,11 +10,6 @@ target_include_directories( sockets_posix
                                 ${COMMON_TRANSPORT_INCLUDE_PUBLIC_DIRS}
                                 ${LOGGING_INCLUDE_DIRS} )
 
-# Organization of HTTP in IDE projects.
-set_target_properties( sockets_posix PROPERTIES FOLDER platform/posix )
-source_group( include FILES include/sockets_posix.h )
-source_group( src FILES ${SOCKETS_SOURCES} )
-
 # Create target for plaintext transport.
 add_library( plaintext_posix
                 ${PLAINTEXT_TRANSPORT_SOURCES} )

--- a/platform/posix/transport/CMakeLists.txt
+++ b/platform/posix/transport/CMakeLists.txt
@@ -10,6 +10,11 @@ target_include_directories( sockets_posix
                                 ${COMMON_TRANSPORT_INCLUDE_PUBLIC_DIRS}
                                 ${LOGGING_INCLUDE_DIRS} )
 
+# Organization of HTTP in IDE projects.
+set_target_properties( sockets_posix PROPERTIES FOLDER platform/posix )
+source_group( include FILES include/sockets_posix.h )
+source_group( src FILES ${SOCKETS_SOURCES} )
+
 # Create target for plaintext transport.
 add_library( plaintext_posix
                 ${PLAINTEXT_TRANSPORT_SOURCES} )

--- a/platform/posix/transport/src/sockets_posix.c
+++ b/platform/posix/transport/src/sockets_posix.c
@@ -277,6 +277,8 @@ static SocketStatus_t attemptConnection( struct addrinfo * pListHead,
         {
             curAttempts += 1;
 
+            /* It is not possible to have coverage for this block because the
+             * number of max attempts is set to be unbounded. */
             if( ( maxAttempts >= 0 ) && ( curAttempts >= maxAttempts ) )
             {
                 /* Fail if no connection could be established. */
@@ -390,9 +392,14 @@ SocketStatus_t Sockets_Connect( int32_t * pTcpSocket,
     struct timeval transportTimeout;
     int32_t setTimeoutStatus = -1;
 
-    if( pServerInfo->pHostName == NULL )
+    if( pServerInfo == NULL )
     {
-        LogError( ( "Parameter check failed: pHostName is NULL." ) );
+        LogError( ( "Parameter check failed: pServerInfo is NULL." ) );
+        returnStatus = SOCKETS_INVALID_PARAMETER;
+    }
+    else if( pServerInfo->pHostName == NULL )
+    {
+        LogError( ( "Parameter check failed: pServerInfo->pHostName is NULL." ) );
         returnStatus = SOCKETS_INVALID_PARAMETER;
     }
     else if( pTcpSocket == NULL )

--- a/platform/posix/transport/utest/CMakeLists.txt
+++ b/platform/posix/transport/utest/CMakeLists.txt
@@ -93,6 +93,6 @@ target_compile_definitions(${utest_name} PUBLIC
             ${mock_define_list}
         )
 
-        target_compile_definitions(${real_name} PUBLIC
+target_compile_definitions(${real_name} PUBLIC
             ${mock_define_list}
         )

--- a/platform/posix/transport/utest/CMakeLists.txt
+++ b/platform/posix/transport/utest/CMakeLists.txt
@@ -88,11 +88,3 @@ create_test(${utest_name}
             "${utest_dep_list}"
             "${test_include_directories}"
         )
-
-target_compile_definitions(${utest_name} PUBLIC
-            ${mock_define_list}
-        )
-
-target_compile_definitions(${real_name} PUBLIC
-            ${mock_define_list}
-        )

--- a/platform/posix/transport/utest/CMakeLists.txt
+++ b/platform/posix/transport/utest/CMakeLists.txt
@@ -47,8 +47,8 @@ list(APPEND test_include_directories
             .
             ${COMMON_TRANSPORT_INCLUDE_PUBLIC_DIRS}
             ${LOGGING_INCLUDE_DIRS}
-            ${OPENSSL_INCLUDE_DIR}/arpa
-            ${OPENSSL_INCLUDE_DIR}/x86_64-linux-gnu/sys
+            /usr/include/arpa
+            /usr/include/x86_64-linux-gnu/sys
             ${OPENSSL_INCLUDE_DIR}
             mocks
         )

--- a/platform/posix/transport/utest/CMakeLists.txt
+++ b/platform/posix/transport/utest/CMakeLists.txt
@@ -1,0 +1,98 @@
+include("../transportFilePaths.cmake")
+project ("transport unit test")
+cmake_minimum_required (VERSION 3.13)
+
+# CMock does not have a built-in C parser. 
+# https://github.com/ThrowTheSwitch/CMock/issues/71
+# Therefore, header files need to be preprocessed before mocks are generated.
+
+# ====================  Define your project name (edit) ========================
+set(project_name "transport")
+
+# =====================  Create your mock here  (edit)  ========================
+
+# list the files to mock here
+list(APPEND mock_list
+                ${OPENSSL_INCLUDE_DIR}/arpa/inet.h
+                ${OPENSSL_INCLUDE_DIR}/x86_64-linux-gnu/sys/socket.h
+                ${OPENSSL_INCLUDE_DIR}/netdb.h
+                ${CMAKE_CURRENT_LIST_DIR}/mocks/close.h
+)
+# list the directories your mocks need
+list(APPEND mock_include_list
+            ""
+)
+#list the definitions of your mocks to control what to be included
+list(APPEND mock_define_list
+            ""
+       )
+
+# ================= Create the library under test here (edit) ==================
+
+# list the files you would like to test here
+list(APPEND real_source_files
+            ${SOCKETS_SOURCES}
+        )
+# list the directories the module under test includes
+list(APPEND real_include_directories
+            .
+            ${COMMON_TRANSPORT_INCLUDE_PUBLIC_DIRS}
+            ${LOGGING_INCLUDE_DIRS}
+        )
+
+# =====================  Create UnitTest Code here (edit)  =====================
+
+# list the directories your test needs to include
+list(APPEND test_include_directories
+            .
+            ${COMMON_TRANSPORT_INCLUDE_PUBLIC_DIRS}
+            ${LOGGING_INCLUDE_DIRS}
+            ${OPENSSL_INCLUDE_DIR}/arpa
+            ${OPENSSL_INCLUDE_DIR}/x86_64-linux-gnu/sys
+            ${OPENSSL_INCLUDE_DIR}
+            mocks
+        )
+
+# =============================  (end edit)  ===================================
+
+set(mock_name "sockets_mock")
+set(real_name "sockets_real")
+
+create_mock_list(${mock_name}
+                "${mock_list}"
+                "${ROOT_DIR}/tools/cmock/project.yml"
+                "${mock_include_list}"
+                "${mock_define_list}"
+        )
+
+create_real_library(${real_name}
+                    "${real_source_files}"
+                    "${real_include_directories}"
+                    "${mock_name}"
+        )
+
+list(APPEND utest_link_list
+            lib${real_name}.a
+            -l${mock_name}
+        )
+
+list(APPEND utest_dep_list
+            ${real_name}
+        )
+
+set(utest_name "sockets_utest")
+set(utest_source "sockets_utest.c")
+create_test(${utest_name}
+            ${utest_source}
+            "${utest_link_list}"
+            "${utest_dep_list}"
+            "${test_include_directories}"
+        )
+
+target_compile_definitions(${utest_name} PUBLIC
+            ${mock_define_list}
+        )
+
+        target_compile_definitions(${real_name} PUBLIC
+            ${mock_define_list}
+        )

--- a/platform/posix/transport/utest/CMakeLists.txt
+++ b/platform/posix/transport/utest/CMakeLists.txt
@@ -13,19 +13,19 @@ set(project_name "transport")
 
 # list the files to mock here
 list(APPEND mock_list
-                ${OPENSSL_INCLUDE_DIR}/arpa/inet.h
-                ${OPENSSL_INCLUDE_DIR}/x86_64-linux-gnu/sys/socket.h
-                ${OPENSSL_INCLUDE_DIR}/netdb.h
-                ${CMAKE_CURRENT_LIST_DIR}/mocks/close.h
-)
+            /usr/include/arpa/inet.h
+            /usr/include/x86_64-linux-gnu/sys/socket.h
+            /usr/include/netdb.h
+            ${CMAKE_CURRENT_LIST_DIR}/mocks/close.h
+        )
 # list the directories your mocks need
 list(APPEND mock_include_list
             ""
-)
+        )
 #list the definitions of your mocks to control what to be included
 list(APPEND mock_define_list
             ""
-       )
+        )
 
 # ================= Create the library under test here (edit) ==================
 

--- a/platform/posix/transport/utest/mocks/close.h
+++ b/platform/posix/transport/utest/mocks/close.h
@@ -1,0 +1,16 @@
+#ifndef CLOSE_H_
+#define CLOSE_H_
+
+/**
+ * @file close.h
+ * @brief This file is used to generate a mock for close(int fd) since mocking
+ * unistd.h itself causes several compilation errors from parsing its macros.
+ */
+
+/* Close the file descriptor FD.
+ *
+ * This function is a cancellation point and therefore not marked with
+ * __THROW.  */
+extern int close( int __fd );
+
+#endif

--- a/platform/posix/transport/utest/sockets_utest.c
+++ b/platform/posix/transport/utest/sockets_utest.c
@@ -186,7 +186,14 @@ void test_Sockets_Connect_Invalid_Params( void )
                                     SEND_RECV_TIMEOUT );
     TEST_ASSERT_EQUAL( SOCKETS_INVALID_PARAMETER, socketStatus );
 
-    /* Passing a hostName should fail. */
+    /* Passing a NULL #ServerInfo_t object should fail. */
+    socketStatus = Sockets_Connect( &tcpSocket,
+                                    NULL,
+                                    SEND_RECV_TIMEOUT,
+                                    SEND_RECV_TIMEOUT );
+    TEST_ASSERT_EQUAL( SOCKETS_INVALID_PARAMETER, socketStatus );
+
+    /* Passing a NULL hostName should fail. */
     memset( &serverInfo, 0, sizeof( ServerInfo_t ) );
     socketStatus = Sockets_Connect( &tcpSocket,
                                     &serverInfo,

--- a/platform/posix/transport/utest/sockets_utest.c
+++ b/platform/posix/transport/utest/sockets_utest.c
@@ -246,7 +246,6 @@ void test_Sockets_Connect_Fail_setsockopt( void )
     int32_t allErrorCases[] = { EBADF, EDOM, EINVAL, EISCONN, ENOPROTOOPT, ENOTSOCK, ENOMEM, ENOBUFS };
 
     serverInfo.pHostName = HOSTNAME;
-
     serverInfo.hostNameLength = strlen( HOSTNAME );
     serverInfo.port = PORT;
 

--- a/platform/posix/transport/utest/sockets_utest.c
+++ b/platform/posix/transport/utest/sockets_utest.c
@@ -19,6 +19,7 @@
 #define PORT                 80
 
 static struct addrinfo * addrInfo;
+static ServerInfo_t serverInfo;
 
 static void allocateAddrInfoLinkedList( struct addrinfo ** head )
 {
@@ -84,6 +85,9 @@ static void freeAddrInfoLinkedList( struct addrinfo * head )
 /* Called before each test method. */
 void setUp()
 {
+    serverInfo.pHostName = HOSTNAME;
+    serverInfo.hostNameLength = strlen( HOSTNAME );
+    serverInfo.port = PORT;
 }
 
 /* Called after each test method. */
@@ -173,7 +177,6 @@ void test_Sockets_Disconnect_Invalid_Socket( void )
 void test_Sockets_Connect_Invalid_Params( void )
 {
     SocketStatus_t socketStatus;
-    ServerInfo_t serverInfo;
     int tcpSocket = 1;
 
     /* Passing a NULL socket should fail. */
@@ -203,12 +206,7 @@ void test_Sockets_Connect_Invalid_Params( void )
 void test_Sockets_Connect_DNS_Lookup_Fails( void )
 {
     SocketStatus_t socketStatus;
-    ServerInfo_t serverInfo;
     int tcpSocket = 1;
-
-    serverInfo.pHostName = HOSTNAME;
-    serverInfo.hostNameLength = strlen( HOSTNAME );
-    serverInfo.port = PORT;
 
     getaddrinfo_ExpectAnyArgsAndReturn( -1 );
 
@@ -222,12 +220,7 @@ void test_Sockets_Connect_DNS_Lookup_Fails( void )
 void test_Sockets_Connect_Every_IP_Address_Fails( void )
 {
     SocketStatus_t socketStatus;
-    ServerInfo_t serverInfo;
     int tcpSocket = 1;
-
-    serverInfo.pHostName = HOSTNAME;
-    serverInfo.hostNameLength = strlen( HOSTNAME );
-    serverInfo.port = PORT;
 
     expectSocketsConnectCalls( -1 );
 
@@ -241,13 +234,12 @@ void test_Sockets_Connect_Every_IP_Address_Fails( void )
 void test_Sockets_Connect_Fail_setsockopt( void )
 {
     SocketStatus_t socketStatus, expectedSocketStatus;
-    ServerInfo_t serverInfo;
     int tcpSocket = 1, i = 1;
-    int32_t allErrorCases[] = { EBADF, EDOM, EINVAL, EISCONN, ENOPROTOOPT, ENOTSOCK, ENOMEM, ENOBUFS };
-
-    serverInfo.pHostName = HOSTNAME;
-    serverInfo.hostNameLength = strlen( HOSTNAME );
-    serverInfo.port = PORT;
+    int32_t allErrorCases[] =
+    {
+        EBADF,       EDOM,     EINVAL, EISCONN,
+        ENOPROTOOPT, ENOTSOCK, ENOMEM, ENOBUFS
+    };
 
     for( i = 0; i < sizeof( allErrorCases ); i++ )
     {
@@ -289,12 +281,7 @@ void test_Sockets_Connect_Fail_setsockopt( void )
 void test_Sockets_Connect_Succeed_On_Nth_IP_Address( void )
 {
     SocketStatus_t socketStatus;
-    ServerInfo_t serverInfo;
     int tcpSocket = 1;
-
-    serverInfo.pHostName = HOSTNAME;
-    serverInfo.hostNameLength = strlen( HOSTNAME );
-    serverInfo.port = PORT;
 
     expectSocketsConnectCalls( NUM_ADDR_INFO );
     setsockopt_ExpectAnyArgsAndReturn( 0 );

--- a/platform/posix/transport/utest/sockets_utest.c
+++ b/platform/posix/transport/utest/sockets_utest.c
@@ -1,0 +1,168 @@
+#include <string.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "unity.h"
+
+/* Include paths for public enums, structures, and macros. */
+#include "sockets_posix.h"
+
+#include "mock_netdb.h"
+#include "mock_socket.h"
+#include "mock_inet.h"
+#include "mock_close.h"
+
+#define NUM_ADDR_INFO        3
+#define SEND_RECV_TIMEOUT    0
+
+/* ============================   UNITY FIXTURES ============================ */
+
+/* Called before each test method. */
+void setUp()
+{
+}
+
+/* Called after each test method. */
+void tearDown()
+{
+}
+
+/* Called at the beginning of the whole suite. */
+void suiteSetUp()
+{
+}
+
+/* Called at the end of the whole suite. */
+int suiteTearDown( int numFailures )
+{
+    return numFailures;
+}
+
+/* ========================================================================== */
+
+void allocateAddrInfoLinkedList( struct addrinfo ** head )
+{
+    struct addrinfo * index = NULL;
+    int i;
+
+    TEST_ASSERT_NOT_NULL( head );
+
+    for( i = 0; i < NUM_ADDR_INFO; i++ )
+    {
+        struct addrinfo * next = malloc( sizeof( struct addrinfo ) );
+        memset( next, 0, sizeof( struct addrinfo ) );
+        next->ai_family = AF_INET;
+        next->ai_socktype = SOCK_STREAM;
+        next->ai_protocol = IPPROTO_TCP;
+        next->ai_next = NULL;
+
+        /* Every other IP address will be IPv4 for coverage. */
+        struct sockaddr * ai_addr = malloc( sizeof( struct sockaddr ) );
+
+        if( i % 2 )
+        {
+            ai_addr->sa_family = AF_INET6;
+        }
+        else
+        {
+            ai_addr->sa_family = AF_INET;
+        }
+
+        next->ai_addr = ai_addr;
+
+        if( i == 0 )
+        {
+            index = next;
+            *head = index;
+        }
+        else
+        {
+            index->ai_next = next;
+            index = index->ai_next;
+        }
+    }
+}
+
+void freeAddrInfoLinkedList( struct addrinfo * head )
+{
+    struct addrinfo * tmp;
+
+    TEST_ASSERT_NOT_NULL( head );
+
+    while( head != NULL )
+    {
+        tmp = head;
+        head = head->ai_next;
+        free( tmp );
+        free( tmp->ai_addr );
+    }
+}
+
+/**
+ * @brief Test Sockets_Disconnect.
+ */
+void test_Sockets_Disconnect_Valid_Socket( void )
+{
+    SocketStatus_t socketStatus;
+    int tcpSocket = 1;
+
+    shutdown_ExpectAnyArgsAndReturn( 0 );
+    close_ExpectAnyArgsAndReturn( 0 );
+
+    socketStatus = Sockets_Disconnect( tcpSocket );
+    TEST_ASSERT_EQUAL( SOCKETS_SUCCESS, socketStatus );
+}
+
+void test_Sockets_Disconnect_Invalid_Socket( void )
+{
+    SocketStatus_t socketStatus;
+    int tcpSocket = 0;
+
+    socketStatus = Sockets_Disconnect( tcpSocket );
+    TEST_ASSERT_EQUAL( SOCKETS_INVALID_PARAMETER, socketStatus );
+}
+
+void test_Sockets_Connect_Valid_Socket( void )
+{
+    SocketStatus_t socketStatus;
+    ServerInfo_t serverInfo;
+    int tcpSocket = 1, i = 1;
+    struct addrinfo * addrInfo;
+
+    serverInfo.pHostName = "google";
+    serverInfo.hostNameLength = strlen( "google" );
+    serverInfo.port = 80;
+
+    allocateAddrInfoLinkedList( &addrInfo );
+    getaddrinfo_ExpectAnyArgsAndReturn( 0 );
+    getaddrinfo_ReturnThruPtr___pai( &addrInfo );
+
+    for( i = 1; i <= NUM_ADDR_INFO; i++ )
+    {
+        socket_ExpectAnyArgsAndReturn( tcpSocket );
+        inet_ntop_ExpectAnyArgsAndReturn( NULL );
+
+        /* The last iteration should make connect() succeed. */
+        if( i < NUM_ADDR_INFO )
+        {
+            connect_ExpectAnyArgsAndReturn( -1 );
+            close_ExpectAnyArgsAndReturn( 0 );
+        }
+        else
+        {
+            connect_ExpectAnyArgsAndReturn( 0 );
+        }
+    }
+
+    freeaddrinfo_ExpectAnyArgs();
+    setsockopt_ExpectAnyArgsAndReturn( 0 );
+    setsockopt_ExpectAnyArgsAndReturn( 0 );
+
+    socketStatus = Sockets_Connect( &tcpSocket,
+                                    &serverInfo,
+                                    SEND_RECV_TIMEOUT,
+                                    SEND_RECV_TIMEOUT );
+    TEST_ASSERT_EQUAL( SOCKETS_SUCCESS, socketStatus );
+
+    freeAddrInfoLinkedList( addrInfo );
+}

--- a/platform/posix/transport/utest/sockets_utest.c
+++ b/platform/posix/transport/utest/sockets_utest.c
@@ -1,7 +1,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <stdlib.h>
-#include <errno.h>
+#include "/usr/include/errno.h"
 
 #include "unity.h"
 

--- a/platform/posix/transport/utest/sockets_utest.c
+++ b/platform/posix/transport/utest/sockets_utest.c
@@ -1,7 +1,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <stdlib.h>
-#include "/usr/include/errno.h"
+#include <errno.h>
 
 #include "unity.h"
 

--- a/tools/cmock/coverage.cmake
+++ b/tools/cmock/coverage.cmake
@@ -64,6 +64,7 @@ execute_process(
         )
 execute_process(
             COMMAND genhtml --rc lcov_branch_coverage=1
+                            --prefix ${ROOT_DIR}
                             --branch-coverage
                             --output-directory ${CMAKE_BINARY_DIR}/coverage
                                 ${CMAKE_BINARY_DIR}/coverage.info

--- a/tools/cmock/project.yml
+++ b/tools/cmock/project.yml
@@ -21,8 +21,7 @@
   :includes:        # This will add these includes to each mock.
     - <stdbool.h>
     - <stdint.h>
-    - <fcntl.h>
-  :treat_externs: :exclude  # Now the extern-ed functions will be mocked.
+  :treat_externs: :include  # Now the extern-ed functions will be mocked.
   :weak: __attribute__((weak))
   :verbosity: 3
   :attributes:
@@ -31,5 +30,12 @@
   :strippables:
     - PRIVILEGED_FUNCTION
     - portDONT_DISCARD
+    - __restrict
+    - \s__THROW
+    - (.*)sendmsg((.|\n|\r)+?\;) #socket.h
+    - (.*)sendmmsg((.|\n|\r)+?\;) #socket.h
+    - (.*)recvmsg((.|\n|\r)+?\;) #socket.h
+    - (.*)recvmmsg((.|\n|\r)+?\;) #socket.h
+    - (.*)getaddrinfo_a((.|\n|\r)*);
+    - (.*)\sgai_((.|\n|\r)*)
     - '(?:fcntl\s*\(+.*?\)+)' # this function is causing some trouble with code coverage as the annotations are calling the mocked one, so we won't mock it
-  :treat_externs: :include

--- a/tools/cmock/project.yml
+++ b/tools/cmock/project.yml
@@ -36,6 +36,6 @@
     - (.*)sendmmsg((.|\n|\r)+?\;) #socket.h
     - (.*)recvmsg((.|\n|\r)+?\;) #socket.h
     - (.*)recvmmsg((.|\n|\r)+?\;) #socket.h
-    - (.*)getaddrinfo_a((.|\n|\r)*);
-    - (.*)\sgai_((.|\n|\r)*)
+    - (.*)getaddrinfo_a((.|\n|\r)+?\;) #netdb.h
+    - (.*)gai_((.|\n|\r)+?\;) #netdb.h
     - '(?:fcntl\s*\(+.*?\)+)' # this function is causing some trouble with code coverage as the annotations are calling the mocked one, so we won't mock it

--- a/tools/cmock/project.yml
+++ b/tools/cmock/project.yml
@@ -26,16 +26,17 @@
   :verbosity: 3
   :attributes:
     - PRIVILEGED_FUNCTION
-    - 'int fcntl(int s, int cmd, ...);'
   :strippables:
     - PRIVILEGED_FUNCTION
     - portDONT_DISCARD
+    # These keywords are found in many POSIX APIs but is stripped as it cannot be parsed by CMock.
     - __restrict
-    - \s__THROW
-    - (.*)sendmsg((.|\n|\r)+?\;) #socket.h
-    - (.*)sendmmsg((.|\n|\r)+?\;) #socket.h
-    - (.*)recvmsg((.|\n|\r)+?\;) #socket.h
-    - (.*)recvmmsg((.|\n|\r)+?\;) #socket.h
-    - (.*)getaddrinfo_a((.|\n|\r)+?\;) #netdb.h
-    - (.*)gai_((.|\n|\r)+?\;) #netdb.h
-    - '(?:fcntl\s*\(+.*?\)+)' # this function is causing some trouble with code coverage as the annotations are calling the mocked one, so we won't mock it
+    - \s__THROW 
+    # These functions in socket.h cannot be parsed correctly by CMock, so we won't mock them.
+    - (.*)sendmsg((.|\n|\r)+?\;)
+    - (.*)sendmmsg((.|\n|\r)+?\;)
+    - (.*)recvmsg((.|\n|\r)+?\;)
+    - (.*)recvmmsg((.|\n|\r)+?\;)
+    # These functions in netdb.h cannot be parsed correctly by CMock, so we won't mock them.
+    - (.*)getaddrinfo_a((.|\n|\r)+?\;)
+    - (.*)gai_((.|\n|\r)+?\;)


### PR DESCRIPTION
Regular expressions are used to massage the header file into something that CMock can parse.
If that doesn't work, then I create a header file with all the functions I want to mock and use that instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
