### PR TITLE
Add #error statements for undefined macros in MQTT integ tests

### DIFF
--- a/libraries/standard/mqtt/integration-test/mqtt_system_test.c
+++ b/libraries/standard/mqtt/integration-test/mqtt_system_test.c
@@ -43,12 +43,21 @@
 /* Include clock for timer. */
 #include "clock.h"
 
+/* Ensure that config macros, required for TLS connection, have been defined. */
 #ifndef BROKER_ENDPOINT
     #error "BROKER_ENDPOINT should be defined for the MQTT integration tests."
 #endif
 
 #ifndef SERVER_ROOT_CA_CERT_PATH
     #error "SERVER_ROOT_CA_CERT_PATH should be defined for the MQTT integration tests."
+#endif
+
+#ifndef CLIENT_CERT_PATH
+    #error "CLIENT_CERT_PATH should be defined for the MQTT integration tests."
+#endif
+
+#ifndef CLIENT_PRIVATE_KEY_PATH
+    #error "CLIENT_PRIVATE_KEY_PATH should be defined for the MQTT integration tests."
 #endif
 
 /**


### PR DESCRIPTION
Improve usability of MQTT integration test target, `mqtt_system_test`, by adding `#error` statements for undefined `CLIENT_CERT_PATH` and `CLIENT_PRIVATE_KEY_PATH` macros so that the issue is caught at compile time instead of at run time

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
