### PR TITLE
Fix warnings in MQTT integration tests

### DIFF
--- a/libraries/standard/mqtt/integration-test/mqtt_system_test.c
+++ b/libraries/standard/mqtt/integration-test/mqtt_system_test.c
@@ -327,7 +327,7 @@ static void eventCallback( MQTTContext_t * pContext,
  *
  * @return -1 to represent failure.
  */
-static int32_t failedRecv( NetworkContext_t * pNetworkContext,
+static int32_t failedRecv( const NetworkContext_t * pNetworkContext,
                            void * pBuffer,
                            size_t bytesToRecv );
 
@@ -650,7 +650,7 @@ static MQTTStatus_t publishToTopic( MQTTContext_t * pContext,
                          packetId );
 }
 
-static int32_t failedRecv( NetworkContext_t * pNetworkContext,
+static int32_t failedRecv( const NetworkContext_t * pNetworkContext,
                            void * pBuffer,
                            size_t bytesToRecv )
 {
@@ -658,7 +658,7 @@ static int32_t failedRecv( NetworkContext_t * pNetworkContext,
     ( void ) bytesToRecv;
 
     /* Terminate the TLS+TCP connection with the broker for the test. */
-    ( void ) Openssl_Disconnect( pNetworkContext );
+    ( void ) Openssl_Disconnect( ( NetworkContext_t * ) pNetworkContext );
 
     return -1;
 }


### PR DESCRIPTION
Fix build warnings in `mqtt_system_test.c` that were introduced by changes in #1161


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
