### PR TITLE
Added --pointer-primitive-check CBMC flag

### DIFF
--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -114,6 +114,7 @@ CBMCFLAGS += \
 	--nan-check \
 	--pointer-check \
 	--pointer-overflow-check \
+	--pointer-primitive-check \
 	--signed-overflow-check \
 	--undefined-shift-check \
 	--unsigned-overflow-check \


### PR DESCRIPTION
This PR adds the `--pointer-primitive-check` flag to CBMC proofs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
