### PR TITLE
Unit tests compiler warning fixes

### DIFF
--- a/libraries/standard/http/utest/http_send_utest.c
+++ b/libraries/standard/http/utest/http_send_utest.c
@@ -239,7 +239,7 @@ static void onHeaderCallback( void * pContext,
 }
 
 /* Successful application transport send interface. */
-static int32_t transportSendSuccess( NetworkContext_t * pNetworkContext,
+static int32_t transportSendSuccess( const NetworkContext_t * pNetworkContext,
                                      const void * pBuffer,
                                      size_t bytesToWrite )
 {
@@ -265,7 +265,7 @@ static int32_t transportSendSuccess( NetworkContext_t * pNetworkContext,
 /* Application transport send interface that returns a network error depending
 * on the call count. Set sendErrorCall to 0 to return an error on the
 * first call. Set sendErrorCall to 1 to return an error on the second call. */
-static int32_t transportSendNetworkError( NetworkContext_t * pNetworkContext,
+static int32_t transportSendNetworkError( const NetworkContext_t * pNetworkContext,
                                           const void * pBuffer,
                                           size_t bytesToWrite )
 {
@@ -286,7 +286,7 @@ static int32_t transportSendNetworkError( NetworkContext_t * pNetworkContext,
  * depending on the call count. Set sendPartialCall to 0 to return less bytes on
  * the first call. Set sendPartialCall to 1 to return less bytes on the second
  * call. */
-static int32_t transportSendLessThanBytesToWrite( NetworkContext_t * pNetworkContext,
+static int32_t transportSendLessThanBytesToWrite( const NetworkContext_t * pNetworkContext,
                                                   const void * pBuffer,
                                                   size_t bytesToWrite )
 {
@@ -308,7 +308,7 @@ static int32_t transportSendLessThanBytesToWrite( NetworkContext_t * pNetworkCon
  * second call. The response to send is set in pNetworkData and the current
  * call count is kept track of in recvCurrentCall. This function will return
  * zero (timeout condition) when recvStopCall matches recvCurrentCall. */
-static int32_t transportRecvSuccess( NetworkContext_t * pNetworkContext,
+static int32_t transportRecvSuccess( const NetworkContext_t * pNetworkContext,
                                      void * pBuffer,
                                      size_t bytesToRead )
 {
@@ -346,7 +346,7 @@ static int32_t transportRecvSuccess( NetworkContext_t * pNetworkContext,
 }
 
 /* Application transport receive that return a network error. */
-static int32_t transportRecvNetworkError( NetworkContext_t * pNetworkContext,
+static int32_t transportRecvNetworkError( const NetworkContext_t * pNetworkContext,
                                           void * pBuffer,
                                           size_t bytesToRead )
 {

--- a/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_lightweight_utest.c
@@ -152,7 +152,7 @@ int suiteTearDown( int numFailures )
 /**
  * @brief Mock successful transport receive by reading data from a buffer.
  */
-static int32_t mockReceive( NetworkContext_t * pNetworkContext,
+static int32_t mockReceive( const NetworkContext_t * pNetworkContext,
                             void * pBuffer,
                             size_t bytesToRecv )
 {
@@ -178,7 +178,7 @@ static int32_t mockReceive( NetworkContext_t * pNetworkContext,
 /**
  * @brief Mock transport receive with no data available.
  */
-static int32_t mockReceiveNoData( NetworkContext_t * pNetworkContext,
+static int32_t mockReceiveNoData( const NetworkContext_t * pNetworkContext,
                                   void * pBuffer,
                                   size_t bytesToRecv )
 {
@@ -193,7 +193,7 @@ static int32_t mockReceiveNoData( NetworkContext_t * pNetworkContext,
 /**
  * @brief Mock transport receive failure.
  */
-static int32_t mockReceiveFailure( NetworkContext_t * pNetworkContext,
+static int32_t mockReceiveFailure( const NetworkContext_t * pNetworkContext,
                                    void * pBuffer,
                                    size_t bytesToRecv )
 {
@@ -208,7 +208,7 @@ static int32_t mockReceiveFailure( NetworkContext_t * pNetworkContext,
 /**
  * @brief Mock transport receive that succeeds once, then fails.
  */
-static int32_t mockReceiveSucceedThenFail( NetworkContext_t * pNetworkContext,
+static int32_t mockReceiveSucceedThenFail( const NetworkContext_t * pNetworkContext,
                                            void * pBuffer,
                                            size_t bytesToRecv )
 {

--- a/libraries/standard/mqtt/utest/mqtt_utest.c
+++ b/libraries/standard/mqtt/utest/mqtt_utest.c
@@ -150,7 +150,7 @@ int suiteTearDown( int numFailures )
  * @brief Mock successful transport send, and write data into buffer for
  * verification.
  */
-static int32_t mockSend( NetworkContext_t * pNetworkContext,
+static int32_t mockSend( const NetworkContext_t * pNetworkContext,
                          const void * pMessage,
                          size_t bytesToSend )
 {
@@ -230,7 +230,7 @@ static uint32_t getTimeDummy( void )
  * @return Number of bytes sent; negative value on error;
  * 0 for timeout or 0 bytes sent.
  */
-static int32_t transportSendSuccess( NetworkContext_t * pNetworkContext,
+static int32_t transportSendSuccess( const NetworkContext_t * pNetworkContext,
                                      const void * pBuffer,
                                      size_t bytesToWrite )
 {
@@ -242,7 +242,7 @@ static int32_t transportSendSuccess( NetworkContext_t * pNetworkContext,
 /**
  * @brief Mocked failed transport send.
  */
-static int32_t transportSendFailure( NetworkContext_t * pNetworkContext,
+static int32_t transportSendFailure( const NetworkContext_t * pNetworkContext,
                                      const void * pBuffer,
                                      size_t bytesToWrite )
 {
@@ -255,7 +255,7 @@ static int32_t transportSendFailure( NetworkContext_t * pNetworkContext,
 /**
  * @brief Mocked transport send that succeeds then fails.
  */
-static int32_t transportSendSucceedThenFail( NetworkContext_t * pNetworkContext,
+static int32_t transportSendSucceedThenFail( const NetworkContext_t * pNetworkContext,
                                              const void * pMessage,
                                              size_t bytesToSend )
 {
@@ -283,7 +283,7 @@ static int32_t transportSendSucceedThenFail( NetworkContext_t * pNetworkContext,
  *
  * @return Number of bytes received; negative value on error.
  */
-static int32_t transportRecvSuccess( NetworkContext_t * pNetworkContext,
+static int32_t transportRecvSuccess( const NetworkContext_t * pNetworkContext,
                                      void * pBuffer,
                                      size_t bytesToRead )
 {
@@ -295,7 +295,7 @@ static int32_t transportRecvSuccess( NetworkContext_t * pNetworkContext,
 /**
  * @brief Mocked failed transport read.
  */
-static int32_t transportRecvFailure( NetworkContext_t * pNetworkContext,
+static int32_t transportRecvFailure( const NetworkContext_t * pNetworkContext,
                                      void * pBuffer,
                                      size_t bytesToRead )
 {
@@ -308,7 +308,7 @@ static int32_t transportRecvFailure( NetworkContext_t * pNetworkContext,
 /**
  * @brief Mocked transport reading one byte at a time.
  */
-static int32_t transportRecvOneByte( NetworkContext_t * pNetworkContext,
+static int32_t transportRecvOneByte( const NetworkContext_t * pNetworkContext,
                                      void * pBuffer,
                                      size_t bytesToRead )
 {
@@ -1034,6 +1034,7 @@ void test_MQTT_Connect_happy_path()
     mqttContext.keepAliveIntervalSec = 0;
     connectInfo.cleanSession = true;
     sessionPresentExpected = false;
+
     /* Populate some state records to make sure they are cleared since a clean session
      * will be established. */
     mqttContext.outgoingPublishRecords[ 0 ].packetId = 1;


### PR DESCRIPTION
A few type mismatch compiler warnings were introduced after this change #1161 

*Description of changes:*
Add const qualifier for the transport interface send and receive implementations in unit tests to avoid warnings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
