### PR TITLE
Fix memory leak in Openssl transport implementation

### DIFF
--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -258,6 +258,12 @@ static int32_t setRootCa( const SSL_CTX * pSslContext,
         }
     }
 
+    /* Free the X509 object used to set the root CA. */
+    if( pRootCa != NULL )
+    {
+        X509_free( pRootCa );
+    }
+
     /* Close the file if it was successfully opened. */
     if( pRootCaFile != NULL )
     {

--- a/platform/posix/transport/utest/mocks/openssl_api.h
+++ b/platform/posix/transport/utest/mocks/openssl_api.h
@@ -123,4 +123,6 @@ extern int SSL_write( SSL * ssl,
 
 const char * ERR_reason_error_string( unsigned long e );
 
+void X509_free( X509 * a );
+
 #endif /* ifndef OPENSSL_API_H_ */

--- a/platform/posix/transport/utest/openssl_utest.c
+++ b/platform/posix/transport/utest/openssl_utest.c
@@ -268,6 +268,7 @@ static OpensslStatus_t failFunctionFrom_Openssl_Connect( FunctionNames_t functio
             }
             else
             {
+                X509_free_ExpectAnyArgs();
                 fclose_ExpectAnyArgsAndReturn( 0 );
             }
         }


### PR DESCRIPTION
This fixes the memory leak by calling `X509_free` in `Openssl_Connect` if `PEM_read_X509` returns a non-NULL object.

```
==5675== 
==5675== HEAP SUMMARY:
==5675==     in use at exit: 0 bytes in 0 blocks
==5675==   total heap usage: 6,369 allocs, 6,369 frees, 535,937 bytes allocated
==5675== 
==5675== All heap blocks were freed -- no leaks are possible
==5675== 
==5675== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
==5675== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
