### PR TITLE
Improve README titles and add TOC to samples README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# AWS IoT Device SDK for Embedded C
+
 **We have released version 4.0.0 beta 1 of this SDK on the [v4_beta](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/v4_beta) branch and encourage everyone to give it a try.**
 
 Version 4 is a new design, and therefore **NOT** backwards compatible with version 3.0.1. We will continue to fix bugs in v3.0.1 even after v4.0.0 is released, but we may not add new features to v3.0.1.

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,7 +1,7 @@
 # Sample apps for the AWS IoT Device SDK for Embedded C
 
 All samples are written in C unless otherwise mentioned. The these sample apps are included in the SDK and described below.
- * [`subscribe_publish_sample`](0#subscribe-publish-sample) - a simple pub/sub MQTT example
+ * [`subscribe_publish_sample`](#subscribe-publish-sample) - a simple pub/sub MQTT example
  * [`subscribe_publish_cpp_sample`](#subscribe-publish-cpp-sample) - a simple pub/sub MQTT example written in C++
  * [`subscribe_publish_library_sample`](#subscribe-publish-library-sample) - a simple pub/sub MQTT example which builds the SDK as a separate library
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,3 +1,15 @@
+# Sample apps for the AWS IoT Device SDK for Embedded C
+
+All samples are written in C unless otherwise mentioned. The these sample apps are included in the SDK and described below.
+ * [`subscribe_publish_sample`](0#subscribe-publish-sample) - a simple pub/sub MQTT example
+ * [`subscribe_publish_cpp_sample`](#subscribe-publish-cpp-sample) - a simple pub/sub MQTT example written in C++
+ * [`subscribe_publish_library_sample`](#subscribe-publish-library-sample) - a simple pub/sub MQTT example which builds the SDK as a separate library
+
+ These sample apps are also provided in this SDK.
+ * [`shadow_sample`](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/master/samples/linux/shadow_sample) - a simple device shadow example using a connected window example
+ * [`shadow_sample_console_echo`](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/master/samples/linux/shadow_sample_console_echo) - a sample to work with the AWS IoT Console interactive guide
+ * [`jobs_sample`](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/master/samples/linux/jobs_sample) - Establishes a connection to the AWS IoT MQTT Platform and performs several operations to demonstrate the basic capabilities of the AWS IoT Jobs platform.
+
 ## Overview
 This folder contains several samples that demonstrate various SDK functions. The Readme file also includes a walk-through of the subscribe publish sample to explain how the SDK is used. The samples are currently provided with Makefiles for building them on linux. For each sample:
 
@@ -10,12 +22,6 @@ This folder contains several samples that demonstrate various SDK functions. The
  * Ensure the certificate has an attached policy which allows the proper permissions for AWS IoT
  * Build the example using make (`make`)
  * Run sample application (./subscribe_publish_sample or ./shadow_sample).  The sample will print status messages to stdout
- * All samples are written in C unless otherwise mentioned. The following sample applications are included:
-	* `subscribe_publish_sample` - a simple pub/sub MQTT example
-	* `subscribe_publish_cpp_sample` - a simple pub/sub MQTT example written in C++
-	* `subscribe_publish_library_sample` - a simple pub/sub MQTT example which builds the SDK as a separate library
-	* `shadow_sample` - a simple device shadow example using a connected window example
-	* `shadow_sample_console_echo` - a sample to work with the AWS IoT Console interactive guide
 
 ## Subscribe Publish Sample
 This is a simple pub/sub MQTT example. It connects a single MQTT client to the server and subscribes to a test topic. Then it proceeds to publish messages on this topic and yields after each publish to ensure that the message was received.

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,14 +1,13 @@
 # Sample apps for the AWS IoT Device SDK for Embedded C
 
 All samples are written in C unless otherwise mentioned. The these sample apps are included in the SDK and described below.
- * [`subscribe_publish_sample`](#subscribe-publish-sample) - a simple pub/sub MQTT example
- * [`subscribe_publish_cpp_sample`](#subscribe-publish-cpp-sample) - a simple pub/sub MQTT example written in C++
- * [`subscribe_publish_library_sample`](#subscribe-publish-library-sample) - a simple pub/sub MQTT example which builds the SDK as a separate library
+ * [`subscribe_publish_sample`](#subscribe-publish-sample) - demonstrates how to publish and subscribe to MQTT messages.
+ * [`subscribe_publish_library_sample`](#subscribe-publish-library-sample) - demonstrates how to create a library that provides support to publish and subscribe to MQTT messages.
 
  These sample apps are also provided in this SDK.
- * [`shadow_sample`](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/master/samples/linux/shadow_sample) - a simple device shadow example using a connected window example
- * [`shadow_sample_console_echo`](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/master/samples/linux/shadow_sample_console_echo) - a sample to work with the AWS IoT Console interactive guide
- * [`jobs_sample`](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/master/samples/linux/jobs_sample) - Establishes a connection to the AWS IoT MQTT Platform and performs several operations to demonstrate the basic capabilities of the AWS IoT Jobs platform.
+ * [`shadow_sample`](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/master/samples/linux/shadow_sample) - demonstrates how to use a simple device shadow in a connected window example.
+ * [`shadow_sample_console_echo`](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/master/samples/linux/shadow_sample_console_echo) - demonstrates how to work with the AWS IoT Console interactive guide.
+ * [`jobs_sample`](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/master/samples/linux/jobs_sample) - demonstrates how to connect to the AWS IoT MQTT platform and perform several operations that use the basic capabilities of the AWS IoT Jobs platform.
 
 ## Overview
 This folder contains several samples that demonstrate various SDK functions. The Readme file also includes a walk-through of the subscribe publish sample to explain how the SDK is used. The samples are currently provided with Makefiles for building them on linux. For each sample:
@@ -40,9 +39,6 @@ This is a simple pub/sub MQTT example. It connects a single MQTT client to the s
  * The sample sends out messages equal to the value set in publish count unless infinite publishing flag is set
 
 For further information on each API please read the API documentation.
-
-## Subscribe Publish Cpp Sample
-This is the same sample as above but it is built using a C++ compiler. It demonstrates how the SDK can be used in a C++ program.
 
 ## Subscribe Publish Library Sample
 This is also the same code as the Subscribe Publish sample. In this case, the SDK is built as a separate library and then used in the sample program.


### PR DESCRIPTION
*Issue #, if available:* N/A
*Description of changes:* Minor text-only edits to provide a smoother transition from the AWS IoT Core Developer Guide to the SDK documentation. (e.g. the links in https://docs.aws.amazon.com/iot/latest/developerguide/iot-connect-devices.html#iot-connect-device-sdks that land on an SDK README page.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
