### PR TITLE
Minor hygiene in mutual auth CMakeLists.txt

### DIFF
--- a/demos/mqtt/mqtt_demo_mutual_auth/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_mutual_auth/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 if(BROKER_ENDPOINT)
     target_compile_definitions(
         ${DEMO_NAME} PRIVATE
-            BROKER_ENDPOINT="${BROKER_ENDPOINT}"
+            BROKER_ENDPOINT="${AWS_IOT_ENDPOINT}"
     )
 endif()
 if(CLIENT_IDENTIFIER)

--- a/demos/mqtt/mqtt_demo_mutual_auth/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_mutual_auth/CMakeLists.txt
@@ -35,16 +35,12 @@ target_include_directories(
         ${LOGGING_INCLUDE_DIRS}
 )
 
+# Set demo configuration for Root CA cert and MQTT client identifier,
+# if passed as CMake variables.
 if(ROOT_CA_CERT_PATH)
     target_compile_definitions(
         ${DEMO_NAME} PRIVATE
             ROOT_CA_CERT_PATH="${ROOT_CA_CERT_PATH}"
-    )
-endif()
-if(BROKER_ENDPOINT)
-    target_compile_definitions(
-        ${DEMO_NAME} PRIVATE
-            BROKER_ENDPOINT="${AWS_IOT_ENDPOINT}"
     )
 endif()
 if(CLIENT_IDENTIFIER)


### PR DESCRIPTION
Remove use of `BROKER_ENDPOINT` CMake variable for mutual auth demo, instead only use the `AWS_IOT_ENDPOINT` CMake variable

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
