### PR TITLE
Update .gitmodules to use HTTPS instead of git in URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/awslabs/aws-templates-for-cbmc-proofs.git
 [submodule "libraries/standard/coreMQTT"]
 	path = libraries/standard/coreMQTT
-	url = git@github.com:FreeRTOS/coreMQTT.git
+	url = https://github.com/FreeRTOS/coreMQTT

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/awslabs/aws-templates-for-cbmc-proofs.git
 [submodule "libraries/standard/coreMQTT"]
 	path = libraries/standard/coreMQTT
-	url = https://github.com/FreeRTOS/coreMQTT
+	url = https://github.com/FreeRTOS/coreMQTT.git


### PR DESCRIPTION
Update .gitmodules to use HTTPS instead of git in URL of coreMQTT repository


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
