### PR TITLE
Make the AWS_MQTT_PORT configurable for CI

### DIFF
--- a/demos/mqtt/mqtt_demo_mutual_auth/demo_config.h
+++ b/demos/mqtt/mqtt_demo_mutual_auth/demo_config.h
@@ -65,7 +65,9 @@
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. When using port 8883, ALPN is not required.
  */
-#define AWS_MQTT_PORT    ( 8883 )
+#ifndef AWS_MQTT_PORT
+    #define AWS_MQTT_PORT    ( 8883 )
+#endif
 
 /**
  * @brief Path of the file containing the server's root CA certificate.


### PR DESCRIPTION
- To test using the ALPN port (443) we wrap AWS_MQTT_PORT in `#ifndef...#endif`. This allows the CI to pass in -DAWS_MQTT_PORT=443 during the build.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
