### PR TITLE
Add Doxygen list of libraries for the main overview

### DIFF
--- a/docs/doxygen/config.doxyfile
+++ b/docs/doxygen/config.doxyfile
@@ -2226,7 +2226,9 @@ SKIP_FUNCTION_MACROS   = YES
 # the path). If a tag file is not located in the directory in which doxygen is
 # run, you must also specify the path to the tagfile here.
 
-TAGFILES               = libraries/standard/coreMQTT/docs/doxygen/output/mqtt.tag=../../../../libraries/standard/coreMQTT/docs/doxygen/output/html
+TAGFILES               = libraries/standard/coreMQTT/docs/doxygen/output/mqtt.tag=../../../../libraries/standard/coreMQTT/docs/doxygen/output/html \
+                         libraries/standard/coreJSON/docs/doxygen/output/json.tag=../../../../libraries/standard/coreJSON/docs/doxygen/output/html \
+                         libraries/aws/device-shadow-for-aws-iot-embedded-sdk/docs/doxygen/output/shadow.tag=../../../../libraries/aws/device-shadow-for-aws-iot-embedded-sdk/docs/doxygen/output/html
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create a
 # tag file that is based on the input files it reads. See section "Linking to

--- a/docs/doxygen/pages.txt
+++ b/docs/doxygen/pages.txt
@@ -2,7 +2,8 @@
 @mainpage Overview
 @brief The AWS IoT Device SDK for Embedded C provides demonstration code and integration tests for a collection of libraries.
 
-The following libraries are part this SDK:
+@section libraries_section Libraries
+The following libraries are part of this SDK:
 - [coreMQTT](@ref mqtt)
 - [device-shadow-for-aws-iot-embedded-sdk](@ref shadow)
 - [coreJSON](@ref json)

--- a/docs/doxygen/pages.txt
+++ b/docs/doxygen/pages.txt
@@ -1,4 +1,9 @@
 /**
 @mainpage Overview
 @brief The AWS IoT Device SDK for Embedded C provides demonstration code and integration tests for a collection of libraries.
+
+The following libraries are part this SDK:
+- [coreMQTT](@ref mqtt)
+- [device-shadow-for-aws-iot-embedded-sdk](@ref shadow)
+- [coreJSON](@ref json)
 */

--- a/docs/doxygen_templates/pages.txt
+++ b/docs/doxygen_templates/pages.txt
@@ -1,5 +1,6 @@
 /**
 @mainpage Overview
+@anchor [<FIXME: library name>]
 @brief [<FIXME: library description>]
 
 [<FIXME: Some useful overview text>]


### PR DESCRIPTION
- Add the list of libraries to the main page.
- Please see these PRs for the anchors:
  https://github.com/FreeRTOS/coreMQTT/pull/47
  https://github.com/FreeRTOS/coreJSON/pull/18
  https://github.com/aws/device-shadow-for-aws-iot-embedded-sdk/pull/13

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
