### PR TITLE
Add Rule 2.3 to MISRA configuration

### DIFF
--- a/tools/coverity/misra.config
+++ b/tools/coverity/misra.config
@@ -19,6 +19,10 @@
             reason: "Allow inclusion of function like macros. Logging is done using function like macros."
         },
         {
+            deviation: "Rule 2.3",
+            reason: "Allow unused types. Library headers may define types intended for the application's use, but not used within the library files."
+        },
+        {
             deviation: "Rule 2.4",
             reason: "Allow unused tags. Some compilers warn if types are not tagged."
         },


### PR DESCRIPTION
Rule 2.3 of MISRA flags types (like structs, enums) that are defined in header files but not used within the library.

Rationale for ignoring: There are use-cases of libraries exposing types in their API for utility by the customer application. Eg. `MQTTSubAckStatus_t` enum that is only used by the calling code.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
