### PR TITLE
Minor hygiene fixes in Shadow demo build

### DIFF
--- a/demos/mqtt/mqtt_demo_subscription_manager/demo_config.h
+++ b/demos/mqtt/mqtt_demo_subscription_manager/demo_config.h
@@ -80,7 +80,9 @@
  *
  * No two clients may use the same client identifier simultaneously.
  */
-#define CLIENT_IDENTIFIER                    "testclient1"
+#ifndef CLIENT_IDENTIFIER
+    #define CLIENT_IDENTIFIER    "testclient1"
+#endif
 
 /**
  * @brief The max size of the registry in the subscription manager.

--- a/demos/shadow/shadow_demo_main/CMakeLists.txt
+++ b/demos/shadow/shadow_demo_main/CMakeLists.txt
@@ -53,12 +53,6 @@ if(ROOT_CA_CERT_PATH)
             ROOT_CA_CERT_PATH="${ROOT_CA_CERT_PATH}"
     )
 endif()
-if(BROKER_ENDPOINT)
-    target_compile_definitions(
-        ${DEMO_NAME} PRIVATE
-            BROKER_ENDPOINT="${BROKER_ENDPOINT}"
-    )
-endif()
 if(CLIENT_IDENTIFIER)
     target_compile_definitions(
         ${DEMO_NAME} PRIVATE

--- a/demos/shadow/shadow_demo_main/demo_config.h
+++ b/demos/shadow/shadow_demo_main/demo_config.h
@@ -117,7 +117,9 @@
  *
  * No two clients may use the same client identifier simultaneously.
  */
-#define CLIENT_IDENTIFIER         "testclient"
+#ifndef CLIENT_IDENTIFIER
+    #define CLIENT_IDENTIFIER    "testclient"
+#endif
 
 /**
  * @brief Size of the network buffer for MQTT packets.


### PR DESCRIPTION
Fixes for Shadow demo include:
* Allowing override of default `CLIENT_IDENTIFIER` value from command line
* Removal of BROKER_ENDPOINT macro definition as demo uses `AWS_IOT_ENDPOINT` macro

Similar fix for MQTT Subscription Manager demo to allow overriding of default `CLIENT_IDENTIFIER` macro

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
