### PR TITLE
Update text of libraries on landing page

### DIFF
--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -3,8 +3,8 @@
 @brief The AWS IoT Device SDK for Embedded C provides demonstration code and integration tests for a collection of libraries.
 
 @section libraries_section Libraries
-The following libraries are part of this SDK:
-- [coreMQTT](@ref mqtt)
-- [device-shadow-for-aws-iot-embedded-sdk](@ref shadow)
-- [coreJSON](@ref json)
+The following libraries (along with their source repositories) are part of this SDK:
+- [MQTT client](@ref mqtt) - [coreMQTT](https://github.com/FreeRTOS/coreMQTT)
+- [AWS IoT Device Shadow client](@ref shadow) - [device-shadow-for-aws-iot-embedded-sdk](https://github.com/aws/device-shadow-for-aws-iot-embedded-sdk)
+- [JSON parser](@ref json) - [coreJSON](https://github.com/FreeRTOS/coreJSON)
 */


### PR DESCRIPTION
Improve readability of bulleted list of libraries (that are part of the SDK) on doxygen landing page from this:
![image](https://user-images.githubusercontent.com/5158611/93153585-71af0e00-f6b6-11ea-8ad5-88df1f8a3e56.png)


to this:
![image](https://user-images.githubusercontent.com/5158611/93153556-5ba14d80-f6b6-11ea-9f12-7c72f6e9b352.png)



By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
