### PR TITLE
Update coreMQTT, coreJSon and Shadow submodules to point to v1.0.0 tag

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,12 @@
 [submodule "libraries/standard/coreMQTT"]
 	path = libraries/standard/coreMQTT
 	url = https://github.com/FreeRTOS/coreMQTT.git
+	branch = v1.0.0
 [submodule "libraries/standard/coreJSON"]
 	path = libraries/standard/coreJSON
 	url = https://github.com/FreeRTOS/coreJSON.git
+	branch = v1.0.0
 [submodule "libraries/aws/device-shadow-for-aws-iot-embedded-sdk"]
 	path = libraries/aws/device-shadow-for-aws-iot-embedded-sdk
 	url = https://github.com/aws/device-shadow-for-aws-iot-embedded-sdk.git
+	branch = v1.0.0


### PR DESCRIPTION
*Description of changes:*
Update coreMQTT, coreJSon and Shadow submodules to point to v1.0.0 tag.
**IMP: Merge this PR only as part of the 202009.00 release.**

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
