### PR TITLE
Prefix MQTT demo doc sections with "MQTT"

### DIFF
--- a/docs/doxygen/demos/demos_subpages.dox
+++ b/docs/doxygen/demos/demos_subpages.dox
@@ -1,5 +1,5 @@
 /**
-@page mqtt_demo_basic_tls Basic TLS Demo
+@page mqtt_demo_basic_tls MQTT Basic TLS Demo
 @brief Demo of an MQTT application that establishes a TLS connection with server-only authentication, and uses QoS 2 level of communication with broker.
 
 This demo uses an OpenSSL-based transport interface implementation to establish a server-authenticated TLS connection, and demonstrates the subscribe-publish workflow of MQTT at QoS 2 level. After subscribing to a single topic filter, it publishes to the same topic and waits for receipt of that message back from the server at QoS 2 level. This cycle of publishing to the broker and receiving the same message back from the broker is repeated indefinitely.
@@ -10,7 +10,7 @@ Messages in this demo are sent at QoS 2, which guarantees exactly one delivery a
 */
 
 /**
-@page mqtt_demo_mutual_auth Mutual Authentication Demo
+@page mqtt_demo_mutual_auth MQTT Mutual Authentication Demo
 @brief Demo of an MQTT application that establishes a TLS connection with both server and client authentication, and uses QoS 1 level of communication with broker.
 
 This demo uses an OpenSSL-based transport interface implementation to establish a server and client-authenticated TLS connection, and demonstrates the subscribe-publish workflow of MQTT at QoS 1 level. After subscribing to a single topic filter, it publishes to the same topic and waits for receipt of that message back from the server at QoS 1 level. This cycle of publishing to the broker and receiving the same message back from the broker is repeated indefinitely.
@@ -21,7 +21,7 @@ Messages in this demo are sent at QoS 1, which guarantees at least one delivery 
 */
 
 /**
-@page mqtt_demo_plaintext Plaintext Demo
+@page mqtt_demo_plaintext MQTT Plaintext Demo
 @brief Demo of an MQTT application that establishes a plaintext (no encryption) TCP connection with the server, and uses QoS 0 level of communication with broker.
 
 This demo uses a POSIX socket-based transport interface implementation to establish a TCP connection, and demonstrates the subscribe-publish workflow of MQTT at Qos 0 level. After subscribing to a single topic filter, it publishes to the same topic and waits for receipt of that message to be returned from the server at QoS 0 level. This cycle of publishing to the broker and receiving the same message back from the broker is repeated indefinitely.
@@ -32,7 +32,7 @@ Messages in this demo are sent at QoS 0, which guarantees at most one delivery a
 */
 
 /**
-@page mqtt_demo_serializer Serializer Demo
+@page mqtt_demo_serializer MQTT Serializer Demo
 @brief Demo of an MQTT application using only the MQTT serializer API to communicate at QoS 0 level with broker over a plaintext (no encryption) TCP connection.
 
 This demo uses POSIX sockets to establish a TCP connection, and demonstrates the subscribe-publish workflow of MQTT at QoS 0 level. After subscribing to a single topic filter, it publishes to the same topic and waits for receipt of that message to be returned from the server at QoS 0 level. It demonstrates use of the serializer API as a lightweight alternative to the standard MQTT API. This cycle of publishing to the broker and receiving the same message back from the broker is repeated indefinitely.
@@ -43,7 +43,7 @@ Messages in this demo are sent at QoS 0, which guarantees at most one delivery a
 */
 
 /**
-@page mqtt_demo_subscription_manager Susbcription Manager Demo
+@page mqtt_demo_subscription_manager MQTT Subscription Manager Demo
 @brief Demo of an MQTT application that subscribes to multiple topic filters using a subscription manager to manage multiple subscriptions, register different callbacks for each subscription, and handle wildcard topics. It establishes a TLS connection with server-only authentication, and communicates at QoS 1 level with the broker.
 
 This demo uses an OpenSSL-based transport interface implementation to establish a server-authenticated TLS connection, and demonstrates the subscribe-publish workflow of MQTT at QoS 1 level, using a subscription manager. Before subscribing to a topic filter, the application registers the filter's unique callback with the subscription manager. After subscription, it publishes to the same topic and waits for receipt of that message to be returned from the server at QoS 1 level. Once received, the subscription manager will invoke the callback registered for the topic filter that matches the topic of the incoming PUBLISH. This subscribe-publish process is repeated for 3 different topic filters, including one wildcard filter. This cycle of publishing to the broker and receiving the same message back from the broker is repeated indefinitely.

--- a/docs/doxygen/demos/demos_subpages.dox
+++ b/docs/doxygen/demos/demos_subpages.dox
@@ -55,7 +55,7 @@ Messages in this demo are sent at QoS 1, which guarantees at least one delivery 
 
 /**
 @page shadow_demo_main Shadow Demo
-@brief Demo application that uses the Device Shadow library, MQTT Client library
+@brief Demo application that uses the AWS IoT Device Shadow library, MQTT Client library,
 and JSON library to interact with the AWS IoT Device Shadow service.
 
 The device is assumed to have the powerOn state, which can be 1 or 0 depending on


### PR DESCRIPTION
- The HTTP library has similarly named demos.
- Other grammar fixes and things found in the doc review

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
