### PR TITLE
Increase size of retry utilities image

### DIFF
--- a/platform/include/retry_utils.h
+++ b/platform/include/retry_utils.h
@@ -67,7 +67,7 @@
  * The functions are used as shown in the diagram below. This is the exponential
  * backoff with jitter loop:
  *
- * @image html retry_utils_flow.png width=25%
+ * @image html retry_utils_flow.png width=60%
  *
  * The following steps give guidance on implementing the Retry Utils. An example
  * implementation of the Retry Utils for a POSIX platform can be found in file


### PR DESCRIPTION
*Description of changes:*
Increases the size of the retry utilities image in the documentation, after the width of the image was increased in #1262. Please look at the documentation (`python tools/doxygen/generate_docs.py -r .`) to see if the image is now an acceptable size.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
