### PR TITLE
Fix the title of the Shadow demo to be more verbose.

### DIFF
--- a/docs/doxygen/demos/demos_subpages.dox
+++ b/docs/doxygen/demos/demos_subpages.dox
@@ -54,7 +54,7 @@ Messages in this demo are sent at QoS 1, which guarantees at least one delivery 
 */
 
 /**
-@page shadow_demo_main Shadow Demo
+@page shadow_demo_main AWS IoT Device Shadow Demo
 @brief Demo application that uses the AWS IoT Device Shadow library, MQTT Client library,
 and JSON library to interact with the AWS IoT Device Shadow service.
 


### PR DESCRIPTION
Change `Shadow Demo` -> `AWS IoT Device Shadow Demo` .

![image](https://user-images.githubusercontent.com/6563840/93283135-c4ef9200-f784-11ea-9442-c93564357dba.png)
 


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
