### PR TITLE
Fix broken links in changelog and contributing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,7 +128,7 @@ Bugfixes/Improvements:
 
 New features:
 
-  - Added unit tests, further details can be found in the testing readme
+  - Added unit tests, further details can be found in the testing [readme](https://github.com/aws/aws-iot-device-sdk-embedded-C/blob/v2.1.0/tests/README.md/)
   - Added sample to demonstrate building the SDK as library
   - Added sample to demonstrate building the SDK in C++
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ These libraries have gone through code quality checks including verification tha
 
 - This release uses submodule references to the following new individual repositories for the MQTT, JSON and AWS IoT Shadow service client libraries under `libraries` folder:
    - [FreeRTOS/coreMQTT](https://github.com/FreeRTOS/coreMQTT) for MQTT client library
-   - [FreeRTOS/coreJSON](https://github.com/FreeRTOS/JSON) for JSON parser library
+   - [FreeRTOS/coreJSON](https://github.com/FreeRTOS/coreJSON) for JSON parser library
    - [aws/device-shadow-for-aws-iot-embedded-sdk](https://github.com/aws/device-shadow-for-aws-iot-embedded-sdk) for AWS IoT Shadow service client library.
 
 - With this release, we are introducing a [date-based versioning scheme](README.md#versioning).
@@ -128,7 +128,7 @@ Bugfixes/Improvements:
 
 New features:
 
-  - Added unit tests, further details can be found in the testing readme [here](https://github.com/aws/aws-iot-device-sdk-embedded-c/blob/master/tests/README.md/)
+  - Added unit tests, further details can be found in the testing readme
   - Added sample to demonstrate building the SDK as library
   - Added sample to demonstrate building the SDK in C++
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ information to effectively respond to your bug report or contribution.
 
 We welcome you to use the GitHub issue tracker to report bugs or suggest features.
 
-When filing an issue, please check [existing open](https://github.com/awslabs/aws-iot-device-sdk-c/issues), or [recently closed](https://github.com/awslabs/aws-iot-device-sdk-c/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already 
+When filing an issue, please check [existing open](https://github.com/aws/aws-iot-device-sdk-embedded-C/issues), or [recently closed](https://github.com/aws/aws-iot-device-sdk-embedded-C/issues?q=is%3Aissue+is%3Aclosed), issues to make sure somebody else hasn't already 
 reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
 
 * A reproducible test case or series of steps
@@ -42,7 +42,7 @@ GitHub provides additional document on [forking a repository](https://help.githu
 
 
 ## Finding contributions to work on
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels ((enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/awslabs/aws-iot-device-sdk-c/labels/help%20wanted) issues is a great place to start. 
+Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels ((enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/aws/aws-iot-device-sdk-embedded-C/labels?q=help+wanted) issues is a great place to start. 
 
 
 ## Code of Conduct
@@ -57,6 +57,6 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## Licensing
 
-See the [LICENSE](https://github.com/awslabs/aws-iot-device-sdk-c/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](./LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
 
 We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.


### PR DESCRIPTION
*Description of changes:*
Fixes links in CHANGELOG.md and CONTRIBUTING.md that returned 404s.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
