### PR TITLE
Update the wording on the metrics comment

### DIFF
--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -999,9 +999,9 @@ static int establishMqttSession( MQTTContext_t * pMqttContext,
      * username/password based client authentication.
      *
      * The username field is populated with voluntary metrics to AWS IoT.
-     * The metrics collected by AWS IoT are the current operating system or
-     * SDK and its version. These metrics help AWS IoT improve security and
-     * provide better technical support.
+     * The metrics collected by AWS IoT are the current operating system, the
+     * operating system's version, and the current hardware platform. These
+     * metrics help AWS IoT improve security and provide better technical support.
      *
      * If client authentication is based on username/password in AWS IoT,
      * the metrics string is appended to the username to support both client

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -999,9 +999,10 @@ static int establishMqttSession( MQTTContext_t * pMqttContext,
      * username/password based client authentication.
      *
      * The username field is populated with voluntary metrics to AWS IoT.
-     * The metrics collected by AWS IoT are the current operating system, the
-     * operating system's version, and the current hardware platform. These
-     * metrics help AWS IoT improve security and provide better technical support.
+     * The metrics collected by AWS IoT are the operating system, the operating
+     * system's version, the hardware platform, and the MQTT Client library
+     * information. These metrics help AWS IoT improve security and provide
+     * better technical support.
      *
      * If client authentication is based on username/password in AWS IoT,
      * the metrics string is appended to the username to support both client


### PR DESCRIPTION
There is a comment in the MQTT mutual auth demo that explains the metrics a bit. This was not update with the last change to the metrics string.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
