### PR TITLE
Update the README.md to ensure that the ca.crt Common Name is different than the server.crt Common Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,12 +182,16 @@ docker pull eclipse-mosquitto:latest
 ```
 2.  `BROKER_ENDPOINT` defined in `demos/mqtt/mqtt_demo_basic_tls/demo_config.h` can now be set to `localhost`.
 
-3. For TLS communication with Mosquitto broker, server and CA credentials need to be created. Use OpenSSL commands to generate the credentials for the Mosquitto server.
+3. For TLS communication with Mosquitto broker, server and CA credentials need to be created.  
+
+Use the following OpenSSL command to generate a CA key and certificate. When prompted, please provide some information for 
+the Distinguished Name and Common Name fields.  
 ```shell
 # Generate CA key and certificate. Provide the Subject field information as appropriate.
 openssl req -x509 -nodes -sha256 -days 365 -newkey rsa:2048 -keyout ca.key -out ca.crt
-```
-
+```  
+Use the following OpenSSL command to generate a sever key and certificate for the Mosquitto broker. When prompted,
+please ensure that the Common Name field is different from the one provided when creating the CA key and certificate.
 ```shell
 # Generate server key and certificate.
 openssl req -nodes -sha256 -new -keyout server.key -out server.csr


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-iot-device-sdk-embedded-C/issues/1281


*Description of changes:*
Update the README.md to ensure that the CA.crt Common Name is different nt than the server.crt Common Name.
The ca.crt created in step 3 cannot be used, in Openssl, to verify the server.crt if the Common Names are the same. All other fields in the Distinguished Name can match.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
