### PR TITLE
MQTT v3: Only return a failure to unlock the mutex, if the write was successful.

### DIFF
--- a/src/aws_iot_mqtt_client_common_internal.c
+++ b/src/aws_iot_mqtt_client_common_internal.c
@@ -310,6 +310,10 @@ IoT_Error_t aws_iot_mqtt_internal_send_packet(AWS_IoT_Client *pClient, size_t le
 	size_t sentLen, sent;
 	IoT_Error_t rc = FAILURE;
 
+#ifdef _ENABLE_THREAD_SUPPORT_
+	IoT_Error_t threadRc;
+#endif
+
 	FUNC_ENTRY;
 
 	if(NULL == pClient || NULL == pTimer) {
@@ -321,9 +325,9 @@ IoT_Error_t aws_iot_mqtt_internal_send_packet(AWS_IoT_Client *pClient, size_t le
 	}
 
 #ifdef _ENABLE_THREAD_SUPPORT_
-	rc = aws_iot_mqtt_client_lock_mutex(pClient, &(pClient->clientData.tls_write_mutex));
-	if(SUCCESS != rc) {
-		FUNC_EXIT_RC(rc);
+	threadRc = aws_iot_mqtt_client_lock_mutex(pClient, &(pClient->clientData.tls_write_mutex));
+	if(SUCCESS != threadRc) {
+		FUNC_EXIT_RC(threadRc);
 	}
 #endif
 
@@ -344,9 +348,9 @@ IoT_Error_t aws_iot_mqtt_internal_send_packet(AWS_IoT_Client *pClient, size_t le
 	}
 
 #ifdef _ENABLE_THREAD_SUPPORT_
-	rc = aws_iot_mqtt_client_unlock_mutex(pClient, &(pClient->clientData.tls_write_mutex));
-	if(SUCCESS != rc) {
-		FUNC_EXIT_RC(rc);
+	threadRc = aws_iot_mqtt_client_unlock_mutex(pClient, &(pClient->clientData.tls_write_mutex));
+	if((SUCCESS != threadRc) && ( SUCCESS == rc )) {
+		FUNC_EXIT_RC(threadRc);
 	}
 #endif
 


### PR DESCRIPTION
Similar to what aws_iot_mqtt_internal_cycle_read() does, I update aws_iot_mqtt_internal_send_packet() to return a failure on the mutex unlock only if the network write was successful. The network write failure has precedence over the possible and extremely rare mutex unlock failure.

Before this change, the success on the mutex unlock swallowed any possible network write failures.

This fixes issue: https://github.com/aws/aws-iot-device-sdk-embedded-C/issues/1247


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
