### PR TITLE
Add GitHub Actions Job for formatting check

### DIFF
--- a/.github/ci.yml
+++ b/.github/ci.yml
@@ -1,0 +1,28 @@
+name: CI Checks
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Uncrustify
+        run: sudo apt-get install uncrustify
+      - name: Check Formatting With Uncrustify
+        run: find . -iname "*.[hc]" -exec uncrustify --check -c tools/uncrustify.cfg {} +
+      - name: Check For Trailing Whitespace
+        run: |
+          set +e
+          grep --exclude="README.md" -rnI -e "[[:blank:]]$" .
+          if [ "$?" = "0" ]; then
+            echo "Files have trailing whitespace."
+            exit 1
+          else
+            exit 0
+          fi


### PR DESCRIPTION
Initite GitHub Action triggers on repository by adding a single job for formatting check.
This will enable running all checks of #1302 before it is merged


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
