### PR TITLE
Lower CMake minimum required version from 3.13.0 to 3.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: make -C build/ help | grep demo | tr -d '. ' | xargs make -C build/
       - name: Build System Tests
         run: make -C build/ help | grep system | tr -d '. ' | xargs make -C build/
-  system-unit-test:
+  unittest:
     runs-on: ubuntu-latest
     steps:
       - name: Clone This Repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,7 @@ jobs:
         run: |
           sudo apt-get install -y lcov
           make -C build/ help | grep utest | tr -d '. ' | xargs make -C build/
-      - name: Build System Tests
-        run: |
-          make -C build/ help | grep system | tr -d '. ' | xargs make -C build/
-      - name: Test
+      - name: Run ctest
         run: |
           cd build/
           ctest -E system --output-on-failure
@@ -79,6 +76,9 @@ jobs:
           path: "build/coverage.info"
           min_coverage: 100
           exclude: "**/*test*"
+      - name: Build System Tests
+        run: |
+          make -C build/ help | grep system | tr -d '. ' | xargs make -C build/
   complexity:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
           mkdir build
           cmake-3.2.0-Linux-x86_64/bin/cmake . -Bbuild/ \
           -G "Unix Makefiles" \
-          -DBUILD_TESTS=1 \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror' \
           -DAWS_IOT_ENDPOINT="aws-iot-endpoint" \
@@ -32,24 +31,34 @@ jobs:
           -DCLIENT_PRIVATE_KEY_PATH="key/path"
       - name: Build Demos
         run: make -C build/ help | grep demo | tr -d '. ' | xargs make -C build/
-      - name: Build System Tests
-        run: make -C build/ help | grep system | tr -d '. ' | xargs make -C build/
-  unittest:
+  tests:
     runs-on: ubuntu-latest
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Build Unit Tests
+      - name: Download CMake 3.14.0
         run: |
-          sudo apt-get install -y lcov
-          cmake -S . -B build/ \
+          curl https://cmake.org/files/v3.14/cmake-3.14.0-Linux-x86_64.tar.gz -o cmake.tar.gz
+          tar -xf cmake.tar.gz
+          mkdir build
+          cmake-3.14.0-Linux-x86_64/bin/cmake . -Bbuild/ \
           -G "Unix Makefiles" \
           -DBUILD_TESTS=1 \
           -DCMAKE_BUILD_TYPE=Debug \
-          -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG'
+          -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG' \
+          -DBROKER_ENDPOINT="broker-endpoint" \
+          -DCLIENT_CERT_PATH="cert/path" \
+          -DROOT_CA_CERT_PATH="cert/path" \
+          -DCLIENT_PRIVATE_KEY_PATH="key/path"
+      - name: Build Unit Tests
+        run: |
+          sudo apt-get install -y lcov
           make -C build/ help | grep utest | tr -d '. ' | xargs make -C build/
+      - name: Build System Tests
+        run: |
+          make -C build/ help | grep system | tr -d '. ' | xargs make -C build/
       - name: Test
         run: |
           cd build/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
         run: |
           curl https://cmake.org/files/v3.2/cmake-3.2.0-Linux-x86_64.tar.gz -o cmake.tar.gz
           tar -xf cmake.tar.gz
-          cmake-3.2.0-Linux-x86_64/bin/cmake -S .. -B ../build/ \
+          mkdir build
+          cmake-3.2.0-Linux-x86_64/bin/cmake -S . -B build/ \
           -G "Unix Makefiles" \
           -DBUILD_TESTS=1 \
           -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           curl https://cmake.org/files/v3.2/cmake-3.2.0-Linux-x86_64.tar.gz -o cmake.tar.gz
           tar -xf cmake.tar.gz
           mkdir build
-          cmake-3.2.0-Linux-x86_64/bin/cmake -S . -B build/ \
+          cmake-3.2.0-Linux-x86_64/bin/cmake . -Bbuild/ \
           -G "Unix Makefiles" \
           -DBUILD_TESTS=1 \
           -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-demo:
+  build-check:
     runs-on: ubuntu-latest
     steps:
       - name: Clone This Repo
@@ -22,6 +22,7 @@ jobs:
           mkdir build
           cmake-3.2.0-Linux-x86_64/bin/cmake . -Bbuild/ \
           -G "Unix Makefiles" \
+          -DBUILD_TESTS=1 \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror' \
           -DAWS_IOT_ENDPOINT="aws-iot-endpoint" \
@@ -31,6 +32,8 @@ jobs:
           -DCLIENT_PRIVATE_KEY_PATH="key/path"
       - name: Build Demos
         run: make -C build/ help | grep demo | tr -d '. ' | xargs make -C build/
+      - name: Build System Tests
+        run: make -C build/ help | grep system | tr -d '. ' | xargs make -C build/
   system-unit-test:
     runs-on: ubuntu-latest
     steps:
@@ -38,20 +41,17 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Download CMake 3.14.0
+      - name: Download CMake 3.2.0
         run: |
-          curl https://cmake.org/files/v3.14/cmake-3.14.0-Linux-x86_64.tar.gz -o cmake.tar.gz
+          curl https://cmake.org/files/v3.2/cmake-3.2.0-Linux-x86_64.tar.gz -o cmake.tar.gz
           tar -xf cmake.tar.gz
           mkdir build
-          cmake-3.14.0-Linux-x86_64/bin/cmake . -Bbuild/ \
+          cmake-3.2.0-Linux-x86_64/bin/cmake . -Bbuild/ \
           -G "Unix Makefiles" \
           -DBUILD_TESTS=1 \
           -DCMAKE_BUILD_TYPE=Debug \
-          -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG' \
-          -DBROKER_ENDPOINT="broker-endpoint" \
-          -DCLIENT_CERT_PATH="cert/path" \
-          -DROOT_CA_CERT_PATH="cert/path" \
-          -DCLIENT_PRIVATE_KEY_PATH="key/path"
+          -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG'
+          make -C build/ help | grep utest | tr -d '. ' | xargs make -C build/
       - name: Build Unit Tests
         run: |
           sudo apt-get install -y lcov
@@ -76,9 +76,6 @@ jobs:
           path: "build/coverage.info"
           min_coverage: 100
           exclude: "**/*test*"
-      - name: Build System Tests
-        run: |
-          make -C build/ help | grep system | tr -d '. ' | xargs make -C build/
   complexity:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Build
+      - name: Build Unit Tests
         run: |
           sudo apt-get install -y lcov
           cmake -S . -B build/ \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: CMake
+      - name: Download CMake 3.2.0
         run: |
           curl https://cmake.org/files/v3.2/cmake-3.2.0-Linux-x86_64.tar.gz -o cmake.tar.gz
           tar -xf cmake.tar.gz
-          cmake-3.2.0-Linux-x86_64/bin/cmake -S . -B build/ \
+          cmake-3.2.0-Linux-x86_64/bin/cmake -S .. -B ../build/ \
           -G "Unix Makefiles" \
           -DBUILD_TESTS=1 \
           -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,9 @@ jobs:
           submodules: recursive
       - name: CMake
         run: |
-          cmake -S . -B build/ \
+          curl https://cmake.org/files/v3.2/cmake-3.2.0-Linux-x86_64.tar.gz -o cmake.tar.gz
+          tar -xf cmake.tar.gz
+          cmake-3.2.0-Linux-x86_64/bin/cmake -S . -B build/ \
           -G "Unix Makefiles" \
           -DBUILD_TESTS=1 \
           -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-check:
+  build-demo:
     runs-on: ubuntu-latest
     steps:
       - name: Clone This Repo
@@ -31,7 +31,7 @@ jobs:
           -DCLIENT_PRIVATE_KEY_PATH="key/path"
       - name: Build Demos
         run: make -C build/ help | grep demo | tr -d '. ' | xargs make -C build/
-  tests:
+  system-unit-test:
     runs-on: ubuntu-latest
     steps:
       - name: Clone This Repo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Project information.
-cmake_minimum_required( VERSION 3.13.0 )
+cmake_minimum_required( VERSION 3.2.0 )
 project( AwsIotDeviceSdkEmbeddedC
          VERSION 202009.00
          LANGUAGES C )

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The libraries in this SDK are not dependent on any operating system. However, th
 
 ### Prerequisites
 
-- CMake 3.13.0 or later for utilizing the build system of the repository.
+- CMake 3.2.0 or later for utilizing the build system of the repository.
 
 - C90 compiler
 

--- a/demos/http/http_demo_basic_tls/CMakeLists.txt
+++ b/demos/http/http_demo_basic_tls/CMakeLists.txt
@@ -4,11 +4,8 @@ set( DEMO_NAME "http_demo_basic_tls" )
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 
 # Demo target.
-add_executable(${DEMO_NAME})
-
-target_sources(
+add_executable(
     ${DEMO_NAME}
-    PRIVATE
         "${DEMO_NAME}.c"
         "../common/src/http_demo_utils.c"
         ${HTTP_SOURCES}

--- a/demos/http/http_demo_mutual_auth/CMakeLists.txt
+++ b/demos/http/http_demo_mutual_auth/CMakeLists.txt
@@ -6,19 +6,16 @@ set( DEMO_NAME "http_demo_mutual_auth" )
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 
 # Demo target.
-add_executable(${DEMO_NAME})
-
-# Add to default target if all required macros needed to run this demo are defined
-check_aws_credentials(${DEMO_NAME})
-
-target_sources(
+add_executable(
     ${DEMO_NAME}
-    PRIVATE
         "${DEMO_NAME}.c"
         "../common/src/http_demo_utils.c"
         ${HTTP_SOURCES}
         ${HTTP_THIRD_PARTY_SOURCES}
 )
+
+# Add to default target if all required macros needed to run this demo are defined
+check_aws_credentials(${DEMO_NAME})
 
 target_link_libraries(
     ${DEMO_NAME}

--- a/demos/http/http_demo_plaintext/CMakeLists.txt
+++ b/demos/http/http_demo_plaintext/CMakeLists.txt
@@ -4,11 +4,8 @@ set( DEMO_NAME "http_demo_plaintext" )
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 
 # Demo target.
-add_executable(${DEMO_NAME})
-
-target_sources(
+add_executable(
     ${DEMO_NAME}
-    PRIVATE
         "${DEMO_NAME}.c"
         "../common/src/http_demo_utils.c"
         ${HTTP_SOURCES}

--- a/demos/mqtt/mqtt_demo_basic_tls/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_basic_tls/CMakeLists.txt
@@ -4,11 +4,8 @@ set( DEMO_NAME "mqtt_demo_basic_tls" )
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 
 # Demo target.
-add_executable(${DEMO_NAME})
-
-target_sources(
+add_executable(
     ${DEMO_NAME}
-    PRIVATE
         "${DEMO_NAME}.c"
         ${MQTT_SOURCES}
         ${MQTT_SERIALIZER_SOURCES}

--- a/demos/mqtt/mqtt_demo_mutual_auth/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_mutual_auth/CMakeLists.txt
@@ -5,18 +5,15 @@ set( DEMO_NAME "mqtt_demo_mutual_auth" )
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 
 # Demo target.
-add_executable(${DEMO_NAME})
-
-# Add to default target if all required macros needed to run this demo are defined
-check_aws_credentials(${DEMO_NAME})
-
-target_sources(
+add_executable(
     ${DEMO_NAME}
-    PRIVATE
         "${DEMO_NAME}.c"
         ${MQTT_SOURCES}
         ${MQTT_SERIALIZER_SOURCES}
 )
+
+# Add to default target if all required macros needed to run this demo are defined
+check_aws_credentials(${DEMO_NAME})
 
 target_link_libraries(
     ${DEMO_NAME}

--- a/demos/mqtt/mqtt_demo_plaintext/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_plaintext/CMakeLists.txt
@@ -4,11 +4,8 @@ set( DEMO_NAME "mqtt_demo_plaintext" )
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 
 # Demo target.
-add_executable(${DEMO_NAME})
-
-target_sources(
+add_executable(
     ${DEMO_NAME}
-    PRIVATE
         "${DEMO_NAME}.c"
         ${MQTT_SOURCES}
         ${MQTT_SERIALIZER_SOURCES}

--- a/demos/mqtt/mqtt_demo_serializer/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_serializer/CMakeLists.txt
@@ -4,11 +4,8 @@ set( DEMO_NAME "mqtt_demo_serializer" )
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 
 # Demo target.
-add_executable(${DEMO_NAME})
-
-target_sources(
+add_executable(
     ${DEMO_NAME}
-    PRIVATE
         "${DEMO_NAME}.c"
         ${MQTT_SERIALIZER_SOURCES}
 )

--- a/demos/mqtt/mqtt_demo_subscription_manager/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_subscription_manager/CMakeLists.txt
@@ -9,18 +9,15 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 set( DEMO_NAME "mqtt_demo_subscription_manager" )
 
 # Demo target.
-add_executable(${DEMO_NAME})
-
-# Add to default target if all required macros needed to run this demo are defined
-check_aws_credentials(${DEMO_NAME})
-
-target_sources(
+add_executable(
     ${DEMO_NAME}
-    PRIVATE
         "${DEMO_NAME}.c"
         ${MQTT_SOURCES}
         ${MQTT_SERIALIZER_SOURCES}
 )
+
+# Add to default target if all required macros needed to run this demo are defined
+check_aws_credentials(${DEMO_NAME})
 
 target_link_libraries(
     ${DEMO_NAME}

--- a/demos/shadow/shadow_demo_main/CMakeLists.txt
+++ b/demos/shadow/shadow_demo_main/CMakeLists.txt
@@ -12,14 +12,8 @@ include( ${CMAKE_SOURCE_DIR}/libraries/aws/device-shadow-for-aws-iot-embedded-sd
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreJSON/jsonFilePaths.cmake )
 
 # Demo target.
-add_executable(${DEMO_NAME})
-
-# Add to default target if all required macros needed to run this demo are defined
-check_aws_credentials(${DEMO_NAME})
-
-target_sources(
+add_executable(
     ${DEMO_NAME}
-    PRIVATE
         "${DEMO_NAME}.c"
         "shadow_demo_helpers.c"
         ${MQTT_SOURCES}
@@ -27,6 +21,9 @@ target_sources(
         ${SHADOW_SOURCES}
         ${JSON_SOURCES}
 )
+
+# Add to default target if all required macros needed to run this demo are defined
+check_aws_credentials(${DEMO_NAME})
 
 target_link_libraries(
     ${DEMO_NAME}

--- a/docs/doxygen/building.dox
+++ b/docs/doxygen/building.dox
@@ -12,7 +12,7 @@ Linux platform. This SDK builds with [CMake](https://cmake.org/), a cross-platfo
 @brief Prerequisites needed to run the demos.
 
 @pre
-- CMake 3.13.0 or later and a C90 compiler.
+- CMake 3.2.0 or later and a C90 compiler.
 
 @pre
 - A supported operating system. The ports provided with this repo are expected to work with all recent versions of the following operating systems, although we cannot guarantee the behavior on all systems.

--- a/integration-test/mqtt/CMakeLists.txt
+++ b/integration-test/mqtt/CMakeLists.txt
@@ -1,5 +1,5 @@
 project ("mqtt system test")
-cmake_minimum_required (VERSION 3.13)
+cmake_minimum_required (VERSION 3.2.0)
 
 # Include MQTT library's source and header path variables.
 include("${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake")

--- a/integration-test/shadow/CMakeLists.txt
+++ b/integration-test/shadow/CMakeLists.txt
@@ -1,5 +1,5 @@
 project ("shadow system test")
-cmake_minimum_required (VERSION 3.13)
+cmake_minimum_required (VERSION 3.2.0)
 
 # Include MQTT library's source and header path variables.
 include("${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake")

--- a/platform/posix/transport/CMakeLists.txt
+++ b/platform/posix/transport/CMakeLists.txt
@@ -52,6 +52,8 @@ target_link_libraries( openssl_posix
                        PUBLIC
                           sockets_posix
                        PRIVATE
+                          # This variable is set by the built-in FindOpenSSL.cmake
+                          # and contains the path to the actual library.
                           ${OPENSSL_LIBRARIES}
                           # SSL uses Threads and on some platforms require
                           # explicit linking.

--- a/platform/posix/transport/CMakeLists.txt
+++ b/platform/posix/transport/CMakeLists.txt
@@ -52,8 +52,7 @@ target_link_libraries( openssl_posix
                        PUBLIC
                           sockets_posix
                        PRIVATE
-                          OpenSSL::Crypto
-                          OpenSSL::SSL
+                          ${OPENSSL_LIBRARIES}
                           # SSL uses Threads and on some platforms require
                           # explicit linking.
                           Threads::Threads

--- a/platform/posix/transport/utest/CMakeLists.txt
+++ b/platform/posix/transport/utest/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(${PLATFORM_DIR}/posix/posixFilePaths.cmake)
 project ("transport unit test")
-cmake_minimum_required (VERSION 3.13)
+cmake_minimum_required (VERSION 3.14)
 
 # CMock does not have a built-in C parser.
 # https://github.com/ThrowTheSwitch/CMock/issues/71

--- a/platform/posix/transport/utest/CMakeLists.txt
+++ b/platform/posix/transport/utest/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(${PLATFORM_DIR}/posix/posixFilePaths.cmake)
 project ("transport unit test")
-cmake_minimum_required (VERSION 3.14)
+cmake_minimum_required (VERSION 3.2.0)
 
 # CMock does not have a built-in C parser.
 # https://github.com/ThrowTheSwitch/CMock/issues/71

--- a/platform/posix/utest/CMakeLists.txt
+++ b/platform/posix/utest/CMakeLists.txt
@@ -1,4 +1,5 @@
 project ("posix unit test")
+cmake_minimum_required (VERSION 3.14)
 
 # ====================  Define your project name (edit) ========================
 set(project_name "posix")

--- a/platform/posix/utest/CMakeLists.txt
+++ b/platform/posix/utest/CMakeLists.txt
@@ -1,5 +1,5 @@
 project ("posix unit test")
-cmake_minimum_required (VERSION 3.14)
+cmake_minimum_required (VERSION 3.2.0)
 
 # ====================  Define your project name (edit) ========================
 set(project_name "posix")

--- a/tools/cmock/coverage.cmake
+++ b/tools/cmock/coverage.cmake
@@ -1,5 +1,5 @@
 # Taken from amazon-freertos repository
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.2.0)
 set(BINARY_DIR ${CMAKE_BINARY_DIR})
 # reset coverage counters
 execute_process(

--- a/tools/cmock/coverage.cmake
+++ b/tools/cmock/coverage.cmake
@@ -1,5 +1,5 @@
 # Taken from amazon-freertos repository
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.2)
 set(BINARY_DIR ${CMAKE_BINARY_DIR})
 # reset coverage counters
 execute_process(
@@ -26,7 +26,7 @@ file(WRITE ${REPORT_FILE} "")
 foreach(testname ${files})
     get_filename_component(test
                            ${testname}
-                           NAME_WLE
+                           NAME_WE
             )
     message("Running ${testname}")
     execute_process(COMMAND ${testname} OUTPUT_FILE ${CMAKE_BINARY_DIR}/${test}_out.txt)

--- a/tools/cmock/create_test.cmake
+++ b/tools/cmock/create_test.cmake
@@ -17,6 +17,9 @@ function(create_test test_name
                     ${test_name}_runner.c
                   DEPENDS ${test_src}
         )
+    link_directories(${CMAKE_CURRENT_BINARY_DIR}
+                     ${CMAKE_CURRENT_BINARY_DIR}/lib
+        )
     add_executable(${test_name} ${test_src} ${test_name}_runner.c)
     set_target_properties(${test_name} PROPERTIES
             COMPILE_FLAG "-O0 -ggdb"
@@ -31,10 +34,6 @@ function(create_test test_name
                                ${include_list}
         )
 
-    target_link_directories(${test_name} PUBLIC
-                            ${CMAKE_CURRENT_BINARY_DIR}
-        )
-
     # link all libraries sent through parameters
     foreach(link IN LISTS link_list)
         target_link_libraries(${test_name} ${link})
@@ -46,9 +45,6 @@ function(create_test test_name
         target_link_libraries(${test_name} ${dependency})
     endforeach()
     target_link_libraries(${test_name} -lgcov unity)
-    target_link_directories(${test_name}  PUBLIC
-                            ${CMAKE_CURRENT_BINARY_DIR}/lib
-            )
     add_test(NAME ${test_name}
              COMMAND ${CMAKE_BINARY_DIR}/bin/tests/${test_name}
              WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
@@ -104,7 +100,7 @@ function(create_mock_list mock_name
                 )
         get_filename_component(mock_file_name
                                ${mock_file}
-                               NAME_WLE
+                               NAME_WE
                 )
         get_filename_component(mock_file_dir
                                ${mock_file}


### PR DESCRIPTION
With these small changes, we can support CMake 3.2.0 or higher. Unfortunately, 3.1.0 has a bug in finding OpenSSL libraries, but CMake 3.2.0 has been tested to work. This change is especially useful for people with older Linux distros.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
