### PR TITLE
Add doxygen warning checks.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,7 @@ jobs:
           do
             cd $LIB
             echo $PWD
+            if [ ! -d docs/doxygen/ ]; then exit 0; fi
             doxygen docs/doxygen/config.doxyfile
             cd $ROOT
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,10 @@ jobs:
           for lib in $(find libraries/aws libraries/standard -maxdepth 1 -mindepth 1)
           do
             cd $lib
-            if [ ! -d docs/doxygen/ ]; then exit 0; fi
+            if [ ! -d docs/doxygen/ ]; then
+              echo "$lib has no Doxygen documentation."
+              exit 0
+            fi
             doxygen docs/doxygen/config.doxyfile
             cd $ROOT
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
             exit 0
           fi
   doxygen:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,11 +127,9 @@ jobs:
       - name: Run Doxygen on all library submodules
         run: |
           ROOT=$PWD
-          LIBS=$(find libraries/aws libraries/standard -maxdepth 1 -mindepth 1)
-          for LIB in $LIBS
+          for lib in $(find libraries/aws libraries/standard -maxdepth 1 -mindepth 1)
           do
-            cd $LIB
-            echo $PWD
+            cd $lib
             if [ ! -d docs/doxygen/ ]; then exit 0; fi
             doxygen docs/doxygen/config.doxyfile
             cd $ROOT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
           for LIB in $LIBS
           do
             cd $LIB
+            echo $PWD
             doxygen docs/doxygen/config.doxyfile
             cd $ROOT
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,3 +114,27 @@ jobs:
           else
             exit 0
           fi
+  doxygen:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install Doxygen
+        run: |
+          wget -qO- "http://doxygen.nl/files/doxygen-1.8.20.linux.bin.tar.gz" | sudo tar --strip-components=1 -xz -C /usr/local
+          sudo apt-get install -y libclang-9-dev
+      - name: Run Doxygen on all library submodules
+        run: |
+          ROOT=$PWD
+          LIBS=$(find libraries/aws libraries/standard -maxdepth 1 -mindepth 1)
+          for LIB in $LIBS
+          do
+            cd $LIB
+            doxygen docs/doxygen/config.doxyfile
+            cd $ROOT
+          done
+      - name: Run Doxygen on CSDK and verify stdout is empty
+        run: |
+          doxygen docs/doxygen/config.doxyfile 2>&1 | tee doxyoutput.txt
+          if [[ "$(wc -c < doxyoutput.txt | bc)" = "0" ]]; then exit 0; else exit 1; fi

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -7,4 +7,6 @@ The following libraries (along with their source repositories) are part of this 
 - [MQTT client](@ref mqtt) - [coreMQTT](https://github.com/FreeRTOS/coreMQTT)
 - [AWS IoT Device Shadow client](@ref shadow) - [device-shadow-for-aws-iot-embedded-sdk](https://github.com/aws/device-shadow-for-aws-iot-embedded-sdk)
 - [JSON parser](@ref json) - [coreJSON](https://github.com/FreeRTOS/coreJSON)
+
+@non_existent_command
 */

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -7,6 +7,4 @@ The following libraries (along with their source repositories) are part of this 
 - [MQTT client](@ref mqtt) - [coreMQTT](https://github.com/FreeRTOS/coreMQTT)
 - [AWS IoT Device Shadow client](@ref shadow) - [device-shadow-for-aws-iot-embedded-sdk](https://github.com/aws/device-shadow-for-aws-iot-embedded-sdk)
 - [JSON parser](@ref json) - [coreJSON](https://github.com/FreeRTOS/coreJSON)
-
-@non_existent_command
 */


### PR DESCRIPTION
### The Doxygen warning check do these steps:
- Recursively clone this repo.
- Run the Doxygen command on each of the library spoke repos. The warnings for the libraries are already checked in the library repo's themselves, so there is no need to check the output.
- Run the Doxygen command on this repo. Check the output for warnings. 

### Test:
- See commit 1a2b8db for the test that adds a warning in the CSDK doxygen. The check fails.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
