### PR TITLE
Modify CBMC proofs to make assumptions about malloc explicit.

### DIFF
--- a/cbmc/proofs/IotMqtt_DeserializeConnack/_IotMqtt_DeserializeConnack_harness.c
+++ b/cbmc/proofs/IotMqtt_DeserializeConnack/_IotMqtt_DeserializeConnack_harness.c
@@ -35,6 +35,7 @@ void harness()
     _mqttPacket_t connack;
 
     connack.pRemainingData = malloc( sizeof( uint8_t ) * connack.remainingLength );
+    __CPROVER_assume( connack.pRemainingData != NULL );
 
     _IotMqtt_DeserializeConnack( &connack );
 }

--- a/cbmc/proofs/IotMqtt_DeserializePuback/_IotMqtt_DeserializePuback_harness.c
+++ b/cbmc/proofs/IotMqtt_DeserializePuback/_IotMqtt_DeserializePuback_harness.c
@@ -35,6 +35,7 @@ void harness()
     _mqttPacket_t puback;
 
     puback.pRemainingData = malloc( sizeof( uint8_t ) * puback.remainingLength );
+    __CPROVER_assume( puback.pRemainingData != NULL );
 
     _IotMqtt_DeserializePuback( &puback );
 }

--- a/cbmc/proofs/IotMqtt_DeserializePublish/_IotMqtt_DeserializePublish_harness.c
+++ b/cbmc/proofs/IotMqtt_DeserializePublish/_IotMqtt_DeserializePublish_harness.c
@@ -36,6 +36,8 @@ void harness()
 
     publishInfo.pTopicName = malloc( publishInfo.topicNameLength );
     publishInfo.pPayload = malloc( publishInfo.payloadLength );
+    __CPROVER_assume( publishInfo.pTopicName != NULL );
+    __CPROVER_assume( publishInfo.pPayload != NULL );
 
     _mqttOperation_t operation;
     operation.u.publish.publishInfo = publishInfo;
@@ -43,7 +45,7 @@ void harness()
     _mqttPacket_t publish;
     publish.pRemainingData = malloc( sizeof( uint8_t ) * publish.remainingLength );
     publish.u.pIncomingPublish = &operation;
-
+    __CPROVER_assume( publish.pRemainingData != NULL );
 
     _IotMqtt_DeserializePublish( &publish );
 }

--- a/cbmc/proofs/IotMqtt_DeserializeSuback/_IotMqtt_DeserializeSuback_harness.c
+++ b/cbmc/proofs/IotMqtt_DeserializeSuback/_IotMqtt_DeserializeSuback_harness.c
@@ -40,6 +40,7 @@ void harness()
     __CPROVER_assume( suback.remainingLength <= BUFFER_SIZE );
     suback.pRemainingData = malloc( sizeof( uint8_t )
                                     * suback.remainingLength );
+    __CPROVER_assume( suback.pRemainingData != NULL );
 
     /* Create packet connection */
     IotMqttConnection_t pConn = allocate_IotMqttConnection( NULL );

--- a/cbmc/proofs/IotMqtt_DeserializeUnsuback/_IotMqtt_DeserializeUnsuback_harness.c
+++ b/cbmc/proofs/IotMqtt_DeserializeUnsuback/_IotMqtt_DeserializeUnsuback_harness.c
@@ -35,6 +35,7 @@ void harness()
     _mqttPacket_t unsuback;
 
     unsuback.pRemainingData = malloc( sizeof( uint8_t ) * unsuback.remainingLength );
+    __CPROVER_assume( unsuback.pRemainingData != NULL );
 
     _IotMqtt_DeserializeUnsuback( &unsuback );
 }

--- a/cbmc/proofs/mqtt_state.c
+++ b/cbmc/proofs/mqtt_state.c
@@ -36,7 +36,10 @@ void * malloc_can_fail( size_t size )
 
 void * allocate_opaque_type()
 {
-    return malloc( 1 ); /* consider using malloc(0) */
+    void * ptr = malloc( 1 );
+
+    __CPROVER_assume( ptr != NULL );
+    return ptr;
 }
 
 /****************************************************************


### PR DESCRIPTION
Some proofs assume that some pointers returned by malloc are not
NULL. This patch modifies those proofs to make these assumptions
explicit with __CPROVER_assume(pointer != NULL) for all such
pointers.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
