### PR TITLE
Temporarily update the Contributing guide to point to the current v202009.00 style guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ To send us a pull request, please:
 
 1. Fork the repository.
 1. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
-1. Ensure that your contributions conform to the [style guide](https://docs.aws.amazon.com/freertos/latest/lib-ref/c-sdk/main/guide_developer_styleguide.html).
+1. Ensure that your contributions conform to the [style guide](https://docs.aws.amazon.com/freertos/latest/lib-ref/embedded-csdk/202009.00/lib-ref/docs/doxygen/output/html/guide_developer_styleguide.html).
 1. Ensure local tests pass.
 1. Commit to your fork using clear commit messages.
 1. Send us a pull request, answering any default questions in the pull request interface.


### PR DESCRIPTION
Update the style guide link in the contributing guide to point to the publicly web hosted v202009.00 docs.

This is a temporary fix until we move the doxygen style guide to style_guide.md format. AN INTERNAL TRACKED ISSUE EXISTS FOR THIS TASK.

**Reasoning**:
We want to move the Doxygen style guide page to Mark Down because of the CSDK version in in the URL of the doxygen, see the bolded 202009.00 below:

docs.aws.amazon.com/freertos/latest/lib-ref/embedded-csdk/**202009.00**/lib-ref/docs/doxygen/output/html/guide_developer_styleguide.html

We want the link in tthe Contributing guide to always point to the latest style without having to come back and update this file for every release. 


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
