### PR TITLE
Add uniqueness to MQTT topics in integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,8 @@ jobs:
           -DBROKER_ENDPOINT="broker-endpoint" \
           -DCLIENT_CERT_PATH="cert/path" \
           -DROOT_CA_CERT_PATH="cert/path" \
-          -DCLIENT_PRIVATE_KEY_PATH="key/path"
+          -DCLIENT_PRIVATE_KEY_PATH="key/path" \
+          -DCLIENT_IDENTIFIER="ci-identifier"
       - name: Build Demos
         run: make -C build/ help | grep demo | tr -d '. ' | xargs make -C build/
       - name: Build System Tests

--- a/integration-test/mqtt/CMakeLists.txt
+++ b/integration-test/mqtt/CMakeLists.txt
@@ -66,6 +66,12 @@ if(BROKER_ENDPOINT)
             BROKER_ENDPOINT="${BROKER_ENDPOINT}"
     )
 endif()
+if(BROKER_ENDPOINT)
+    target_compile_definitions(
+        ${stest_name} PRIVATE
+            CLIENT_IDENTIFIER="${CLIENT_IDENTIFIER}"
+    )
+endif()
 if(ROOT_CA_CERT_PATH)
     target_compile_definitions(
         ${stest_name} PRIVATE

--- a/integration-test/mqtt/mqtt_system_test.c
+++ b/integration-test/mqtt/mqtt_system_test.c
@@ -47,7 +47,8 @@
 /* Include clock for timer. */
 #include "clock.h"
 
-/* Ensure that config macros, required for TLS connection, have been defined. */
+/* Ensure that config macros, required for the mutually authenticated MQTT connection,
+ * have been defined. */
 #ifndef BROKER_ENDPOINT
     #error "BROKER_ENDPOINT should be defined for the MQTT integration tests."
 #endif
@@ -62,6 +63,10 @@
 
 #ifndef CLIENT_PRIVATE_KEY_PATH
     #error "CLIENT_PRIVATE_KEY_PATH should be defined for the MQTT integration tests."
+#endif
+
+#ifndef CLIENT_IDENTIFIER
+    #error "CLIENT_IDENTIFIER should be defined for the MQTT integration tests."
 #endif
 
 /**
@@ -108,12 +113,12 @@
 /**
  * @brief Sample topic filter to subscribe to.
  */
-#define TEST_MQTT_TOPIC                         "/iot/integration/test"
+#define TEST_MQTT_TOPIC                         CLIENT_IDENTIFIER "/iot/integration/test"
 
 /**
  * @brief Sample topic filter 2 to use in tests.
  */
-#define TEST_MQTT_TOPIC_2                       "/iot/integration/test2"
+#define TEST_MQTT_TOPIC_2                       CLIENT_IDENTIFIER "/iot/integration/test2"
 
 /**
  * @brief Length of sample topic filter.
@@ -123,7 +128,7 @@
 /**
  * @brief Sample topic filter to subscribe to.
  */
-#define TEST_MQTT_LWT_TOPIC                     "/iot/integration/test/lwt"
+#define TEST_MQTT_LWT_TOPIC                     CLIENT_IDENTIFIER "/iot/integration/test/lwt"
 
 /**
  * @brief Length of sample topic filter.
@@ -138,7 +143,7 @@
 /**
  * @brief Client identifier for MQTT session in the tests.
  */
-#define TEST_CLIENT_IDENTIFIER                  "MQTT-Test"
+#define TEST_CLIENT_IDENTIFIER                  CLIENT_IDENTIFIER
 
 /**
  * @brief Length of the client identifier.
@@ -148,7 +153,7 @@
 /**
  * @brief Client identifier for use in LWT tests.
  */
-#define TEST_CLIENT_IDENTIFIER_LWT              "MQTT-Test-LWT"
+#define TEST_CLIENT_IDENTIFIER_LWT              CLIENT_IDENTIFIER "-LWT"
 
 /**
  * @brief Length of LWT client identifier.

--- a/integration-test/mqtt/test_config.h
+++ b/integration-test/mqtt/test_config.h
@@ -81,4 +81,10 @@
  * * #define ROOT_CA_CERT_PATH    "...insert here..."
  */
 
+/**
+ * @brief The unique client Identifier that will be used by the tests.
+ *
+ * #define CLIENT_IDENTIFIER    "...insert here..."
+ */
+
 #endif /* ifndef TEST_CONFIG_H_ */


### PR DESCRIPTION
Avoid interference of tests between parallel executions of integration tests against same broker due to use of the same MQTT topics.
Add configurable client ID as prefix to MQTT topics used in integration tests

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
