### PR TITLE
Readme info for maximum fragment length

### DIFF
--- a/external_libs/mbedTLS/README.txt
+++ b/external_libs/mbedTLS/README.txt
@@ -3,3 +3,7 @@
 # You'll need to download mbedTLS from the official ARMmbed repository and
 # place the files here. We recommend that you pick the latest version of 2.16
 # LTS release in order to have up-to-date security fixes.
+
+# Note that this SDK will not negotiate the TLS Maximum Fragment Length even if
+# it is enabled in mbedTLS' configuration. Therefore, you should ensure content
+# buffers used by mbedTLS are at least 16384 bytes in length.

--- a/external_libs/mbedTLS/README.txt
+++ b/external_libs/mbedTLS/README.txt
@@ -6,4 +6,5 @@
 
 # Note that this SDK will not negotiate the TLS Maximum Fragment Length even if
 # it is enabled in mbedTLS' configuration. Therefore, you should ensure content
-# buffers used by mbedTLS are at least 16384 bytes in length.
+# buffers used by mbedTLS are at least 16384 bytes in length to use the largest
+# maximum record length supported by TLS.

--- a/platform/linux/mbedtls/network_mbedtls_wrapper.c
+++ b/platform/linux/mbedtls/network_mbedtls_wrapper.c
@@ -213,6 +213,19 @@ IoT_Error_t iot_tls_connect(Network *pNetwork, TLSConnectParams *params) {
 		}
 	}
 
+    /* Set Maximum Fragment Length if enabled. */
+#ifdef MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
+	/* Enable the max fragment extension. 4096 bytes is currently the largest fragment size permitted.
+	 * See RFC 8449 https://tools.ietf.org/html/rfc8449 for more information.
+	 *
+	 * Smaller values can be found in "mbedtls/include/ssl.h".
+	 */
+	if((ret = mbedtls_ssl_conf_max_frag_len(&(tlsDataParams->conf), MBEDTLS_SSL_MAX_FRAG_LEN_4096)) != 0) {
+		IOT_ERROR(" failed\n  ! mbedtls_ssl_conf_max_frag_len returned -0x%x\n\n", -ret);
+		return SSL_CONNECTION_ERROR;
+	}
+#endif
+
 	/* Assign the resulting configuration to the SSL context. */
 	if((ret = mbedtls_ssl_setup(&(tlsDataParams->ssl), &(tlsDataParams->conf))) != 0) {
 		IOT_ERROR(" failed\n  ! mbedtls_ssl_setup returned -0x%x\n\n", -ret);

--- a/platform/linux/mbedtls/network_mbedtls_wrapper.c
+++ b/platform/linux/mbedtls/network_mbedtls_wrapper.c
@@ -213,19 +213,6 @@ IoT_Error_t iot_tls_connect(Network *pNetwork, TLSConnectParams *params) {
 		}
 	}
 
-    /* Set Maximum Fragment Length if enabled. */
-#ifdef MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
-	/* Enable the max fragment extension. 4096 bytes is currently the largest fragment size permitted.
-	 * See RFC 8449 https://tools.ietf.org/html/rfc8449 for more information.
-	 *
-	 * Smaller values can be found in "mbedtls/include/ssl.h".
-	 */
-	if((ret = mbedtls_ssl_conf_max_frag_len(&(tlsDataParams->conf), MBEDTLS_SSL_MAX_FRAG_LEN_4096)) != 0) {
-		IOT_ERROR(" failed\n  ! mbedtls_ssl_conf_max_frag_len returned -0x%x\n\n", -ret);
-		return SSL_CONNECTION_ERROR;
-	}
-#endif
-
 	/* Assign the resulting configuration to the SSL context. */
 	if((ret = mbedtls_ssl_setup(&(tlsDataParams->ssl), &(tlsDataParams->conf))) != 0) {
 		IOT_ERROR(" failed\n  ! mbedtls_ssl_setup returned -0x%x\n\n", -ret);


### PR DESCRIPTION
*Description of changes:*
Adds some information in mbedtls README about the max fragment length extension

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
