### PR TITLE
Make CBMC run with all property checking flags.

### DIFF
--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -119,6 +119,8 @@ CBMCFLAGS += \
 	--undefined-shift-check \
 	--unsigned-overflow-check \
 	--unwinding-assertions \
+	--malloc-fail-null \
+	--malloc-may-fail
 
 goto: $(ENTRY).goto
 


### PR DESCRIPTION
This pull request adds to the list of undefined behaviors that CBMC checks for, and it runs CBMC with the new model of malloc that allows malloc either to fail and return NULL or return a valid pointer.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
