### PR TITLE
TRANSPORT_SEND_RECEIVE_TIMEOUT_MS was too short

### DIFF
--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -167,7 +167,7 @@
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
-#define TRANSPORT_SEND_RECV_TIMEOUT_MS      ( 200 )
+#define TRANSPORT_SEND_RECV_TIMEOUT_MS      ( 500 )
 
 /*-----------------------------------------------------------*/
 

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -245,7 +245,7 @@
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
-#define TRANSPORT_SEND_RECV_TIMEOUT_MS      ( 100 )
+#define TRANSPORT_SEND_RECV_TIMEOUT_MS      ( 500 )
 
 /**
  * @brief The MQTT metrics string expected by AWS IoT.

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
@@ -149,7 +149,7 @@
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
-#define TRANSPORT_SEND_RECV_TIMEOUT_MS      ( 20 )
+#define TRANSPORT_SEND_RECV_TIMEOUT_MS      ( 500 )
 
 /*-----------------------------------------------------------*/
 

--- a/demos/mqtt/mqtt_demo_serializer/mqtt_demo_serializer.c
+++ b/demos/mqtt/mqtt_demo_serializer/mqtt_demo_serializer.c
@@ -106,7 +106,7 @@
 /**
  * @brief Socket layer transportTimeout in milliseconds.
  */
-#define TRANSPORT_SEND_RECV_TIMEOUT_MS       ( 200U )
+#define TRANSPORT_SEND_RECV_TIMEOUT_MS       ( 500U )
 
 /**
  * @brief Number of time network receive will be attempted

--- a/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
+++ b/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
@@ -216,7 +216,7 @@
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
-#define TRANSPORT_SEND_RECV_TIMEOUT_MS          ( 200 )
+#define TRANSPORT_SEND_RECV_TIMEOUT_MS          ( 500 )
 
 /*-----------------------------------------------------------*/
 

--- a/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
+++ b/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
@@ -145,7 +145,7 @@
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
-#define TRANSPORT_SEND_RECV_TIMEOUT_MS      ( 100 )
+#define TRANSPORT_SEND_RECV_TIMEOUT_MS      ( 500 )
 
 /**
  * @brief The MQTT metrics string expected by AWS IoT.


### PR DESCRIPTION
*Issue #, if available:*

None.

*Description of changes:*

In trying to connect to **eu-west-1**, from Australia, the default timeouts in some of the demos were too short. Suffering SSL handshake failures. MQTT mutual auth, shadows and subscription manager. Changed the other demos just for consistency. 

Cost me an hour to figure it out (assumed it was a certificate issue at first). Hopefully this saves someone else an hour. I think there's not much downside to a longer timeout in demo code.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
