### PR TITLE
HTTP Library: Update .method to .pMethod + Update Return Enums

### DIFF
--- a/demos/http/common/include/http_demo_utils.h
+++ b/demos/http/common/include/http_demo_utils.h
@@ -77,7 +77,7 @@ int32_t connectToServerWithBackoffRetries( TransportConnect_t connectFunction,
  * @return The status of the parsing attempt:
  * HTTPSuccess if the path was successfully parsed,
  * HTTP_PARSER_INTERNAL_ERROR if there was an error parsing the URL,
- * or HTTP_NO_RESPONSE if the path was not found.
+ * or HTTPNoResponse if the path was not found.
  */
 HTTPStatus_t getUrlPath( const char * pUrl,
                          size_t urlLen,
@@ -107,7 +107,7 @@ HTTPStatus_t getUrlPath( const char * pUrl,
  * @return The status of the parsing attempt:
  * HTTPSuccess if the path was successfully parsed,
  * HTTP_PARSER_INTERNAL_ERROR if there was an error parsing the URL,
- * or HTTP_NO_RESPONSE if the path was not found.
+ * or HTTPNoResponse if the path was not found.
  */
 HTTPStatus_t getUrlAddress( const char * pUrl,
                             size_t urlLen,

--- a/demos/http/common/include/http_demo_utils.h
+++ b/demos/http/common/include/http_demo_utils.h
@@ -75,7 +75,7 @@ int32_t connectToServerWithBackoffRetries( TransportConnect_t connectFunction,
  * @param[out] pPathLen Length of the path.
  *
  * @return The status of the parsing attempt:
- * HTTP_SUCCESS if the path was successfully parsed,
+ * HTTPSuccess if the path was successfully parsed,
  * HTTP_PARSER_INTERNAL_ERROR if there was an error parsing the URL,
  * or HTTP_NO_RESPONSE if the path was not found.
  */
@@ -105,7 +105,7 @@ HTTPStatus_t getUrlPath( const char * pUrl,
  * @param[out] pAddressLen Length of the address.
  *
  * @return The status of the parsing attempt:
- * HTTP_SUCCESS if the path was successfully parsed,
+ * HTTPSuccess if the path was successfully parsed,
  * HTTP_PARSER_INTERNAL_ERROR if there was an error parsing the URL,
  * or HTTP_NO_RESPONSE if the path was not found.
  */

--- a/demos/http/common/include/http_demo_utils.h
+++ b/demos/http/common/include/http_demo_utils.h
@@ -76,7 +76,7 @@ int32_t connectToServerWithBackoffRetries( TransportConnect_t connectFunction,
  *
  * @return The status of the parsing attempt:
  * HTTPSuccess if the path was successfully parsed,
- * HTTP_PARSER_INTERNAL_ERROR if there was an error parsing the URL,
+ * HTTPParserInternalError if there was an error parsing the URL,
  * or HTTPNoResponse if the path was not found.
  */
 HTTPStatus_t getUrlPath( const char * pUrl,
@@ -106,7 +106,7 @@ HTTPStatus_t getUrlPath( const char * pUrl,
  *
  * @return The status of the parsing attempt:
  * HTTPSuccess if the path was successfully parsed,
- * HTTP_PARSER_INTERNAL_ERROR if there was an error parsing the URL,
+ * HTTPParserInternalError if there was an error parsing the URL,
  * or HTTPNoResponse if the path was not found.
  */
 HTTPStatus_t getUrlAddress( const char * pUrl,

--- a/demos/http/common/src/http_demo_utils.c
+++ b/demos/http/common/src/http_demo_utils.c
@@ -238,7 +238,7 @@ bool getS3ObjectFileSize( size_t * pFileSize,
     /* Initialize the request object. */
     requestInfo.pHost = pHost;
     requestInfo.hostLen = hostLen;
-    requestInfo.method = HTTP_METHOD_GET;
+    requestInfo.pMethod = HTTP_METHOD_GET;
     requestInfo.methodLen = sizeof( HTTP_METHOD_GET ) - 1;
     requestInfo.pPath = pPath;
     requestInfo.pathLen = strlen( pPath );

--- a/demos/http/common/src/http_demo_utils.c
+++ b/demos/http/common/src/http_demo_utils.c
@@ -116,7 +116,7 @@ HTTPStatus_t getUrlPath( const char * pUrl,
                         ( int32_t ) urlLen,
                         pUrl,
                         parserStatus ) );
-            httpStatus = HTTP_PARSER_INTERNAL_ERROR;
+            httpStatus = HTTPParserInternalError;
         }
     }
 
@@ -176,7 +176,7 @@ HTTPStatus_t getUrlAddress( const char * pUrl,
                         ( int32_t ) urlLen,
                         pUrl,
                         parserStatus ) );
-            httpStatus = HTTP_PARSER_INTERNAL_ERROR;
+            httpStatus = HTTPParserInternalError;
         }
     }
 

--- a/demos/http/common/src/http_demo_utils.c
+++ b/demos/http/common/src/http_demo_utils.c
@@ -95,7 +95,7 @@ HTTPStatus_t getUrlPath( const char * pUrl,
     /* http-parser status. Initialized to 1 to signify failure. */
     int parserStatus = 1;
     struct http_parser_url urlParser;
-    HTTPStatus_t httpStatus = HTTP_SUCCESS;
+    HTTPStatus_t httpStatus = HTTPSuccess;
 
     /* Sets all members in urlParser to 0. */
     http_parser_url_init( &urlParser );
@@ -106,7 +106,7 @@ HTTPStatus_t getUrlPath( const char * pUrl,
         httpStatus = HTTP_INVALID_PARAMETER;
     }
 
-    if( httpStatus == HTTP_SUCCESS )
+    if( httpStatus == HTTPSuccess )
     {
         parserStatus = http_parser_parse_url( pUrl, urlLen, 0, &urlParser );
 
@@ -120,7 +120,7 @@ HTTPStatus_t getUrlPath( const char * pUrl,
         }
     }
 
-    if( httpStatus == HTTP_SUCCESS )
+    if( httpStatus == HTTPSuccess )
     {
         *pPathLen = ( size_t ) ( urlParser.field_data[ UF_PATH ].len );
 
@@ -135,7 +135,7 @@ HTTPStatus_t getUrlPath( const char * pUrl,
         }
     }
 
-    if( httpStatus != HTTP_SUCCESS )
+    if( httpStatus != HTTPSuccess )
     {
         LogError( ( "Error parsing the path from URL %s. Error code: %d",
                     pUrl,
@@ -155,7 +155,7 @@ HTTPStatus_t getUrlAddress( const char * pUrl,
     /* http-parser status. Initialized to 1 to signify failure. */
     int parserStatus = 1;
     struct http_parser_url urlParser;
-    HTTPStatus_t httpStatus = HTTP_SUCCESS;
+    HTTPStatus_t httpStatus = HTTPSuccess;
 
     /* Sets all members in urlParser to 0. */
     http_parser_url_init( &urlParser );
@@ -166,7 +166,7 @@ HTTPStatus_t getUrlAddress( const char * pUrl,
         httpStatus = HTTP_INVALID_PARAMETER;
     }
 
-    if( httpStatus == HTTP_SUCCESS )
+    if( httpStatus == HTTPSuccess )
     {
         parserStatus = http_parser_parse_url( pUrl, urlLen, 0, &urlParser );
 
@@ -180,7 +180,7 @@ HTTPStatus_t getUrlAddress( const char * pUrl,
         }
     }
 
-    if( httpStatus == HTTP_SUCCESS )
+    if( httpStatus == HTTPSuccess )
     {
         *pAddressLen = ( size_t ) ( urlParser.field_data[ UF_HOST ].len );
 
@@ -195,7 +195,7 @@ HTTPStatus_t getUrlAddress( const char * pUrl,
         }
     }
 
-    if( httpStatus != HTTP_SUCCESS )
+    if( httpStatus != HTTPSuccess )
     {
         LogError( ( "Error parsing the address from URL %s. Error code %d",
                     pUrl,
@@ -214,7 +214,7 @@ bool getS3ObjectFileSize( size_t * pFileSize,
                           const char * pPath )
 {
     bool returnStatus = false;
-    HTTPStatus_t httpStatus = HTTP_SUCCESS;
+    HTTPStatus_t httpStatus = HTTPSuccess;
     HTTPRequestHeaders_t requestHeaders;
     HTTPRequestInfo_t requestInfo;
     HTTPResponse_t response;
@@ -262,7 +262,7 @@ bool getS3ObjectFileSize( size_t * pFileSize,
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders,
                                                       &requestInfo );
 
-    if( httpStatus == HTTP_SUCCESS )
+    if( httpStatus == HTTPSuccess )
     {
         /* Add the header to get bytes=0-0. S3 will respond with a Content-Range
          * header that contains the size of the file in it. This header will
@@ -271,7 +271,7 @@ bool getS3ObjectFileSize( size_t * pFileSize,
         httpStatus = HTTPClient_AddRangeHeader( &requestHeaders, 0, 0 );
     }
 
-    if( httpStatus == HTTP_SUCCESS )
+    if( httpStatus == HTTPSuccess )
     {
         /* Send the request and receive the response. */
         httpStatus = HTTPClient_Send( pTransportInterface,
@@ -282,7 +282,7 @@ bool getS3ObjectFileSize( size_t * pFileSize,
                                       0 );
     }
 
-    if( httpStatus == HTTP_SUCCESS )
+    if( httpStatus == HTTPSuccess )
     {
         LogDebug( ( "Received HTTP response from %s%s...",
                     pHost, pPath ) );
@@ -320,7 +320,7 @@ bool getS3ObjectFileSize( size_t * pFileSize,
                     response.statusCode ) );
     }
 
-    if( ( returnStatus == true ) && ( httpStatus == HTTP_SUCCESS ) )
+    if( ( returnStatus == true ) && ( httpStatus == HTTPSuccess ) )
     {
         /* Parse the Content-Range header value to get the file size. */
         pFileSizeStr = strstr( contentRangeValStr, "/" );
@@ -349,12 +349,12 @@ bool getS3ObjectFileSize( size_t * pFileSize,
                     HTTPClient_strerror( httpStatus ) ) );
     }
 
-    if( ( returnStatus == false ) || ( httpStatus != HTTP_SUCCESS ) )
+    if( ( returnStatus == false ) || ( httpStatus != HTTPSuccess ) )
     {
         LogError( ( "An error occurred in getting the file size from %s. Error=%s.",
                     pHost,
                     HTTPClient_strerror( httpStatus ) ) );
     }
 
-    return( ( returnStatus == true ) && ( httpStatus == HTTP_SUCCESS ) );
+    return( ( returnStatus == true ) && ( httpStatus == HTTPSuccess ) );
 }

--- a/demos/http/common/src/http_demo_utils.c
+++ b/demos/http/common/src/http_demo_utils.c
@@ -126,7 +126,7 @@ HTTPStatus_t getUrlPath( const char * pUrl,
 
         if( *pPathLen == 0 )
         {
-            httpStatus = HTTP_NO_RESPONSE;
+            httpStatus = HTTPNoResponse;
             *pPath = NULL;
         }
         else
@@ -186,7 +186,7 @@ HTTPStatus_t getUrlAddress( const char * pUrl,
 
         if( *pAddressLen == 0 )
         {
-            httpStatus = HTTP_NO_RESPONSE;
+            httpStatus = HTTPNoResponse;
             *pAddress = NULL;
         }
         else

--- a/demos/http/common/src/http_demo_utils.c
+++ b/demos/http/common/src/http_demo_utils.c
@@ -103,7 +103,7 @@ HTTPStatus_t getUrlPath( const char * pUrl,
     if( ( pUrl == NULL ) || ( pPath == NULL ) || ( pPathLen == NULL ) )
     {
         LogError( ( "NULL parameter passed to getUrlPath()." ) );
-        httpStatus = HTTP_INVALID_PARAMETER;
+        httpStatus = HTTPInvalidParameter;
     }
 
     if( httpStatus == HTTPSuccess )
@@ -163,7 +163,7 @@ HTTPStatus_t getUrlAddress( const char * pUrl,
     if( ( pUrl == NULL ) || ( pAddress == NULL ) || ( pAddressLen == NULL ) )
     {
         LogError( ( "NULL parameter passed to getUrlAddress()." ) );
-        httpStatus = HTTP_INVALID_PARAMETER;
+        httpStatus = HTTPInvalidParameter;
     }
 
     if( httpStatus == HTTPSuccess )
@@ -338,7 +338,7 @@ bool getS3ObjectFileSize( size_t * pFileSize,
         {
             LogError( ( "Error using strtoul to get the file size from %s: fileSize=%d.",
                         pFileSizeStr, ( int32_t ) *pFileSize ) );
-            httpStatus = HTTP_INVALID_PARAMETER;
+            httpStatus = HTTPInvalidParameter;
         }
 
         LogInfo( ( "The file is %d bytes long.", ( int32_t ) *pFileSize ) );

--- a/demos/http/common/src/presigned_urls_gen.py
+++ b/demos/http/common/src/presigned_urls_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import boto3
 from botocore.client import Config

--- a/demos/http/http_demo_basic_tls/http_demo_basic_tls.c
+++ b/demos/http/http_demo_basic_tls/http_demo_basic_tls.c
@@ -276,7 +276,7 @@ static int32_t sendHttpRequest( const TransportInterface_t * pTransportInterface
     HTTPRequestHeaders_t requestHeaders;
 
     /* Return value of all methods from the HTTP Client library API. */
-    HTTPStatus_t httpStatus = HTTP_SUCCESS;
+    HTTPStatus_t httpStatus = HTTPSuccess;
 
     assert( pMethod != NULL );
     assert( pPath != NULL );
@@ -305,7 +305,7 @@ static int32_t sendHttpRequest( const TransportInterface_t * pTransportInterface
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders,
                                                       &requestInfo );
 
-    if( httpStatus == HTTP_SUCCESS )
+    if( httpStatus == HTTPSuccess )
     {
         /* Initialize the response object. The same buffer used for storing
          * request headers is reused here. */
@@ -336,7 +336,7 @@ static int32_t sendHttpRequest( const TransportInterface_t * pTransportInterface
                     HTTPClient_strerror( httpStatus ) ) );
     }
 
-    if( httpStatus == HTTP_SUCCESS )
+    if( httpStatus == HTTPSuccess )
     {
         LogInfo( ( "Received HTTP response from %.*s%.*s...\n"
                    "Response Headers:\n%.*s\n"
@@ -357,7 +357,7 @@ static int32_t sendHttpRequest( const TransportInterface_t * pTransportInterface
                     HTTPClient_strerror( httpStatus ) ) );
     }
 
-    if( httpStatus != HTTP_SUCCESS )
+    if( httpStatus != HTTPSuccess )
     {
         returnStatus = EXIT_FAILURE;
     }

--- a/demos/http/http_demo_basic_tls/http_demo_basic_tls.c
+++ b/demos/http/http_demo_basic_tls/http_demo_basic_tls.c
@@ -289,7 +289,7 @@ static int32_t sendHttpRequest( const TransportInterface_t * pTransportInterface
     /* Initialize the request object. */
     requestInfo.pHost = SERVER_HOST;
     requestInfo.hostLen = SERVER_HOST_LENGTH;
-    requestInfo.method = pMethod;
+    requestInfo.pMethod = pMethod;
     requestInfo.methodLen = methodLen;
     requestInfo.pPath = pPath;
     requestInfo.pathLen = pathLen;
@@ -313,7 +313,7 @@ static int32_t sendHttpRequest( const TransportInterface_t * pTransportInterface
         response.bufferLen = USER_BUFFER_LENGTH;
 
         LogInfo( ( "Sending HTTP %.*s request to %.*s%.*s...",
-                   ( int32_t ) requestInfo.methodLen, requestInfo.method,
+                   ( int32_t ) requestInfo.methodLen, requestInfo.pMethod,
                    ( int32_t ) SERVER_HOST_LENGTH, SERVER_HOST,
                    ( int32_t ) requestInfo.pathLen, requestInfo.pPath ) );
         LogDebug( ( "Request Headers:\n%.*s\n"
@@ -351,7 +351,7 @@ static int32_t sendHttpRequest( const TransportInterface_t * pTransportInterface
     else
     {
         LogError( ( "Failed to send HTTP %.*s request to %.*s%.*s: Error=%s.",
-                    ( int32_t ) requestInfo.methodLen, requestInfo.method,
+                    ( int32_t ) requestInfo.methodLen, requestInfo.pMethod,
                     ( int32_t ) SERVER_HOST_LENGTH, SERVER_HOST,
                     ( int32_t ) requestInfo.pathLen, requestInfo.pPath,
                     HTTPClient_strerror( httpStatus ) ) );

--- a/demos/http/http_demo_mutual_auth/http_demo_mutual_auth.c
+++ b/demos/http/http_demo_mutual_auth/http_demo_mutual_auth.c
@@ -244,7 +244,7 @@ static int32_t sendHttpRequest( const TransportInterface_t * pTransportInterface
     /* Initialize the request object. */
     requestInfo.pHost = AWS_IOT_ENDPOINT;
     requestInfo.hostLen = AWS_IOT_ENDPOINT_LENGTH;
-    requestInfo.method = pMethod;
+    requestInfo.pMethod = pMethod;
     requestInfo.methodLen = methodLen;
     requestInfo.pPath = pPath;
     requestInfo.pathLen = pathLen;
@@ -268,7 +268,7 @@ static int32_t sendHttpRequest( const TransportInterface_t * pTransportInterface
         response.bufferLen = USER_BUFFER_LENGTH;
 
         LogInfo( ( "Sending HTTP %.*s request to %.*s%.*s...",
-                   ( int32_t ) requestInfo.methodLen, requestInfo.method,
+                   ( int32_t ) requestInfo.methodLen, requestInfo.pMethod,
                    ( int32_t ) AWS_IOT_ENDPOINT_LENGTH, AWS_IOT_ENDPOINT,
                    ( int32_t ) requestInfo.pathLen, requestInfo.pPath ) );
         LogDebug( ( "Request Headers:\n%.*s\n"
@@ -306,7 +306,7 @@ static int32_t sendHttpRequest( const TransportInterface_t * pTransportInterface
     else
     {
         LogError( ( "Failed to send HTTP %.*s request to %.*s%.*s: Error=%s.",
-                    ( int32_t ) requestInfo.methodLen, requestInfo.method,
+                    ( int32_t ) requestInfo.methodLen, requestInfo.pMethod,
                     ( int32_t ) AWS_IOT_ENDPOINT_LENGTH, AWS_IOT_ENDPOINT,
                     ( int32_t ) requestInfo.pathLen, requestInfo.pPath,
                     HTTPClient_strerror( httpStatus ) ) );

--- a/demos/http/http_demo_mutual_auth/http_demo_mutual_auth.c
+++ b/demos/http/http_demo_mutual_auth/http_demo_mutual_auth.c
@@ -231,7 +231,7 @@ static int32_t sendHttpRequest( const TransportInterface_t * pTransportInterface
     HTTPRequestHeaders_t requestHeaders;
 
     /* Return value of all methods from the HTTP Client library API. */
-    HTTPStatus_t httpStatus = HTTP_SUCCESS;
+    HTTPStatus_t httpStatus = HTTPSuccess;
 
     assert( pMethod != NULL );
     assert( pPath != NULL );
@@ -260,7 +260,7 @@ static int32_t sendHttpRequest( const TransportInterface_t * pTransportInterface
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders,
                                                       &requestInfo );
 
-    if( httpStatus == HTTP_SUCCESS )
+    if( httpStatus == HTTPSuccess )
     {
         /* Initialize the response object. The same buffer used for storing
          * request headers is reused here. */
@@ -291,7 +291,7 @@ static int32_t sendHttpRequest( const TransportInterface_t * pTransportInterface
                     HTTPClient_strerror( httpStatus ) ) );
     }
 
-    if( httpStatus == HTTP_SUCCESS )
+    if( httpStatus == HTTPSuccess )
     {
         LogInfo( ( "Received HTTP response from %.*s%.*s...\n"
                    "Response Headers:\n%.*s\n"
@@ -312,7 +312,7 @@ static int32_t sendHttpRequest( const TransportInterface_t * pTransportInterface
                     HTTPClient_strerror( httpStatus ) ) );
     }
 
-    if( httpStatus != HTTP_SUCCESS )
+    if( httpStatus != HTTPSuccess )
     {
         returnStatus = EXIT_FAILURE;
     }

--- a/demos/http/http_demo_plaintext/http_demo_plaintext.c
+++ b/demos/http/http_demo_plaintext/http_demo_plaintext.c
@@ -256,7 +256,7 @@ static int32_t sendHttpRequest( const TransportInterface_t * pTransportInterface
     HTTPRequestHeaders_t requestHeaders;
 
     /* Return value of all methods from the HTTP Client library API. */
-    HTTPStatus_t httpStatus = HTTP_SUCCESS;
+    HTTPStatus_t httpStatus = HTTPSuccess;
 
     assert( pMethod != NULL );
     assert( pPath != NULL );
@@ -285,7 +285,7 @@ static int32_t sendHttpRequest( const TransportInterface_t * pTransportInterface
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders,
                                                       &requestInfo );
 
-    if( httpStatus == HTTP_SUCCESS )
+    if( httpStatus == HTTPSuccess )
     {
         /* Initialize the response object. The same buffer used for storing
          * request headers is reused here. */
@@ -316,7 +316,7 @@ static int32_t sendHttpRequest( const TransportInterface_t * pTransportInterface
                     HTTPClient_strerror( httpStatus ) ) );
     }
 
-    if( httpStatus == HTTP_SUCCESS )
+    if( httpStatus == HTTPSuccess )
     {
         LogInfo( ( "Received HTTP response from %.*s%.*s...\n"
                    "Response Headers:\n%.*s\n"
@@ -337,7 +337,7 @@ static int32_t sendHttpRequest( const TransportInterface_t * pTransportInterface
                     HTTPClient_strerror( httpStatus ) ) );
     }
 
-    if( httpStatus != HTTP_SUCCESS )
+    if( httpStatus != HTTPSuccess )
     {
         returnStatus = EXIT_FAILURE;
     }

--- a/demos/http/http_demo_plaintext/http_demo_plaintext.c
+++ b/demos/http/http_demo_plaintext/http_demo_plaintext.c
@@ -269,7 +269,7 @@ static int32_t sendHttpRequest( const TransportInterface_t * pTransportInterface
     /* Initialize the request object. */
     requestInfo.pHost = SERVER_HOST;
     requestInfo.hostLen = SERVER_HOST_LENGTH;
-    requestInfo.method = pMethod;
+    requestInfo.pMethod = pMethod;
     requestInfo.methodLen = methodLen;
     requestInfo.pPath = pPath;
     requestInfo.pathLen = pathLen;
@@ -293,7 +293,7 @@ static int32_t sendHttpRequest( const TransportInterface_t * pTransportInterface
         response.bufferLen = USER_BUFFER_LENGTH;
 
         LogInfo( ( "Sending HTTP %.*s request to %.*s%.*s...",
-                   ( int32_t ) requestInfo.methodLen, requestInfo.method,
+                   ( int32_t ) requestInfo.methodLen, requestInfo.pMethod,
                    ( int32_t ) SERVER_HOST_LENGTH, SERVER_HOST,
                    ( int32_t ) requestInfo.pathLen, requestInfo.pPath ) );
         LogDebug( ( "Request Headers:\n%.*s\n"
@@ -331,7 +331,7 @@ static int32_t sendHttpRequest( const TransportInterface_t * pTransportInterface
     else
     {
         LogError( ( "Failed to send HTTP %.*s request to %.*s%.*s: Error=%s.",
-                    ( int32_t ) requestInfo.methodLen, requestInfo.method,
+                    ( int32_t ) requestInfo.methodLen, requestInfo.pMethod,
                     ( int32_t ) SERVER_HOST_LENGTH, SERVER_HOST,
                     ( int32_t ) requestInfo.pathLen, requestInfo.pPath,
                     HTTPClient_strerror( httpStatus ) ) );

--- a/demos/http/http_demo_s3_download/http_demo_s3_download.c
+++ b/demos/http/http_demo_s3_download/http_demo_s3_download.c
@@ -165,7 +165,7 @@ static bool downloadS3ObjectFile( const TransportInterface_t * pTransportInterfa
 static int32_t connectToServer( NetworkContext_t * pNetworkContext )
 {
     int32_t returnStatus = EXIT_FAILURE;
-    HTTPStatus_t httpStatus = HTTP_SUCCESS;
+    HTTPStatus_t httpStatus = HTTPSuccess;
 
     /* The location of the host address within the pre-signed URL. */
     const char * pAddress = NULL;
@@ -187,7 +187,7 @@ static int32_t connectToServer( NetworkContext_t * pNetworkContext )
                                 &pAddress,
                                 &serverHostLength );
 
-    returnStatus = ( httpStatus == HTTP_SUCCESS ) ? EXIT_SUCCESS : EXIT_FAILURE;
+    returnStatus = ( httpStatus == HTTPSuccess ) ? EXIT_SUCCESS : EXIT_FAILURE;
 
     if( returnStatus == EXIT_SUCCESS )
     {
@@ -226,7 +226,7 @@ static bool downloadS3ObjectFile( const TransportInterface_t * pTransportInterfa
                                   const char * pPath )
 {
     bool returnStatus = false;
-    HTTPStatus_t httpStatus = HTTP_SUCCESS;
+    HTTPStatus_t httpStatus = HTTPSuccess;
 
     /* The size of the file we are trying to download in S3. */
     size_t fileSize = 0;
@@ -285,12 +285,12 @@ static bool downloadS3ObjectFile( const TransportInterface_t * pTransportInterfa
     /* Here we iterate sending byte range requests until the full file has been
      * downloaded. We keep track of the next byte to download with curByte. When
      * this reaches the fileSize we stop downloading. */
-    while( ( returnStatus == true ) && ( httpStatus == HTTP_SUCCESS ) && ( curByte < fileSize ) )
+    while( ( returnStatus == true ) && ( httpStatus == HTTPSuccess ) && ( curByte < fileSize ) )
     {
         httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders,
                                                           &requestInfo );
 
-        if( httpStatus == HTTP_SUCCESS )
+        if( httpStatus == HTTPSuccess )
         {
             httpStatus = HTTPClient_AddRangeHeader( &requestHeaders,
                                                     curByte,
@@ -302,7 +302,7 @@ static bool downloadS3ObjectFile( const TransportInterface_t * pTransportInterfa
                         HTTPClient_strerror( httpStatus ) ) );
         }
 
-        if( httpStatus == HTTP_SUCCESS )
+        if( httpStatus == HTTPSuccess )
         {
             LogInfo( ( "Downloading bytes %d-%d, out of %d total bytes, from %s...:  ",
                        ( int32_t ) ( curByte ),
@@ -325,7 +325,7 @@ static bool downloadS3ObjectFile( const TransportInterface_t * pTransportInterfa
                         HTTPClient_strerror( httpStatus ) ) );
         }
 
-        if( httpStatus == HTTP_SUCCESS )
+        if( httpStatus == HTTPSuccess )
         {
             LogDebug( ( "Received HTTP response from %s%s...",
                         serverHost, pPath ) );
@@ -362,7 +362,7 @@ static bool downloadS3ObjectFile( const TransportInterface_t * pTransportInterfa
         }
     }
 
-    return( ( returnStatus == true ) && ( httpStatus == HTTP_SUCCESS ) );
+    return( ( returnStatus == true ) && ( httpStatus == HTTPSuccess ) );
 }
 
 /*-----------------------------------------------------------*/
@@ -389,7 +389,7 @@ int main( int argc,
     /* Return value of private functions. */
     bool ret = false;
     /* HTTPS Client library return status. */
-    HTTPStatus_t httpStatus = HTTP_SUCCESS;
+    HTTPStatus_t httpStatus = HTTPSuccess;
 
     /* The length of the path within the pre-signed URL. This variable is
      * defined in order to store the length returned from parsing the URL, but
@@ -455,7 +455,7 @@ int main( int argc,
                                      &pPath,
                                      &pathLen );
 
-            returnStatus = ( httpStatus == HTTP_SUCCESS ) ? EXIT_SUCCESS : EXIT_FAILURE;
+            returnStatus = ( httpStatus == HTTPSuccess ) ? EXIT_SUCCESS : EXIT_FAILURE;
         }
 
         if( returnStatus == EXIT_SUCCESS )

--- a/demos/http/http_demo_s3_download/http_demo_s3_download.c
+++ b/demos/http/http_demo_s3_download/http_demo_s3_download.c
@@ -247,7 +247,7 @@ static bool downloadS3ObjectFile( const TransportInterface_t * pTransportInterfa
     /* Initialize the request object. */
     requestInfo.pHost = serverHost;
     requestInfo.hostLen = serverHostLength;
-    requestInfo.method = HTTP_METHOD_GET;
+    requestInfo.pMethod = HTTP_METHOD_GET;
     requestInfo.methodLen = HTTP_METHOD_GET_LENGTH;
     requestInfo.pPath = pPath;
     requestInfo.pathLen = strlen( pPath );

--- a/demos/http/http_demo_s3_download_multithreaded/http_demo_s3_download_multithreaded.c
+++ b/demos/http/http_demo_s3_download_multithreaded/http_demo_s3_download_multithreaded.c
@@ -293,7 +293,7 @@ static int connectToServer( NetworkContext_t * pNetworkContext )
     ServerInfo_t serverInfo = { 0 };
 
     /* The host address string extracted from S3_PRESIGNED_GET_URL. */
-    char serverHost[ sizeof( S3_PRESIGNED_GET_URL ) ];
+    char serverHost[ sizeof( S3_PRESIGNED_GET_URL ) ] = { 0 };
 
     /* Initialize TLS credentials. */
     opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
@@ -956,6 +956,13 @@ int main( int argc,
 
             queueSettings.mq_msgsize = sizeof( ResponseItem_t );
 
+            if( requestQueue == -1 )
+            {
+                LogError( ( "Failed to open request queue with error %s.",
+                            strerror( errno ) ) );
+                returnStatus = EXIT_FAILURE;
+            }
+
             responseQueue = mq_open( RESPONSE_QUEUE,
 
                                      /* These options create a queue if it does
@@ -966,13 +973,6 @@ int main( int argc,
                                      O_CREAT | O_NONBLOCK | O_RDONLY,
                                      QUEUE_PERMISSIONS,
                                      &queueSettings );
-
-            if( requestQueue == -1 )
-            {
-                LogError( ( "Failed to open request queue with error %s.",
-                            strerror( errno ) ) );
-                returnStatus = EXIT_FAILURE;
-            }
 
             if( responseQueue == -1 )
             {

--- a/demos/http/http_demo_s3_download_multithreaded/http_demo_s3_download_multithreaded.c
+++ b/demos/http/http_demo_s3_download_multithreaded/http_demo_s3_download_multithreaded.c
@@ -954,14 +954,14 @@ int main( int argc,
                                     QUEUE_PERMISSIONS,
                                     &queueSettings );
 
-            queueSettings.mq_msgsize = sizeof( ResponseItem_t );
-
             if( requestQueue == -1 )
             {
                 LogError( ( "Failed to open request queue with error %s.",
                             strerror( errno ) ) );
                 returnStatus = EXIT_FAILURE;
             }
+
+            queueSettings.mq_msgsize = sizeof( ResponseItem_t );
 
             responseQueue = mq_open( RESPONSE_QUEUE,
 

--- a/demos/http/http_demo_s3_download_multithreaded/http_demo_s3_download_multithreaded.c
+++ b/demos/http/http_demo_s3_download_multithreaded/http_demo_s3_download_multithreaded.c
@@ -353,7 +353,7 @@ static bool downloadS3ObjectFile( const char * pHost,
     /* Initialize the request object. */
     requestInfo.pHost = pHost;
     requestInfo.hostLen = hostLen;
-    requestInfo.method = HTTP_METHOD_GET;
+    requestInfo.pMethod = HTTP_METHOD_GET;
     requestInfo.methodLen = HTTP_METHOD_GET_LENGTH;
     requestInfo.pPath = pRequest;
     requestInfo.pathLen = requestUriLen;

--- a/demos/http/http_demo_s3_download_multithreaded/http_demo_s3_download_multithreaded.c
+++ b/demos/http/http_demo_s3_download_multithreaded/http_demo_s3_download_multithreaded.c
@@ -456,7 +456,7 @@ static QueueOpStatus_t requestS3ObjectRange( const HTTPRequestInfo_t * requestIn
                                              const size_t end )
 {
     QueueOpStatus_t returnStatus = QUEUE_OP_SUCCESS;
-    HTTPStatus_t httpStatus = HTTP_SUCCESS;
+    HTTPStatus_t httpStatus = HTTPSuccess;
 
     /* Return value of mq_send. */
     int mqerror = 0;
@@ -471,7 +471,7 @@ static QueueOpStatus_t requestS3ObjectRange( const HTTPRequestInfo_t * requestIn
     httpStatus = HTTPClient_InitializeRequestHeaders( &( requestItem.requestHeaders ),
                                                       requestInfo );
 
-    if( httpStatus != HTTP_SUCCESS )
+    if( httpStatus != HTTPSuccess )
     {
         LogError( ( "Failed to initialize HTTP request headers: Error=%s.",
                     HTTPClient_strerror( httpStatus ) ) );
@@ -484,7 +484,7 @@ static QueueOpStatus_t requestS3ObjectRange( const HTTPRequestInfo_t * requestIn
                                                 start,
                                                 end );
 
-        if( httpStatus != HTTP_SUCCESS )
+        if( httpStatus != HTTPSuccess )
         {
             LogError( ( "Failed to add Range header to request headers: Error=%s.",
                         HTTPClient_strerror( httpStatus ) ) );
@@ -576,7 +576,7 @@ static bool getS3ObjectFileSizeMulti( const HTTPRequestInfo_t * requestInfo,
                                       size_t * pFileSize )
 {
     bool returnStatus = true;
-    HTTPStatus_t httpStatus = HTTP_SUCCESS;
+    HTTPStatus_t httpStatus = HTTPSuccess;
     QueueOpStatus_t queueOpStatus = QUEUE_OP_SUCCESS;
 
     /* Request data sent over queue. */
@@ -631,7 +631,7 @@ static bool getS3ObjectFileSizeMulti( const HTTPRequestInfo_t * requestInfo,
                                             ( const char ** ) &contentRangeValStr,
                                             &contentRangeValStrLength );
 
-        if( httpStatus != HTTP_SUCCESS )
+        if( httpStatus != HTTPSuccess )
         {
             LogError( ( "Failed to read Content-Range header from HTTP response: Error=%s.",
                         HTTPClient_strerror( httpStatus ) ) );
@@ -702,7 +702,7 @@ static pid_t startHTTPThread( const TransportInterface_t * pTransportInterface )
 
         for( ; ; )
         {
-            HTTPStatus_t httpStatus = HTTP_SUCCESS;
+            HTTPStatus_t httpStatus = HTTPSuccess;
 
             /* Return value of mq_receive. */
             int mqread = 0;
@@ -739,7 +739,7 @@ static pid_t startHTTPThread( const TransportInterface_t * pTransportInterface )
                                           &responseItem.response,
                                           0 );
 
-            if( httpStatus != HTTP_SUCCESS )
+            if( httpStatus != HTTPSuccess )
             {
                 LogError( ( "Failed to send HTTP request: Error=%s.",
                             HTTPClient_strerror( httpStatus ) ) );
@@ -841,7 +841,7 @@ int main( int argc,
     for( ; ; )
     {
         /* HTTPS Client library return status. */
-        HTTPStatus_t httpStatus = HTTP_SUCCESS;
+        HTTPStatus_t httpStatus = HTTPSuccess;
 
         /* The location of the path within the pre-signed URL. */
         const char * pPath = NULL;
@@ -889,7 +889,7 @@ int main( int argc,
              * the end of the S3 presigned URL. */
             requestUriLen = strlen( pPath );
 
-            if( httpStatus != HTTP_SUCCESS )
+            if( httpStatus != HTTPSuccess )
             {
                 returnStatus = EXIT_FAILURE;
             }
@@ -903,7 +903,7 @@ int main( int argc,
                                         &pHost,
                                         &hostLen );
 
-            if( httpStatus != HTTP_SUCCESS )
+            if( httpStatus != HTTPSuccess )
             {
                 returnStatus = EXIT_FAILURE;
             }

--- a/demos/http/http_demo_s3_upload/http_demo_s3_upload.c
+++ b/demos/http/http_demo_s3_upload/http_demo_s3_upload.c
@@ -210,7 +210,7 @@ static bool uploadS3ObjectFile( const TransportInterface_t * pTransportInterface
 static int32_t connectToServer( NetworkContext_t * pNetworkContext )
 {
     int32_t returnStatus = EXIT_FAILURE;
-    HTTPStatus_t httpStatus = HTTP_SUCCESS;
+    HTTPStatus_t httpStatus = HTTPSuccess;
 
     /* The location of the host address within the pre-signed URL. */
     const char * pAddress = NULL;
@@ -232,7 +232,7 @@ static int32_t connectToServer( NetworkContext_t * pNetworkContext )
                                 &pAddress,
                                 &serverHostLength );
 
-    returnStatus = ( httpStatus == HTTP_SUCCESS ) ? EXIT_SUCCESS : EXIT_FAILURE;
+    returnStatus = ( httpStatus == HTTPSuccess ) ? EXIT_SUCCESS : EXIT_FAILURE;
 
     if( returnStatus == EXIT_SUCCESS )
     {
@@ -307,7 +307,7 @@ static bool uploadS3ObjectFile( const TransportInterface_t * pTransportInterface
                                 const char * pPath )
 {
     bool returnStatus = false;
-    HTTPStatus_t httpStatus = HTTP_SUCCESS;
+    HTTPStatus_t httpStatus = HTTPSuccess;
 
     assert( pPath != NULL );
 
@@ -337,13 +337,13 @@ static bool uploadS3ObjectFile( const TransportInterface_t * pTransportInterface
     response.pBuffer = userBuffer;
     response.bufferLen = USER_BUFFER_LENGTH;
 
-    if( httpStatus == HTTP_SUCCESS )
+    if( httpStatus == HTTPSuccess )
     {
         httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders,
                                                           &requestInfo );
     }
 
-    if( httpStatus == HTTP_SUCCESS )
+    if( httpStatus == HTTPSuccess )
     {
         LogInfo( ( "Uploading file..." ) );
         LogDebug( ( "Request Headers:\n%.*s",
@@ -362,7 +362,7 @@ static bool uploadS3ObjectFile( const TransportInterface_t * pTransportInterface
                     HTTPClient_strerror( httpStatus ) ) );
     }
 
-    if( httpStatus == HTTP_SUCCESS )
+    if( httpStatus == HTTPSuccess )
     {
         LogDebug( ( "Received HTTP response from %s%s...",
                     serverHost, pPath ) );
@@ -395,7 +395,7 @@ static bool uploadS3ObjectFile( const TransportInterface_t * pTransportInterface
                     response.statusCode ) );
     }
 
-    return( ( returnStatus == true ) && ( httpStatus == HTTP_SUCCESS ) );
+    return( ( returnStatus == true ) && ( httpStatus == HTTPSuccess ) );
 }
 
 /*-----------------------------------------------------------*/
@@ -422,7 +422,7 @@ int main( int argc,
     /* Return value of private functions. */
     bool ret = false;
     /* HTTPS Client library return status. */
-    HTTPStatus_t httpStatus = HTTP_SUCCESS;
+    HTTPStatus_t httpStatus = HTTPSuccess;
 
     /* The length of the path within the pre-signed URL. This variable is
      * defined in order to store the length returned from parsing the URL, but
@@ -488,7 +488,7 @@ int main( int argc,
                                      &pPath,
                                      &pathLen );
 
-            returnStatus = ( httpStatus == HTTP_SUCCESS ) ? EXIT_SUCCESS : EXIT_FAILURE;
+            returnStatus = ( httpStatus == HTTPSuccess ) ? EXIT_SUCCESS : EXIT_FAILURE;
         }
 
         if( returnStatus == EXIT_SUCCESS )
@@ -510,7 +510,7 @@ int main( int argc,
                                      &pPath,
                                      &pathLen );
 
-            returnStatus = ( httpStatus == HTTP_SUCCESS ) ? EXIT_SUCCESS : EXIT_FAILURE;
+            returnStatus = ( httpStatus == HTTPSuccess ) ? EXIT_SUCCESS : EXIT_FAILURE;
         }
 
         if( returnStatus == EXIT_SUCCESS )

--- a/demos/http/http_demo_s3_upload/http_demo_s3_upload.c
+++ b/demos/http/http_demo_s3_upload/http_demo_s3_upload.c
@@ -319,7 +319,7 @@ static bool uploadS3ObjectFile( const TransportInterface_t * pTransportInterface
     /* Initialize the request object. */
     requestInfo.pHost = serverHost;
     requestInfo.hostLen = serverHostLength;
-    requestInfo.method = HTTP_METHOD_PUT;
+    requestInfo.pMethod = HTTP_METHOD_PUT;
     requestInfo.methodLen = HTTP_METHOD_PUT_LENGTH;
     requestInfo.pPath = pPath;
     requestInfo.pathLen = strlen( pPath );

--- a/demos/lexicon.txt
+++ b/demos/lexicon.txt
@@ -66,7 +66,10 @@ http
 httpbin
 httpclient
 httpmethodpaths
+httpnoresponse
+httpparserinternalerror
 https
+httpsuccess
 httpthread
 ifdef
 ifndef

--- a/integration-test/http/http_system_test.c
+++ b/integration-test/http/http_system_test.c
@@ -193,7 +193,7 @@ static void sendHttpRequest( const TransportInterface_t * pTransportInterface,
                              const char * pPath )
 {
     /* Status returned by methods in HTTP Client Library API. */
-    HTTPStatus_t httpStatus = HTTP_NETWORK_ERROR;
+    HTTPStatus_t httpStatus = HTTPNetworkError;
     /* Tracks number of retry requests made to the HTTP server. */
     uint8_t retryCount = 0;
 
@@ -263,14 +263,14 @@ static void sendHttpRequest( const TransportInterface_t * pTransportInterface,
                                       &response,
                                       0 );
 
-        if( httpStatus == HTTP_NETWORK_ERROR )
+        if( httpStatus == HTTPNetworkError )
         {
             LogDebug( ( "A network error has occured, retrying request." ) );
             resetTest();
         }
 
         retryCount++;
-    } while( ( httpStatus == HTTP_NETWORK_ERROR ) && ( retryCount < MAX_RETRY_COUNT ) );
+    } while( ( httpStatus == HTTPNetworkError ) && ( retryCount < MAX_RETRY_COUNT ) );
 
     TEST_ASSERT_EQUAL( HTTPSuccess, httpStatus );
 

--- a/integration-test/http/http_system_test.c
+++ b/integration-test/http/http_system_test.c
@@ -216,7 +216,7 @@ static void sendHttpRequest( const TransportInterface_t * pTransportInterface,
     /* Initialize the request object. */
     requestInfo.pHost = SERVER_HOST;
     requestInfo.hostLen = SERVER_HOST_LENGTH;
-    requestInfo.method = pMethod;
+    requestInfo.pMethod = pMethod;
     requestInfo.methodLen = strlen( pMethod );
     requestInfo.pPath = pPath;
     requestInfo.pathLen = strlen( pPath );
@@ -235,7 +235,7 @@ static void sendHttpRequest( const TransportInterface_t * pTransportInterface,
     response.bufferLen = USER_BUFFER_LENGTH;
 
     LogDebug( ( "Sending HTTP %.*s request to %.*s%.*s...",
-                ( int32_t ) requestInfo.methodLen, requestInfo.method,
+                ( int32_t ) requestInfo.methodLen, requestInfo.pMethod,
                 ( int32_t ) SERVER_HOST_LENGTH, SERVER_HOST,
                 ( int32_t ) requestInfo.pathLen, requestInfo.pPath ) );
 

--- a/integration-test/http/http_system_test.c
+++ b/integration-test/http/http_system_test.c
@@ -247,7 +247,7 @@ static void sendHttpRequest( const TransportInterface_t * pTransportInterface,
          * be re-initialized after a failed request. */
         httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders,
                                                           &requestInfo );
-        TEST_ASSERT_EQUAL( HTTP_SUCCESS, httpStatus );
+        TEST_ASSERT_EQUAL( HTTPSuccess, httpStatus );
         TEST_ASSERT_NOT_EQUAL( 0, requestHeaders.headersLen );
 
         LogDebug( ( "Request Headers:\n%.*s\n"
@@ -272,7 +272,7 @@ static void sendHttpRequest( const TransportInterface_t * pTransportInterface,
         retryCount++;
     } while( ( httpStatus == HTTP_NETWORK_ERROR ) && ( retryCount < MAX_RETRY_COUNT ) );
 
-    TEST_ASSERT_EQUAL( HTTP_SUCCESS, httpStatus );
+    TEST_ASSERT_EQUAL( HTTPSuccess, httpStatus );
 
     LogDebug( ( "Received HTTP response from %.*s%.*s...\n"
                 "Response Headers:\n%.*s\n"


### PR DESCRIPTION
*Description of changes:*
This PR:
- Update the coreHTTP submodule to the latest, for changes to the struct field and enum names.
- Updates `HTTPRequestInfo_t.method` to `HTTPRequestInfo_t.pMethod`, for consistency.
- Updates all HTTPStatus_t enums from uppercase to upper camel case, for consistency.
- Require Python3 in the presigned URL generation script, fixes the shebang.
- Initialize a local array to zero in the HTTP S3 Multithreaded demo, this was missed.
- Check errno right after the error in the HTTP S3 Multithreaded demo, the generic errno needs to checked following the error.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
