### PR TITLE
Remove looping from HTTP mutual auth demo

### DIFF
--- a/demos/http/http_demo_mutual_auth/http_demo_mutual_auth.c
+++ b/demos/http/http_demo_mutual_auth/http_demo_mutual_auth.c
@@ -77,11 +77,6 @@
  */
 #define IOT_CORE_ALPN_PROTOCOL_NAME    "\x0ex-amzn-http-ca"
 
-/**
- * @brief Delay in seconds between each iteration of the demo.
- */
-#define DEMO_LOOP_DELAY_SECONDS        ( 5U )
-
 /* Check that transport timeout for transport send and receive is defined. */
 #ifndef TRANSPORT_SEND_RECV_TIMEOUT_MS
     #define TRANSPORT_SEND_RECV_TIMEOUT_MS    ( 1000 )


### PR DESCRIPTION
To prevent unnecessary AWS IoT resource usage, this PR stops the demo from looping endlessly.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
