### PR TITLE
Add porting section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ If you have downloaded the repo without using the `--recurse-submodules` argumen
 git submodule update --init --recursive
 ```
 
+## Porting C-SDK libraries
+All libraries depend the ISO C90 standard library and additionally, on `stdint.h` library for fixed-width integers including  `uint8_t`, `int8_t`, `uint16_t`, `uint32_t` and `int32_t`, and constant macros like `UINT16_MAX`. If your platform does not support the `stdint.h` library, definition of the mentioned fixed-width integer types will be required for porting any C-SDK library to your platform.
+
+The following libraries have additional requirements for porting. Please refer to the library-specific guides for porting the libraries to your platform:
+* [MQTT client library Porting Guide](https://docs.aws.amazon.com/freertos/latest/lib-ref/embedded-csdk/202009.00/lib-ref/libraries/standard/coreMQTT/docs/doxygen/output/html/mqtt_porting.html)
+* [AWS IoT Device Shadow library Porting Guide](https://docs.aws.amazon.com/freertos/latest/lib-ref/embedded-csdk/202009.00/lib-ref/libraries/aws/device-shadow-for-aws-iot-embedded-sdk/docs/doxygen/output/html/shadow_porting.html)
+* [AWS IoT Device Defender library Porting Guide](https://github.com/aws/device-defender-for-aws-iot-embedded-sdk/blob/master/docs/doxygen/porting.dox)
 
 ## Building and Running Demos
 

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ git submodule update --init --recursive
 ```
 
 ## Porting C-SDK Libraries
-All libraries depend the ISO C90 standard library and additionally, on `stdint.h` library for fixed-width integers including  `uint8_t`, `int8_t`, `uint16_t`, `uint32_t` and `int32_t`, and constant macros like `UINT16_MAX`. If your platform does not support the `stdint.h` library, definition of the mentioned fixed-width integer types will be required for porting any C-SDK library to your platform.
+All libraries depend the on ISO C90 standard library and additionally, on the `stdint.h` library for fixed-width integers including  `uint8_t`, `int8_t`, `uint16_t`, `uint32_t` and `int32_t`, and constant macros like `UINT16_MAX`. If your platform does not support the `stdint.h` library, definition of the mentioned fixed-width integer types will be required for porting any C-SDK library to your platform.
 
-The following libraries have additional requirements for porting. Please refer to the library-specific guides for porting the libraries to your platform:
+The following libraries have additional requirements for porting. Please refer to the library-specific guides for porting the corresponding library to your platform:
 * [MQTT client library Porting Guide](https://docs.aws.amazon.com/freertos/latest/lib-ref/embedded-csdk/202009.00/lib-ref/libraries/standard/coreMQTT/docs/doxygen/output/html/mqtt_porting.html)
 * [AWS IoT Device Shadow library Porting Guide](https://docs.aws.amazon.com/freertos/latest/lib-ref/embedded-csdk/202009.00/lib-ref/libraries/aws/device-shadow-for-aws-iot-embedded-sdk/docs/doxygen/output/html/shadow_porting.html)
 * [AWS IoT Device Defender library Porting Guide](https://github.com/aws/device-defender-for-aws-iot-embedded-sdk/blob/master/docs/doxygen/porting.dox)

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ If you have downloaded the repo without using the `--recurse-submodules` argumen
 git submodule update --init --recursive
 ```
 
-## Porting C-SDK libraries
+## Porting C-SDK Libraries
 All libraries depend the ISO C90 standard library and additionally, on `stdint.h` library for fixed-width integers including  `uint8_t`, `int8_t`, `uint16_t`, `uint32_t` and `int32_t`, and constant macros like `UINT16_MAX`. If your platform does not support the `stdint.h` library, definition of the mentioned fixed-width integer types will be required for porting any C-SDK library to your platform.
 
 The following libraries have additional requirements for porting. Please refer to the library-specific guides for porting the libraries to your platform:

--- a/README.md
+++ b/README.md
@@ -96,12 +96,13 @@ git submodule update --init --recursive
 ```
 
 ## Porting C-SDK Libraries
-All libraries depend the on ISO C90 standard library and additionally, on the `stdint.h` library for fixed-width integers including  `uint8_t`, `int8_t`, `uint16_t`, `uint32_t` and `int32_t`, and constant macros like `UINT16_MAX`. If your platform does not support the `stdint.h` library, definition of the mentioned fixed-width integer types will be required for porting any C-SDK library to your platform.
+All libraries depend the on ISO C90 standard library and additionally on the `stdint.h` library for fixed-width integers, including  `uint8_t`, `int8_t`, `uint16_t`, `uint32_t` and `int32_t`, and constant macros like `UINT16_MAX`. If your platform does not support the `stdint.h` library, definitions of the mentioned fixed-width integer types will be required for porting any C-SDK library to your platform.
 
 The following libraries have additional requirements for porting. Please refer to the library-specific guides for porting the corresponding library to your platform:
-* [MQTT client library Porting Guide](https://docs.aws.amazon.com/freertos/latest/lib-ref/embedded-csdk/202009.00/lib-ref/libraries/standard/coreMQTT/docs/doxygen/output/html/mqtt_porting.html)
-* [AWS IoT Device Shadow library Porting Guide](https://docs.aws.amazon.com/freertos/latest/lib-ref/embedded-csdk/202009.00/lib-ref/libraries/aws/device-shadow-for-aws-iot-embedded-sdk/docs/doxygen/output/html/shadow_porting.html)
-* [AWS IoT Device Defender library Porting Guide](https://github.com/aws/device-defender-for-aws-iot-embedded-sdk/blob/master/docs/doxygen/porting.dox)
+* [MQTT client library porting guide](https://docs.aws.amazon.com/freertos/latest/lib-ref/embedded-csdk/202011.00/lib-ref/libraries/standard/coreMQTT/docs/doxygen/output/html/mqtt_porting.html)
+* [HTTP client library porting guide](https://docs.aws.amazon.com/freertos/latest/lib-ref/embedded-csdk/202011.00/lib-ref/libraries/standard/coreHTTP/docs/doxygen/output/html/http_porting.html)
+* [AWS IoT Device Shadow library porting guide](https://docs.aws.amazon.com/freertos/latest/lib-ref/embedded-csdk/202011.00/lib-ref/libraries/aws/device-shadow-for-aws-iot-embedded-sdk/docs/doxygen/output/html/shadow_porting.html)
+* [AWS IoT Device Defender library porting guide](https://docs.aws.amazon.com/freertos/latest/lib-ref/embedded-csdk/202011.00/lib-ref/libraries/aws/device-defender-for-aws-iot-embedded-sdk/docs/doxygen/output/html/defender_porting.html)
 
 ## Building and Running Demos
 


### PR DESCRIPTION
Add a **Porting C-SDK Libraries** section to README to provide links to porting guides to libraries. This will make it more expressive to the reader that C-SDK libraries can be ported to non-POSIX platforms