### PR TITLE
Update MQTT configs to use 5 seconds as keep-alive timeout

### DIFF
--- a/demos/mqtt/mqtt_demo_basic_tls/core_mqtt_config.h
+++ b/demos/mqtt/mqtt_demo_basic_tls/core_mqtt_config.h
@@ -74,6 +74,6 @@
  * If a ping response is not received before this timeout, then
  * #MQTT_ProcessLoop will return #MQTTKeepAliveTimeout.
  */
-#define MQTT_PINGRESP_TIMEOUT_MS      ( 500U )
+#define MQTT_PINGRESP_TIMEOUT_MS      ( 5000U )
 
 #endif /* ifndef CORE_MQTT_CONFIG_H_ */

--- a/demos/mqtt/mqtt_demo_mutual_auth/core_mqtt_config.h
+++ b/demos/mqtt/mqtt_demo_mutual_auth/core_mqtt_config.h
@@ -73,6 +73,6 @@
  * If a ping response is not received before this timeout, then
  * #MQTT_ProcessLoop will return #MQTTKeepAliveTimeout.
  */
-#define MQTT_PINGRESP_TIMEOUT_MS      ( 500U )
+#define MQTT_PINGRESP_TIMEOUT_MS      ( 5000U )
 
 #endif /* ifndef CORE_MQTT_CONFIG_H_ */

--- a/demos/mqtt/mqtt_demo_subscription_manager/core_mqtt_config.h
+++ b/demos/mqtt/mqtt_demo_subscription_manager/core_mqtt_config.h
@@ -74,7 +74,7 @@
  * If a ping response is not received before this timeout, then
  * #MQTT_ProcessLoop will return #MQTTKeepAliveTimeout.
  */
-#define MQTT_PINGRESP_TIMEOUT_MS      ( 500U )
+#define MQTT_PINGRESP_TIMEOUT_MS      ( 5000U )
 
 
 #endif /* ifndef CORE_MQTT_CONFIG_H_ */

--- a/demos/shadow/shadow_demo_main/core_mqtt_config.h
+++ b/demos/shadow/shadow_demo_main/core_mqtt_config.h
@@ -74,6 +74,6 @@
  * If a ping response is not received before this timeout, then
  * #MQTT_ProcessLoop will return #MQTTKeepAliveTimeout.
  */
-#define MQTT_PINGRESP_TIMEOUT_MS      ( 500U )
+#define MQTT_PINGRESP_TIMEOUT_MS      ( 5000U )
 
 #endif /* ifndef CORE_MQTT_CONFIG_H_ */

--- a/integration-test/mqtt/core_mqtt_config.h
+++ b/integration-test/mqtt/core_mqtt_config.h
@@ -68,6 +68,6 @@
  * If a ping response is not received before this timeout, then
  * #MQTT_ProcessLoop will return #MQTTKeepAliveTimeout.
  */
-#define MQTT_PINGRESP_TIMEOUT_MS      ( 500U )
+#define MQTT_PINGRESP_TIMEOUT_MS      ( 5000U )
 
 #endif /* ifndef CORE_MQTT_CONFIG_H_ */

--- a/integration-test/shadow/core_mqtt_config.h
+++ b/integration-test/shadow/core_mqtt_config.h
@@ -68,6 +68,6 @@
  * If a ping response is not received before this timeout, then
  * #MQTT_ProcessLoop will return #MQTTKeepAliveTimeout.
  */
-#define MQTT_PINGRESP_TIMEOUT_MS      ( 500U )
+#define MQTT_PINGRESP_TIMEOUT_MS      ( 5000U )
 
 #endif /* ifndef CORE_MQTT_CONFIG_H_ */


### PR DESCRIPTION
Update the keep-alive timeout values in MQTT config files of demos and tests to be realistic based on timeout ping response delays of AWS IoT broker