### PR TITLE
Automatically clone submodules of libraries upon building with cmake

### DIFF
--- a/libraries/3rdparty/CMakeLists.txt
+++ b/libraries/3rdparty/CMakeLists.txt
@@ -1,4 +1,13 @@
 if(${BUILD_TESTS})
+    if( NOT EXISTS ${3RDPARTY_DIR}/CMock/.git )
+        # Attempt to clone submodule.
+        if( ${BUILD_CLONE_SUBMODULES} )
+            clone_library( ${submodule_dir} 0 )
+        else()
+            message( FATAL_ERROR "A required submodule does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
+        endif()
+    endif()
+
     add_library(cmock STATIC
         "${ROOT_DIR}/libraries/3rdparty/CMock/src/cmock.c"
     )

--- a/libraries/3rdparty/CMakeLists.txt
+++ b/libraries/3rdparty/CMakeLists.txt
@@ -1,12 +1,5 @@
 if(${BUILD_TESTS})
-    if( NOT EXISTS ${3RDPARTY_DIR}/CMock/.git )
-        # Attempt to clone submodule.
-        if( ${BUILD_CLONE_SUBMODULES} )
-            clone_library( ${submodule_dir} 0 )
-        else()
-            message( FATAL_ERROR "A required submodule does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
-        endif()
-    endif()
+    clone_library( ${3RDPARTY_DIR}/CMock 0 )
 
     add_library(cmock STATIC
         "${ROOT_DIR}/libraries/3rdparty/CMock/src/cmock.c"

--- a/libraries/3rdparty/CMakeLists.txt
+++ b/libraries/3rdparty/CMakeLists.txt
@@ -1,6 +1,4 @@
 if(${BUILD_TESTS})
-    clone_library( ${3RDPARTY_DIR}/CMock 0 )
-
     add_library(cmock STATIC
         "${ROOT_DIR}/libraries/3rdparty/CMock/src/cmock.c"
     )

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -2,25 +2,27 @@
 add_subdirectory(${3RDPARTY_DIR})
 
 # Macro utility to clone a library and source-related submodules.
-macro( clone_library working_dir )
-        find_package( Git REQUIRED )
-        execute_process( COMMAND rm -rf ${submodule_dir}
-                         COMMAND ${GIT_EXECUTABLE} submodule update --init ${submodule_dir}
-                         WORKING_DIRECTORY ${ROOT_DIR}
-                         RESULT_VARIABLE LIB_CLONE_RESULT )
-        if( NOT ${LIB_CLONE_RESULT} STREQUAL "0" )
-            message( FATAL_ERROR "Failed to clone submodule ${submodule_dir}." )
-        endif()
+macro( clone_library submodule_dir clone_source )
+    find_package( Git REQUIRED )
+    execute_process( COMMAND rm -rf ${submodule_dir}
+                        COMMAND ${GIT_EXECUTABLE} submodule update --init ${submodule_dir}
+                        WORKING_DIRECTORY ${ROOT_DIR}
+                        RESULT_VARIABLE LIB_CLONE_RESULT )
+    if( NOT ${LIB_CLONE_RESULT} STREQUAL "0" )
+        message( FATAL_ERROR "Failed to clone submodule ${submodule_dir}." )
+    endif()
+    if(${clone_source})
         # Sources may have submodules like from the depedency directory
         execute_process( COMMAND ${GIT_EXECUTABLE} submodule update --init -- source
-                         WORKING_DIRECTORY ${submodule_dir}
-                         RESULT_VARIABLE LIB_CLONE_RESULT )
+                            WORKING_DIRECTORY ${submodule_dir}
+                            RESULT_VARIABLE LIB_CLONE_RESULT )
         if( NOT ${LIB_CLONE_RESULT} STREQUAL "0" )
             message( FATAL_ERROR "Failed to submodules from sources." )
         endif()
+    endif()
 endmacro()
 
-set( SUBMODULE_DIRS
+set( LIBRARY_SUBMODULES
        ${MODULES_DIR}/standard/coreHTTP
        ${MODULES_DIR}/standard/coreJSON
        ${MODULES_DIR}/standard/coreMQTT
@@ -28,11 +30,11 @@ set( SUBMODULE_DIRS
        ${MODULES_DIR}/aws/device-shadow-for-aws-iot-embedded-sdk
        ${MODULES_DIR}/aws/jobs-for-aws-iot-embedded-sdk )
 
-foreach(submodule_dir IN ITEMS ${SUBMODULE_DIRS})
+foreach(submodule_dir IN ITEMS ${LIBRARY_SUBMODULES})
     if( NOT EXISTS ${submodule_dir}/.git )
         # Attempt to clone submodule.
         if( ${BUILD_CLONE_SUBMODULES} )
-            clone_library( ${submodule_dir} )
+            clone_library( ${submodule_dir} 1 )
         else()
             message( FATAL_ERROR "A required submodule does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
         endif()

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -1,6 +1,3 @@
-# Add build configuration for all 3rd party modules.
-add_subdirectory(${3RDPARTY_DIR})
-
 # Macro utility to clone a library and source-related submodules.
 macro( clone_library submodule_dir clone_source )
     find_package( Git REQUIRED )
@@ -40,3 +37,6 @@ set( LIBRARY_SUBMODULES
 foreach(submodule_dir IN ITEMS ${LIBRARY_SUBMODULES})
     clone_library( ${submodule_dir} 1 )  
 endforeach()
+
+# Add build configuration for all 3rd party modules.
+add_subdirectory(${3RDPARTY_DIR})

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -35,7 +35,7 @@ set( LIBRARY_SUBMODULES
        ${MODULES_DIR}/aws/jobs-for-aws-iot-embedded-sdk )
 
 foreach(submodule_dir IN ITEMS ${LIBRARY_SUBMODULES})
-    clone_library( ${submodule_dir} 1 )  
+    clone_library( ${submodule_dir} 1 )
 endforeach()
 
 # Add build configuration for all 3rd party modules.

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -4,20 +4,27 @@ add_subdirectory(${3RDPARTY_DIR})
 # Macro utility to clone a library and source-related submodules.
 macro( clone_library submodule_dir clone_source )
     find_package( Git REQUIRED )
-    execute_process( COMMAND rm -rf ${submodule_dir}
+    if( NOT EXISTS ${submodule_dir}/.git )
+        # Attempt to clone submodule.
+        if( ${BUILD_CLONE_SUBMODULES} )
+            execute_process( COMMAND rm -rf ${submodule_dir}
                         COMMAND ${GIT_EXECUTABLE} submodule update --init ${submodule_dir}
                         WORKING_DIRECTORY ${ROOT_DIR}
                         RESULT_VARIABLE LIB_CLONE_RESULT )
-    if( NOT ${LIB_CLONE_RESULT} STREQUAL "0" )
-        message( FATAL_ERROR "Failed to clone submodule ${submodule_dir}." )
-    endif()
-    if(${clone_source})
-        # Sources may have submodules like from the depedency directory
-        execute_process( COMMAND ${GIT_EXECUTABLE} submodule update --init -- source
-                            WORKING_DIRECTORY ${submodule_dir}
-                            RESULT_VARIABLE LIB_CLONE_RESULT )
-        if( NOT ${LIB_CLONE_RESULT} STREQUAL "0" )
-            message( FATAL_ERROR "Failed to submodules from sources." )
+            if( NOT ${LIB_CLONE_RESULT} STREQUAL "0" )
+                message( FATAL_ERROR "Failed to clone submodule ${submodule_dir}." )
+            endif()
+            if(${clone_source})
+                # Sources may have submodules like from the depedency directory
+                execute_process( COMMAND ${GIT_EXECUTABLE} submodule update --init -- source
+                                    WORKING_DIRECTORY ${submodule_dir}
+                                    RESULT_VARIABLE LIB_CLONE_RESULT )
+                if( NOT ${LIB_CLONE_RESULT} STREQUAL "0" )
+                    message( FATAL_ERROR "Failed to submodules from sources." )
+                endif()
+            endif()
+        else()
+            message( FATAL_ERROR "A required submodule does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
         endif()
     endif()
 endmacro()
@@ -31,12 +38,5 @@ set( LIBRARY_SUBMODULES
        ${MODULES_DIR}/aws/jobs-for-aws-iot-embedded-sdk )
 
 foreach(submodule_dir IN ITEMS ${LIBRARY_SUBMODULES})
-    if( NOT EXISTS ${submodule_dir}/.git )
-        # Attempt to clone submodule.
-        if( ${BUILD_CLONE_SUBMODULES} )
-            clone_library( ${submodule_dir} 1 )
-        else()
-            message( FATAL_ERROR "A required submodule does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
-        endif()
-    endif()
+    clone_library( ${submodule_dir} 1 )  
 endforeach()

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Add build configuration for all 3rd party modules.
+add_subdirectory(${3RDPARTY_DIR})
+
 # Macro utility to clone a library and source-related submodules.
 macro( clone_library working_dir )
         find_package( Git REQUIRED )
@@ -5,13 +8,15 @@ macro( clone_library working_dir )
                          COMMAND ${GIT_EXECUTABLE} submodule update --init ${submodule_dir}
                          WORKING_DIRECTORY ${ROOT_DIR}
                          RESULT_VARIABLE LIB_CLONE_RESULT )
+        if( NOT ${LIB_CLONE_RESULT} STREQUAL "0" )
+            message( FATAL_ERROR "Failed to clone submodule ${submodule_dir}." )
+        endif()
         # Sources may have submodules like from the depedency directory
         execute_process( COMMAND ${GIT_EXECUTABLE} submodule update --init -- source
                          WORKING_DIRECTORY ${submodule_dir}
                          RESULT_VARIABLE LIB_CLONE_RESULT )
-
         if( NOT ${LIB_CLONE_RESULT} STREQUAL "0" )
-                message( FATAL_ERROR "Failed to clone submodule ${submodule_dir}." )
+            message( FATAL_ERROR "Failed to submodules from sources." )
         endif()
 endmacro()
 

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -1,30 +1,18 @@
 # Macro utility to clone a library and source-related submodules.
-macro( clone_library submodule_dir clone_source )
+macro( clone_path path )
     find_package( Git REQUIRED )
-    if( NOT EXISTS ${submodule_dir}/.git )
-        # Attempt to clone submodule.
-        if( ${BUILD_CLONE_SUBMODULES} )
-            execute_process( COMMAND rm -rf ${submodule_dir}
-                        COMMAND ${GIT_EXECUTABLE} submodule update --init ${submodule_dir}
-                        WORKING_DIRECTORY ${ROOT_DIR}
-                        RESULT_VARIABLE LIB_CLONE_RESULT )
-            if( NOT ${LIB_CLONE_RESULT} STREQUAL "0" )
-                message( FATAL_ERROR "Failed to clone submodule ${submodule_dir}." )
-            endif()
-            if(${clone_source})
-                # Sources may have submodules like from the depedency directory
-                execute_process( COMMAND ${GIT_EXECUTABLE} submodule update --init -- source
-                                    WORKING_DIRECTORY ${submodule_dir}
-                                    RESULT_VARIABLE LIB_CLONE_RESULT )
-                if( NOT ${LIB_CLONE_RESULT} STREQUAL "0" )
-                    message( FATAL_ERROR "Failed to submodules from sources." )
-                endif()
-            endif()
-        else()
-            message( FATAL_ERROR "A required submodule does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
+    # Attempt to clone submodules.
+    if( ${BUILD_CLONE_SUBMODULES} )
+        execute_process( COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- ${path}
+                         WORKING_DIRECTORY ${ROOT_DIR}
+                         RESULT_VARIABLE LIB_CLONE_RESULT )
+        if( NOT ${LIB_CLONE_RESULT} STREQUAL "0" )
+            message( FATAL_ERROR "Failed to clone submodules." )
         endif()
     endif()
 endmacro()
+
+clone_path( ${MODULES_DIR} )
 
 set( LIBRARY_SUBMODULES
        ${MODULES_DIR}/standard/coreHTTP
@@ -35,7 +23,9 @@ set( LIBRARY_SUBMODULES
        ${MODULES_DIR}/aws/jobs-for-aws-iot-embedded-sdk )
 
 foreach(submodule_dir IN ITEMS ${LIBRARY_SUBMODULES})
-    clone_library( ${submodule_dir} 1 )
+    if( NOT EXISTS ${submodule_dir}/.git )
+        message( FATAL_ERROR "The required submodule {} does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
+    endif()
 endforeach()
 
 # Add build configuration for all 3rd party modules.

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -5,7 +5,7 @@ add_subdirectory(${3RDPARTY_DIR})
 macro( clone_library submodule_dir )
         find_package( Git REQUIRED )
         execute_process( COMMAND rm -rf ${submodule_dir}
-                         COMMAND ${GIT_EXECUTABLE} submodule update --init ${submodule_dir}
+                         COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive ${submodule_dir}
                          WORKING_DIRECTORY ${ROOT_DIR}
                          RESULT_VARIABLE LIB_CLONE_RESULT )
 
@@ -16,7 +16,6 @@ endmacro()
 
 set(SUBMODULE_DIRS
       ${MODULES_DIR}/standard/coreHTTP
-      ${MODULES_DIR}/standard/coreHTTP/source/dependency/3rdparty/http_parser
       ${MODULES_DIR}/standard/coreJSON
       ${MODULES_DIR}/standard/coreMQTT
       ${MODULES_DIR}/aws/device-defender-for-aws-iot-embedded-sdk

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -1,26 +1,27 @@
-# Add build configuration for all 3rd party modules.
-add_subdirectory(${3RDPARTY_DIR})
-
-# Macro utility to clone the coreMQTT submodule.
-macro( clone_library submodule_dir )
+# Macro utility to clone a library and source-related submodules.
+macro( clone_library working_dir )
         find_package( Git REQUIRED )
         execute_process( COMMAND rm -rf ${submodule_dir}
-                         COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive ${submodule_dir}
+                         COMMAND ${GIT_EXECUTABLE} submodule update --init ${submodule_dir}
                          WORKING_DIRECTORY ${ROOT_DIR}
+                         RESULT_VARIABLE LIB_CLONE_RESULT )
+        # Sources may have submodules like from the depedency directory
+        execute_process( COMMAND ${GIT_EXECUTABLE} submodule update --init -- source
+                         WORKING_DIRECTORY ${submodule_dir}
                          RESULT_VARIABLE LIB_CLONE_RESULT )
 
         if( NOT ${LIB_CLONE_RESULT} STREQUAL "0" )
-                message( FATAL_ERROR "Failed to clone submodule." )
+                message( FATAL_ERROR "Failed to clone submodule ${submodule_dir}." )
         endif()
 endmacro()
 
-set(SUBMODULE_DIRS
-      ${MODULES_DIR}/standard/coreHTTP
-      ${MODULES_DIR}/standard/coreJSON
-      ${MODULES_DIR}/standard/coreMQTT
-      ${MODULES_DIR}/aws/device-defender-for-aws-iot-embedded-sdk
-      ${MODULES_DIR}/aws/device-shadow-for-aws-iot-embedded-sdk
-      ${MODULES_DIR}/aws/jobs-for-aws-iot-embedded-sdk )
+set( SUBMODULE_DIRS
+       ${MODULES_DIR}/standard/coreHTTP
+       ${MODULES_DIR}/standard/coreJSON
+       ${MODULES_DIR}/standard/coreMQTT
+       ${MODULES_DIR}/aws/device-defender-for-aws-iot-embedded-sdk
+       ${MODULES_DIR}/aws/device-shadow-for-aws-iot-embedded-sdk
+       ${MODULES_DIR}/aws/jobs-for-aws-iot-embedded-sdk )
 
 foreach(submodule_dir IN ITEMS ${SUBMODULE_DIRS})
     if( NOT EXISTS ${submodule_dir}/.git )

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -14,19 +14,5 @@ endmacro()
 
 clone_path( ${MODULES_DIR} )
 
-set( LIBRARY_SUBMODULES
-       ${MODULES_DIR}/standard/coreHTTP
-       ${MODULES_DIR}/standard/coreJSON
-       ${MODULES_DIR}/standard/coreMQTT
-       ${MODULES_DIR}/aws/device-defender-for-aws-iot-embedded-sdk
-       ${MODULES_DIR}/aws/device-shadow-for-aws-iot-embedded-sdk
-       ${MODULES_DIR}/aws/jobs-for-aws-iot-embedded-sdk )
-
-foreach(submodule_dir IN ITEMS ${LIBRARY_SUBMODULES})
-    if( NOT EXISTS ${submodule_dir}/.git )
-        message( FATAL_ERROR "The required submodule {} does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
-    endif()
-endforeach()
-
 # Add build configuration for all 3rd party modules.
 add_subdirectory(${3RDPARTY_DIR})

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -2,15 +2,34 @@
 add_subdirectory(${3RDPARTY_DIR})
 
 # Macro utility to clone the coreMQTT submodule.
-macro( clone_mqtt )
+macro( clone_library submodule_dir )
         find_package( Git REQUIRED )
-        message( "Cloning submodule coreMQTT." )
-        execute_process( COMMAND rm -rf ${MODULES_DIR}/standard/coreMQTT
-                         COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive libraries/standard/coreMQTT
+        execute_process( COMMAND rm -rf ${submodule_dir}
+                         COMMAND ${GIT_EXECUTABLE} submodule update --init ${submodule_dir}
                          WORKING_DIRECTORY ${ROOT_DIR}
-                         RESULT_VARIABLE MQTT_CLONE_RESULT )
+                         RESULT_VARIABLE LIB_CLONE_RESULT )
 
-        if( NOT ${MQTT_CLONE_RESULT} STREQUAL "0" )
-                message( FATAL_ERROR "Failed to clone coreMQTT submodule." )
+        if( NOT ${LIB_CLONE_RESULT} STREQUAL "0" )
+                message( FATAL_ERROR "Failed to clone submodule." )
         endif()
 endmacro()
+
+set(SUBMODULE_DIRS
+      ${MODULES_DIR}/standard/coreHTTP
+      ${MODULES_DIR}/standard/coreHTTP/source/dependency/3rdparty/http_parser
+      ${MODULES_DIR}/standard/coreJSON
+      ${MODULES_DIR}/standard/coreMQTT
+      ${MODULES_DIR}/aws/device-defender-for-aws-iot-embedded-sdk
+      ${MODULES_DIR}/aws/device-shadow-for-aws-iot-embedded-sdk
+      ${MODULES_DIR}/aws/jobs-for-aws-iot-embedded-sdk )
+
+foreach(submodule_dir IN ITEMS ${SUBMODULE_DIRS})
+    if( NOT EXISTS ${submodule_dir}/.git )
+        # Attempt to clone submodule.
+        if( ${BUILD_CLONE_SUBMODULES} )
+            clone_library( ${submodule_dir} )
+        else()
+            message( FATAL_ERROR "A required submodule does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
+        endif()
+    endif()
+endforeach()

--- a/platform/posix/transport/CMakeLists.txt
+++ b/platform/posix/transport/CMakeLists.txt
@@ -6,7 +6,7 @@ include( ${PLATFORM_DIR}/posix/posixFilePaths.cmake )
 if( NOT EXISTS ${MODULES_DIR}/standard/coreMQTT/source )
     # Attempt to clone coreMQTT.
     if( ${BUILD_CLONE_SUBMODULES} )
-        clone_mqtt()
+        clone_library( ${MODULES_DIR}/standard/coreMQTT )
     else()
         message( FATAL_ERROR "The required submodule coreMQTT does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
     endif()

--- a/platform/posix/transport/CMakeLists.txt
+++ b/platform/posix/transport/CMakeLists.txt
@@ -1,13 +1,6 @@
 # Include filepaths for source and include.
 include( ${PLATFORM_DIR}/posix/posixFilePaths.cmake )
 
-# The transport_interface.h in coreMQTT is the single source of truth,
-# so make sure the submodule is cloned.
-clone_path( ${MODULES_DIR}/standard/coreMQTT )
-if( NOT EXISTS ${MODULES_DIR}/standard/coreMQTT/.git )
-    message( FATAL_ERROR "The required coreMQTT submodule does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
-endif()
-
 set( TRANSPORT_INTERFACE_INCLUDE_DIR
      ${MODULES_DIR}/standard/coreMQTT/source/interface )
 

--- a/platform/posix/transport/CMakeLists.txt
+++ b/platform/posix/transport/CMakeLists.txt
@@ -3,12 +3,12 @@ include( ${PLATFORM_DIR}/posix/posixFilePaths.cmake )
 
 # The transport_interface.h in coreMQTT is the single source of truth,
 # so make sure the submodule is cloned.
-if( NOT EXISTS ${MODULES_DIR}/standard/coreMQTT/source )
-    # Attempt to clone coreMQTT.
+if( NOT EXISTS ${submodule_dir}/.git )
+    # Attempt to clone submodule.
     if( ${BUILD_CLONE_SUBMODULES} )
-        clone_library( ${MODULES_DIR}/standard/coreMQTT )
+        clone_library( "${MODULES_DIR}/standard/coreMQTT" )
     else()
-        message( FATAL_ERROR "The required submodule coreMQTT does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
+        message( FATAL_ERROR "A required submodule does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
     endif()
 endif()
 

--- a/platform/posix/transport/CMakeLists.txt
+++ b/platform/posix/transport/CMakeLists.txt
@@ -6,7 +6,7 @@ include( ${PLATFORM_DIR}/posix/posixFilePaths.cmake )
 if( NOT EXISTS ${submodule_dir}/.git )
     # Attempt to clone submodule.
     if( ${BUILD_CLONE_SUBMODULES} )
-        clone_library( "${MODULES_DIR}/standard/coreMQTT" 1 )
+        clone_library( ${MODULES_DIR}/standard/coreMQTT 1 )
     else()
         message( FATAL_ERROR "A required submodule does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
     endif()

--- a/platform/posix/transport/CMakeLists.txt
+++ b/platform/posix/transport/CMakeLists.txt
@@ -3,14 +3,7 @@ include( ${PLATFORM_DIR}/posix/posixFilePaths.cmake )
 
 # The transport_interface.h in coreMQTT is the single source of truth,
 # so make sure the submodule is cloned.
-if( NOT EXISTS ${submodule_dir}/.git )
-    # Attempt to clone submodule.
-    if( ${BUILD_CLONE_SUBMODULES} )
-        clone_library( ${MODULES_DIR}/standard/coreMQTT 1 )
-    else()
-        message( FATAL_ERROR "A required submodule does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
-    endif()
-endif()
+clone_library( ${MODULES_DIR}/standard/coreMQTT 1 )
 
 set( TRANSPORT_INTERFACE_INCLUDE_DIR
      ${MODULES_DIR}/standard/coreMQTT/source/interface )

--- a/platform/posix/transport/CMakeLists.txt
+++ b/platform/posix/transport/CMakeLists.txt
@@ -3,7 +3,7 @@ include( ${PLATFORM_DIR}/posix/posixFilePaths.cmake )
 
 # The transport_interface.h in coreMQTT is the single source of truth,
 # so make sure the submodule is cloned.
-clone_library( ${MODULES_DIR}/standard/coreMQTT 1 )
+clone_path( ${MODULES_DIR}/standard/coreMQTT )
 
 set( TRANSPORT_INTERFACE_INCLUDE_DIR
      ${MODULES_DIR}/standard/coreMQTT/source/interface )

--- a/platform/posix/transport/CMakeLists.txt
+++ b/platform/posix/transport/CMakeLists.txt
@@ -4,6 +4,9 @@ include( ${PLATFORM_DIR}/posix/posixFilePaths.cmake )
 # The transport_interface.h in coreMQTT is the single source of truth,
 # so make sure the submodule is cloned.
 clone_path( ${MODULES_DIR}/standard/coreMQTT )
+if( NOT EXISTS ${MODULES_DIR}/standard/coreMQTT/.git )
+    message( FATAL_ERROR "The required coreMQTT submodule does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
+endif()
 
 set( TRANSPORT_INTERFACE_INCLUDE_DIR
      ${MODULES_DIR}/standard/coreMQTT/source/interface )

--- a/platform/posix/transport/CMakeLists.txt
+++ b/platform/posix/transport/CMakeLists.txt
@@ -6,7 +6,7 @@ include( ${PLATFORM_DIR}/posix/posixFilePaths.cmake )
 if( NOT EXISTS ${submodule_dir}/.git )
     # Attempt to clone submodule.
     if( ${BUILD_CLONE_SUBMODULES} )
-        clone_library( "${MODULES_DIR}/standard/coreMQTT" )
+        clone_library( "${MODULES_DIR}/standard/coreMQTT" 1 )
     else()
         message( FATAL_ERROR "A required submodule does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
     endif()

--- a/platform/posix/transport/utest/CMakeLists.txt
+++ b/platform/posix/transport/utest/CMakeLists.txt
@@ -6,17 +6,6 @@ cmake_minimum_required (VERSION 3.2.0)
 # https://github.com/ThrowTheSwitch/CMock/issues/71
 # Therefore, header files need to be preprocessed before mocks are generated.
 
-# The transport interface unit tests use the coreMQTT's transport_interface.h,
-# so make sure the submodule is cloned.
-if( NOT EXISTS ${MODULES_DIR}/standard/coreMQTT/source )
-    # Attempt to clone coreMQTT.
-    if( ${BUILD_CLONE_SUBMODULES} )
-        clone_mqtt()
-    else()
-        message( FATAL_ERROR "The required submodule coreMQTT does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
-    endif()
-endif()
-
 # ====================  Define your project name (edit) ========================
 set(project_name "transport")
 


### PR DESCRIPTION
Automatically clone submodules of library upon building with cmake

We used to just fail when the user had not cloned submodules

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
