### PR TITLE
Make OPENSSL_USE_STATIC_LIBS requirement conditional on build type

### DIFF
--- a/platform/posix/transport/CMakeLists.txt
+++ b/platform/posix/transport/CMakeLists.txt
@@ -37,7 +37,11 @@ target_link_libraries( plaintext_posix
 add_library( openssl_posix
                 ${OPENSSL_TRANSPORT_SOURCES} )
 
-set( OPENSSL_USE_STATIC_LIBS TRUE )
+# For static library builds, link against static library of OpenSSL
+# for openssl_posix target.
+if(BUILD_SHARED_LIBS)
+    set( OPENSSL_USE_STATIC_LIBS TRUE )
+endif()
 find_package( OpenSSL REQUIRED )
 
 # Verify the minimum OpenSSL version required

--- a/platform/posix/transport/CMakeLists.txt
+++ b/platform/posix/transport/CMakeLists.txt
@@ -39,7 +39,7 @@ add_library( openssl_posix
 
 # For static library builds, link against static library of OpenSSL
 # for openssl_posix target.
-if(BUILD_SHARED_LIBS)
+if(NOT BUILD_SHARED_LIBS)
     set( OPENSSL_USE_STATIC_LIBS TRUE )
 endif()
 find_package( OpenSSL REQUIRED )


### PR DESCRIPTION
Currently, the `openssl_posix` library is ALWAYS linked against `libssl.a` for both `libopenssl_posix.a` (static library build) and `liboepnssl_posix.so` (shared library) builds. This can cause issues on platforms where static library does not link by default with shared libraries, thereby, showing the `relocation R_X86_64_32 against .rodata.str1.1` error. This PR updates the CMake configuration to link `libssl.a` ONLY when building static libraries