### PR TITLE
Check if .git directory exists before cloning submodules

### DIFF
--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -12,7 +12,9 @@ macro( clone_path path )
     endif()
 endmacro()
 
-clone_path( ${MODULES_DIR} )
+if( EXISTS ${ROOT_DIR}/.git )
+    clone_path( ${MODULES_DIR} )
+endif()
 
 # Add build configuration for all 3rd party modules.
 add_subdirectory(${3RDPARTY_DIR})


### PR DESCRIPTION
This makes it so that users who download the zip will not have to automatically clone submodules since the zip does not have the .git directory.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
