### PR TITLE
Remove unused aws-templates-for-cbmc-proofs from master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "libraries/3rdparty/CMock"]
 	path = libraries/3rdparty/CMock
 	url = https://github.com/ThrowTheSwitch/CMock
-[submodule "tools/aws-templates-for-cbmc-proofs"]
-	path = tools/aws-templates-for-cbmc-proofs
-	url = https://github.com/awslabs/aws-templates-for-cbmc-proofs.git
 [submodule "libraries/standard/coreMQTT"]
 	path = libraries/standard/coreMQTT
 	url = https://github.com/FreeRTOS/coreMQTT.git


### PR DESCRIPTION
CBMC proofs live with the library repositories. This removes the submodule that was added months ago.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
