### PR TITLE
Fix memory leak in tearDown of integration tests

### DIFF
--- a/integration-test/mqtt/mqtt_system_test.c
+++ b/integration-test/mqtt/mqtt_system_test.c
@@ -826,6 +826,8 @@ void tearDown()
     /* Terminate TLS session and TCP connection. */
     ( void ) Openssl_Disconnect( &networkContext );
 
+    /* Make any assertions at the end that may prevent #Openssl_Disconnect from
+     * being called and ultimately cause a memory leak. */
     TEST_ASSERT_EQUAL( MQTTSuccess, status );
 }
 

--- a/integration-test/mqtt/mqtt_system_test.c
+++ b/integration-test/mqtt/mqtt_system_test.c
@@ -807,6 +807,8 @@ void setUp()
 /* Called after each test method. */
 void tearDown()
 {
+    MQTTStatus_t status;
+
     /* Free memory, if allocated during test case execution. */
     if( incomingInfo.pTopicName != NULL )
     {
@@ -819,10 +821,12 @@ void tearDown()
     }
 
     /* Terminate MQTT connection. */
-    TEST_ASSERT_EQUAL( MQTTSuccess, MQTT_Disconnect( &context ) );
+    status = MQTT_Disconnect( &context );
 
     /* Terminate TLS session and TCP connection. */
     ( void ) Openssl_Disconnect( &networkContext );
+
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
 }
 
 /* ========================== Test Cases ============================ */

--- a/integration-test/mqtt/mqtt_system_test.c
+++ b/integration-test/mqtt/mqtt_system_test.c
@@ -807,7 +807,8 @@ void setUp()
 /* Called after each test method. */
 void tearDown()
 {
-    MQTTStatus_t status;
+    MQTTStatus_t mqttStatus;
+    OpensslStatus_t opensslStatus;
 
     /* Free memory, if allocated during test case execution. */
     if( incomingInfo.pTopicName != NULL )
@@ -821,14 +822,15 @@ void tearDown()
     }
 
     /* Terminate MQTT connection. */
-    status = MQTT_Disconnect( &context );
+    mqttStatus = MQTT_Disconnect( &context );
 
     /* Terminate TLS session and TCP connection. */
-    ( void ) Openssl_Disconnect( &networkContext );
+    opensslStatus = Openssl_Disconnect( &networkContext );
 
-    /* Make any assertions at the end that may prevent #Openssl_Disconnect from
-     * being called and ultimately cause a memory leak. */
-    TEST_ASSERT_EQUAL( MQTTSuccess, status );
+    /* Make any assertions at the end so that all memory is deallocated before
+     * the end of this function. */
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    TEST_ASSERT_EQUAL( OPENSSL_SUCCESS, opensslStatus );
 }
 
 /* ========================== Test Cases ============================ */

--- a/integration-test/mqtt/mqtt_system_test.c
+++ b/integration-test/mqtt/mqtt_system_test.c
@@ -826,7 +826,7 @@ void tearDown()
     /* Terminate TLS session and TCP connection. */
     ( void ) Openssl_Disconnect( &networkContext );
 
-    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    TEST_ASSERT_EQUAL( MQTTSuccess, status );
 }
 
 /* ========================== Test Cases ============================ */

--- a/integration-test/shadow/shadow_system_test.c
+++ b/integration-test/shadow/shadow_system_test.c
@@ -696,7 +696,8 @@ void setUp( void )
 /* Called after each test method. */
 void tearDown( void )
 {
-    MQTTStatus_t status;
+    MQTTStatus_t mqttStatus;
+    OpensslStatus_t opensslStatus;
 
     /* Free memory, if allocated during test case execution. */
     if( incomingInfo.pTopicName != NULL )
@@ -710,14 +711,15 @@ void tearDown( void )
     }
 
     /* Terminate MQTT connection. */
-    status = MQTT_Disconnect( &context );
+    mqttStatus = MQTT_Disconnect( &context );
 
     /* Terminate TLS session and TCP connection. */
-    ( void ) Openssl_Disconnect( &networkContext );
+    opensslStatus = Openssl_Disconnect( &networkContext );
 
-    /* Make any assertions at the end that may prevent #Openssl_Disconnect from
-     * being called and ultimately cause a memory leak. */
-    TEST_ASSERT_EQUAL( MQTTSuccess, status );
+    /* Make any assertions at the end so that all memory is deallocated before
+     * the end of this function. */
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    TEST_ASSERT_EQUAL( OPENSSL_SUCCESS, opensslStatus );
 }
 
 /* ========================== Test Cases ============================ */

--- a/integration-test/shadow/shadow_system_test.c
+++ b/integration-test/shadow/shadow_system_test.c
@@ -696,6 +696,8 @@ void setUp( void )
 /* Called after each test method. */
 void tearDown( void )
 {
+    MQTTStatus_t status;
+
     /* Free memory, if allocated during test case execution. */
     if( incomingInfo.pTopicName != NULL )
     {
@@ -708,10 +710,14 @@ void tearDown( void )
     }
 
     /* Terminate MQTT connection. */
-    TEST_ASSERT_EQUAL( MQTTSuccess, MQTT_Disconnect( &context ) );
+    status = MQTT_Disconnect( &context ) );
 
     /* Terminate TLS session and TCP connection. */
     ( void ) Openssl_Disconnect( &networkContext );
+
+    /* Make any assertions at the end that may prevent #Openssl_Disconnect from
+     * being called and ultimately cause a memory leak. */
+    TEST_ASSERT_EQUAL( MQTTSuccess, status );
 }
 
 /* ========================== Test Cases ============================ */

--- a/integration-test/shadow/shadow_system_test.c
+++ b/integration-test/shadow/shadow_system_test.c
@@ -710,7 +710,7 @@ void tearDown( void )
     }
 
     /* Terminate MQTT connection. */
-    status = MQTT_Disconnect( &context ) );
+    status = MQTT_Disconnect( &context );
 
     /* Terminate TLS session and TCP connection. */
     ( void ) Openssl_Disconnect( &networkContext );


### PR DESCRIPTION
If the assertion on the returned status of `MQTT_Disconnect` fails, then `Openssl_Disconnect` will never be called. This means that the memory will remain allocated while a new connection will be established for the next test case, causing a memory leak.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
