### PR TITLE
Add git-secrets check to the GHA.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: aws/git-secrets
+          ref: master
           path: git-secrets
       - name: Install git-secrets
         run: cd git-secrets && sudo make install && cd ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,10 +183,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Checkout aws/git-secrets
+      - name: Checkout awslabs/git-secrets
         uses: actions/checkout@v2
         with:
-          repository: aws/git-secrets
+          repository: awslabs/git-secrets
           ref: master
           path: git-secrets
       - name: Install git-secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,3 +177,20 @@ jobs:
         run: |
           doxygen docs/doxygen/config.doxyfile 2>&1 | tee doxyoutput.txt
           if [[ "$(wc -c < doxyoutput.txt | bc)" = "0" ]]; then exit 0; else exit 1; fi
+  git-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Checkout aws/git-secrets
+        uses: actions/checkout@v2
+        with:
+          repository: aws/git-secrets
+          path: git-secrets
+      - name: Install git-secrets
+        run: cd git-secrets && sudo make install && cd ..
+      - name: Run git-secrets
+        run: |
+          git-secrets --register-aws
+          git-secrets --scan

--- a/demos/http/http_demo_s3_download/demo_config.h
+++ b/demos/http/http_demo_s3_download/demo_config.h
@@ -110,8 +110,4 @@
  */
 #define RANGE_REQUEST_LENGTH              ( 2048 )
 
-#define S3_PRESIGNED_GET_URL    "https://sarem-public.s3.amazonaws.com/gettysberg.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIJ6R5GYH52KZ3LBA%2F20201112%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20201112T225234Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=2858d525f021f6abe9d595269b97153bcaada2ecc6f026a624ffd60bd42a3ed0"
-
-#define S3_PRESIGNED_PUT_URL    "https://sarem-public.s3.amazonaws.com/gettysberg.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIJ6R5GYH52KZ3LBA%2F20201112%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20201112T225234Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=58a9ba9bcfb675ee7784a51fef3279d34335e10072a1bf0b78699faa9f7823ef"
-
 #endif /* ifndef DEMO_CONFIG_H_ */

--- a/demos/http/http_demo_s3_download/demo_config.h
+++ b/demos/http/http_demo_s3_download/demo_config.h
@@ -110,4 +110,8 @@
  */
 #define RANGE_REQUEST_LENGTH              ( 2048 )
 
+#define S3_PRESIGNED_GET_URL    "https://sarem-public.s3.amazonaws.com/gettysberg.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIJ6R5GYH52KZ3LBA%2F20201112%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20201112T225234Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=2858d525f021f6abe9d595269b97153bcaada2ecc6f026a624ffd60bd42a3ed0"
+
+#define S3_PRESIGNED_PUT_URL    "https://sarem-public.s3.amazonaws.com/gettysberg.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIJ6R5GYH52KZ3LBA%2F20201112%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20201112T225234Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=58a9ba9bcfb675ee7784a51fef3279d34335e10072a1bf0b78699faa9f7823ef"
+
 #endif /* ifndef DEMO_CONFIG_H_ */


### PR DESCRIPTION
Add git-secrets check to the GHAs. This is a second line of defense against things like an Amazon account number being checked into the repo. The first line of defense is developers running git-secrets in their pre-commit hooks.

See https://github.com/aws/aws-iot-device-sdk-embedded-C/runs/1393292362 for the successful test run.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
