### PR TITLE
Add tracking branch for coreJSON

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -23,9 +23,9 @@
 	url = https://github.com/aws/jobs-for-aws-iot-embedded-sdk.git
 [submodule "libraries/aws/device-defender-for-aws-iot-embedded-sdk"]
 	path = libraries/aws/device-defender-for-aws-iot-embedded-sdk
-        branch = main
+	branch = main
 	url = https://github.com/aws/device-defender-for-aws-iot-embedded-sdk.git
 [submodule "libraries/standard/corePKCS11"]
 	path = libraries/standard/corePKCS11
-        branch = main
+	branch = main
 	url = https://github.com/FreeRTOS/corePKCS11.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,9 +3,11 @@
 	url = https://github.com/ThrowTheSwitch/CMock
 [submodule "libraries/standard/coreMQTT"]
 	path = libraries/standard/coreMQTT
+	branch = main
 	url = https://github.com/FreeRTOS/coreMQTT.git
 [submodule "libraries/standard/coreHTTP"]
 	path = libraries/standard/coreHTTP
+	branch = main
 	url = https://github.com/FreeRTOS/coreHTTP.git
 [submodule "libraries/standard/coreJSON"]
 	path = libraries/standard/coreJSON
@@ -13,12 +15,14 @@
 	url = https://github.com/FreeRTOS/coreJSON.git
 [submodule "libraries/aws/device-shadow-for-aws-iot-embedded-sdk"]
 	path = libraries/aws/device-shadow-for-aws-iot-embedded-sdk
+	branch = main
 	url = https://github.com/aws/device-shadow-for-aws-iot-embedded-sdk.git
 [submodule "libraries/aws/jobs-for-aws-iot-embedded-sdk"]
 	path = libraries/aws/jobs-for-aws-iot-embedded-sdk
 	url = https://github.com/aws/jobs-for-aws-iot-embedded-sdk.git
 [submodule "libraries/aws/device-defender-for-aws-iot-embedded-sdk"]
 	path = libraries/aws/device-defender-for-aws-iot-embedded-sdk
+        branch = main
 	url = https://github.com/aws/device-defender-for-aws-iot-embedded-sdk.git
 [submodule "libraries/standard/corePKCS11"]
 	path = libraries/standard/corePKCS11

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,12 +19,13 @@
 	url = https://github.com/aws/device-shadow-for-aws-iot-embedded-sdk.git
 [submodule "libraries/aws/jobs-for-aws-iot-embedded-sdk"]
 	path = libraries/aws/jobs-for-aws-iot-embedded-sdk
-	url = https://github.com/aws/jobs-for-aws-iot-embedded-sdk.git
 	branch = main
+	url = https://github.com/aws/jobs-for-aws-iot-embedded-sdk.git
 [submodule "libraries/aws/device-defender-for-aws-iot-embedded-sdk"]
 	path = libraries/aws/device-defender-for-aws-iot-embedded-sdk
         branch = main
 	url = https://github.com/aws/device-defender-for-aws-iot-embedded-sdk.git
 [submodule "libraries/standard/corePKCS11"]
 	path = libraries/standard/corePKCS11
+        branch = main
 	url = https://github.com/FreeRTOS/corePKCS11.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -20,6 +20,7 @@
 [submodule "libraries/aws/jobs-for-aws-iot-embedded-sdk"]
 	path = libraries/aws/jobs-for-aws-iot-embedded-sdk
 	url = https://github.com/aws/jobs-for-aws-iot-embedded-sdk.git
+	branch = main
 [submodule "libraries/aws/device-defender-for-aws-iot-embedded-sdk"]
 	path = libraries/aws/device-defender-for-aws-iot-embedded-sdk
         branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,6 +9,7 @@
 	url = https://github.com/FreeRTOS/coreHTTP.git
 [submodule "libraries/standard/coreJSON"]
 	path = libraries/standard/coreJSON
+	branch = main
 	url = https://github.com/FreeRTOS/coreJSON.git
 [submodule "libraries/aws/device-shadow-for-aws-iot-embedded-sdk"]
 	path = libraries/aws/device-shadow-for-aws-iot-embedded-sdk


### PR DESCRIPTION
*Description of changes:*
`git submodule update --remote -f` fails for `coreJSON` submodule as the submodule pointer update is attempted on `origin/master` instead of `origin/main`

```
╰─➤  git submodule update --init -f --remote
Submodule path 'libraries/3rdparty/CMock': checked out '9c1c6a05dc7aa41d6a2da39b9f916be373ef050e'
Submodule path 'libraries/aws/device-defender-for-aws-iot-embedded-sdk': checked out '9ba281dafdf7f48941fc7f20740716883019fcfc'
Submodule path 'libraries/aws/device-shadow-for-aws-iot-embedded-sdk': checked out 'fabbece424c03f2f90a2c5b1117bcb44cbe9257b'
Submodule path 'libraries/aws/jobs-for-aws-iot-embedded-sdk': checked out '2c6628c36cb905763037265776d0d811ec7f863d'
Submodule path 'libraries/standard/coreHTTP': checked out '0882657628eb7df12dc957f9b122601fd3054a68'
fatal: Needed a single revision
Unable to find current origin/master revision in submodule path 'libraries/standard/coreJSON'
```

This PR fixes the issue by adding a tracking branch configuration for the `coreJSON`  submodule.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
