### PR TITLE
Enable SNI for all TLS demos and integration tests

### DIFF
--- a/demos/defender/defender_demo_json/mqtt_operations.c
+++ b/demos/defender/defender_demo_json/mqtt_operations.c
@@ -359,6 +359,7 @@ static bool connectToBrokerWithBackoffRetries( NetworkContext_t * pNetworkContex
     opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
     opensslCredentials.pClientCertPath = CLIENT_CERT_PATH;
     opensslCredentials.pPrivateKeyPath = CLIENT_PRIVATE_KEY_PATH;
+    opensslCredentials.sniHostName = AWS_IOT_ENDPOINT;
 
     if( AWS_MQTT_PORT == 443 )
     {

--- a/demos/http/http_demo_basic_tls/http_demo_basic_tls.c
+++ b/demos/http/http_demo_basic_tls/http_demo_basic_tls.c
@@ -225,6 +225,7 @@ static int32_t connectToServer( NetworkContext_t * pNetworkContext )
     /* Initialize TLS credentials. */
     ( void ) memset( &opensslCredentials, 0, sizeof( opensslCredentials ) );
     opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
+    opensslCredentials.sniHostName = SERVER_HOST;
 
     /* Initialize server information. */
     serverInfo.pHostName = SERVER_HOST;

--- a/demos/http/http_demo_mutual_auth/http_demo_mutual_auth.c
+++ b/demos/http/http_demo_mutual_auth/http_demo_mutual_auth.c
@@ -168,6 +168,7 @@ static int32_t connectToServer( NetworkContext_t * pNetworkContext )
     opensslCredentials.pClientCertPath = CLIENT_CERT_PATH;
     opensslCredentials.pPrivateKeyPath = CLIENT_PRIVATE_KEY_PATH;
     opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
+    opensslCredentials.sniHostName = AWS_IOT_ENDPOINT;
 
     /* ALPN is required when communicating to AWS IoT Core over port 443 through HTTP. */
     if( AWS_HTTPS_PORT == 443 )

--- a/demos/http/http_demo_s3_download/http_demo_s3_download.c
+++ b/demos/http/http_demo_s3_download/http_demo_s3_download.c
@@ -678,4 +678,3 @@ int main( int argc,
 
     return returnStatus;
 }
-}

--- a/demos/http/http_demo_s3_download/http_demo_s3_download.c
+++ b/demos/http/http_demo_s3_download/http_demo_s3_download.c
@@ -204,9 +204,9 @@ static int32_t connectToServer( NetworkContext_t * pNetworkContext )
     /* Status returned by OpenSSL transport implementation. */
     OpensslStatus_t opensslStatus;
     /* Credentials to establish the TLS connection. */
-    OpensslCredentials_t opensslCredentials = {0};
+    OpensslCredentials_t opensslCredentials = { 0 };
     /* Information about the server to send the HTTP requests. */
-    ServerInfo_t serverInfo = {0};
+    ServerInfo_t serverInfo = { 0 };
 
     /* Retrieve the address location and length from S3_PRESIGNED_GET_URL. */
     httpStatus = getUrlAddress( S3_PRESIGNED_GET_URL,
@@ -677,4 +677,5 @@ int main( int argc,
     ( void ) Openssl_Disconnect( &networkContext );
 
     return returnStatus;
+}
 }

--- a/demos/http/http_demo_s3_download/http_demo_s3_download.c
+++ b/demos/http/http_demo_s3_download/http_demo_s3_download.c
@@ -211,6 +211,7 @@ static int32_t connectToServer( NetworkContext_t * pNetworkContext )
     /* Initialize TLS credentials. */
     ( void ) memset( &opensslCredentials, 0, sizeof( opensslCredentials ) );
     opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
+    opensslCredentials.sniHostName = S3_PRESIGNED_GET_URL;
 
     /* Retrieve the address location and length from S3_PRESIGNED_GET_URL. */
     httpStatus = getUrlAddress( S3_PRESIGNED_GET_URL,
@@ -233,7 +234,7 @@ static int32_t connectToServer( NetworkContext_t * pNetworkContext )
         serverInfo.port = HTTPS_PORT;
 
         /* Establish a TLS session with the HTTP server. This example connects
-         * to the HTTP server as specified in SERVER_HOST and HTTPS_PORT in
+         * to the HTTP server as specified in S3_PRESIGNED_GET_URL and HTTPS_PORT in
          * demo_config.h. */
         LogInfo( ( "Establishing a TLS session with %s:%d.",
                    serverHost,

--- a/demos/http/http_demo_s3_download/http_demo_s3_download.c
+++ b/demos/http/http_demo_s3_download/http_demo_s3_download.c
@@ -204,21 +204,15 @@ static int32_t connectToServer( NetworkContext_t * pNetworkContext )
     /* Status returned by OpenSSL transport implementation. */
     OpensslStatus_t opensslStatus;
     /* Credentials to establish the TLS connection. */
-    OpensslCredentials_t opensslCredentials;
+    OpensslCredentials_t opensslCredentials = {0};
     /* Information about the server to send the HTTP requests. */
-    ServerInfo_t serverInfo;
-
-    /* Initialize TLS credentials. */
-    ( void ) memset( &opensslCredentials, 0, sizeof( opensslCredentials ) );
-    opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
-    opensslCredentials.sniHostName = S3_PRESIGNED_GET_URL;
+    ServerInfo_t serverInfo = {0};
 
     /* Retrieve the address location and length from S3_PRESIGNED_GET_URL. */
     httpStatus = getUrlAddress( S3_PRESIGNED_GET_URL,
                                 S3_PRESIGNED_GET_URL_LENGTH,
                                 &pAddress,
                                 &serverHostLength );
-
     returnStatus = ( httpStatus == HTTPSuccess ) ? EXIT_SUCCESS : EXIT_FAILURE;
 
     if( returnStatus == EXIT_SUCCESS )
@@ -227,6 +221,10 @@ static int32_t connectToServer( NetworkContext_t * pNetworkContext )
          * S3_PRESIGNED_GET_URL. */
         memcpy( serverHost, pAddress, serverHostLength );
         serverHost[ serverHostLength ] = '\0';
+
+        /* Initialize TLS credentials. */
+        opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
+        opensslCredentials.sniHostName = serverHost;
 
         /* Initialize server information. */
         serverInfo.pHostName = serverHost;

--- a/demos/http/http_demo_s3_download_multithreaded/http_demo_s3_download_multithreaded.c
+++ b/demos/http/http_demo_s3_download_multithreaded/http_demo_s3_download_multithreaded.c
@@ -315,6 +315,7 @@ static int connectToServer( NetworkContext_t * pNetworkContext )
 
     /* Initialize TLS credentials. */
     opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
+    opensslCredentials.sniHostName = serverHost;
 
     /* serverHost should consist only of the host address located in S3_PRESIGNED_GET_URL. */
     memcpy( serverHost, pHost, hostLen );

--- a/demos/http/http_demo_s3_upload/http_demo_s3_upload.c
+++ b/demos/http/http_demo_s3_upload/http_demo_s3_upload.c
@@ -246,6 +246,7 @@ static int32_t connectToServer( NetworkContext_t * pNetworkContext )
     /* Initialize TLS credentials. */
     ( void ) memset( &opensslCredentials, 0, sizeof( opensslCredentials ) );
     opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
+    opensslCredentials.sniHostName = S3_PRESIGNED_PUT_URL;
 
     /* Retrieve the address location and length from S3_PRESIGNED_PUT_URL. */
     httpStatus = getUrlAddress( S3_PRESIGNED_PUT_URL,

--- a/demos/http/http_demo_s3_upload/http_demo_s3_upload.c
+++ b/demos/http/http_demo_s3_upload/http_demo_s3_upload.c
@@ -239,14 +239,9 @@ static int32_t connectToServer( NetworkContext_t * pNetworkContext )
     /* Status returned by OpenSSL transport implementation. */
     OpensslStatus_t opensslStatus;
     /* Credentials to establish the TLS connection. */
-    OpensslCredentials_t opensslCredentials;
+    OpensslCredentials_t opensslCredentials = { 0 };
     /* Information about the server to send the HTTP requests. */
-    ServerInfo_t serverInfo;
-
-    /* Initialize TLS credentials. */
-    ( void ) memset( &opensslCredentials, 0, sizeof( opensslCredentials ) );
-    opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
-    opensslCredentials.sniHostName = S3_PRESIGNED_PUT_URL;
+    ServerInfo_t serverInfo = { 0 };
 
     /* Retrieve the address location and length from S3_PRESIGNED_PUT_URL. */
     httpStatus = getUrlAddress( S3_PRESIGNED_PUT_URL,
@@ -262,6 +257,10 @@ static int32_t connectToServer( NetworkContext_t * pNetworkContext )
          * S3_PRESIGNED_PUT_URL. */
         memcpy( serverHost, pAddress, serverHostLength );
         serverHost[ serverHostLength ] = '\0';
+
+        /* Initialize TLS credentials. */
+        opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
+        opensslCredentials.sniHostName = serverHost;
 
         /* Initialize server information. */
         serverInfo.pHostName = serverHost;

--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -469,6 +469,7 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
     /* Initialize credentials for establishing TLS session. */
     memset( &opensslCredentials, 0, sizeof( OpensslCredentials_t ) );
     opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
+    opensslCredentials.sniHostName = BROKER_ENDPOINT;
 
     /* Initialize reconnect attempts and interval */
     RetryUtils_InitializeParams( &reconnectParams,

--- a/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
+++ b/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
@@ -538,6 +538,7 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
     /* Initialize credentials for establishing TLS session. */
     memset( &opensslCredentials, 0, sizeof( OpensslCredentials_t ) );
     opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
+    opensslCredentials.sniHostName = BROKER_ENDPOINT;
 
     /* Seed pseudo random number generator (provided by ISO C standard library) for
      * use by retry utils library when retrying failed connection attempts to broker. */

--- a/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
+++ b/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
@@ -340,6 +340,7 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
     opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
     opensslCredentials.pClientCertPath = CLIENT_CERT_PATH;
     opensslCredentials.pPrivateKeyPath = CLIENT_PRIVATE_KEY_PATH;
+    opensslCredentials.sniHostName = AWS_IOT_ENDPOINT;
 
     if( AWS_MQTT_PORT == 443 )
     {

--- a/integration-test/http/http_system_test.c
+++ b/integration-test/http/http_system_test.c
@@ -257,6 +257,7 @@ static void connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContex
     /* Reset or initialize file-scoped global variables. */
     ( void ) memset( &opensslCredentials, 0, sizeof( opensslCredentials ) );
     opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
+    opensslCredentials.sniHostName = SERVER_HOST;
 
     serverInfo.pHostName = SERVER_HOST;
     serverInfo.hostNameLength = SERVER_HOST_LENGTH;

--- a/integration-test/mqtt/mqtt_system_test.c
+++ b/integration-test/mqtt/mqtt_system_test.c
@@ -776,6 +776,7 @@ void setUp()
     opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
     opensslCredentials.pClientCertPath = CLIENT_CERT_PATH;
     opensslCredentials.pPrivateKeyPath = CLIENT_PRIVATE_KEY_PATH;
+    opensslCredentials.sniHostname = AWS_IOT_ENDPOINT;
 
     serverInfo.pHostName = BROKER_ENDPOINT;
     serverInfo.hostNameLength = BROKER_ENDPOINT_LENGTH;

--- a/integration-test/mqtt/mqtt_system_test.c
+++ b/integration-test/mqtt/mqtt_system_test.c
@@ -776,7 +776,7 @@ void setUp()
     opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
     opensslCredentials.pClientCertPath = CLIENT_CERT_PATH;
     opensslCredentials.pPrivateKeyPath = CLIENT_PRIVATE_KEY_PATH;
-    opensslCredentials.sniHostname = AWS_IOT_ENDPOINT;
+    opensslCredentials.sniHostName = BROKER_ENDPOINT;
 
     serverInfo.pHostName = BROKER_ENDPOINT;
     serverInfo.hostNameLength = BROKER_ENDPOINT_LENGTH;

--- a/integration-test/shadow/shadow_system_test.c
+++ b/integration-test/shadow/shadow_system_test.c
@@ -675,6 +675,7 @@ void setUp( void )
     opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
     opensslCredentials.pClientCertPath = CLIENT_CERT_PATH;
     opensslCredentials.pPrivateKeyPath = CLIENT_PRIVATE_KEY_PATH;
+    opensslCredentials.sniHostName = AWS_IOT_ENDPOINT;
     serverInfo.pHostName = AWS_IOT_ENDPOINT;
     serverInfo.hostNameLength = AWS_IOT_ENDPOINT_LENGTH;
     serverInfo.port = AWS_MQTT_PORT;


### PR DESCRIPTION
Some servers require SNI to be enabled or won't allow the handshake.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
