### PR TITLE
Update demos and tests for backoffAlgorithm API change

### DIFF
--- a/demos/defender/defender_demo_json/mqtt_operations.c
+++ b/demos/defender/defender_demo_json/mqtt_operations.c
@@ -372,8 +372,9 @@ static bool connectToBrokerWithBackoffRetries( NetworkContext_t * pNetworkContex
         opensslCredentials.alpnProtosLen = ALPN_PROTOCOL_NAME_LENGTH;
     }
 
-    /* Seed pseudo random number generator (provided by ISO C standard library) for
-     * use by retry utils library when retrying failed connection attempts to broker. */
+    /* Seed pseudo random number generator used in the demo for
+     * backoff period calculation when retrying failed network operations
+     * with broker. */
 
     /* Get current time to seed pseudo random number generator. */
     ( void ) clock_gettime( CLOCK_REALTIME, &tp );

--- a/demos/defender/defender_demo_json/mqtt_operations.c
+++ b/demos/defender/defender_demo_json/mqtt_operations.c
@@ -330,7 +330,7 @@ static bool handlePublishResend( MQTTContext_t * pMqttContext );
 
 static uint32_t generateRandomNumber()
 {
-    return( rand() & UINT32_MAX );
+    return( rand() );
 }
 
 /*-----------------------------------------------------------*/

--- a/demos/defender/defender_demo_json/mqtt_operations.c
+++ b/demos/defender/defender_demo_json/mqtt_operations.c
@@ -253,11 +253,8 @@ static MQTTPublishCallback_t appPublishCallback = NULL;
 /**
  * @brief The random number generator to use for exponential backoff with
  * jitter retry logic.
- * This function is an implementation the #BackoffAlgorithm_RNG_t interface type
- * of the retry utils library API.
  *
- * @return The generated random number. This function ALWAYS succeeds
- * in generating a random number.
+ * @return The generated random number.
  */
 static uint32_t generateRandomNumber();
 

--- a/demos/defender/defender_demo_json/mqtt_operations.c
+++ b/demos/defender/defender_demo_json/mqtt_operations.c
@@ -259,7 +259,7 @@ static MQTTPublishCallback_t appPublishCallback = NULL;
  * @return The generated random number. This function ALWAYS succeeds
  * in generating a random number.
  */
-static int32_t generateRandomNumber();
+static uint32_t generateRandomNumber();
 
 /**
  * @brief Connect to the MQTT broker with reconnection retries.
@@ -331,9 +331,9 @@ static void mqttCallback( MQTTContext_t * pMqttContext,
 static bool handlePublishResend( MQTTContext_t * pMqttContext );
 /*-----------------------------------------------------------*/
 
-static int32_t generateRandomNumber()
+static uint32_t generateRandomNumber()
 {
-    return( rand() % ( INT32_MAX ) );
+    return( rand() & UINT32_MAX );
 }
 
 /*-----------------------------------------------------------*/
@@ -384,8 +384,7 @@ static bool connectToBrokerWithBackoffRetries( NetworkContext_t * pNetworkContex
     BackoffAlgorithm_InitializeParams( &reconnectParams,
                                        CONNECTION_RETRY_BACKOFF_BASE_MS,
                                        CONNECTION_RETRY_MAX_BACKOFF_DELAY_MS,
-                                       CONNECTION_RETRY_MAX_ATTEMPTS,
-                                       generateRandomNumber );
+                                       CONNECTION_RETRY_MAX_ATTEMPTS );
 
     /* Attempt to connect to MQTT broker. If connection fails, retry after
      * a timeout. Timeout value will exponentially increase until maximum
@@ -412,9 +411,8 @@ static bool connectToBrokerWithBackoffRetries( NetworkContext_t * pNetworkContex
         }
         else
         {
-            /* Get back-off value (in milliseconds) for the next connection retry. */
-            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams, &nextRetryBackOff );
-            assert( backoffAlgStatus != BackoffAlgorithmRngFailure );
+            /* Generate a random number and get back-off value (in milliseconds) for the next connection retry. */
+            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams, generateRandomNumber(), &nextRetryBackOff );
 
             if( backoffAlgStatus == BackoffAlgorithmRetriesExhausted )
             {

--- a/demos/http/common/src/http_demo_utils.c
+++ b/demos/http/common/src/http_demo_utils.c
@@ -76,7 +76,7 @@ static uint32_t generateRandomNumber();
 
 static uint32_t generateRandomNumber()
 {
-    return( rand() & UINT32_MAX );
+    return( rand() );
 }
 
 /*-----------------------------------------------------------*/

--- a/demos/http/common/src/http_demo_utils.c
+++ b/demos/http/common/src/http_demo_utils.c
@@ -73,13 +73,13 @@
  * @return The generated random number. This function ALWAYS succeeds
  * in generating a random number.
  */
-static int32_t generateRandomNumber();
+static uint32_t generateRandomNumber();
 
 /*-----------------------------------------------------------*/
 
-static int32_t generateRandomNumber()
+static uint32_t generateRandomNumber()
 {
-    return( rand() % ( INT32_MAX ) );
+    return( rand() & UINT32_MAX );
 }
 
 /*-----------------------------------------------------------*/
@@ -109,8 +109,7 @@ int32_t connectToServerWithBackoffRetries( TransportConnect_t connectFunction,
     BackoffAlgorithm_InitializeParams( &reconnectParams,
                                        CONNECTION_RETRY_BACKOFF_BASE_MS,
                                        CONNECTION_RETRY_MAX_BACKOFF_DELAY_MS,
-                                       CONNECTION_RETRY_MAX_ATTEMPTS,
-                                       generateRandomNumber );
+                                       CONNECTION_RETRY_MAX_ATTEMPTS );
 
     /* Attempt to connect to HTTP server. If connection fails, retry after
      * a timeout. Timeout value will exponentially increase until maximum
@@ -121,9 +120,8 @@ int32_t connectToServerWithBackoffRetries( TransportConnect_t connectFunction,
 
         if( returnStatus != EXIT_SUCCESS )
         {
-            /* Get back-off value (in milliseconds) for the next connection retry. */
-            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams, &nextRetryBackOff );
-            assert( backoffAlgStatus != BackoffAlgorithmRngFailure );
+            /* Generate a random number and get back-off value (in milliseconds) for the next connection retry. */
+            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams, generateRandomNumber(), &nextRetryBackOff );
 
             if( backoffAlgStatus == BackoffAlgorithmSuccess )
             {

--- a/demos/http/common/src/http_demo_utils.c
+++ b/demos/http/common/src/http_demo_utils.c
@@ -97,8 +97,9 @@ int32_t connectToServerWithBackoffRetries( TransportConnect_t connectFunction,
 
     assert( connectFunction != NULL );
 
-    /* Seed pseudo random number generator (provided by ISO C standard library) for
-     * use by retry utils library when retrying failed connection attempts to broker. */
+    /* Seed pseudo random number generator used in the demo for
+     * backoff period calculation when retrying failed network operations
+     * with broker. */
 
     /* Get current time to seed pseudo random number generator. */
     ( void ) clock_gettime( CLOCK_REALTIME, &tp );

--- a/demos/http/common/src/http_demo_utils.c
+++ b/demos/http/common/src/http_demo_utils.c
@@ -67,11 +67,8 @@
 /**
  * @brief The random number generator to use for exponential backoff with
  * jitter retry logic.
- * This function is an implementation the #BackoffAlgorithm_RNG_t interface type
- * of the retry utils library API.
  *
- * @return The generated random number. This function ALWAYS succeeds
- * in generating a random number.
+ * @return The generated random number.
  */
 static uint32_t generateRandomNumber();
 

--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -444,7 +444,7 @@ static int handleResubscribe( MQTTContext_t * pMqttContext );
 
 static uint32_t generateRandomNumber()
 {
-    return( rand() & UINT32_MAX );
+    return( rand() );
 }
 
 /*-----------------------------------------------------------*/

--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -254,11 +254,8 @@ static MQTTSubAckStatus_t globalSubAckStatus = MQTTSubAckFailure;
 /**
  * @brief The random number generator to use for exponential backoff with
  * jitter retry logic.
- * This function is an implementation the #BackoffAlgorithm_RNG_t interface type
- * of the retry utils library API.
  *
- * @return The generated random number. This function ALWAYS succeeds
- * in generating a random number.
+ * @return The generated random number.
  */
 static uint32_t generateRandomNumber();
 

--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -260,7 +260,7 @@ static MQTTSubAckStatus_t globalSubAckStatus = MQTTSubAckFailure;
  * @return The generated random number. This function ALWAYS succeeds
  * in generating a random number.
  */
-static int32_t generateRandomNumber();
+static uint32_t generateRandomNumber();
 
 /**
  * @brief Connect to MQTT broker with reconnection retries.
@@ -445,9 +445,9 @@ static int handleResubscribe( MQTTContext_t * pMqttContext );
 
 /*-----------------------------------------------------------*/
 
-static int32_t generateRandomNumber()
+static uint32_t generateRandomNumber()
 {
-    return( rand() % ( INT32_MAX ) );
+    return( rand() & UINT32_MAX );
 }
 
 /*-----------------------------------------------------------*/
@@ -475,8 +475,7 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
     BackoffAlgorithm_InitializeParams( &reconnectParams,
                                        CONNECTION_RETRY_BACKOFF_BASE_MS,
                                        CONNECTION_RETRY_MAX_BACKOFF_DELAY_MS,
-                                       CONNECTION_RETRY_MAX_ATTEMPTS,
-                                       generateRandomNumber );
+                                       CONNECTION_RETRY_MAX_ATTEMPTS );
 
     /* Attempt to connect to MQTT broker. If connection fails, retry after
      * a timeout. Timeout value will exponentially increase till maximum
@@ -499,9 +498,8 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
 
         if( opensslStatus != OPENSSL_SUCCESS )
         {
-            /* Get back-off value (in milliseconds) for the next connection retry. */
-            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams, &nextRetryBackOff );
-            assert( backoffAlgStatus != BackoffAlgorithmRngFailure );
+            /* Generate a random number and get back-off value (in milliseconds) for the next connection retry. */
+            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams, generateRandomNumber(), &nextRetryBackOff );
 
             if( backoffAlgStatus == BackoffAlgorithmRetriesExhausted )
             {
@@ -740,8 +738,7 @@ static int handleResubscribe( MQTTContext_t * pMqttContext )
     BackoffAlgorithm_InitializeParams( &retryParams,
                                        CONNECTION_RETRY_BACKOFF_BASE_MS,
                                        CONNECTION_RETRY_MAX_BACKOFF_DELAY_MS,
-                                       CONNECTION_RETRY_MAX_ATTEMPTS,
-                                       generateRandomNumber );
+                                       CONNECTION_RETRY_MAX_ATTEMPTS );
 
     do
     {
@@ -783,9 +780,8 @@ static int handleResubscribe( MQTTContext_t * pMqttContext )
          * server rejection of the subscription request. */
         if( globalSubAckStatus == MQTTSubAckFailure )
         {
-            /* Get back-off value (in milliseconds) for the next re-subscribe attempt. */
-            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &retryParams, &nextRetryBackOff );
-            assert( backoffAlgStatus != BackoffAlgorithmRngFailure );
+            /* Generate a random number and get back-off value (in milliseconds) for the next re-subscribe attempt. */
+            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &retryParams, generateRandomNumber(), &nextRetryBackOff );
 
             if( backoffAlgStatus == BackoffAlgorithmRetriesExhausted )
             {

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -362,7 +362,7 @@ static MQTTSubAckStatus_t globalSubAckStatus = MQTTSubAckFailure;
  * @return The generated random number. This function ALWAYS succeeds
  * in generating a random number.
  */
-static int32_t generateRandomNumber();
+static uint32_t generateRandomNumber();
 
 /**
  * @brief Connect to MQTT broker with reconnection retries.
@@ -547,9 +547,9 @@ static int handleResubscribe( MQTTContext_t * pMqttContext );
 
 /*-----------------------------------------------------------*/
 
-static int32_t generateRandomNumber()
+static uint32_t generateRandomNumber()
 {
-    return( rand() % ( INT32_MAX ) );
+    return( rand() & UINT32_MAX );
 }
 
 /*-----------------------------------------------------------*/
@@ -611,8 +611,7 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
     BackoffAlgorithm_InitializeParams( &reconnectParams,
                                        CONNECTION_RETRY_BACKOFF_BASE_MS,
                                        CONNECTION_RETRY_MAX_BACKOFF_DELAY_MS,
-                                       CONNECTION_RETRY_MAX_ATTEMPTS,
-                                       generateRandomNumber );
+                                       CONNECTION_RETRY_MAX_ATTEMPTS );
 
     /* Attempt to connect to MQTT broker. If connection fails, retry after
      * a timeout. Timeout value will exponentially increase until maximum
@@ -635,9 +634,8 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
 
         if( opensslStatus != OPENSSL_SUCCESS )
         {
-            /* Get back-off value (in milliseconds) for the next connection retry. */
-            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams, &nextRetryBackOff );
-            assert( backoffAlgStatus != BackoffAlgorithmRngFailure );
+            /* Generate a random number and get back-off value (in milliseconds) for the next connection retry. */
+            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams, generateRandomNumber(), &nextRetryBackOff );
 
             if( backoffAlgStatus == BackoffAlgorithmRetriesExhausted )
             {
@@ -870,8 +868,7 @@ static int handleResubscribe( MQTTContext_t * pMqttContext )
     BackoffAlgorithm_InitializeParams( &retryParams,
                                        CONNECTION_RETRY_BACKOFF_BASE_MS,
                                        CONNECTION_RETRY_MAX_BACKOFF_DELAY_MS,
-                                       CONNECTION_RETRY_MAX_ATTEMPTS,
-                                       generateRandomNumber );
+                                       CONNECTION_RETRY_MAX_ATTEMPTS );
 
     do
     {
@@ -913,9 +910,8 @@ static int handleResubscribe( MQTTContext_t * pMqttContext )
          * server rejection of the subscription request. */
         if( globalSubAckStatus == MQTTSubAckFailure )
         {
-            /* Get back-off value (in milliseconds) for the next re-subscribe attempt. */
-            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &retryParams, &nextRetryBackOff );
-            assert( backoffAlgStatus != BackoffAlgorithmRngFailure );
+            /* Generate a random number and get back-off value (in milliseconds) for the next re-subscribe attempt. */
+            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &retryParams, generateRandomNumber(), &nextRetryBackOff );
 
             if( backoffAlgStatus == BackoffAlgorithmRetriesExhausted )
             {

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -356,11 +356,8 @@ static MQTTSubAckStatus_t globalSubAckStatus = MQTTSubAckFailure;
 /**
  * @brief The random number generator to use for exponential backoff with
  * jitter retry logic.
- * This function is an implementation the #BackoffAlgorithm_RNG_t interface type
- * of the retry utils library API.
  *
- * @return The generated random number. This function ALWAYS succeeds
- * in generating a random number.
+ * @return The generated random number.
  */
 static uint32_t generateRandomNumber();
 

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -546,7 +546,7 @@ static int handleResubscribe( MQTTContext_t * pMqttContext );
 
 static uint32_t generateRandomNumber()
 {
-    return( rand() & UINT32_MAX );
+    return( rand() );
 }
 
 /*-----------------------------------------------------------*/

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
@@ -211,11 +211,8 @@ static MQTTSubAckStatus_t globalSubAckStatus = MQTTSubAckFailure;
 /**
  * @brief The random number generator to use for exponential backoff with
  * jitter retry logic.
- * This function is an implementation the #BackoffAlgorithm_RNG_t interface type
- * of the retry utils library API.
  *
- * @return The generated random number. This function ALWAYS succeeds
- * in generating a random number.
+ * @return The generated random number.
  */
 static uint32_t generateRandomNumber();
 

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
@@ -338,7 +338,7 @@ static int handleResubscribe( MQTTContext_t * pMqttContext );
 
 static uint32_t generateRandomNumber()
 {
-    return( rand() & UINT32_MAX );
+    return( rand() );
 }
 
 /*-----------------------------------------------------------*/

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
@@ -217,7 +217,7 @@ static MQTTSubAckStatus_t globalSubAckStatus = MQTTSubAckFailure;
  * @return The generated random number. This function ALWAYS succeeds
  * in generating a random number.
  */
-static int32_t generateRandomNumber();
+static uint32_t generateRandomNumber();
 
 /**
  * @brief Connect to MQTT broker with reconnection retries.
@@ -339,9 +339,9 @@ static int handleResubscribe( MQTTContext_t * pMqttContext );
 
 /*-----------------------------------------------------------*/
 
-static int32_t generateRandomNumber()
+static uint32_t generateRandomNumber()
 {
-    return( rand() % ( INT32_MAX ) );
+    return( rand() & UINT32_MAX );
 }
 
 /*-----------------------------------------------------------*/
@@ -363,8 +363,7 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
     BackoffAlgorithm_InitializeParams( &reconnectParams,
                                        CONNECTION_RETRY_BACKOFF_BASE_MS,
                                        CONNECTION_RETRY_MAX_BACKOFF_DELAY_MS,
-                                       CONNECTION_RETRY_MAX_ATTEMPTS,
-                                       generateRandomNumber );
+                                       CONNECTION_RETRY_MAX_ATTEMPTS );
 
     /* Attempt to connect to MQTT broker. If connection fails, retry after
      * a timeout. Timeout value will exponentially increase till maximum
@@ -386,9 +385,8 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
 
         if( socketStatus != SOCKETS_SUCCESS )
         {
-            /* Get back-off value (in milliseconds) for the next connection retry. */
-            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams, &nextRetryBackOff );
-            assert( backoffAlgStatus != BackoffAlgorithmRngFailure );
+            /* Generate a random number and get back-off value (in milliseconds) for the next connection retry. */
+            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams, generateRandomNumber(), &nextRetryBackOff );
 
             if( backoffAlgStatus == BackoffAlgorithmRetriesExhausted )
             {
@@ -477,8 +475,7 @@ static int handleResubscribe( MQTTContext_t * pMqttContext )
     BackoffAlgorithm_InitializeParams( &retryParams,
                                        CONNECTION_RETRY_BACKOFF_BASE_MS,
                                        CONNECTION_RETRY_MAX_BACKOFF_DELAY_MS,
-                                       CONNECTION_RETRY_MAX_ATTEMPTS,
-                                       generateRandomNumber );
+                                       CONNECTION_RETRY_MAX_ATTEMPTS );
 
     do
     {
@@ -520,9 +517,8 @@ static int handleResubscribe( MQTTContext_t * pMqttContext )
          * server rejection of the subscription request. */
         if( globalSubAckStatus == MQTTSubAckFailure )
         {
-            /* Get back-off value (in milliseconds) for the next re-subscribe attempt. */
-            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &retryParams, &nextRetryBackOff );
-            assert( backoffAlgStatus != BackoffAlgorithmRngFailure );
+            /* Generate a random number and get back-off value (in milliseconds) for the next re-subscribe attempt. */
+            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &retryParams, generateRandomNumber(), &nextRetryBackOff );
 
             if( backoffAlgStatus == BackoffAlgorithmRetriesExhausted )
             {

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
@@ -1026,8 +1026,9 @@ int main( int argc,
     ( void ) argc;
     ( void ) argv;
 
-    /* Seed pseudo random number generator (provided by ISO C standard library) for
-     * use by retry utils library when retrying failed connection attempts to broker. */
+    /* Seed pseudo random number generator used in the demo for
+     * backoff period calculation when retrying failed network operations
+     * with broker. */
 
     /* Get current time to seed pseudo random number generator. */
     ( void ) clock_gettime( CLOCK_REALTIME, &tp );

--- a/demos/mqtt/mqtt_demo_serializer/mqtt_demo_serializer.c
+++ b/demos/mqtt/mqtt_demo_serializer/mqtt_demo_serializer.c
@@ -150,7 +150,7 @@
  * @return The generated random number. This function ALWAYS succeeds
  * in generating a random number.
  */
-static int32_t generateRandomNumber();
+static uint32_t generateRandomNumber();
 
 /**
  * @brief Connect to MQTT broker with reconnection retries.
@@ -341,10 +341,9 @@ static uint16_t getNextPacketIdentifier( void )
 
 /*-----------------------------------------------------------*/
 
-
-static int32_t generateRandomNumber()
+static uint32_t generateRandomNumber()
 {
-    return( rand() % ( INT32_MAX ) );
+    return( rand() & UINT32_MAX );
 }
 
 /*-----------------------------------------------------------*/
@@ -375,8 +374,7 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
     BackoffAlgorithm_InitializeParams( &reconnectParams,
                                        CONNECTION_RETRY_BACKOFF_BASE_MS,
                                        CONNECTION_RETRY_MAX_BACKOFF_DELAY_MS,
-                                       CONNECTION_RETRY_MAX_ATTEMPTS,
-                                       generateRandomNumber );
+                                       CONNECTION_RETRY_MAX_ATTEMPTS );
 
     /* Attempt to connect to MQTT broker. If connection fails, retry after
      * a timeout. Timeout value will exponentially increase till maximum
@@ -398,9 +396,8 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
 
         if( socketStatus != SOCKETS_SUCCESS )
         {
-            /* Get back-off value (in milliseconds) for the next connection retry. */
-            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams, &nextRetryBackOff );
-            assert( backoffAlgStatus != BackoffAlgorithmRngFailure );
+            /* Generate a random number and get back-off value (in milliseconds) for the next connection retry. */
+            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams, generateRandomNumber(), &nextRetryBackOff );
 
             if( backoffAlgStatus == BackoffAlgorithmRetriesExhausted )
             {
@@ -945,8 +942,7 @@ int main( int argc,
             BackoffAlgorithm_InitializeParams( &retryParams,
                                                CONNECTION_RETRY_BACKOFF_BASE_MS,
                                                CONNECTION_RETRY_MAX_BACKOFF_DELAY_MS,
-                                               CONNECTION_RETRY_MAX_ATTEMPTS,
-                                               generateRandomNumber );
+                                               CONNECTION_RETRY_MAX_ATTEMPTS );
 
             do
             {
@@ -997,9 +993,8 @@ int main( int argc,
                     /* Process incoming PINGRESP from the broker */
                     mqttProcessIncomingPacket( &networkContext, &fixedBuffer );
 
-                    /* Get back-off value (in milliseconds) for the next re-subscribe attempt. */
-                    backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &retryParams, &nextRetryBackOff );
-                    assert( backoffAlgStatus != BackoffAlgorithmRngFailure );
+                    /* Generate a random number and get back-off value (in milliseconds) for the next re-subscribe attempt. */
+                    backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &retryParams, generateRandomNumber(), &nextRetryBackOff );
 
                     if( backoffAlgStatus == BackoffAlgorithmRetriesExhausted )
                     {

--- a/demos/mqtt/mqtt_demo_serializer/mqtt_demo_serializer.c
+++ b/demos/mqtt/mqtt_demo_serializer/mqtt_demo_serializer.c
@@ -144,11 +144,8 @@
 /**
  * @brief The random number generator to use for exponential backoff with
  * jitter retry logic.
- * This function is an implementation the #BackoffAlgorithm_RNG_t interface type
- * of the retry utils library API.
  *
- * @return The generated random number. This function ALWAYS succeeds
- * in generating a random number.
+ * @return The generated random number.
  */
 static uint32_t generateRandomNumber();
 

--- a/demos/mqtt/mqtt_demo_serializer/mqtt_demo_serializer.c
+++ b/demos/mqtt/mqtt_demo_serializer/mqtt_demo_serializer.c
@@ -340,7 +340,7 @@ static uint16_t getNextPacketIdentifier( void )
 
 static uint32_t generateRandomNumber()
 {
-    return( rand() & UINT32_MAX );
+    return( rand() );
 }
 
 /*-----------------------------------------------------------*/

--- a/demos/mqtt/mqtt_demo_serializer/mqtt_demo_serializer.c
+++ b/demos/mqtt/mqtt_demo_serializer/mqtt_demo_serializer.c
@@ -362,8 +362,9 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
     serverInfo.hostNameLength = BROKER_ENDPOINT_LENGTH;
     serverInfo.port = BROKER_PORT;
 
-    /* Seed pseudo random number generator (provided by ISO C standard library) for
-     * use by retry utils library when retrying failed connection attempts to broker. */
+    /* Seed pseudo random number generator used in the demo for
+     * backoff period calculation when retrying failed network operations
+     * with broker. */
 
     /* Get current time to seed pseudo random number generator. */
     ( void ) clock_gettime( CLOCK_REALTIME, &tp );

--- a/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
+++ b/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
@@ -306,11 +306,8 @@ static bool globalReceivedPrecipitationData = false;
 /**
  * @brief The random number generator to use for exponential backoff with
  * jitter retry logic.
- * This function is an implementation the #BackoffAlgorithm_RNG_t interface type
- * of the retry utils library API.
  *
- * @return The generated random number. This function ALWAYS succeeds
- * in generating a random number.
+ * @return The generated random number.
  */
 static uint32_t generateRandomNumber();
 

--- a/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
+++ b/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
@@ -539,8 +539,9 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
     opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
     opensslCredentials.sniHostName = BROKER_ENDPOINT;
 
-    /* Seed pseudo random number generator (provided by ISO C standard library) for
-     * use by retry utils library when retrying failed connection attempts to broker. */
+    /* Seed pseudo random number generator used in the demo for
+     * backoff period calculation when retrying failed network operations
+     * with broker. */
 
     /* Get current time to seed pseudo random number generator. */
     ( void ) clock_gettime( CLOCK_REALTIME, &tp );

--- a/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
+++ b/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
@@ -312,7 +312,7 @@ static bool globalReceivedPrecipitationData = false;
  * @return The generated random number. This function ALWAYS succeeds
  * in generating a random number.
  */
-static int32_t generateRandomNumber();
+static uint32_t generateRandomNumber();
 
 /**
  * @brief Connect to MQTT broker with reconnection retries.
@@ -512,10 +512,9 @@ static int publishToTopicAndProcessIncomingMessage( MQTTContext_t * pMqttContext
 
 /*-----------------------------------------------------------*/
 
-
-static int32_t generateRandomNumber()
+static uint32_t generateRandomNumber()
 {
-    return( rand() % ( INT32_MAX ) );
+    return( rand() & UINT32_MAX );
 }
 
 /*-----------------------------------------------------------*/
@@ -553,8 +552,7 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
     BackoffAlgorithm_InitializeParams( &reconnectParams,
                                        CONNECTION_RETRY_BACKOFF_BASE_MS,
                                        CONNECTION_RETRY_MAX_BACKOFF_DELAY_MS,
-                                       CONNECTION_RETRY_MAX_ATTEMPTS,
-                                       generateRandomNumber );
+                                       CONNECTION_RETRY_MAX_ATTEMPTS );
 
     /* Attempt to connect to MQTT broker. If connection fails, retry after
      * a timeout. Timeout value will exponentially increase until maximum
@@ -577,9 +575,8 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
 
         if( opensslStatus != OPENSSL_SUCCESS )
         {
-            /* Get back-off value (in milliseconds) for the next connection retry. */
-            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams, &nextRetryBackOff );
-            assert( backoffAlgStatus != BackoffAlgorithmRngFailure );
+            /* Generate a random number and get back-off value (in milliseconds) for the next connection retry. */
+            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams, generateRandomNumber(), &nextRetryBackOff );
 
             if( backoffAlgStatus == BackoffAlgorithmRetriesExhausted )
             {

--- a/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
+++ b/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
@@ -511,7 +511,7 @@ static int publishToTopicAndProcessIncomingMessage( MQTTContext_t * pMqttContext
 
 static uint32_t generateRandomNumber()
 {
-    return( rand() & UINT32_MAX );
+    return( rand() );
 }
 
 /*-----------------------------------------------------------*/

--- a/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
+++ b/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
@@ -246,11 +246,8 @@ static bool mqttSessionEstablished = false;
 /**
  * @brief The random number generator to use for exponential backoff with
  * jitter retry logic.
- * This function is an implementation the #BackoffAlgorithm_RNG_t interface type
- * of the retry utils library API.
  *
- * @return The generated random number. This function ALWAYS succeeds
- * in generating a random number.
+ * @return The generated random number.
  */
 static uint32_t generateRandomNumber();
 

--- a/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
+++ b/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
@@ -252,7 +252,7 @@ static bool mqttSessionEstablished = false;
  * @return The generated random number. This function ALWAYS succeeds
  * in generating a random number.
  */
-static int32_t generateRandomNumber();
+static uint32_t generateRandomNumber();
 
 /**
  * @brief Connect to MQTT broker with reconnection retries.
@@ -312,9 +312,9 @@ static int handlePublishResend( MQTTContext_t * pMqttContext );
 
 /*-----------------------------------------------------------*/
 
-static int32_t generateRandomNumber()
+static uint32_t generateRandomNumber()
 {
-    return( rand() % ( INT32_MAX ) );
+    return( rand() & UINT32_MAX );
 }
 
 /*-----------------------------------------------------------*/
@@ -365,8 +365,7 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
     BackoffAlgorithm_InitializeParams( &reconnectParams,
                                        CONNECTION_RETRY_BACKOFF_BASE_MS,
                                        CONNECTION_RETRY_MAX_BACKOFF_DELAY_MS,
-                                       CONNECTION_RETRY_MAX_ATTEMPTS,
-                                       generateRandomNumber );
+                                       CONNECTION_RETRY_MAX_ATTEMPTS );
 
     /* Attempt to connect to MQTT broker. If connection fails, retry after
      * a timeout. Timeout value will exponentially increase until maximum
@@ -389,9 +388,8 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
 
         if( opensslStatus != OPENSSL_SUCCESS )
         {
-            /* Get back-off value (in milliseconds) for the next connection retry. */
-            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams, &nextRetryBackOff );
-            assert( backoffAlgStatus != BackoffAlgorithmRngFailure );
+            /* Generate a random number and get back-off value (in milliseconds) for the next connection retry. */
+            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams, generateRandomNumber(), &nextRetryBackOff );
 
             if( backoffAlgStatus == BackoffAlgorithmRetriesExhausted )
             {

--- a/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
+++ b/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
@@ -311,7 +311,7 @@ static int handlePublishResend( MQTTContext_t * pMqttContext );
 
 static uint32_t generateRandomNumber()
 {
-    return( rand() & UINT32_MAX );
+    return( rand() );
 }
 
 /*-----------------------------------------------------------*/

--- a/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
+++ b/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
@@ -353,8 +353,9 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
         opensslCredentials.alpnProtosLen = ALPN_PROTOCOL_NAME_LENGTH;
     }
 
-    /* Seed pseudo random number generator (provided by ISO C standard library) for
-     * use by retry utils library when retrying failed connection attempts to broker. */
+    /* Seed pseudo random number generator used in the demo for
+     * backoff period calculation when retrying failed network operations
+     * with broker. */
 
     /* Get current time to seed pseudo random number generator. */
     ( void ) clock_gettime( CLOCK_REALTIME, &tp );

--- a/docs/doxygen/config.doxyfile
+++ b/docs/doxygen/config.doxyfile
@@ -2240,7 +2240,9 @@ TAGFILES               = libraries/standard/coreMQTT/docs/doxygen/output/mqtt.ta
                          libraries/aws/device-shadow-for-aws-iot-embedded-sdk/docs/doxygen/output/shadow.tag=../../../../libraries/aws/device-shadow-for-aws-iot-embedded-sdk/docs/doxygen/output/html \
                          libraries/standard/coreHTTP/docs/doxygen/output/http.tag=../../../../libraries/standard/coreHTTP/docs/doxygen/output\html \
                          libraries/aws/device-defender-for-aws-iot-embedded-sdk/docs/doxygen/output/defender.tag=../../../../libraries/aws/device-defender-for-aws-iot-embedded-sdk/docs/doxygen/output/html \
-                         libraries/aws/jobs-for-aws-iot-embedded-sdk/docs/doxygen/output/jobs.tag=../../../../libraries/aws/jobs-for-aws-iot-embedded-sdk/docs/doxygen/output/html
+                         libraries/aws/jobs-for-aws-iot-embedded-sdk/docs/doxygen/output/jobs.tag=../../../../libraries/aws/jobs-for-aws-iot-embedded-sdk/docs/doxygen/output/html \
+                         libraries/standard/backoffAlgorithm/docs/doxygen/output/backoffalgorithm.tag=../../../../libraries/standard/backoffAlgorithm/docs/doxygen/output/html
+
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create a
 # tag file that is based on the input files it reads. See section "Linking to

--- a/integration-test/http/http_system_test.c
+++ b/integration-test/http/http_system_test.c
@@ -175,11 +175,8 @@ static size_t networkDataLen = 0U;
 /**
  * @brief The random number generator to use for exponential backoff with
  * jitter retry logic.
- * This function is an implementation the #BackoffAlgorithm_RNG_t interface type
- * of the retry utils library API.
  *
- * @return The generated random number. This function ALWAYS succeeds
- * in generating a random number.
+ * @return The generated random number.
  */
 static uint32_t generateRandomNumber();
 

--- a/integration-test/http/http_system_test.c
+++ b/integration-test/http/http_system_test.c
@@ -181,7 +181,7 @@ static size_t networkDataLen = 0U;
  * @return The generated random number. This function ALWAYS succeeds
  * in generating a random number.
  */
-static int32_t generateRandomNumber();
+static uint32_t generateRandomNumber();
 
 /**
  * @brief Connect to HTTP server with reconnection retries.
@@ -236,9 +236,9 @@ static int32_t transportSendStub( NetworkContext_t * pNetworkContext,
 
 /*-----------------------------------------------------------*/
 
-static int32_t generateRandomNumber()
+static uint32_t generateRandomNumber()
 {
-    return( rand() % ( INT32_MAX ) );
+    return( rand() & UINT32_MAX );
 }
 
 /*-----------------------------------------------------------*/
@@ -275,8 +275,7 @@ static void connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContex
     BackoffAlgorithm_InitializeParams( &reconnectParams,
                                        CONNECTION_RETRY_BACKOFF_BASE_MS,
                                        CONNECTION_RETRY_MAX_BACKOFF_DELAY_MS,
-                                       CONNECTION_RETRY_MAX_ATTEMPTS,
-                                       generateRandomNumber );
+                                       CONNECTION_RETRY_MAX_ATTEMPTS );
 
     /* Attempt to connect to HTTP server. If connection fails, retry after
      * a timeout. Timeout value will exponentially increase until maximum
@@ -293,9 +292,8 @@ static void connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContex
 
         if( opensslStatus != OPENSSL_SUCCESS )
         {
-            /* Get back-off value (in milliseconds) for the next connection retry. */
-            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams, &nextRetryBackOff );
-            assert( backoffAlgStatus != BackoffAlgorithmRngFailure );
+            /* Generate a random number and get back-off value (in milliseconds) for the next connection retry. */
+            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams, generateRandomNumber(), &nextRetryBackOff );
 
             if( backoffAlgStatus == BackoffAlgorithmSuccess )
             {

--- a/integration-test/http/http_system_test.c
+++ b/integration-test/http/http_system_test.c
@@ -235,7 +235,7 @@ static int32_t transportSendStub( NetworkContext_t * pNetworkContext,
 
 static uint32_t generateRandomNumber()
 {
-    return( rand() & UINT32_MAX );
+    return( rand() );
 }
 
 /*-----------------------------------------------------------*/

--- a/integration-test/http/http_system_test.c
+++ b/integration-test/http/http_system_test.c
@@ -263,8 +263,9 @@ static void connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContex
     serverInfo.hostNameLength = SERVER_HOST_LENGTH;
     serverInfo.port = HTTPS_PORT;
 
-    /* Seed pseudo random number generator (provided by ISO C standard library) for
-     * use by retry utils library when retrying failed connection attempts to broker. */
+    /* Seed pseudo random number generator used in the demo for
+     * backoff period calculation when retrying failed network operations
+     * with broker. */
 
     /* Get current time to seed pseudo random number generator. */
     ( void ) clock_gettime( CLOCK_REALTIME, &tp );


### PR DESCRIPTION
The API of `FreeRTOS/backoffAlgorithm` library has changed to remove dependency on random number generator; instead require the caller to generate the random number and pass it to the `BackoffAlgorithm_GetNextBackoff` API for backoff period calculation. This PR updates the submodule pointer commit, and updates the demos and tests to use the simplied library API