### PR TITLE
Remove non-relevant statement from doxygen manual

### DIFF
--- a/docs/doxygen/building.dox
+++ b/docs/doxygen/building.dox
@@ -27,8 +27,6 @@ It is required to setup an AWS account and access the AWS IoT Console for runnin
 -  [Setup an AWS account](https://docs.aws.amazon.com/iot/latest/developerguide/iot-console-signin.html).
 -  [Sign-in to the AWS IoT Console](https://docs.aws.amazon.com/iot/latest/developerguide/iot-console-signin.html) after setting up the AWS account.
 
-*Note: If using the Provisioning library, a fleet provisioning template, a provisioning claim, IoT policies and IAM policies need to be setup for the AWS account. Complete the steps to setup your device and AWS IoT account outlined [here](https://docs.aws.amazon.com/iot/latest/developerguide/provision-wo-cert.html#use-claim).*
-
 @section configuring_mutual_auth_demo Configuring the Mutual Auth Demo
 @brief Passing configuration settings to run the mutual auth demo.
 


### PR DESCRIPTION
Remove the statement about **Fleet Provisioning** library from the doxygen manual. The library is not yet part of the `main` branch