### PR TITLE
Support multiple transports in the same compilation unit

### DIFF
--- a/demos/defender/defender_demo_json/mqtt_operations.c
+++ b/demos/defender/defender_demo_json/mqtt_operations.c
@@ -197,6 +197,12 @@ typedef struct PublishPackets
      */
     MQTTPublishInfo_t pubInfo;
 } PublishPackets_t;
+
+/* Each compilation unit must define the NetworkContext struct. */
+struct NetworkContext
+{
+    OpensslParams_t * pParams;
+};
 /*-----------------------------------------------------------*/
 
 /**

--- a/demos/defender/defender_demo_json/mqtt_operations.c
+++ b/demos/defender/defender_demo_json/mqtt_operations.c
@@ -239,6 +239,11 @@ static MQTTContext_t mqttContext = { 0 };
 static NetworkContext_t networkContext = { 0 };
 
 /**
+ * @brief The parameters for Openssl operation.
+ */
+static OpensslParams_t opensslParams = { 0 };
+
+/**
  * @brief The flag to indicate that the mqtt session is established.
  */
 static bool mqttSessionEstablished = false;
@@ -345,6 +350,9 @@ static bool connectToBrokerWithBackoffRetries( NetworkContext_t * pNetworkContex
     OpensslCredentials_t opensslCredentials;
     uint16_t nextRetryBackOff = 0U;
     struct timespec tp;
+
+    /* Set the pParams member of the network context with desired transport. */
+    pNetworkContext->pParams = &opensslParams;
 
     /* Initialize information to connect to the MQTT broker. */
     serverInfo.pHostName = AWS_IOT_ENDPOINT;

--- a/demos/http/common/src/http_demo_utils.c
+++ b/demos/http/common/src/http_demo_utils.c
@@ -64,10 +64,12 @@
 
 /*-----------------------------------------------------------*/
 
-/* Each compilation unit must define the NetworkContext struct. */
+/* Each compilation unit must define the NetworkContext struct.
+ * Because these utilities are shared by both plaintext and TLS demos,
+ * we must define pParams as void *. */
 struct NetworkContext
 {
-    OpensslParams_t * pParams;
+    void * pParams;
 };
 
 /*-----------------------------------------------------------*/

--- a/demos/http/common/src/http_demo_utils.c
+++ b/demos/http/common/src/http_demo_utils.c
@@ -64,6 +64,14 @@
 
 /*-----------------------------------------------------------*/
 
+/* Each compilation unit must define the NetworkContext struct. */
+struct NetworkContext
+{
+    OpensslParams_t * pParams;
+};
+
+/*-----------------------------------------------------------*/
+
 /**
  * @brief The random number generator to use for exponential backoff with
  * jitter retry logic.

--- a/demos/http/http_demo_basic_tls/http_demo_basic_tls.c
+++ b/demos/http/http_demo_basic_tls/http_demo_basic_tls.c
@@ -390,6 +390,7 @@ int main( int argc,
     TransportInterface_t transportInterface;
     /* The network context for the transport layer interface. */
     NetworkContext_t networkContext;
+    PlaintextParams_t plaintextParams;
     /* An array of HTTP paths to request. */
     const httpPathStrings_t httpMethodPaths[] =
     {
@@ -409,6 +410,9 @@ int main( int argc,
 
     ( void ) argc;
     ( void ) argv;
+
+    /* Set the pParams member of the network context with desired transport. */
+    networkContext.pParams = &opensslParams;
 
     for( ; ; )
     {

--- a/demos/http/http_demo_basic_tls/http_demo_basic_tls.c
+++ b/demos/http/http_demo_basic_tls/http_demo_basic_tls.c
@@ -398,7 +398,7 @@ int main( int argc,
     TransportInterface_t transportInterface;
     /* The network context for the transport layer interface. */
     NetworkContext_t networkContext;
-    PlaintextParams_t plaintextParams;
+    OpensslParams_t opensslParams;
     /* An array of HTTP paths to request. */
     const httpPathStrings_t httpMethodPaths[] =
     {

--- a/demos/http/http_demo_basic_tls/http_demo_basic_tls.c
+++ b/demos/http/http_demo_basic_tls/http_demo_basic_tls.c
@@ -183,6 +183,14 @@ static uint8_t userBuffer[ USER_BUFFER_LENGTH ];
 
 /*-----------------------------------------------------------*/
 
+/* Each compilation unit must define the NetworkContext struct. */
+struct NetworkContext
+{
+    OpensslParams_t * pParams;
+};
+
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Connect to HTTP server with reconnection retries.
  *

--- a/demos/http/http_demo_mutual_auth/http_demo_mutual_auth.c
+++ b/demos/http/http_demo_mutual_auth/http_demo_mutual_auth.c
@@ -124,6 +124,14 @@ static uint8_t userBuffer[ USER_BUFFER_LENGTH ];
 
 /*-----------------------------------------------------------*/
 
+/* Each compilation unit must define the NetworkContext struct. */
+struct NetworkContext
+{
+    OpensslParams_t * pParams;
+};
+
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Connect to HTTP server with reconnection retries.
  *

--- a/demos/http/http_demo_mutual_auth/http_demo_mutual_auth.c
+++ b/demos/http/http_demo_mutual_auth/http_demo_mutual_auth.c
@@ -340,9 +340,13 @@ int main( int argc,
     TransportInterface_t transportInterface;
     /* The network context for the transport layer interface. */
     NetworkContext_t networkContext;
+    OpensslParams_t opensslParams;
 
     ( void ) argc;
     ( void ) argv;
+
+    /* Set the pParams member of the network context with desired transport. */
+    networkContext.pParams = &opensslParams;
 
     /**************************** Connect. ******************************/
 

--- a/demos/http/http_demo_plaintext/http_demo_plaintext.c
+++ b/demos/http/http_demo_plaintext/http_demo_plaintext.c
@@ -368,6 +368,7 @@ int main( int argc,
     TransportInterface_t transportInterface;
     /* The network context for the transport layer interface. */
     NetworkContext_t networkContext;
+    PlaintextParams_t plaintextParams;
     /* An array of HTTP paths to request. */
     const httpPathStrings_t httpMethodPaths[] =
     {
@@ -387,6 +388,9 @@ int main( int argc,
 
     ( void ) argc;
     ( void ) argv;
+
+    /* Set the pParams member of the network context with desired transport. */
+    networkContext.pParams = &plaintextParams;
 
     for( ; ; )
     {

--- a/demos/http/http_demo_plaintext/http_demo_plaintext.c
+++ b/demos/http/http_demo_plaintext/http_demo_plaintext.c
@@ -170,6 +170,14 @@ static uint8_t userBuffer[ USER_BUFFER_LENGTH ];
 
 /*-----------------------------------------------------------*/
 
+/* Each compilation unit must define the NetworkContext struct. */
+struct NetworkContext
+{
+    PlaintextParams_t * pParams;
+};
+
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Connect to HTTP server with reconnection retries.
  *

--- a/demos/http/http_demo_s3_download/http_demo_s3_download.c
+++ b/demos/http/http_demo_s3_download/http_demo_s3_download.c
@@ -145,6 +145,14 @@ static const char * pPath;
 
 /*-----------------------------------------------------------*/
 
+/* Each compilation unit must define the NetworkContext struct. */
+struct NetworkContext
+{
+    OpensslParams_t * pParams;
+};
+
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Connect to HTTP server with reconnection retries.
  *

--- a/demos/http/http_demo_s3_download/http_demo_s3_download.c
+++ b/demos/http/http_demo_s3_download/http_demo_s3_download.c
@@ -604,9 +604,13 @@ int main( int argc,
     TransportInterface_t transportInterface;
     /* The network context for the transport layer interface. */
     NetworkContext_t networkContext;
+    OpensslParams_t opensslParams;
 
     ( void ) argc;
     ( void ) argv;
+
+    /* Set the pParams member of the network context with desired transport. */
+    networkContext.pParams = &opensslParams;
 
     LogInfo( ( "HTTP Client Synchronous S3 download demo using pre-signed URL:\n%s",
                S3_PRESIGNED_GET_URL ) );

--- a/demos/http/http_demo_s3_download_multithreaded/http_demo_s3_download_multithreaded.c
+++ b/demos/http/http_demo_s3_download_multithreaded/http_demo_s3_download_multithreaded.c
@@ -203,6 +203,14 @@ typedef enum QueueOpStatus
 
 /*-----------------------------------------------------------*/
 
+/* Each compilation unit must define the NetworkContext struct. */
+struct NetworkContext
+{
+    OpensslParams_t * pParams;
+};
+
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Connect to HTTP server with reconnection retries.
  *

--- a/demos/http/http_demo_s3_download_multithreaded/http_demo_s3_download_multithreaded.c
+++ b/demos/http/http_demo_s3_download_multithreaded/http_demo_s3_download_multithreaded.c
@@ -865,6 +865,7 @@ int main( int argc,
     TransportInterface_t transportInterface = { 0 };
     /* The network context for the transport layer interface. */
     NetworkContext_t networkContext = { 0 };
+    OpensslParams_t opensslParams = { 0 };
 
     /* Queue for HTTP requests. Requests are written by the main thread,
      * and serviced by the HTTP thread. */
@@ -879,6 +880,9 @@ int main( int argc,
 
     ( void ) argc;
     ( void ) argv;
+
+    /* Set the pParams member of the network context with desired transport. */
+    networkContext.pParams = &opensslParams;
 
     LogInfo( ( "HTTP Client multi-threaded S3 download demo using pre-signed URL:\n%s", S3_PRESIGNED_GET_URL ) );
 

--- a/demos/http/http_demo_s3_upload/http_demo_s3_upload.c
+++ b/demos/http/http_demo_s3_upload/http_demo_s3_upload.c
@@ -165,6 +165,14 @@ static const char * pPath;
 
 /*-----------------------------------------------------------*/
 
+/* Each compilation unit must define the NetworkContext struct. */
+struct NetworkContext
+{
+    OpensslParams_t * pParams;
+};
+
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Connect to HTTP server with reconnection retries.
  *

--- a/demos/http/http_demo_s3_upload/http_demo_s3_upload.c
+++ b/demos/http/http_demo_s3_upload/http_demo_s3_upload.c
@@ -628,9 +628,13 @@ int main( int argc,
     TransportInterface_t transportInterface;
     /* The network context for the transport layer interface. */
     NetworkContext_t networkContext;
+    OpensslParams_t opensslParams;
 
     ( void ) argc;
     ( void ) argv;
+
+    /* Set the pParams member of the network context with desired transport. */
+    networkContext.pParams = &opensslParams;
 
     LogInfo( ( "HTTP Client Synchronous S3 upload demo using pre-signed PUT URL:\n%s",
                S3_PRESIGNED_PUT_URL ) );

--- a/demos/lexicon.txt
+++ b/demos/lexicon.txt
@@ -125,6 +125,7 @@ deserialize
 deserialized
 deserializer
 deserializing
+desired
 dev
 developerguide
 devicepublickeyasciihex
@@ -304,6 +305,7 @@ mutex
 mutexes
 mxz
 necesarily
+networkcontext
 ni
 nist
 noninfringement
@@ -395,6 +397,7 @@ pouttcpportsarray
 poutudpportsarray
 poweron
 ppacketinfo
+pparams
 ppath
 ppathlen
 ppayload
@@ -533,6 +536,7 @@ toolchain
 topicbuffer
 topicfilterlength
 topiclength
+transport
 transportinterface
 transporttimeout
 txt

--- a/demos/lexicon.txt
+++ b/demos/lexicon.txt
@@ -536,7 +536,6 @@ toolchain
 topicbuffer
 topicfilterlength
 topiclength
-transport
 transportinterface
 transporttimeout
 txt

--- a/demos/lexicon.txt
+++ b/demos/lexicon.txt
@@ -125,7 +125,6 @@ deserialize
 deserialized
 deserializer
 deserializing
-desired
 dev
 developerguide
 devicepublickeyasciihex

--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -251,6 +251,14 @@ static MQTTSubAckStatus_t globalSubAckStatus = MQTTSubAckFailure;
 
 /*-----------------------------------------------------------*/
 
+/* Each compilation unit must define the NetworkContext struct. */
+struct NetworkContext
+{
+    OpensslParams_t * pParams;
+};
+
+/*-----------------------------------------------------------*/
+
 /**
  * @brief The random number generator to use for exponential backoff with
  * jitter retry logic.

--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -1370,11 +1370,15 @@ int main( int argc,
     int returnStatus = EXIT_SUCCESS;
     MQTTContext_t mqttContext = { 0 };
     NetworkContext_t networkContext = { 0 };
+    OpensslParams_t opensslParams = { 0 };
     bool clientSessionPresent = false;
     struct timespec tp;
 
     ( void ) argc;
     ( void ) argv;
+
+    /* Set the pParams member of the network context with desired transport. */
+    networkContext.pParams = &opensslParams;
 
     /* Seed pseudo random number generator (provided by ISO C standard library) for
      * use by retry utils library when retrying failed network operations. */

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -353,6 +353,14 @@ static MQTTSubAckStatus_t globalSubAckStatus = MQTTSubAckFailure;
 
 /*-----------------------------------------------------------*/
 
+/* Each compilation unit must define the NetworkContext struct. */
+struct NetworkContext
+{
+    OpensslParams_t * pParams;
+};
+
+/*-----------------------------------------------------------*/
+
 /**
  * @brief The random number generator to use for exponential backoff with
  * jitter retry logic.

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -1510,11 +1510,15 @@ int main( int argc,
     int returnStatus = EXIT_SUCCESS;
     MQTTContext_t mqttContext = { 0 };
     NetworkContext_t networkContext = { 0 };
+    OpensslParams_t opensslParams = { 0 };
     bool clientSessionPresent = false;
     struct timespec tp;
 
     ( void ) argc;
     ( void ) argv;
+
+    /* Set the pParams member of the network context with desired transport. */
+    networkContext.pParams = &opensslParams;
 
     /* Seed pseudo random number generator (provided by ISO C standard library) for
      * use by retry utils library when retrying failed network operations. */

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
@@ -208,6 +208,14 @@ static MQTTSubAckStatus_t globalSubAckStatus = MQTTSubAckFailure;
 
 /*-----------------------------------------------------------*/
 
+/* Each compilation unit must define the NetworkContext struct. */
+struct NetworkContext
+{
+    PlaintextParams_t * pParams;
+};
+
+/*-----------------------------------------------------------*/
+
 /**
  * @brief The random number generator to use for exponential backoff with
  * jitter retry logic.

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
@@ -1018,10 +1018,14 @@ int main( int argc,
 {
     int returnStatus = EXIT_SUCCESS;
     NetworkContext_t networkContext = { 0 };
+    PlaintextParams_t plaintextParams = { 0 };
     struct timespec tp;
 
     ( void ) argc;
     ( void ) argv;
+
+    /* Set the pParams member of the network context with desired transport. */
+    networkContext.pParams = &plaintextParams;
 
     /* Seed pseudo random number generator used in the demo for
      * backoff period calculation when retrying failed network operations

--- a/demos/mqtt/mqtt_demo_serializer/mqtt_demo_serializer.c
+++ b/demos/mqtt/mqtt_demo_serializer/mqtt_demo_serializer.c
@@ -903,12 +903,16 @@ int main( int argc,
     bool controlPacketSent = false;
     bool publishPacketSent = false;
     NetworkContext_t networkContext = { 0 };
+    OpensslParams_t opensslParams = { 0 };
     BackoffAlgorithmStatus_t backoffAlgStatus = BackoffAlgorithmSuccess;
     BackoffAlgorithmContext_t retryParams;
     uint16_t nextRetryBackOff = 0U;
 
     ( void ) argc;
     ( void ) argv;
+
+    /* Set the pParams member of the network context with desired transport. */
+    networkContext.pParams = &opensslParams;
 
     /***
      * Set Fixed size buffer structure that is required by API to serialize

--- a/demos/mqtt/mqtt_demo_serializer/mqtt_demo_serializer.c
+++ b/demos/mqtt/mqtt_demo_serializer/mqtt_demo_serializer.c
@@ -141,6 +141,14 @@
 
 /*-----------------------------------------------------------*/
 
+/* Each compilation unit must define the NetworkContext struct. */
+struct NetworkContext
+{
+    PlaintextParams_t * pParams;
+};
+
+/*-----------------------------------------------------------*/
+
 /**
  * @brief The random number generator to use for exponential backoff with
  * jitter retry logic.
@@ -903,7 +911,7 @@ int main( int argc,
     bool controlPacketSent = false;
     bool publishPacketSent = false;
     NetworkContext_t networkContext = { 0 };
-    OpensslParams_t opensslParams = { 0 };
+    PlaintextParams_t plaintextParams = { 0 };
     BackoffAlgorithmStatus_t backoffAlgStatus = BackoffAlgorithmSuccess;
     BackoffAlgorithmContext_t retryParams;
     uint16_t nextRetryBackOff = 0U;
@@ -912,7 +920,7 @@ int main( int argc,
     ( void ) argv;
 
     /* Set the pParams member of the network context with desired transport. */
-    networkContext.pParams = &opensslParams;
+    networkContext.pParams = &plaintextParams;
 
     /***
      * Set Fixed size buffer structure that is required by API to serialize

--- a/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
+++ b/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
@@ -303,6 +303,14 @@ static bool globalReceivedPrecipitationData = false;
 
 /*-----------------------------------------------------------*/
 
+/* Each compilation unit must define the NetworkContext struct. */
+struct NetworkContext
+{
+    OpensslParams_t * pParams;
+};
+
+/*-----------------------------------------------------------*/
+
 /**
  * @brief The random number generator to use for exponential backoff with
  * jitter retry logic.

--- a/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
+++ b/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
@@ -1328,9 +1328,13 @@ int main( int argc,
 {
     int returnStatus = EXIT_SUCCESS;
     NetworkContext_t networkContext;
+    OpensslParams_t opensslParams;
 
     ( void ) argc;
     ( void ) argv;
+
+    /* Set the pParams member of the network context with desired transport. */
+    networkContext.pParams = &opensslParams;
 
     for( ; ; )
     {

--- a/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
+++ b/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
@@ -237,6 +237,11 @@ static MQTTContext_t mqttContext = { 0 };
 static NetworkContext_t networkContext = { 0 };
 
 /**
+ * @brief The parameters for Openssl operation.
+ */
+static OpensslParams_t opensslParams = { 0 };
+
+/**
  * @brief The flag to indicate the mqtt session changed.
  */
 static bool mqttSessionEstablished = false;
@@ -326,6 +331,9 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
     OpensslCredentials_t opensslCredentials;
     uint16_t nextRetryBackOff = 0U;
     struct timespec tp;
+
+    /* Set the pParams member of the network context with desired transport. */
+    pNetworkContext->pParams = &opensslParams;
 
     /* Initialize information to connect to the MQTT broker. */
     serverInfo.pHostName = AWS_IOT_ENDPOINT;

--- a/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
+++ b/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
@@ -201,6 +201,14 @@ typedef struct PublishPackets
 
 /*-----------------------------------------------------------*/
 
+/* Each compilation unit must define the NetworkContext struct. */
+struct NetworkContext
+{
+    OpensslParams_t * pParams;
+};
+
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Packet Identifier generated when Subscribe request was sent to the broker;
  * it is used to match received Subscribe ACK to the transmitted subscribe.
@@ -245,14 +253,6 @@ static OpensslParams_t opensslParams = { 0 };
  * @brief The flag to indicate the mqtt session changed.
  */
 static bool mqttSessionEstablished = false;
-
-/*-----------------------------------------------------------*/
-
-/* Each compilation unit must define the NetworkContext struct. */
-struct NetworkContext
-{
-    OpensslParams_t * pParams;
-};
 
 /*-----------------------------------------------------------*/
 

--- a/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
+++ b/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
@@ -248,6 +248,14 @@ static bool mqttSessionEstablished = false;
 
 /*-----------------------------------------------------------*/
 
+/* Each compilation unit must define the NetworkContext struct. */
+struct NetworkContext
+{
+    OpensslParams_t * pParams;
+};
+
+/*-----------------------------------------------------------*/
+
 /**
  * @brief The random number generator to use for exponential backoff with
  * jitter retry logic.

--- a/integration-test/http/http_system_test.c
+++ b/integration-test/http/http_system_test.c
@@ -321,8 +321,8 @@ static void connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContex
     } while( ( opensslStatus != OPENSSL_SUCCESS ) && ( backoffAlgStatus == BackoffAlgorithmSuccess ) );
 
     TEST_ASSERT_EQUAL( OPENSSL_SUCCESS, opensslStatus );
-    TEST_ASSERT_NOT_EQUAL( -1, networkContext.socketDescriptor );
-    TEST_ASSERT_NOT_NULL( networkContext.pSsl );
+    TEST_ASSERT_NOT_EQUAL( -1, opensslParams.socketDescriptor );
+    TEST_ASSERT_NOT_NULL( opensslParams.pSsl );
 }
 
 /*-----------------------------------------------------------*/

--- a/integration-test/http/http_system_test.c
+++ b/integration-test/http/http_system_test.c
@@ -134,6 +134,11 @@
 static NetworkContext_t networkContext;
 
 /**
+ * @brief Parameters for the Openssl Context.
+ */
+static OpensslParams_t opensslParams;
+
+/**
  * @brief The transport layer interface used by the HTTP Client library.
  */
 static TransportInterface_t transportInterface;
@@ -169,6 +174,14 @@ static uint8_t * pNetworkData = NULL;
  * @brief The length of the network data to return in the transportRecvStub.
  */
 static size_t networkDataLen = 0U;
+
+/*-----------------------------------------------------------*/
+
+/* Each compilation unit must define the NetworkContext struct. */
+struct NetworkContext
+{
+    OpensslParams_t * pParams;
+};
 
 /*-----------------------------------------------------------*/
 
@@ -259,6 +272,8 @@ static void connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContex
     serverInfo.pHostName = SERVER_HOST;
     serverInfo.hostNameLength = SERVER_HOST_LENGTH;
     serverInfo.port = HTTPS_PORT;
+
+    pNetworkContext->pParams = &opensslParams;
 
     /* Seed pseudo random number generator used in the demo for
      * backoff period calculation when retrying failed network operations

--- a/integration-test/lexicon.txt
+++ b/integration-test/lexicon.txt
@@ -237,6 +237,7 @@ mutex
 mutexes
 mxz
 necesarily
+networkcontext
 networkdatalen
 ni
 nist

--- a/integration-test/mqtt/mqtt_system_test.c
+++ b/integration-test/mqtt/mqtt_system_test.c
@@ -1057,8 +1057,8 @@ void test_MQTT_Connect_LWT( void )
                                                          &opensslCredentials,
                                                          TRANSPORT_SEND_RECV_TIMEOUT_MS,
                                                          TRANSPORT_SEND_RECV_TIMEOUT_MS ) );
-    TEST_ASSERT_NOT_EQUAL( -1, secondNetworkContext.socketDescriptor );
-    TEST_ASSERT_NOT_NULL( secondNetworkContext.pSsl );
+    TEST_ASSERT_NOT_EQUAL( -1, secondOpensslParams.socketDescriptor );
+    TEST_ASSERT_NOT_NULL( secondOpensslParams.pSsl );
 
     /* Establish MQTT session on top of the TCP+TLS connection. */
     useLWTClientIdentifier = true;

--- a/integration-test/mqtt/mqtt_system_test.c
+++ b/integration-test/mqtt/mqtt_system_test.c
@@ -1257,7 +1257,6 @@ void test_MQTT_Resend_Unacked_Publish_QoS1( void )
     /* Verify that the library has stored the PUBLISH as an incomplete operation. */
     TEST_ASSERT_NOT_EQUAL( MQTT_PACKET_ID_INVALID, context.outgoingPublishRecords[ 0 ].packetId );
 
-
     /* Reset the transport receive function in the context. */
     context.transportInterface.recv = Openssl_Recv;
 

--- a/integration-test/mqtt/mqtt_system_test.c
+++ b/integration-test/mqtt/mqtt_system_test.c
@@ -737,8 +737,8 @@ static void startPersistentSession()
                                                          &opensslCredentials,
                                                          TRANSPORT_SEND_RECV_TIMEOUT_MS,
                                                          TRANSPORT_SEND_RECV_TIMEOUT_MS ) );
-    TEST_ASSERT_NOT_EQUAL( -1, networkContext.socketDescriptor );
-    TEST_ASSERT_NOT_NULL( networkContext.pSsl );
+    TEST_ASSERT_NOT_EQUAL( -1, opensslParams.socketDescriptor );
+    TEST_ASSERT_NOT_NULL( opensslParams.pSsl );
 
     /* Establish a new MQTT connection for a persistent session with the broker. */
     establishMqttSession( &context, &networkContext, false, &persistentSession );
@@ -753,8 +753,8 @@ static void resumePersistentSession()
                                                          &opensslCredentials,
                                                          TRANSPORT_SEND_RECV_TIMEOUT_MS,
                                                          TRANSPORT_SEND_RECV_TIMEOUT_MS ) );
-    TEST_ASSERT_NOT_EQUAL( -1, networkContext.socketDescriptor );
-    TEST_ASSERT_NOT_NULL( networkContext.pSsl );
+    TEST_ASSERT_NOT_EQUAL( -1, opensslParams.socketDescriptor );
+    TEST_ASSERT_NOT_NULL( opensslParams.pSsl );
 
     /* Re-establish the persistent session with the broker by connecting with "clean session" flag set to 0. */
     TEST_ASSERT_FALSE( persistentSession );
@@ -812,8 +812,8 @@ void setUp()
                                                          &opensslCredentials,
                                                          TRANSPORT_SEND_RECV_TIMEOUT_MS,
                                                          TRANSPORT_SEND_RECV_TIMEOUT_MS ) );
-    TEST_ASSERT_NOT_EQUAL( -1, networkContext.socketDescriptor );
-    TEST_ASSERT_NOT_NULL( networkContext.pSsl );
+    TEST_ASSERT_NOT_EQUAL( -1, opensslParams.socketDescriptor );
+    TEST_ASSERT_NOT_NULL( opensslParams.pSsl );
 
     /* Establish MQTT session on top of the TCP+TLS connection. */
     establishMqttSession( &context, &networkContext, true, &persistentSession );

--- a/integration-test/mqtt/mqtt_system_test.c
+++ b/integration-test/mqtt/mqtt_system_test.c
@@ -230,6 +230,11 @@ static uint16_t globalPublishPacketIdentifier = 0U;
 static NetworkContext_t networkContext;
 
 /**
+ * @brief Parameters for the Openssl Context.
+ */
+static OpensslParams_t opensslParams;
+
+/**
  * @brief Represents the hostname and port of the broker.
  */
 static ServerInfo_t serverInfo;
@@ -311,6 +316,12 @@ static uint8_t packetTypeForDisconnection = MQTT_PACKET_TYPE_INVALID;
  * to MQTT broker.
  */
 static int clientIdRandNumber;
+
+/* Each compilation unit must define the NetworkContext struct. */
+struct NetworkContext
+{
+    OpensslParams_t * pParams;
+};
 
 /**
  * @brief Sends an MQTT CONNECT packet over the already connected TCP socket.
@@ -773,10 +784,13 @@ void setUp()
     packetTypeForDisconnection = MQTT_PACKET_TYPE_INVALID;
     memset( &incomingInfo, 0u, sizeof( MQTTPublishInfo_t ) );
     memset( &opensslCredentials, 0u, sizeof( OpensslCredentials_t ) );
+    memset( &opensslParams, 0u, sizeof( OpensslParams_t ) );
     opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
     opensslCredentials.pClientCertPath = CLIENT_CERT_PATH;
     opensslCredentials.pPrivateKeyPath = CLIENT_PRIVATE_KEY_PATH;
     opensslCredentials.sniHostName = BROKER_ENDPOINT;
+
+    networkContext.pParams = &opensslParams;
 
     serverInfo.pHostName = BROKER_ENDPOINT;
     serverInfo.hostNameLength = BROKER_ENDPOINT_LENGTH;
@@ -1030,8 +1044,11 @@ void test_MQTT_Subscribe_Publish_With_Qos_2( void )
 void test_MQTT_Connect_LWT( void )
 {
     NetworkContext_t secondNetworkContext = { 0 };
+    OpensslParams_t secondOpensslParams = { 0 };
     bool sessionPresent;
     MQTTContext_t secondContext;
+
+    secondNetworkContext.pParams = &secondOpensslParams;
 
     /* Establish a second TCP connection with the server endpoint, then
      * a TLS session. The server info and credentials can be reused. */

--- a/integration-test/shadow/shadow_system_test.c
+++ b/integration-test/shadow/shadow_system_test.c
@@ -701,8 +701,8 @@ void setUp( void )
                                                          &opensslCredentials,
                                                          TRANSPORT_SEND_RECV_TIMEOUT_MS,
                                                          TRANSPORT_SEND_RECV_TIMEOUT_MS ) );
-    TEST_ASSERT_NOT_EQUAL( -1, networkContext.socketDescriptor );
-    TEST_ASSERT_NOT_NULL( networkContext.pSsl );
+    TEST_ASSERT_NOT_EQUAL( -1, opensslParams.socketDescriptor );
+    TEST_ASSERT_NOT_NULL( opensslParams.pSsl );
 
     /* Establish MQTT session on top of the TCP+TLS connection. */
     establishMqttSession( &context, &networkContext, true, &persistentSession );

--- a/integration-test/shadow/shadow_system_test.c
+++ b/integration-test/shadow/shadow_system_test.c
@@ -171,6 +171,11 @@ static uint16_t globalPublishPacketIdentifier = 0U;
 static NetworkContext_t networkContext;
 
 /**
+ * @brief Parameters for the Openssl Context.
+ */
+static OpensslParams_t opensslParams;
+
+/**
  * @brief Represents the hostname and port of the broker.
  */
 static ServerInfo_t serverInfo;
@@ -266,6 +271,12 @@ static bool receivedGetAcceptedResult = false;
  * @brief Flag to represent result from a /get/rejected  is received from the broker.
  */
 static bool receivedGetRejectedResult = false;
+
+/* Each compilation unit must define the NetworkContext struct. */
+struct NetworkContext
+{
+    OpensslParams_t * pParams;
+};
 
 /**
  * @brief Sends an MQTT CONNECT packet over the already connected TCP socket.
@@ -672,6 +683,7 @@ void setUp( void )
 
     memset( &incomingInfo, 0u, sizeof( MQTTPublishInfo_t ) );
     memset( &opensslCredentials, 0u, sizeof( OpensslCredentials_t ) );
+    memset( &opensslParams, 0u, sizeof( OpensslParams_t ) );
     opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
     opensslCredentials.pClientCertPath = CLIENT_CERT_PATH;
     opensslCredentials.pPrivateKeyPath = CLIENT_PRIVATE_KEY_PATH;
@@ -679,6 +691,8 @@ void setUp( void )
     serverInfo.pHostName = AWS_IOT_ENDPOINT;
     serverInfo.hostNameLength = AWS_IOT_ENDPOINT_LENGTH;
     serverInfo.port = AWS_MQTT_PORT;
+
+    networkContext.pParams = &opensslParams;
 
     /* Establish a TCP connection with the server endpoint, then
      * establish TLS session on top of TCP connection. */

--- a/platform/lexicon.txt
+++ b/platform/lexicon.txt
@@ -101,6 +101,7 @@ plisthead
 pnetworkcontext
 png
 popensslcredentials
+popensslparams
 posix
 pprivatekeypath
 pretryparams

--- a/platform/posix/transport/include/openssl_posix.h
+++ b/platform/posix/transport/include/openssl_posix.h
@@ -59,17 +59,17 @@
 #include "sockets_posix.h"
 
 /**
- * @brief Definition of the network context for the transport interface
+ * @brief Parameters for the transport-interface
  * implementation that uses OpenSSL and POSIX sockets.
  *
  * @note For this transport implementation, the socket descriptor and
  * SSL context is used.
  */
-struct NetworkContext
+typedef struct OpensslParams
 {
     int32_t socketDescriptor;
     SSL * pSsl;
-};
+} OpensslParams_t;
 
 /**
  * @brief OpenSSL Connect / Disconnect return status.

--- a/platform/posix/transport/include/plaintext_posix.h
+++ b/platform/posix/transport/include/plaintext_posix.h
@@ -54,12 +54,13 @@
 #include "sockets_posix.h"
 
 /**
- * @brief Definition of the network context.
+ * @brief Parameters for the transport-interface
+ * implementation that uses plaintext POSIX sockets.
  */
-struct NetworkContext
+typedef struct PlaintextParams
 {
     int32_t socketDescriptor;
-};
+} PlaintextParams_t;
 
 /**
  * @brief Establish TCP connection to server.

--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -706,7 +706,7 @@ int32_t Openssl_Recv( NetworkContext_t * pNetworkContext,
                       size_t bytesToRecv )
 {
     OpensslParams_t * pOpensslParams = NULL;
-    int32_t bytesReceived = -1;
+    int32_t bytesReceived = 0;
     int32_t sslError = 0;
 
     if( ( pNetworkContext == NULL ) || ( pNetworkContext->pParams == NULL ) )
@@ -756,7 +756,7 @@ int32_t Openssl_Send( NetworkContext_t * pNetworkContext,
                       size_t bytesToSend )
 {
     OpensslParams_t * pOpensslParams = NULL;
-    int32_t bytesSent = -1;
+    int32_t bytesSent = 0;
     int32_t sslError = 0;
 
     /* Unused parameter when logs are disabled. */

--- a/platform/posix/transport/src/plaintext_posix.c
+++ b/platform/posix/transport/src/plaintext_posix.c
@@ -33,6 +33,14 @@
 
 /*-----------------------------------------------------------*/
 
+/* Each compilation unit must define the NetworkContext struct. */
+struct NetworkContext
+{
+    PlaintextParams_t * pParams;
+};
+
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Log possible error from send/recv.
  *
@@ -56,16 +64,45 @@ SocketStatus_t Plaintext_Connect( NetworkContext_t * pNetworkContext,
                                   uint32_t sendTimeoutMs,
                                   uint32_t recvTimeoutMs )
 {
-    return Sockets_Connect( &pNetworkContext->socketDescriptor,
-                            pServerInfo,
-                            sendTimeoutMs,
-                            recvTimeoutMs );
+    SocketStatus_t returnStatus = SOCKETS_SUCCESS;
+    PlaintextParams_t * pPlaintextParams = NULL;
+
+    /* Validate parameters. */
+    if( ( pNetworkContext == NULL ) || ( pNetworkContext->pParams == NULL ) )
+    {
+        LogError( ( "Parameter check failed: pNetworkContext is NULL." ) );
+        returnStatus = SOCKETS_INVALID_PARAMETER;
+    }
+    else
+    {
+        pPlaintextParams = pNetworkContext->pParams;
+        returnStatus = Sockets_Connect( &pPlaintextParams->socketDescriptor,
+                                        pServerInfo,
+                                        sendTimeoutMs,
+                                        recvTimeoutMs )
+    }
+
+    return returnStatus;
 }
 /*-----------------------------------------------------------*/
 
 SocketStatus_t Plaintext_Disconnect( const NetworkContext_t * pNetworkContext )
 {
-    return Sockets_Disconnect( pNetworkContext->socketDescriptor );
+    PlaintextParams_t * pPlaintextParams = NULL;
+
+    /* Validate parameters. */
+    if( ( pNetworkContext == NULL ) || ( pNetworkContext->pParams == NULL ) )
+    {
+        LogError( ( "Parameter check failed: pNetworkContext is NULL." ) );
+        returnStatus = SOCKETS_INVALID_PARAMETER;
+    }
+    else
+    {
+        pPlaintextParams = pNetworkContext->pParams;
+        returnStatus = Sockets_Disconnect( pPlaintextParams->socketDescriptor );
+    }
+
+    return returnStatus;
 }
 /*-----------------------------------------------------------*/
 
@@ -76,18 +113,20 @@ int32_t Plaintext_Recv( NetworkContext_t * pNetworkContext,
                         void * pBuffer,
                         size_t bytesToRecv )
 {
+    PlaintextParams_t * pPlaintextParams = NULL;
     int32_t bytesReceived = -1, selectStatus = -1, getTimeoutStatus = -1;
     struct timeval recvTimeout;
     socklen_t recvTimeoutLen;
     fd_set readfds;
 
-    assert( pNetworkContext != NULL );
+    assert( pNetworkContext != NULL && pNetworkContext->pParams != NULL );
     assert( pBuffer != NULL );
     assert( bytesToRecv > 0 );
 
     /* Get receive timeout from the socket to use as the timeout for #select. */
+    pPlaintextParams = pNetworkContext->pParams;
     recvTimeoutLen = ( socklen_t ) sizeof( recvTimeout );
-    getTimeoutStatus = getsockopt( pNetworkContext->socketDescriptor,
+    getTimeoutStatus = getsockopt( pPlaintextParams->socketDescriptor,
                                    SOL_SOCKET,
                                    SO_RCVTIMEO,
                                    &recvTimeout,
@@ -130,10 +169,10 @@ int32_t Plaintext_Recv( NetworkContext_t * pNetworkContext,
     /* coverity[misra_c_2012_rule_10_1_violation] */
     /* coverity[misra_c_2012_rule_13_4_violation] */
     /* coverity[misra_c_2012_rule_10_8_violation] */
-    FD_SET( pNetworkContext->socketDescriptor, &readfds );
+    FD_SET( pPlaintextParams->socketDescriptor, &readfds );
 
     /* Check if there is data to read from the socket. */
-    selectStatus = select( pNetworkContext->socketDescriptor + 1,
+    selectStatus = select( pPlaintextParams->socketDescriptor + 1,
                            &readfds,
                            NULL,
                            NULL,
@@ -142,7 +181,7 @@ int32_t Plaintext_Recv( NetworkContext_t * pNetworkContext,
     if( selectStatus > 0 )
     {
         /* The socket is available for receiving data. */
-        bytesReceived = ( int32_t ) recv( pNetworkContext->socketDescriptor,
+        bytesReceived = ( int32_t ) recv( pPlaintextParams->socketDescriptor,
                                           pBuffer,
                                           bytesToRecv,
                                           0 );
@@ -183,18 +222,20 @@ int32_t Plaintext_Send( NetworkContext_t * pNetworkContext,
                         const void * pBuffer,
                         size_t bytesToSend )
 {
+    PlaintextParams_t * pPlaintextParams = NULL;
     int32_t bytesSent = -1, selectStatus = -1, getTimeoutStatus = -1;
     struct timeval sendTimeout;
     socklen_t sendTimeoutLen;
     fd_set writefds;
 
-    assert( pNetworkContext != NULL );
+    assert( pNetworkContext != NULL && pNetworkContext->pParams != NULL );
     assert( pBuffer != NULL );
     assert( bytesToSend > 0 );
 
     /* Get send timeout from the socket to use as the timeout for #select. */
+    pPlaintextParams = pNetworkContext->pParams;
     sendTimeoutLen = ( socklen_t ) sizeof( sendTimeout );
-    getTimeoutStatus = getsockopt( pNetworkContext->socketDescriptor,
+    getTimeoutStatus = getsockopt( pPlaintextParams->socketDescriptor,
                                    SOL_SOCKET,
                                    SO_SNDTIMEO,
                                    &sendTimeout,
@@ -236,9 +277,9 @@ int32_t Plaintext_Send( NetworkContext_t * pNetworkContext,
     /* coverity[misra_c_2012_rule_10_1_violation] */
     /* coverity[misra_c_2012_rule_13_4_violation] */
     /* coverity[misra_c_2012_rule_10_8_violation] */
-    FD_SET( pNetworkContext->socketDescriptor, &writefds );
+    FD_SET( pPlaintextParams->socketDescriptor, &writefds );
     /* Check if data can be written to the socket. */
-    selectStatus = select( pNetworkContext->socketDescriptor + 1,
+    selectStatus = select( pPlaintextParams->socketDescriptor + 1,
                            NULL,
                            &writefds,
                            NULL,
@@ -247,7 +288,7 @@ int32_t Plaintext_Send( NetworkContext_t * pNetworkContext,
     if( selectStatus > 0 )
     {
         /* The socket is available for sending data. */
-        bytesSent = ( int32_t ) send( pNetworkContext->socketDescriptor,
+        bytesSent = ( int32_t ) send( pPlaintextParams->socketDescriptor,
                                       pBuffer,
                                       bytesToSend,
                                       0 );

--- a/platform/posix/transport/src/plaintext_posix.c
+++ b/platform/posix/transport/src/plaintext_posix.c
@@ -79,7 +79,7 @@ SocketStatus_t Plaintext_Connect( NetworkContext_t * pNetworkContext,
         returnStatus = Sockets_Connect( &pPlaintextParams->socketDescriptor,
                                         pServerInfo,
                                         sendTimeoutMs,
-                                        recvTimeoutMs )
+                                        recvTimeoutMs );
     }
 
     return returnStatus;

--- a/platform/posix/transport/src/plaintext_posix.c
+++ b/platform/posix/transport/src/plaintext_posix.c
@@ -88,6 +88,7 @@ SocketStatus_t Plaintext_Connect( NetworkContext_t * pNetworkContext,
 
 SocketStatus_t Plaintext_Disconnect( const NetworkContext_t * pNetworkContext )
 {
+    SocketStatus_t returnStatus = SOCKETS_SUCCESS;
     PlaintextParams_t * pPlaintextParams = NULL;
 
     /* Validate parameters. */

--- a/platform/posix/transport/utest/openssl_utest.c
+++ b/platform/posix/transport/utest/openssl_utest.c
@@ -730,6 +730,11 @@ void test_Openssl_Send_Invalid_Params( void )
     bytesSent = Openssl_Send( NULL, opensslBuffer, BYTES_TO_SEND );
     TEST_ASSERT_EQUAL( 0, bytesSent );
 
+    networkContext.pParams = NULL;
+    bytesSent = Openssl_Send( &networkContext, opensslBuffer, BYTES_TO_SEND );
+    TEST_ASSERT_EQUAL( 0, bytesSent );
+    networkContext.pParams = &opensslParams;
+
     /* SSL object must not be NULL. Otherwise, no bytes are sent. */
     opensslParams.pSsl = NULL;
     bytesSent = Openssl_Send( &networkContext, opensslBuffer, BYTES_TO_SEND );
@@ -779,6 +784,11 @@ void test_Openssl_Recv_Invalid_Params( void )
 
     bytesReceived = Openssl_Recv( NULL, opensslBuffer, BYTES_TO_RECV );
     TEST_ASSERT_EQUAL( 0, bytesReceived );
+
+    networkContext.pParams = NULL;
+    bytesReceived = Openssl_Recv( &networkContext, opensslBuffer, BYTES_TO_RECV );
+    TEST_ASSERT_EQUAL( 0, bytesReceived );
+    networkContext.pParams = &opensslParams;
 
     /* SSL object must not be NULL. Otherwise, no bytes are sent. */
     opensslParams.pSsl = NULL;

--- a/platform/posix/transport/utest/openssl_utest.c
+++ b/platform/posix/transport/utest/openssl_utest.c
@@ -110,7 +110,7 @@ void setUp()
     serverInfo.hostNameLength = strlen( HOSTNAME );
     serverInfo.port = PORT;
 
-    opensslParams.pParams = &opensslParams;
+    networkContext.pParams = &opensslParams;
 
     memset( &opensslCredentials, 0, sizeof( OpensslCredentials_t ) );
     opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;

--- a/platform/posix/transport/utest/openssl_utest.c
+++ b/platform/posix/transport/utest/openssl_utest.c
@@ -681,6 +681,10 @@ void test_Openssl_Disconnect_NULL_Network_Context( void )
 
     returnStatus = Openssl_Disconnect( NULL );
     TEST_ASSERT_EQUAL( OPENSSL_INVALID_PARAMETER, returnStatus );
+
+    networkContext.pParams = NULL;
+    returnStatus = Openssl_Disconnect( &networkContext );
+    TEST_ASSERT_EQUAL( OPENSSL_INVALID_PARAMETER, returnStatus );
 }
 
 /**
@@ -691,7 +695,7 @@ void test_Openssl_Disconnect_Succeeds( void )
     OpensslStatus_t returnStatus;
 
     /* First, SSL object is NULL. */
-    memset( &networkContext, 0, sizeof( NetworkContext_t ) );
+    opensslParams.pSsl = NULL;
     Sockets_Disconnect_ExpectAnyArgsAndReturn( SOCKETS_SUCCESS );
     returnStatus = Openssl_Disconnect( &networkContext );
     TEST_ASSERT_EQUAL( OPENSSL_SUCCESS, returnStatus );

--- a/platform/posix/transport/utest/openssl_utest.c
+++ b/platform/posix/transport/utest/openssl_utest.c
@@ -697,6 +697,7 @@ void test_Openssl_Disconnect_Succeeds( void )
     TEST_ASSERT_EQUAL( OPENSSL_SUCCESS, returnStatus );
 
     /* Now, set SSL object for coverage. */
+    networkContext.pParams = &opensslParams;
     opensslParams.pSsl = &ssl;
     SSL_shutdown_ExpectAnyArgsAndReturn( 0 );
     SSL_shutdown_ExpectAnyArgsAndReturn( 0 );

--- a/platform/posix/transport/utest/openssl_utest.c
+++ b/platform/posix/transport/utest/openssl_utest.c
@@ -59,6 +59,12 @@
 /* The size of the buffer passed to #Openssl_Send and #Openssl_Recv. */
 #define BUFFER_LEN              4
 
+/* Each compilation unit must define the NetworkContext struct. */
+struct NetworkContext
+{
+    OpensslParams_t * pParams;
+};
+
 /* Objects used by the OpenSSL transport implementation. */
 static ServerInfo_t serverInfo = { 0 };
 static OpensslCredentials_t opensslCredentials = { 0 };
@@ -94,12 +100,6 @@ typedef enum FunctionNames
     SSL_connect_fn,
     SSL_get_verify_result_fn
 } FunctionNames_t;
-
-/* Each compilation unit must define the NetworkContext struct. */
-struct NetworkContext
-{
-    OpensslParams_t * pParams;
-};
 
 /* ============================   UNITY FIXTURES ============================ */
 

--- a/platform/posix/transport/utest/plaintext_utest.c
+++ b/platform/posix/transport/utest/plaintext_utest.c
@@ -55,8 +55,9 @@
 /* The error returned from #send or #recv. */
 #define SEND_RECV_ERROR      -1
 
-static ServerInfo_t serverInfo;
-static NetworkContext_t networkContext;
+static ServerInfo_t serverInfo = { 0 };
+static NetworkContext_t networkContext = { 0 };
+static PlaintextParams_t plaintextParams = { 0 };
 static uint8_t plaintextBuffer[ BUFFER_LEN ] = { 0 };
 
 /* Possible transport status codes referencing the ones from #errno.h. The last
@@ -69,6 +70,12 @@ static uint8_t errorNumbers[] =
     EAGAIN,    EWOULDBLOCK, UNKNOWN_ERRNO
 };
 
+/* Each compilation unit must define the NetworkContext struct. */
+struct NetworkContext
+{
+    PlaintextParams_t * pParams;
+};
+
 /* ============================   UNITY FIXTURES ============================ */
 
 /* Called before each test method. */
@@ -77,6 +84,8 @@ void setUp()
     serverInfo.pHostName = HOSTNAME;
     serverInfo.hostNameLength = strlen( HOSTNAME );
     serverInfo.port = PORT;
+
+    networkContext.pParams = &plaintextParams;
 }
 
 /* Called after each test method. */
@@ -115,6 +124,22 @@ void test_Plaintext_Connect_Forwards_From_Sockets_Connect( void )
 }
 
 /**
+ * @brief Test that a NULL network context returns an error.
+ */
+void test_Plaintext_Connect_Invalid_Params( void )
+{
+    SocketStatus_t socketStatus = SOCKETS_SUCCESS;
+    NetworkContext_t networkContext = { 0 };
+
+    socketStatus = Plaintext_Connect( NULL );
+    TEST_ASSERT_EQUAL( SOCKETS_INVALID_PARAMETER, socketStatus );
+
+    networkContext.pParams = NULL;
+    socketStatus = Plaintext_Connect( &networkContext );
+    TEST_ASSERT_EQUAL( SOCKETS_INVALID_PARAMETER, socketStatus );
+}
+
+/**
  * @brief Test that #Plaintext_Disconnect forwards the status from #Sockets_Disconnect.
  *
  * @note #Plaintext_Disconnect is just a wrapper function to #Sockets_Disconnect.
@@ -126,6 +151,22 @@ void test_Plaintext_Disconnect_Forwards_From_Sockets_Disconnect( void )
     Sockets_Disconnect_ExpectAnyArgsAndReturn( SOCKETS_SUCCESS );
     socketStatus = Plaintext_Disconnect( &networkContext );
     TEST_ASSERT_EQUAL( SOCKETS_SUCCESS, socketStatus );
+}
+
+/**
+ * @brief Test that a NULL network context returns an error.
+ */
+void test_Plaintext_Disconnect_Invalid_Params( void )
+{
+    SocketStatus_t socketStatus = SOCKETS_SUCCESS;
+    NetworkContext_t networkContext = { 0 };
+
+    socketStatus = Plaintext_Disconnect( NULL );
+    TEST_ASSERT_EQUAL( SOCKETS_INVALID_PARAMETER, socketStatus );
+
+    networkContext.pParams = NULL;
+    socketStatus = Plaintext_Disconnect( &networkContext );
+    TEST_ASSERT_EQUAL( SOCKETS_INVALID_PARAMETER, socketStatus );
 }
 
 /**

--- a/platform/posix/transport/utest/plaintext_utest.c
+++ b/platform/posix/transport/utest/plaintext_utest.c
@@ -55,6 +55,12 @@
 /* The error returned from #send or #recv. */
 #define SEND_RECV_ERROR      -1
 
+/* Each compilation unit must define the NetworkContext struct. */
+struct NetworkContext
+{
+    PlaintextParams_t * pParams;
+};
+
 static ServerInfo_t serverInfo = { 0 };
 static NetworkContext_t networkContext = { 0 };
 static PlaintextParams_t plaintextParams = { 0 };
@@ -68,12 +74,6 @@ static uint8_t errorNumbers[] =
     EINVAL,    ENOTCONN,    ENOTSOCK,     EOPNOTSUPP,
     ETIMEDOUT, EMSGSIZE,    EPIPE,
     EAGAIN,    EWOULDBLOCK, UNKNOWN_ERRNO
-};
-
-/* Each compilation unit must define the NetworkContext struct. */
-struct NetworkContext
-{
-    PlaintextParams_t * pParams;
 };
 
 /* ============================   UNITY FIXTURES ============================ */
@@ -131,11 +131,17 @@ void test_Plaintext_Connect_Invalid_Params( void )
     SocketStatus_t socketStatus = SOCKETS_SUCCESS;
     NetworkContext_t networkContext = { 0 };
 
-    socketStatus = Plaintext_Connect( NULL );
+    socketStatus = Plaintext_Connect( NULL,
+                                      &serverInfo,
+                                      SEND_RECV_TIMEOUT,
+                                      SEND_RECV_TIMEOUT );
     TEST_ASSERT_EQUAL( SOCKETS_INVALID_PARAMETER, socketStatus );
 
     networkContext.pParams = NULL;
-    socketStatus = Plaintext_Connect( &networkContext );
+    socketStatus = Plaintext_Connect( &networkContext,
+                                      &serverInfo,
+                                      SEND_RECV_TIMEOUT,
+                                      SEND_RECV_TIMEOUT );
     TEST_ASSERT_EQUAL( SOCKETS_INVALID_PARAMETER, socketStatus );
 }
 


### PR DESCRIPTION
By removing the definition of the NetworkContext struct in the header file, we allow the application to define it. This allows an application writer to use multiple transports in the same compilation unit. That way, multiple .c files do not have to be created for each transport.

All these changes are tested to work in CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
