### PR TITLE
Add retries to demos with one loop

### DIFF
--- a/demos/defender/defender_demo_json/defender_demo.c
+++ b/demos/defender/defender_demo_json/defender_demo.c
@@ -89,6 +89,19 @@
 #define DEFENDER_RESPONSE_REPORT_ID_FIELD_LENGTH    ( sizeof( DEFENDER_RESPONSE_REPORT_ID_FIELD ) - 1 )
 
 /**
+ * @brief The maximum number of times to run the loop in this demo.
+ */
+#ifndef DEFENDER_MAX_DEMO_COUNT
+    #define DEFENDER_MAX_DEMO_COUNT    ( 3 )
+#endif
+
+/**
+ * @brief Time in seconds to wait between retries of the demo loop if
+ * demo loop fails.
+ */
+#define DELAY_BETWEEN_DEMO_ITERATIONS_S    ( 5 )
+
+/**
  * @brief Status values of the device defender report.
  */
 typedef enum
@@ -514,198 +527,225 @@ int main( int argc,
     bool status = false;
     int exitStatus = EXIT_FAILURE;
     uint32_t reportLength = 0, i, mqttSessionEstablished = 0;
+    int demoRunCount = 0;
 
     /* Silence compiler warnings about unused variables. */
     ( void ) argc;
     ( void ) argv;
 
-    /* Start with report not received. */
-    reportStatus = ReportStatusNotReceived;
-
-    /* Set a report Id to be used.
-     *
-     * Reports for a Thing with a previously used report ID will be assumed to
-     * be duplicates and discarded by the Device Defender service. The report
-     * ID needs to be unique per report sent with a given Thing. We recommend
-     * using an increasing unique id such as the current timestamp. */
-    reportId = time( NULL );
-
-    /****************************** Connect. ******************************/
-
-    /* Attempts to connect to the AWS IoT MQTT broker over TCP. If the
-     * connection fails, retries after a timeout. Timeout value will
-     * exponentially increase until maximum attempts are reached. */
-    LogInfo( ( "Establishing MQTT session..." ) );
-    status = EstablishMqttSession( publishCallback );
-
-    if( status != true )
+    do
     {
-        LogError( ( "Failed to establish MQTT session." ) );
-    }
-    else
-    {
-        mqttSessionEstablished = 1;
-    }
+        /* Start with report not received. */
+        reportStatus = ReportStatusNotReceived;
 
-    /******************** Subscribe to Defender topics. *******************/
+        /* Set a report Id to be used.
+         *
+         * Reports for a Thing with a previously used report ID will be assumed to
+         * be duplicates and discarded by the Device Defender service. The report
+         * ID needs to be unique per report sent with a given Thing. We recommend
+         * using an increasing unique id such as the current timestamp. */
+        reportId = time( NULL );
 
-    /* Attempt to subscribe to the AWS IoT Device Defender topics.
-     * Since this demo is using JSON, in subscribeToDefenderTopics() we
-     * subscribe to the topics to which accepted and rejected responses are
-     * received from after publishing a JSON report.
-     *
-     * This demo uses a constant #democonfigTHING_NAME known at compile time
-     * therefore we use macros to assemble defender topic strings.
-     * If the thing name is known at run time, then we could use the API
-     * #Defender_GetTopic instead.
-     *
-     * For example, for the JSON accepted responses topic:
-     *
-     * #define TOPIC_BUFFER_LENGTH      ( 256U )
-     *
-     * // Every device should have a unique thing name registered with AWS IoT Core.
-     * // This example assumes that the device has a unique serial number which is
-     * // registered as the thing name with AWS IoT Core.
-     * const char * pThingName = GetDeviceSerialNumber();
-     * uint16_t thingNameLength = ( uint16_t ) strlen( pThingname );
-     * char topicBuffer[ TOPIC_BUFFER_LENGTH ] = { 0 };
-     * uint16_t topicLength = 0;
-     * DefenderStatus_t status = DefenderSuccess;
-     *
-     * status = Defender_GetTopic( &( topicBuffer[ 0 ] ),
-     *                             TOPIC_BUFFER_LENGTH,
-     *                             pThingName,
-     *                             thingNameLength,
-     *                             DefenderJsonReportAccepted,
-     *                             &( topicLength ) );
-     */
-    if( status == true )
-    {
-        LogInfo( ( "Subscribing to defender topics..." ) );
-        status = subscribeToDefenderTopics();
+        /****************************** Connect. ******************************/
+
+        /* Attempts to connect to the AWS IoT MQTT broker over TCP. If the
+         * connection fails, retries after a timeout. Timeout value will
+         * exponentially increase until maximum attempts are reached. */
+        LogInfo( ( "Establishing MQTT session..." ) );
+        status = EstablishMqttSession( publishCallback );
 
         if( status != true )
         {
-            LogError( ( "Failed to subscribe to defender topics." ) );
+            LogError( ( "Failed to establish MQTT session." ) );
         }
-    }
-
-    /*********************** Collect device metrics. **********************/
-
-    /* We then need to collect the metrics that will be sent to the AWS IoT
-     * Device Defender service. This demo uses the functions declared in
-     * metrics_collector.h to collect network metrics. For this demo, the
-     * implementation of these functions are in metrics_collector.c and
-     * collects metrics using tcp_netstat utility for FreeRTOS+TCP. */
-    if( status == true )
-    {
-        LogInfo( ( "Collecting device metrics..." ) );
-        status = collectDeviceMetrics();
-
-        if( status != true )
+        else
         {
-            LogError( ( "Failed to collect device metrics." ) );
+            mqttSessionEstablished = 1;
         }
-    }
 
-    /********************** Generate defender report. *********************/
+        /******************** Subscribe to Defender topics. *******************/
 
-    /* The data needs to be incorporated into a JSON formatted report,
-     * which follows the format expected by the Device Defender service.
-     * This format is documented here:
-     * https://docs.aws.amazon.com/iot/latest/developerguide/detect-device-side-metrics.html
-     */
-    if( status == true )
-    {
-        LogInfo( ( "Generating device defender report..." ) );
-        status = generateDeviceMetricsReport( &( reportLength ) );
-
-        if( status != true )
+        /* Attempt to subscribe to the AWS IoT Device Defender topics.
+         * Since this demo is using JSON, in subscribeToDefenderTopics() we
+         * subscribe to the topics to which accepted and rejected responses are
+         * received from after publishing a JSON report.
+         *
+         * This demo uses a constant #democonfigTHING_NAME known at compile time
+         * therefore we use macros to assemble defender topic strings.
+         * If the thing name is known at run time, then we could use the API
+         * #Defender_GetTopic instead.
+         *
+         * For example, for the JSON accepted responses topic:
+         *
+         * #define TOPIC_BUFFER_LENGTH      ( 256U )
+         *
+         * // Every device should have a unique thing name registered with AWS IoT Core.
+         * // This example assumes that the device has a unique serial number which is
+         * // registered as the thing name with AWS IoT Core.
+         * const char * pThingName = GetDeviceSerialNumber();
+         * uint16_t thingNameLength = ( uint16_t ) strlen( pThingname );
+         * char topicBuffer[ TOPIC_BUFFER_LENGTH ] = { 0 };
+         * uint16_t topicLength = 0;
+         * DefenderStatus_t status = DefenderSuccess;
+         *
+         * status = Defender_GetTopic( &( topicBuffer[ 0 ] ),
+         *                             TOPIC_BUFFER_LENGTH,
+         *                             pThingName,
+         *                             thingNameLength,
+         *                             DefenderJsonReportAccepted,
+         *                             &( topicLength ) );
+         */
+        if( status == true )
         {
-            LogError( ( "Failed to generate device defender report." ) );
-        }
-    }
+            LogInfo( ( "Subscribing to defender topics..." ) );
+            status = subscribeToDefenderTopics();
 
-    /********************** Publish defender report. **********************/
-
-    /* The report is then published to the Device Defender service. This report
-     * is published to the MQTT topic for publishing JSON reports. As before,
-     * we use the defender library macros to create the topic string, though
-     * #Defender_GetTopic could be used if the Thing name is acquired at
-     * run time */
-    if( status == true )
-    {
-        LogInfo( ( "Publishing device defender report..." ) );
-        status = publishDeviceMetricsReport( reportLength );
-
-        if( status != true )
-        {
-            LogError( ( "Failed to publish device defender report." ) );
-        }
-    }
-
-    /* Wait for the response to our report. Response will be handled by the
-     * callback passed to establishMqttSession() earlier.
-     * The callback will verify that the MQTT messages received are from the
-     * defender service's topic. Based on whether the response comes from
-     * the accepted or rejected topics, it updates reportStatus. */
-    if( status == true )
-    {
-        for( i = 0; i < DEFENDER_RESPONSE_WAIT_SECONDS; i++ )
-        {
-            ( void ) ProcessLoop();
-
-            /* reportStatus is updated in the publishCallback. */
-            if( reportStatus != ReportStatusNotReceived )
+            if( status != true )
             {
-                break;
+                LogError( ( "Failed to subscribe to defender topics." ) );
+            }
+        }
+
+        /*********************** Collect device metrics. **********************/
+
+        /* We then need to collect the metrics that will be sent to the AWS IoT
+         * Device Defender service. This demo uses the functions declared in
+         * metrics_collector.h to collect network metrics. For this demo, the
+         * implementation of these functions are in metrics_collector.c and
+         * collects metrics using tcp_netstat utility for FreeRTOS+TCP. */
+        if( status == true )
+        {
+            LogInfo( ( "Collecting device metrics..." ) );
+            status = collectDeviceMetrics();
+
+            if( status != true )
+            {
+                LogError( ( "Failed to collect device metrics." ) );
+            }
+        }
+
+        /********************** Generate defender report. *********************/
+
+        /* The data needs to be incorporated into a JSON formatted report,
+         * which follows the format expected by the Device Defender service.
+         * This format is documented here:
+         * https://docs.aws.amazon.com/iot/latest/developerguide/detect-device-side-metrics.html
+         */
+        if( status == true )
+        {
+            LogInfo( ( "Generating device defender report..." ) );
+            status = generateDeviceMetricsReport( &( reportLength ) );
+
+            if( status != true )
+            {
+                LogError( ( "Failed to generate device defender report." ) );
+            }
+        }
+
+        /********************** Publish defender report. **********************/
+
+        /* The report is then published to the Device Defender service. This report
+         * is published to the MQTT topic for publishing JSON reports. As before,
+         * we use the defender library macros to create the topic string, though
+         * #Defender_GetTopic could be used if the Thing name is acquired at
+         * run time */
+        if( status == true )
+        {
+            LogInfo( ( "Publishing device defender report..." ) );
+            status = publishDeviceMetricsReport( reportLength );
+
+            if( status != true )
+            {
+                LogError( ( "Failed to publish device defender report." ) );
+            }
+        }
+
+        /* Wait for the response to our report. Response will be handled by the
+         * callback passed to establishMqttSession() earlier.
+         * The callback will verify that the MQTT messages received are from the
+         * defender service's topic. Based on whether the response comes from
+         * the accepted or rejected topics, it updates reportStatus. */
+        if( status == true )
+        {
+            for( i = 0; i < DEFENDER_RESPONSE_WAIT_SECONDS; i++ )
+            {
+                ( void ) ProcessLoop();
+
+                /* reportStatus is updated in the publishCallback. */
+                if( reportStatus != ReportStatusNotReceived )
+                {
+                    break;
+                }
+
+                /* Wait for sometime between consecutive executions of ProcessLoop. */
+                sleep( 1 );
+            }
+        }
+
+        /**************************** Disconnect. *****************************/
+
+        /* Unsubscribe and disconnect if MQTT session was established. Per the MQTT
+         * protocol spec, it is okay to send UNSUBSCRIBE even if no corresponding
+         * subscription exists on the broker. Therefore, it is okay to attempt
+         * unsubscribe even if one more subscribe failed earlier. */
+        if( reportStatus == ReportStatusNotReceived )
+        {
+            LogError( ( "Failed to receive response from AWS IoT Device Defender Service." ) );
+            status = false;
+        }
+
+        /* Unsubscribe and disconnect if MQTT session was established. Per the MQTT
+         * protocol spec, it is okay to send UNSUBSCRIBE even if no corresponding
+         * subscription exists on the broker. Therefore, it is okay to attempt
+         * unsubscribe even if one more subscribe failed earlier. */
+        if( mqttSessionEstablished == 1 )
+        {
+            LogInfo( ( "Unsubscribing from defender topics..." ) );
+            status = unsubscribeFromDefenderTopics();
+
+            if( status != true )
+            {
+                LogError( ( "Failed to unsubscribe from defender topics." ) );
             }
 
-            /* Wait for sometime between consecutive executions of ProcessLoop. */
-            sleep( 1 );
+            LogInfo( ( "Closing MQTT session..." ) );
+            ( void ) DisconnectMqttSession();
         }
-    }
 
-    /**************************** Disconnect. *****************************/
+        /****************************** Finish. ******************************/
 
-    /* Unsubscribe and disconnect if MQTT session was established. Per the MQTT
-     * protocol spec, it is okay to send UNSUBSCRIBE even if no corresponding
-     * subscription exists on the broker. Therefore, it is okay to attempt
-     * unsubscribe even if one more subscribe failed earlier. */
-    if( reportStatus == ReportStatusNotReceived )
-    {
-        LogError( ( "Failed to receive response from AWS IoT Device Defender Service." ) );
-        status = false;
-    }
-
-    /* Unsubscribe and disconnect if MQTT session was established. Per the MQTT
-     * protocol spec, it is okay to send UNSUBSCRIBE even if no corresponding
-     * subscription exists on the broker. Therefore, it is okay to attempt
-     * unsubscribe even if one more subscribe failed earlier. */
-    if( mqttSessionEstablished == 1 )
-    {
-        LogInfo( ( "Unsubscribing from defender topics..." ) );
-        status = unsubscribeFromDefenderTopics();
-
-        if( status != true )
+        if( ( status == true ) && ( reportStatus == ReportStatusAccepted ) )
         {
-            LogError( ( "Failed to unsubscribe from defender topics." ) );
+            exitStatus = EXIT_SUCCESS;
         }
 
-        LogInfo( ( "Closing MQTT session..." ) );
-        ( void ) DisconnectMqttSession();
-    }
+        /******************* Retry in case of failure. ***********************/
 
-    /****************************** Finish. ******************************/
+        /* Increment the demo run count. */
+        demoRunCount++;
 
-    if( ( status == true ) && ( reportStatus == ReportStatusAccepted ) )
+        if( exitStatus == EXIT_SUCCESS )
+        {
+            LogInfo( ( "Demo iteration %d is successful.", demoRunCount ) );
+        }
+        /* Attempt to retry a failed iteration of demo for up to #DEFENDER_MAX_DEMO_COUNT times. */
+        else if( demoRunCount < DEFENDER_MAX_DEMO_COUNT )
+        {
+            LogWarn( ( "Demo iteration %d failed. Retrying...", demoRunCount ) );
+            sleep( DELAY_BETWEEN_DEMO_ITERATIONS_S );
+        }
+        /* Failed all #DEFENDER_MAX_DEMO_COUNT demo iterations. */
+        else
+        {
+            LogError( ( "All %d demo iterations failed.", DEFENDER_MAX_DEMO_COUNT ) );
+            break;
+        }
+    } while( exitStatus != EXIT_SUCCESS );
+
+    /* Log demo success. */
+    if( exitStatus == EXIT_SUCCESS )
     {
-        exitStatus = EXIT_SUCCESS;
         LogInfo( ( "Demo completed successfully." ) );
-    }
-    else
-    {
-        LogError( ( "Demo failed." ) );
     }
 
     return exitStatus;

--- a/demos/defender/defender_demo_json/defender_demo.c
+++ b/demos/defender/defender_demo_json/defender_demo.c
@@ -90,16 +90,19 @@
 
 /**
  * @brief The maximum number of times to run the loop in this demo.
+ *
+ * @note The demo loop is attempted to re-run only if it fails in an iteration.
+ * Once the demo loop succeeds in an iteration, the demo exits successfully.
  */
-#ifndef DEFENDER_MAX_DEMO_COUNT
-    #define DEFENDER_MAX_DEMO_COUNT    ( 3 )
+#ifndef DEFENDER_MAX_DEMO_LOOP_COUNT
+    #define DEFENDER_MAX_DEMO_LOOP_COUNT    ( 3 )
 #endif
 
 /**
  * @brief Time in seconds to wait between retries of the demo loop if
  * demo loop fails.
  */
-#define DELAY_BETWEEN_DEMO_ITERATIONS_S    ( 5 )
+#define DELAY_BETWEEN_DEMO_RETRY_ITERATIONS_S    ( 5 )
 
 /**
  * @brief Status values of the device defender report.
@@ -728,16 +731,16 @@ int main( int argc,
         {
             LogInfo( ( "Demo iteration %d is successful.", demoRunCount ) );
         }
-        /* Attempt to retry a failed iteration of demo for up to #DEFENDER_MAX_DEMO_COUNT times. */
-        else if( demoRunCount < DEFENDER_MAX_DEMO_COUNT )
+        /* Attempt to retry a failed iteration of demo for up to #DEFENDER_MAX_DEMO_LOOP_COUNT times. */
+        else if( demoRunCount < DEFENDER_MAX_DEMO_LOOP_COUNT )
         {
             LogWarn( ( "Demo iteration %d failed. Retrying...", demoRunCount ) );
-            sleep( DELAY_BETWEEN_DEMO_ITERATIONS_S );
+            sleep( DELAY_BETWEEN_DEMO_RETRY_ITERATIONS_S );
         }
-        /* Failed all #DEFENDER_MAX_DEMO_COUNT demo iterations. */
+        /* Failed all #DEFENDER_MAX_DEMO_LOOP_COUNT demo iterations. */
         else
         {
-            LogError( ( "All %d demo iterations failed.", DEFENDER_MAX_DEMO_COUNT ) );
+            LogError( ( "All %d demo iterations failed.", DEFENDER_MAX_DEMO_LOOP_COUNT ) );
             break;
         }
     } while( exitStatus != EXIT_SUCCESS );

--- a/demos/http/http_demo_s3_download/http_demo_s3_download.c
+++ b/demos/http/http_demo_s3_download/http_demo_s3_download.c
@@ -101,16 +101,19 @@
 
 /**
  * @brief The maximum number of times to run the loop in this demo.
+ *
+ * @note The demo loop is attempted to re-run only if it fails in an iteration.
+ * Once the demo loop succeeds in an iteration, the demo exits successfully.
  */
-#ifndef HTTP_MAX_DEMO_COUNT
-    #define HTTP_MAX_DEMO_COUNT    ( 3 )
+#ifndef HTTP_MAX_DEMO_LOOP_COUNT
+    #define HTTP_MAX_DEMO_LOOP_COUNT    ( 3 )
 #endif
 
 /**
  * @brief Time in seconds to wait between retries of the demo loop if
  * demo loop fails.
  */
-#define DELAY_BETWEEN_DEMO_ITERATIONS_S    ( 5 )
+#define DELAY_BETWEEN_DEMO_RETRY_ITERATIONS_S    ( 5 )
 
 /**
  * @brief A buffer used in the demo for storing HTTP request headers and HTTP
@@ -693,16 +696,16 @@ int main( int argc,
         {
             LogInfo( ( "Demo iteration %d is successful.", demoRunCount ) );
         }
-        /* Attempt to retry a failed iteration of demo for up to #HTTP_MAX_DEMO_COUNT times. */
-        else if( demoRunCount < HTTP_MAX_DEMO_COUNT )
+        /* Attempt to retry a failed iteration of demo for up to #HTTP_MAX_DEMO_LOOP_COUNT times. */
+        else if( demoRunCount < HTTP_MAX_DEMO_LOOP_COUNT )
         {
             LogWarn( ( "Demo iteration %d failed. Retrying...", demoRunCount ) );
-            sleep( DELAY_BETWEEN_DEMO_ITERATIONS_S );
+            sleep( DELAY_BETWEEN_DEMO_RETRY_ITERATIONS_S );
         }
-        /* Failed all #HTTP_MAX_DEMO_COUNT demo iterations. */
+        /* Failed all #HTTP_MAX_DEMO_LOOP_COUNT demo iterations. */
         else
         {
-            LogError( ( "All %d demo iterations failed.", HTTP_MAX_DEMO_COUNT ) );
+            LogError( ( "All %d demo iterations failed.", HTTP_MAX_DEMO_LOOP_COUNT ) );
             break;
         }
     } while( returnStatus != EXIT_SUCCESS );

--- a/demos/http/http_demo_s3_download/http_demo_s3_download.c
+++ b/demos/http/http_demo_s3_download/http_demo_s3_download.c
@@ -100,6 +100,19 @@
 #define HTTP_STATUS_CODE_PARTIAL_CONTENT          206
 
 /**
+ * @brief The maximum number of times to run the loop in this demo.
+ */
+#ifndef HTTP_MAX_DEMO_COUNT
+    #define HTTP_MAX_DEMO_COUNT    ( 3 )
+#endif
+
+/**
+ * @brief Time in seconds to wait between retries of the demo loop if
+ * demo loop fails.
+ */
+#define DELAY_BETWEEN_DEMO_ITERATIONS_S    ( 5 )
+
+/**
  * @brief A buffer used in the demo for storing HTTP request headers and HTTP
  * response headers and body.
  *
@@ -592,6 +605,7 @@ int main( int argc,
     bool ret = false;
     /* HTTPS Client library return status. */
     HTTPStatus_t httpStatus = HTTPSuccess;
+    int demoRunCount = 0;
 
     /* The length of the path within the pre-signed URL. This variable is
      * defined in order to store the length returned from parsing the URL, but
@@ -611,11 +625,12 @@ int main( int argc,
     LogInfo( ( "HTTP Client Synchronous S3 download demo using pre-signed URL:\n%s",
                S3_PRESIGNED_GET_URL ) );
 
-    /**************************** Connect. ******************************/
-
-    /* Establish TLS connection on top of TCP connection using OpenSSL. */
-    if( returnStatus == EXIT_SUCCESS )
+    do
     {
+        /**************************** Connect. ******************************/
+
+        /* Establish TLS connection on top of TCP connection using OpenSSL. */
+
         /* Attempt to connect to the HTTP server. If connection fails, retry
          * after a timeout. The timeout value will be exponentially
          * increased until either the maximum number of attempts or the
@@ -632,49 +647,71 @@ int main( int argc,
             LogError( ( "Failed to connect to HTTP server %s.",
                         serverHost ) );
         }
-    }
 
-    /* Define the transport interface. */
-    if( returnStatus == EXIT_SUCCESS )
-    {
-        ( void ) memset( &transportInterface, 0, sizeof( transportInterface ) );
-        transportInterface.recv = Openssl_Recv;
-        transportInterface.send = Openssl_Send;
-        transportInterface.pNetworkContext = &networkContext;
-    }
+        /* Define the transport interface. */
+        if( returnStatus == EXIT_SUCCESS )
+        {
+            ( void ) memset( &transportInterface, 0, sizeof( transportInterface ) );
+            transportInterface.recv = Openssl_Recv;
+            transportInterface.send = Openssl_Send;
+            transportInterface.pNetworkContext = &networkContext;
+        }
 
-    /******************** Download S3 Object File. **********************/
+        /******************** Download S3 Object File. **********************/
 
-    if( returnStatus == EXIT_SUCCESS )
-    {
-        /* Retrieve the path location from S3_PRESIGNED_GET_URL. This
-         * function returns the length of the path without the query into
-         * pathLen, which is left unused in this demo. */
-        httpStatus = getUrlPath( S3_PRESIGNED_GET_URL,
-                                 S3_PRESIGNED_GET_URL_LENGTH,
-                                 &pPath,
-                                 &pathLen );
+        if( returnStatus == EXIT_SUCCESS )
+        {
+            /* Retrieve the path location from S3_PRESIGNED_GET_URL. This
+             * function returns the length of the path without the query into
+             * pathLen, which is left unused in this demo. */
+            httpStatus = getUrlPath( S3_PRESIGNED_GET_URL,
+                                     S3_PRESIGNED_GET_URL_LENGTH,
+                                     &pPath,
+                                     &pathLen );
 
-        returnStatus = ( httpStatus == HTTPSuccess ) ? EXIT_SUCCESS : EXIT_FAILURE;
-    }
+            returnStatus = ( httpStatus == HTTPSuccess ) ? EXIT_SUCCESS : EXIT_FAILURE;
+        }
 
-    if( returnStatus == EXIT_SUCCESS )
-    {
-        ret = downloadS3ObjectFile( &transportInterface,
-                                    pPath );
-        returnStatus = ( ret == true ) ? EXIT_SUCCESS : EXIT_FAILURE;
-    }
+        if( returnStatus == EXIT_SUCCESS )
+        {
+            ret = downloadS3ObjectFile( &transportInterface,
+                                        pPath );
+            returnStatus = ( ret == true ) ? EXIT_SUCCESS : EXIT_FAILURE;
+        }
+
+        /************************** Disconnect. *****************************/
+
+        /* End the TLS session, then close the TCP connection. */
+        ( void ) Openssl_Disconnect( &networkContext );
+
+        /******************* Retry in case of failure. **********************/
+
+        /* Increment the demo run count. */
+        demoRunCount++;
+
+        if( returnStatus == EXIT_SUCCESS )
+        {
+            LogInfo( ( "Demo iteration %d is successful.", demoRunCount ) );
+        }
+        /* Attempt to retry a failed iteration of demo for up to #HTTP_MAX_DEMO_COUNT times. */
+        else if( demoRunCount < HTTP_MAX_DEMO_COUNT )
+        {
+            LogWarn( ( "Demo iteration %d failed. Retrying...", demoRunCount ) );
+            sleep( DELAY_BETWEEN_DEMO_ITERATIONS_S );
+        }
+        /* Failed all #HTTP_MAX_DEMO_COUNT demo iterations. */
+        else
+        {
+            LogError( ( "All %d demo iterations failed.", HTTP_MAX_DEMO_COUNT ) );
+            break;
+        }
+    } while( returnStatus != EXIT_SUCCESS );
 
     if( returnStatus == EXIT_SUCCESS )
     {
         /* Log a message indicating an iteration completed successfully. */
         LogInfo( ( "Demo completed successfully." ) );
     }
-
-    /************************** Disconnect. *****************************/
-
-    /* End the TLS session, then close the TCP connection. */
-    ( void ) Openssl_Disconnect( &networkContext );
 
     return returnStatus;
 }

--- a/demos/http/http_demo_s3_upload/http_demo_s3_upload.c
+++ b/demos/http/http_demo_s3_upload/http_demo_s3_upload.c
@@ -121,16 +121,19 @@
 
 /**
  * @brief The maximum number of times to run the loop in this demo.
+ *
+ * @note The demo loop is attempted to re-run only if it fails in an iteration.
+ * Once the demo loop succeeds in an iteration, the demo exits successfully.
  */
-#ifndef HTTP_MAX_DEMO_COUNT
-    #define HTTP_MAX_DEMO_COUNT    ( 3 )
+#ifndef HTTP_MAX_DEMO_LOOP_COUNT
+    #define HTTP_MAX_DEMO_LOOP_COUNT    ( 3 )
 #endif
 
 /**
  * @brief Time in seconds to wait between retries of the demo loop if
  * demo loop fails.
  */
-#define DELAY_BETWEEN_DEMO_ITERATIONS_S    ( 5 )
+#define DELAY_BETWEEN_DEMO_RETRY_ITERATIONS_S    ( 5 )
 
 /**
  * @brief A buffer used in the demo for storing HTTP request headers and HTTP
@@ -740,16 +743,16 @@ int main( int argc,
         {
             LogInfo( ( "Demo iteration %d is successful.", demoRunCount ) );
         }
-        /* Attempt to retry a failed iteration of demo for up to #HTTP_MAX_DEMO_COUNT times. */
-        else if( demoRunCount < HTTP_MAX_DEMO_COUNT )
+        /* Attempt to retry a failed iteration of demo for up to #HTTP_MAX_DEMO_LOOP_COUNT times. */
+        else if( demoRunCount < HTTP_MAX_DEMO_LOOP_COUNT )
         {
             LogWarn( ( "Demo iteration %d failed. Retrying...", demoRunCount ) );
-            sleep( DELAY_BETWEEN_DEMO_ITERATIONS_S );
+            sleep( DELAY_BETWEEN_DEMO_RETRY_ITERATIONS_S );
         }
-        /* Failed all #HTTP_MAX_DEMO_COUNT demo iterations. */
+        /* Failed all #HTTP_MAX_DEMO_LOOP_COUNT demo iterations. */
         else
         {
-            LogError( ( "All %d demo iterations failed.", HTTP_MAX_DEMO_COUNT ) );
+            LogError( ( "All %d demo iterations failed.", HTTP_MAX_DEMO_LOOP_COUNT ) );
             break;
         }
     } while( returnStatus != EXIT_SUCCESS );

--- a/demos/http/http_demo_s3_upload/http_demo_s3_upload.c
+++ b/demos/http/http_demo_s3_upload/http_demo_s3_upload.c
@@ -120,6 +120,19 @@
 #define HTTP_STATUS_CODE_PARTIAL_CONTENT          206
 
 /**
+ * @brief The maximum number of times to run the loop in this demo.
+ */
+#ifndef HTTP_MAX_DEMO_COUNT
+    #define HTTP_MAX_DEMO_COUNT    ( 3 )
+#endif
+
+/**
+ * @brief Time in seconds to wait between retries of the demo loop if
+ * demo loop fails.
+ */
+#define DELAY_BETWEEN_DEMO_ITERATIONS_S    ( 5 )
+
+/**
  * @brief A buffer used in the demo for storing HTTP request headers and HTTP
  * response headers and body.
  *
@@ -616,6 +629,7 @@ int main( int argc,
     bool ret = false;
     /* HTTPS Client library return status. */
     HTTPStatus_t httpStatus = HTTPSuccess;
+    int demoRunCount = 0;
 
     /* The length of the path within the pre-signed URL. This variable is
      * defined in order to store the length returned from parsing the URL, but
@@ -635,11 +649,12 @@ int main( int argc,
     LogInfo( ( "HTTP Client Synchronous S3 upload demo using pre-signed PUT URL:\n%s",
                S3_PRESIGNED_PUT_URL ) );
 
-    /**************************** Connect. ******************************/
-
-    /* Establish TLS connection on top of TCP connection using OpenSSL. */
-    if( returnStatus == EXIT_SUCCESS )
+    do
     {
+        /**************************** Connect. ******************************/
+
+        /* Establish TLS connection on top of TCP connection using OpenSSL. */
+
         /* Attempt to connect to the HTTP server. If connection fails, retry
          * after a timeout. The timeout value will be exponentially
          * increased until either the maximum number of attempts or the
@@ -656,72 +671,94 @@ int main( int argc,
             LogError( ( "Failed to connect to HTTP server %s.",
                         serverHost ) );
         }
-    }
 
-    /* Define the transport interface. */
-    if( returnStatus == EXIT_SUCCESS )
-    {
-        ( void ) memset( &transportInterface, 0, sizeof( transportInterface ) );
-        transportInterface.recv = Openssl_Recv;
-        transportInterface.send = Openssl_Send;
-        transportInterface.pNetworkContext = &networkContext;
-    }
+        /* Define the transport interface. */
+        if( returnStatus == EXIT_SUCCESS )
+        {
+            ( void ) memset( &transportInterface, 0, sizeof( transportInterface ) );
+            transportInterface.recv = Openssl_Recv;
+            transportInterface.send = Openssl_Send;
+            transportInterface.pNetworkContext = &networkContext;
+        }
 
-    /********************** Upload S3 Object File. **********************/
+        /********************** Upload S3 Object File. **********************/
 
-    if( returnStatus == EXIT_SUCCESS )
-    {
-        /* Retrieve the path location from S3_PRESIGNED_PUT_URL. This
-         * function returns the length of the path without the query into
-         * pathLen, which is left unused in this demo. */
-        httpStatus = getUrlPath( S3_PRESIGNED_PUT_URL,
-                                 S3_PRESIGNED_PUT_URL_LENGTH,
-                                 &pPath,
-                                 &pathLen );
+        if( returnStatus == EXIT_SUCCESS )
+        {
+            /* Retrieve the path location from S3_PRESIGNED_PUT_URL. This
+             * function returns the length of the path without the query into
+             * pathLen, which is left unused in this demo. */
+            httpStatus = getUrlPath( S3_PRESIGNED_PUT_URL,
+                                     S3_PRESIGNED_PUT_URL_LENGTH,
+                                     &pPath,
+                                     &pathLen );
 
-        returnStatus = ( httpStatus == HTTPSuccess ) ? EXIT_SUCCESS : EXIT_FAILURE;
-    }
+            returnStatus = ( httpStatus == HTTPSuccess ) ? EXIT_SUCCESS : EXIT_FAILURE;
+        }
 
-    if( returnStatus == EXIT_SUCCESS )
-    {
-        ret = uploadS3ObjectFile( &transportInterface,
-                                  pPath );
-        returnStatus = ( ret == true ) ? EXIT_SUCCESS : EXIT_FAILURE;
-    }
-
-    /******************* Verify S3 Object File Upload. ********************/
-
-    if( returnStatus == EXIT_SUCCESS )
-    {
-        /* Retrieve the path location from S3_PRESIGNED_GET_URL. This
-         * function returns the length of the path without the query into
-         * pathLen. */
-        httpStatus = getUrlPath( S3_PRESIGNED_GET_URL,
-                                 S3_PRESIGNED_GET_URL_LENGTH,
-                                 &pPath,
-                                 &pathLen );
-
-        returnStatus = ( httpStatus == HTTPSuccess ) ? EXIT_SUCCESS : EXIT_FAILURE;
-    }
-
-    if( returnStatus == EXIT_SUCCESS )
-    {
-        /* Verify the file exists by retrieving the file size. */
-        ret = verifyS3ObjectFileSize( &transportInterface,
+        if( returnStatus == EXIT_SUCCESS )
+        {
+            ret = uploadS3ObjectFile( &transportInterface,
                                       pPath );
-        returnStatus = ( ret == true ) ? EXIT_SUCCESS : EXIT_FAILURE;
-    }
+            returnStatus = ( ret == true ) ? EXIT_SUCCESS : EXIT_FAILURE;
+        }
+
+        /******************* Verify S3 Object File Upload. ********************/
+
+        if( returnStatus == EXIT_SUCCESS )
+        {
+            /* Retrieve the path location from S3_PRESIGNED_GET_URL. This
+             * function returns the length of the path without the query into
+             * pathLen. */
+            httpStatus = getUrlPath( S3_PRESIGNED_GET_URL,
+                                     S3_PRESIGNED_GET_URL_LENGTH,
+                                     &pPath,
+                                     &pathLen );
+
+            returnStatus = ( httpStatus == HTTPSuccess ) ? EXIT_SUCCESS : EXIT_FAILURE;
+        }
+
+        if( returnStatus == EXIT_SUCCESS )
+        {
+            /* Verify the file exists by retrieving the file size. */
+            ret = verifyS3ObjectFileSize( &transportInterface,
+                                          pPath );
+            returnStatus = ( ret == true ) ? EXIT_SUCCESS : EXIT_FAILURE;
+        }
+
+        /************************** Disconnect. *****************************/
+
+        /* End the TLS session, then close the TCP connection. */
+        ( void ) Openssl_Disconnect( &networkContext );
+
+        /******************* Retry in case of failure. **********************/
+
+        /* Increment the demo run count. */
+        demoRunCount++;
+
+        if( returnStatus == EXIT_SUCCESS )
+        {
+            LogInfo( ( "Demo iteration %d is successful.", demoRunCount ) );
+        }
+        /* Attempt to retry a failed iteration of demo for up to #HTTP_MAX_DEMO_COUNT times. */
+        else if( demoRunCount < HTTP_MAX_DEMO_COUNT )
+        {
+            LogWarn( ( "Demo iteration %d failed. Retrying...", demoRunCount ) );
+            sleep( DELAY_BETWEEN_DEMO_ITERATIONS_S );
+        }
+        /* Failed all #HTTP_MAX_DEMO_COUNT demo iterations. */
+        else
+        {
+            LogError( ( "All %d demo iterations failed.", HTTP_MAX_DEMO_COUNT ) );
+            break;
+        }
+    } while( returnStatus != EXIT_SUCCESS );
 
     if( returnStatus == EXIT_SUCCESS )
     {
         /* Log a message indicating an iteration completed successfully. */
         LogInfo( ( "Demo completed successfully." ) );
     }
-
-    /************************** Disconnect. *****************************/
-
-    /* End the TLS session, then close the TCP connection. */
-    ( void ) Openssl_Disconnect( &networkContext );
 
     return returnStatus;
 }

--- a/demos/lexicon.txt
+++ b/demos/lexicon.txt
@@ -467,6 +467,7 @@ resubscribe
 resubscription
 retrievehttpresponse
 retryutils
+returnstatus
 rfc
 ripemd
 rng

--- a/demos/shadow/shadow_demo_main/shadow_demo_main.c
+++ b/demos/shadow/shadow_demo_main/shadow_demo_main.c
@@ -150,20 +150,23 @@
 
 /**
  * @brief The maximum number of times to run the loop in this demo.
+ *
+ * @note The demo loop is attempted to re-run only if it fails in an iteration.
+ * Once the demo loop succeeds in an iteration, the demo exits successfully.
  */
-#ifndef SHADOW_MAX_DEMO_COUNT
-    #define SHADOW_MAX_DEMO_COUNT    ( 3 )
+#ifndef SHADOW_MAX_DEMO_LOOP_COUNT
+    #define SHADOW_MAX_DEMO_LOOP_COUNT    ( 3 )
 #endif
 
 /**
  * @brief Time in seconds to wait between retries of the demo loop if
  * demo loop fails.
  */
-#define DELAY_BETWEEN_DEMO_ITERATIONS_S                 ( 5 )
+#define DELAY_BETWEEN_DEMO_RETRY_ITERATIONS_S           ( 5 )
 
 /**
  * @brief JSON key for response code that indicates the type of error in
- * the error document received on topic `delete/rejected`.
+ * the error document received on topic `/delete/rejected`.
  */
 #define SHADOW_DELETE_REJECTED_ERROR_CODE_KEY           "code"
 
@@ -209,8 +212,8 @@ static bool deleteResponseReceived = false;
  * The Shadow delete status will be updated by the incoming publishes on the
  * MQTT topics for delete acknowledgement from AWS IoT message broker
  * (accepted/rejected). Shadow document is considered to be deleted if an
- * incoming publish is received on `delete/accepted` topic or an incoming
- * publish is received on `delete/rejected` topic with error code 404. Code 404
+ * incoming publish is received on `/delete/accepted` topic or an incoming
+ * publish is received on `/delete/rejected` topic with error code 404. Code 404
  * indicates that the Shadow document does not exist for the Thing yet.
  */
 static bool shadowDeleted = false;
@@ -678,13 +681,13 @@ int main( int argc,
             shadowDeleted = false;
 
             /* First of all, try to delete any Shadow document in the cloud.
-             * Try to subscribe to `delete/accepted` and `delete/rejected` topics. */
+             * Try to subscribe to `/delete/accepted` and `/delete/rejected` topics. */
             returnStatus = SubscribeToTopic( SHADOW_TOPIC_STRING_DELETE_ACCEPTED( THING_NAME ),
                                              SHADOW_TOPIC_LENGTH_DELETE_ACCEPTED( THING_NAME_LENGTH ) );
 
             if( returnStatus == EXIT_SUCCESS )
             {
-                /* Try to subscribe to `delete/rejected` topic. */
+                /* Try to subscribe to `/delete/rejected` topic. */
                 returnStatus = SubscribeToTopic( SHADOW_TOPIC_STRING_DELETE_REJECTED( THING_NAME ),
                                                  SHADOW_TOPIC_LENGTH_DELETE_REJECTED( THING_NAME_LENGTH ) );
             }
@@ -699,7 +702,7 @@ int main( int argc,
                                                0U );
             }
 
-            /* Unsubscribe from the `delete/accepted` and 'delete/rejected` topics.*/
+            /* Unsubscribe from the `/delete/accepted` and 'delete/rejected` topics.*/
             if( returnStatus == EXIT_SUCCESS )
             {
                 returnStatus = UnsubscribeFromTopic( SHADOW_TOPIC_STRING_DELETE_ACCEPTED( THING_NAME ),
@@ -712,7 +715,7 @@ int main( int argc,
                                                      SHADOW_TOPIC_LENGTH_DELETE_REJECTED( THING_NAME_LENGTH ) );
             }
 
-            /* Check if an incoming publish on `delete/accepted` or `delete/rejected`
+            /* Check if an incoming publish on `/delete/accepted` or `/delete/rejected`
              * topics. If a response is not received, mark the demo execution as a failure.*/
             if( ( returnStatus == EXIT_SUCCESS ) && ( deleteResponseReceived != true ) )
             {
@@ -866,16 +869,16 @@ int main( int argc,
         {
             LogInfo( ( "Demo iteration %d is successful.", demoRunCount ) );
         }
-        /* Attempt to retry a failed iteration of demo for up to #SHADOW_MAX_DEMO_COUNT times. */
-        else if( demoRunCount < SHADOW_MAX_DEMO_COUNT )
+        /* Attempt to retry a failed iteration of demo for up to #SHADOW_MAX_DEMO_LOOP_COUNT times. */
+        else if( demoRunCount < SHADOW_MAX_DEMO_LOOP_COUNT )
         {
             LogWarn( ( "Demo iteration %d failed. Retrying...", demoRunCount ) );
-            sleep( DELAY_BETWEEN_DEMO_ITERATIONS_S );
+            sleep( DELAY_BETWEEN_DEMO_RETRY_ITERATIONS_S );
         }
-        /* Failed all #SHADOW_MAX_DEMO_COUNT demo iterations. */
+        /* Failed all #SHADOW_MAX_DEMO_LOOP_COUNT demo iterations. */
         else
         {
-            LogError( ( "All %d demo iterations failed.", SHADOW_MAX_DEMO_COUNT ) );
+            LogError( ( "All %d demo iterations failed.", SHADOW_MAX_DEMO_LOOP_COUNT ) );
             break;
         }
     } while( returnStatus != EXIT_SUCCESS );

--- a/demos/shadow/shadow_demo_main/shadow_demo_main.c
+++ b/demos/shadow/shadow_demo_main/shadow_demo_main.c
@@ -328,7 +328,7 @@ static void deleteRejectedHandler( MQTTPublishInfo_t * pPublishInfo )
     LogInfo( ( "Error code:%ld.", errorCode ) );
 
     /* Mark Shadow delete operation as a success if error code is 404. */
-    if( errorCode == 404 )
+    if( errorCode == 404UL )
     {
         shadowDeleted = true;
     }
@@ -719,7 +719,24 @@ int main( int argc,
              * topics. If a response is not received, mark the demo execution as a failure.*/
             if( ( returnStatus == EXIT_SUCCESS ) && ( deleteResponseReceived != true ) )
             {
+                LogError( ( "Failed to receive a response for Shadow delete." ) );
                 returnStatus = EXIT_FAILURE;
+            }
+
+            /* Check if Shadow document delete was successful. A delete can be
+             * successful in cases listed below.
+             *  1. If an incoming publish is received on `/delete/accepted` topic.
+             *  2. If an incoming publish is received on `/delete/rejected` topic
+             *     with an error code 404. This indicates that a delete was
+             *     attempted when a Shadow document is not available for the
+             *     Thing. */
+            if( returnStatus == EXIT_SUCCESS )
+            {
+                if( shadowDeleted == false )
+                {
+                    LogError( ( "Shadow delete operation failed." ) );
+                    returnStatus = EXIT_FAILURE;
+                }
             }
 
             /* Successfully connect to MQTT broker, the next step is


### PR DESCRIPTION
*Description of changes:*
Add retries to demos with one loop. Retry logic in demo will attempt to run the demo loop again if an intermediate failure happens.
Adding retries to demos which doesn't have a retry.
Retry logic is added to 
1. Defender demo
2. Shadow demo.
3. coreHTTP S3 demos.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
