### PR TITLE
Align test and demos with latest corePKCS code.

### DIFF
--- a/demos/pkcs11/pkcs11_demo_sign_and_verify/pkcs11_demo_sign_and_verify.c
+++ b/demos/pkcs11/pkcs11_demo_sign_and_verify/pkcs11_demo_sign_and_verify.c
@@ -158,7 +158,7 @@ CK_RV PKCS11SignVerifyDemo( void )
     {
         result = xFindObjectWithLabelAndClass( session,
                                                pkcs11demoPRIVATE_KEY_LABEL,
-                                               strlen( pkcs11demoPRIVATE_KEY_LABEL ),
+                                               sizeof( pkcs11demoPRIVATE_KEY_LABEL ),
                                                CKO_PRIVATE_KEY,
                                                &privateKeyHandle );
     }
@@ -169,7 +169,7 @@ CK_RV PKCS11SignVerifyDemo( void )
     {
         result = xFindObjectWithLabelAndClass( session,
                                                pkcs11demoPUBLIC_KEY_LABEL,
-                                               strlen( pkcs11demoPUBLIC_KEY_LABEL ),
+                                               sizeof( pkcs11demoPUBLIC_KEY_LABEL ),
                                                CKO_PRIVATE_KEY,
                                                &publicKeyHandle );
     }

--- a/demos/pkcs11/pkcs11_demo_sign_and_verify/pkcs11_demo_sign_and_verify.c
+++ b/demos/pkcs11/pkcs11_demo_sign_and_verify/pkcs11_demo_sign_and_verify.c
@@ -158,6 +158,7 @@ CK_RV PKCS11SignVerifyDemo( void )
     {
         result = xFindObjectWithLabelAndClass( session,
                                                pkcs11demoPRIVATE_KEY_LABEL,
+                                               strlen( pkcs11demoPRIVATE_KEY_LABEL ),
                                                CKO_PRIVATE_KEY,
                                                &privateKeyHandle );
     }
@@ -168,6 +169,7 @@ CK_RV PKCS11SignVerifyDemo( void )
     {
         result = xFindObjectWithLabelAndClass( session,
                                                pkcs11demoPUBLIC_KEY_LABEL,
+                                               strlen( pkcs11demoPUBLIC_KEY_LABEL ),
                                                CKO_PRIVATE_KEY,
                                                &publicKeyHandle );
     }

--- a/integration-test/pkcs11/system-tests/pkcs11_system_test.c
+++ b/integration-test/pkcs11/system-tests/pkcs11_system_test.c
@@ -251,7 +251,7 @@ static void findObjectTest( CK_OBJECT_HANDLE_PTR privateKeyHandlePtr,
     /* Happy Path - Find a previously created object. */
     result = xFindObjectWithLabelAndClass( globalSession,
                                            pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS,
-                                           strlen( pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ),
+                                           sizeof( pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ),
                                            CKO_PRIVATE_KEY,
                                            privateKeyHandlePtr );
     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, result, "Failed to find private key after closing and reopening a session." );
@@ -260,7 +260,7 @@ static void findObjectTest( CK_OBJECT_HANDLE_PTR privateKeyHandlePtr,
     /* TODO: Add the code sign key and root ca. */
     result = xFindObjectWithLabelAndClass( globalSession,
                                            pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS,
-                                           strlen( pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS ),
+                                           sizeof( pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS ),
                                            CKO_PUBLIC_KEY,
                                            publicKeyHandlePtr );
     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, result, "Failed to find public key after closing and reopening a session." );
@@ -269,7 +269,7 @@ static void findObjectTest( CK_OBJECT_HANDLE_PTR privateKeyHandlePtr,
 
     result = xFindObjectWithLabelAndClass( globalSession,
                                            pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS,
-                                           strlen( pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS ),
+                                           sizeof( pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS ),
                                            CKO_CERTIFICATE,
                                            pcertificateHandle );
 
@@ -279,7 +279,7 @@ static void findObjectTest( CK_OBJECT_HANDLE_PTR privateKeyHandlePtr,
     /* Try to find an object that has never been created. */
     result = xFindObjectWithLabelAndClass( globalSession,
                                            ( char * ) "This label doesn't exist",
-                                           strlen( ( char * ) "This label doesn't exist" ),
+                                           sizeof( "This label doesn't exist" ),
                                            CKO_PUBLIC_KEY,
                                            &testObjectHandle );
     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, result, "Incorrect error code finding object that doesn't exist" );
@@ -720,7 +720,7 @@ void test_GetAttributeValue_RSA( void )
 
     result = xFindObjectWithLabelAndClass( globalSession,
                                            pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS,
-                                           strlen( pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ),
+                                           sizeof( pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ),
                                            CKO_PRIVATE_KEY,
                                            &privateKeyHandle );
     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, result, "Failed to find RSA private key." );
@@ -728,7 +728,7 @@ void test_GetAttributeValue_RSA( void )
 
     result = xFindObjectWithLabelAndClass( globalSession,
                                            pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS,
-                                           strlen( pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS ),
+                                           sizeof( pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS ),
                                            CKO_CERTIFICATE,
                                            &certificateHandle );
     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, result, "Failed to find RSA certificate." );

--- a/integration-test/pkcs11/system-tests/pkcs11_system_test.c
+++ b/integration-test/pkcs11/system-tests/pkcs11_system_test.c
@@ -716,19 +716,19 @@ void test_GetAttributeValue_RSA( void )
     CK_BYTE certificateValue[ CERTIFICATE_VALUE_LENGTH ];
     CK_BYTE keyComponent[ ( pkcs11RSA_2048_MODULUS_BITS / 8 ) + 1 ] = { 0 };
 
-    result = xFindObjectWithLabelAndClass( globalSession, 
-            pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, 
-            strlen( pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ), 
-            CKO_PRIVATE_KEY, 
-            &privateKeyHandle );
+    result = xFindObjectWithLabelAndClass( globalSession,
+                                           pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS,
+                                           strlen( pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ),
+                                           CKO_PRIVATE_KEY,
+                                           &privateKeyHandle );
     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, result, "Failed to find RSA private key." );
     TEST_ASSERT_NOT_EQUAL_MESSAGE( CK_INVALID_HANDLE, privateKeyHandle, "Invalid object handle found for RSA private key." );
 
-    result = xFindObjectWithLabelAndClass( globalSession, 
-            pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS, 
-            strlen( pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS ), 
-            CKO_CERTIFICATE, 
-            &certificateHandle );
+    result = xFindObjectWithLabelAndClass( globalSession,
+                                           pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS,
+                                           strlen( pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS ),
+                                           CKO_CERTIFICATE,
+                                           &certificateHandle );
     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, result, "Failed to find RSA certificate." );
     TEST_ASSERT_NOT_EQUAL_MESSAGE( CK_INVALID_HANDLE, certificateHandle, "Invalid object handle found for RSA certificate." );
 

--- a/integration-test/pkcs11/system-tests/pkcs11_system_test.c
+++ b/integration-test/pkcs11/system-tests/pkcs11_system_test.c
@@ -67,7 +67,7 @@
 #define EC_D_LENGTH                 32
 
 /* See core_pkcs11_mbedtls.c for length explanation. */
-#define pkcs11EC_POINT_LENGTH                 ( ( 32UL * 2UL ) + 1UL + 1UL + 1UL )
+#define pkcs11EC_POINT_LENGTH       ( ( 32UL * 2UL ) + 1UL + 1UL + 1UL )
 
 typedef struct RsaParams_t
 {

--- a/integration-test/pkcs11/system-tests/pkcs11_system_test.c
+++ b/integration-test/pkcs11/system-tests/pkcs11_system_test.c
@@ -228,6 +228,7 @@ static CK_RV destroyTestCredentials( void )
     {
         result = xFindObjectWithLabelAndClass( globalSession,
                                                ( char * ) pkcsLabels[ labelCount ],
+                                               strlen( ( char * ) pkcsLabels[ labelCount ] ),
                                                class[ labelCount ],
                                                &object );
         TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, result, "Found an object after deleting it.\r\n" );
@@ -248,6 +249,7 @@ static void findObjectTest( CK_OBJECT_HANDLE_PTR privateKeyHandlePtr,
     /* Happy Path - Find a previously created object. */
     result = xFindObjectWithLabelAndClass( globalSession,
                                            pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS,
+                                           strlen( pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ),
                                            CKO_PRIVATE_KEY,
                                            privateKeyHandlePtr );
     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, result, "Failed to find private key after closing and reopening a session." );
@@ -256,6 +258,7 @@ static void findObjectTest( CK_OBJECT_HANDLE_PTR privateKeyHandlePtr,
     /* TODO: Add the code sign key and root ca. */
     result = xFindObjectWithLabelAndClass( globalSession,
                                            pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS,
+                                           strlen( pkcs11testLABEL_DEVICE_PUBLIC_KEY_FOR_TLS ),
                                            CKO_PUBLIC_KEY,
                                            publicKeyHandlePtr );
     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, result, "Failed to find public key after closing and reopening a session." );
@@ -264,6 +267,7 @@ static void findObjectTest( CK_OBJECT_HANDLE_PTR privateKeyHandlePtr,
 
     result = xFindObjectWithLabelAndClass( globalSession,
                                            pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS,
+                                           strlen( pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS ),
                                            CKO_CERTIFICATE,
                                            pcertificateHandle );
 
@@ -273,6 +277,7 @@ static void findObjectTest( CK_OBJECT_HANDLE_PTR privateKeyHandlePtr,
     /* Try to find an object that has never been created. */
     result = xFindObjectWithLabelAndClass( globalSession,
                                            ( char * ) "This label doesn't exist",
+                                           strlen( ( char * ) "This label doesn't exist" ),
                                            CKO_PUBLIC_KEY,
                                            &testObjectHandle );
     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, result, "Incorrect error code finding object that doesn't exist" );
@@ -711,11 +716,19 @@ void test_GetAttributeValue_RSA( void )
     CK_BYTE certificateValue[ CERTIFICATE_VALUE_LENGTH ];
     CK_BYTE keyComponent[ ( pkcs11RSA_2048_MODULUS_BITS / 8 ) + 1 ] = { 0 };
 
-    result = xFindObjectWithLabelAndClass( globalSession, pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, CKO_PRIVATE_KEY, &privateKeyHandle );
+    result = xFindObjectWithLabelAndClass( globalSession, 
+            pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, 
+            strlen( pkcs11testLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ), 
+            CKO_PRIVATE_KEY, 
+            &privateKeyHandle );
     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, result, "Failed to find RSA private key." );
     TEST_ASSERT_NOT_EQUAL_MESSAGE( CK_INVALID_HANDLE, privateKeyHandle, "Invalid object handle found for RSA private key." );
 
-    result = xFindObjectWithLabelAndClass( globalSession, pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS, CKO_CERTIFICATE, &certificateHandle );
+    result = xFindObjectWithLabelAndClass( globalSession, 
+            pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS, 
+            strlen( pkcs11testLABEL_DEVICE_CERTIFICATE_FOR_TLS ), 
+            CKO_CERTIFICATE, 
+            &certificateHandle );
     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, result, "Failed to find RSA certificate." );
     TEST_ASSERT_NOT_EQUAL_MESSAGE( CK_INVALID_HANDLE, certificateHandle, "Invalid object handle found for RSA certificate." );
 
@@ -1323,7 +1336,7 @@ void test_GenerateKeyPair_EC( void )
     CK_OBJECT_HANDLE publicKeyHandle = CK_INVALID_HANDLE;
     CK_OBJECT_HANDLE certificateHandle = CK_INVALID_HANDLE;
 
-    CK_BYTE ecPoint[ 256 ] = { 0 };
+    CK_BYTE ecPoint[ 67 ] = { 0 };
     CK_BYTE privateKeyBuffer[ 32 ] = { 0 };
     CK_KEY_TYPE keyType;
     CK_ATTRIBUTE template;
@@ -1727,7 +1740,7 @@ static CK_RV provisionPublicKey( CK_SESSION_HANDLE session,
     {
         CK_BYTE ecParams[] = pkcs11DER_ENCODED_OID_P256;
         size_t length;
-        CK_BYTE ecPoint[ 256 ] = { 0 };
+        CK_BYTE ecPoint[ 67 ] = { 0 };
 
         mbedtls_ecdsa_context * ecdsaContextPtr = ( mbedtls_ecdsa_context * ) mbedPkContext.pk_ctx;
 
@@ -1975,6 +1988,7 @@ static CK_RV destroyProvidedObjects( CK_SESSION_HANDLE session,
 
         result = xFindObjectWithLabelAndClass( session,
                                                ( char * ) labelPtr,
+                                               strlen( ( char * ) labelPtr ),
                                                class[ index ],
                                                &objectHandle );
 
@@ -1990,6 +2004,7 @@ static CK_RV destroyProvidedObjects( CK_SESSION_HANDLE session,
             {
                 result = xFindObjectWithLabelAndClass( session,
                                                        ( char * ) labelPtr,
+                                                       strlen( ( char * ) labelPtr ),
                                                        class[ index ],
                                                        &objectHandle );
             }

--- a/integration-test/pkcs11/system-tests/pkcs11_system_test.c
+++ b/integration-test/pkcs11/system-tests/pkcs11_system_test.c
@@ -66,6 +66,8 @@
 #define EC_PARAMS_LENGTH            10
 #define EC_D_LENGTH                 32
 
+/* See core_pkcs11_mbedtls.c for length explanation. */
+#define pkcs11EC_POINT_LENGTH                 ( ( 32UL * 2UL ) + 1UL + 1UL + 1UL )
 
 typedef struct RsaParams_t
 {
@@ -1336,7 +1338,7 @@ void test_GenerateKeyPair_EC( void )
     CK_OBJECT_HANDLE publicKeyHandle = CK_INVALID_HANDLE;
     CK_OBJECT_HANDLE certificateHandle = CK_INVALID_HANDLE;
 
-    CK_BYTE ecPoint[ 67 ] = { 0 };
+    CK_BYTE ecPoint[ pkcs11EC_POINT_LENGTH ] = { 0 };
     CK_BYTE privateKeyBuffer[ 32 ] = { 0 };
     CK_KEY_TYPE keyType;
     CK_ATTRIBUTE template;
@@ -1740,7 +1742,7 @@ static CK_RV provisionPublicKey( CK_SESSION_HANDLE session,
     {
         CK_BYTE ecParams[] = pkcs11DER_ENCODED_OID_P256;
         size_t length;
-        CK_BYTE ecPoint[ 67 ] = { 0 };
+        CK_BYTE ecPoint[ pkcs11EC_POINT_LENGTH ] = { 0 };
 
         mbedtls_ecdsa_context * ecdsaContextPtr = ( mbedtls_ecdsa_context * ) mbedPkContext.pk_ctx;
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There is a minor change to the corePKCS11 `core_pkcs11.h` API to avoid the use of strlen to find the length of a label.

Support has been added for importing RSA public keys.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
