### PR TITLE
Use millisecond sleep for backoff

### DIFF
--- a/demos/defender/defender_demo_json/mqtt_operations.c
+++ b/demos/defender/defender_demo_json/mqtt_operations.c
@@ -128,11 +128,6 @@
 #define CONNECTION_RETRY_BACKOFF_BASE_MS         ( 500U )
 
 /**
- * @brief Number of milliseconds in a second.
- */
-#define NUM_MILLISECONDS_IN_SECOND               ( 1000U )
-
-/**
  * @brief Timeout for receiving CONNACK packet in milliseconds.
  */
 #define CONNACK_RECV_TIMEOUT_MS                  ( 1000U )
@@ -432,8 +427,10 @@ static bool connectToBrokerWithBackoffRetries( NetworkContext_t * pNetworkContex
             }
             else if( backoffAlgStatus == BackoffAlgorithmSuccess )
             {
-                LogWarn( ( "Connection to the broker failed. Retrying connection after backoff." ) );
-                ( void ) sleep( nextRetryBackOff / NUM_MILLISECONDS_IN_SECOND );
+                LogWarn( ( "Connection to the broker failed. Retrying connection "
+                           "after %hu ms backoff.",
+                           ( unsigned short ) nextRetryBackOff ) );
+                Clock_SleepMs( nextRetryBackOff );
             }
         }
     } while( ( opensslStatus != OPENSSL_SUCCESS ) && ( backoffAlgStatus == BackoffAlgorithmSuccess ) );

--- a/demos/http/common/src/http_demo_utils.c
+++ b/demos/http/common/src/http_demo_utils.c
@@ -37,6 +37,9 @@
 /*Include backoff algorithm header for retry logic.*/
 #include "backoff_algorithm.h"
 
+/*Include clock header for millisecond sleep function. */
+#include "clock.h"
+
 /* Third party parser utilities. */
 #include "http_parser.h"
 
@@ -56,11 +59,6 @@
  * @brief The base back-off delay (in milliseconds) to use for connection retry attempts.
  */
 #define CONNECTION_RETRY_BACKOFF_BASE_MS         ( 500U )
-
-/**
- * @brief Number of milliseconds in a second.
- */
-#define NUM_MILLISECONDS_IN_SECOND               ( 1000U )
 
 /*-----------------------------------------------------------*/
 
@@ -133,8 +131,10 @@ int32_t connectToServerWithBackoffRetries( TransportConnect_t connectFunction,
 
             if( backoffAlgStatus == BackoffAlgorithmSuccess )
             {
-                LogWarn( ( "Connection to the HTTP server failed. Retrying connection after backoff." ) );
-                ( void ) sleep( nextRetryBackOff / NUM_MILLISECONDS_IN_SECOND );
+                LogWarn( ( "Connection to the HTTP server failed. Retrying "
+                           "connection after %hu ms backoff.",
+                           ( unsigned short ) nextRetryBackOff ) );
+                Clock_SleepMs( nextRetryBackOff );
             }
             else
             {

--- a/demos/http/http_demo_basic_tls/CMakeLists.txt
+++ b/demos/http/http_demo_basic_tls/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(
 target_link_libraries(
     ${DEMO_NAME}
     PRIVATE
+        clock_posix
         openssl_posix
 )
 

--- a/demos/http/http_demo_mutual_auth/CMakeLists.txt
+++ b/demos/http/http_demo_mutual_auth/CMakeLists.txt
@@ -24,6 +24,7 @@ check_aws_credentials(${DEMO_NAME})
 target_link_libraries(
     ${DEMO_NAME}
     PRIVATE
+        clock_posix
         openssl_posix
 )
 

--- a/demos/http/http_demo_plaintext/CMakeLists.txt
+++ b/demos/http/http_demo_plaintext/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(
 target_link_libraries(
     ${DEMO_NAME}
     PRIVATE
+        clock_posix
         plaintext_posix
 )
 

--- a/demos/http/http_demo_s3_download/CMakeLists.txt
+++ b/demos/http/http_demo_s3_download/CMakeLists.txt
@@ -22,6 +22,7 @@ check_presigned_urls(${DEMO_NAME})
 target_link_libraries(
     ${DEMO_NAME}
     PRIVATE
+        clock_posix
         openssl_posix
 )
 

--- a/demos/http/http_demo_s3_download_multithreaded/CMakeLists.txt
+++ b/demos/http/http_demo_s3_download_multithreaded/CMakeLists.txt
@@ -22,6 +22,7 @@ check_presigned_urls(${DEMO_NAME})
 target_link_libraries(
     ${DEMO_NAME}
     PRIVATE
+        clock_posix
         openssl_posix
         rt
 )

--- a/demos/http/http_demo_s3_upload/CMakeLists.txt
+++ b/demos/http/http_demo_s3_upload/CMakeLists.txt
@@ -22,6 +22,7 @@ check_presigned_urls(${DEMO_NAME})
 target_link_libraries(
     ${DEMO_NAME}
     PRIVATE
+        clock_posix
         openssl_posix
 )
 

--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -110,11 +110,6 @@
 #define CONNECTION_RETRY_BACKOFF_BASE_MS         ( 500U )
 
 /**
- * @brief Number of milliseconds in a second.
- */
-#define NUM_MILLISECONDS_IN_SECOND               ( 1000U )
-
-/**
  * @brief Timeout for receiving CONNACK packet in milli seconds.
  */
 #define CONNACK_RECV_TIMEOUT_MS                  ( 1000U )
@@ -513,8 +508,10 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
             }
             else if( backoffAlgStatus == BackoffAlgorithmSuccess )
             {
-                LogWarn( ( "Connection to the broker failed. Retrying connection after backoff." ) );
-                ( void ) sleep( nextRetryBackOff / NUM_MILLISECONDS_IN_SECOND );
+                LogWarn( ( "Connection to the broker failed. Retrying connection "
+                           "after %hu ms backoff.",
+                           ( unsigned short ) nextRetryBackOff ) );
+                Clock_SleepMs( nextRetryBackOff );
             }
         }
     } while( ( opensslStatus != OPENSSL_SUCCESS ) && ( backoffAlgStatus == BackoffAlgorithmSuccess ) );
@@ -795,8 +792,10 @@ static int handleResubscribe( MQTTContext_t * pMqttContext )
             }
             else if( backoffAlgStatus == BackoffAlgorithmSuccess )
             {
-                LogWarn( ( "Server rejected subscription request. Retrying connection after backoff." ) );
-                ( void ) sleep( nextRetryBackOff / NUM_MILLISECONDS_IN_SECOND );
+                LogWarn( ( "Server rejected subscription request. Retrying "
+                           "connection after %hu ms backoff.",
+                           ( unsigned short ) nextRetryBackOff ) );
+                Clock_SleepMs( nextRetryBackOff );
             }
         }
     } while( ( globalSubAckStatus == MQTTSubAckFailure ) && ( backoffAlgStatus == BackoffAlgorithmSuccess ) );

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -189,11 +189,6 @@
 #define CONNECTION_RETRY_BACKOFF_BASE_MS         ( 500U )
 
 /**
- * @brief Number of milliseconds in a second.
- */
-#define NUM_MILLISECONDS_IN_SECOND               ( 1000U )
-
-/**
  * @brief Timeout for receiving CONNACK packet in milli seconds.
  */
 #define CONNACK_RECV_TIMEOUT_MS                  ( 1000U )
@@ -649,8 +644,10 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
             }
             else if( backoffAlgStatus == BackoffAlgorithmSuccess )
             {
-                LogWarn( ( "Connection to the broker failed. Retrying connection after backoff." ) );
-                ( void ) sleep( nextRetryBackOff / NUM_MILLISECONDS_IN_SECOND );
+                LogWarn( ( "Connection to the broker failed. Retrying connection "
+                           "after %hu ms backoff.",
+                           ( unsigned short ) nextRetryBackOff ) );
+                Clock_SleepMs( nextRetryBackOff );
             }
         }
     } while( ( opensslStatus != OPENSSL_SUCCESS ) && ( backoffAlgStatus == BackoffAlgorithmSuccess ) );
@@ -925,8 +922,10 @@ static int handleResubscribe( MQTTContext_t * pMqttContext )
             }
             else if( backoffAlgStatus == BackoffAlgorithmSuccess )
             {
-                LogWarn( ( "Server rejected subscription request. Retrying connection after backoff." ) );
-                ( void ) sleep( nextRetryBackOff / NUM_MILLISECONDS_IN_SECOND );
+                LogWarn( ( "Server rejected subscription request. Retrying "
+                           "connection after %hu ms backoff.",
+                           ( unsigned short ) nextRetryBackOff ) );
+                Clock_SleepMs( nextRetryBackOff );
             }
         }
     } while( ( globalSubAckStatus == MQTTSubAckFailure ) && ( backoffAlgStatus == BackoffAlgorithmSuccess ) );

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
@@ -104,11 +104,6 @@
 #define CONNECTION_RETRY_BACKOFF_BASE_MS         ( 500U )
 
 /**
- * @brief Number of milliseconds in a second.
- */
-#define NUM_MILLISECONDS_IN_SECOND               ( 1000U )
-
-/**
  * @brief Timeout for receiving CONNACK packet in milli seconds.
  */
 #define CONNACK_RECV_TIMEOUT_MS                  ( 1000U )
@@ -400,8 +395,10 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
             }
             else if( backoffAlgStatus == BackoffAlgorithmSuccess )
             {
-                LogWarn( ( "Connection to the broker failed. Retrying connection after backoff." ) );
-                ( void ) sleep( nextRetryBackOff / NUM_MILLISECONDS_IN_SECOND );
+                LogWarn( ( "Connection to the broker failed. Retrying connection "
+                           "after %hu ms backoff.",
+                           ( unsigned short ) nextRetryBackOff ) );
+                Clock_SleepMs( nextRetryBackOff );
             }
         }
     } while( ( socketStatus != SOCKETS_SUCCESS ) && ( backoffAlgStatus == BackoffAlgorithmSuccess ) );
@@ -532,8 +529,10 @@ static int handleResubscribe( MQTTContext_t * pMqttContext )
             }
             else if( backoffAlgStatus == BackoffAlgorithmSuccess )
             {
-                LogWarn( ( "Server rejected subscription request. Retrying connection after backoff." ) );
-                ( void ) sleep( nextRetryBackOff / NUM_MILLISECONDS_IN_SECOND );
+                LogWarn( ( "Server rejected subscription request. Retrying "
+                           "connection after %hu ms backoff.",
+                           ( unsigned short ) nextRetryBackOff ) );
+                Clock_SleepMs( nextRetryBackOff );
             }
         }
     } while( ( globalSubAckStatus == MQTTSubAckFailure ) && ( backoffAlgStatus == BackoffAlgorithmSuccess ) );

--- a/demos/mqtt/mqtt_demo_serializer/mqtt_demo_serializer.c
+++ b/demos/mqtt/mqtt_demo_serializer/mqtt_demo_serializer.c
@@ -58,6 +58,9 @@
 /*Include backoff algorithm header for retry logic.*/
 #include "backoff_algorithm.h"
 
+/*Include clock header for millisecond sleep function. */
+#include "clock.h"
+
 /* Check that the broker endpoint is defined. */
 #ifndef BROKER_ENDPOINT
     #error "Please define an MQTT broker endpoint, BROKER_ENDPOINT, in demo_config.h."
@@ -87,11 +90,6 @@
  * @brief The base back-off delay (in milliseconds) to use for connection retry attempts.
  */
 #define CONNECTION_RETRY_BACKOFF_BASE_MS         ( 500U )
-
-/**
- * @brief Number of milliseconds in a second.
- */
-#define NUM_MILLISECONDS_IN_SECOND               ( 1000U )
 
 /**
  * @brief The topic to subscribe and publish to in the example.
@@ -412,8 +410,10 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
             }
             else if( backoffAlgStatus == BackoffAlgorithmSuccess )
             {
-                LogWarn( ( "Connection to the broker failed. Retrying connection after backoff." ) );
-                ( void ) sleep( nextRetryBackOff / NUM_MILLISECONDS_IN_SECOND );
+                LogWarn( ( "Connection to the broker failed. Retrying connection "
+                           "after %hu ms backoff.",
+                           ( unsigned short ) nextRetryBackOff ) );
+                Clock_SleepMs( nextRetryBackOff );
             }
         }
     } while( ( socketStatus != SOCKETS_SUCCESS ) && ( backoffAlgStatus == BackoffAlgorithmSuccess ) );
@@ -1012,8 +1012,10 @@ int main( int argc,
                     }
                     else if( backoffAlgStatus == BackoffAlgorithmSuccess )
                     {
-                        LogWarn( ( "Server rejected subscription request. Retrying connection after backoff." ) );
-                        ( void ) sleep( nextRetryBackOff / NUM_MILLISECONDS_IN_SECOND );
+                        LogWarn( ( "Server rejected subscription request. "
+                                   "Retrying connection after %hu ms backoff.",
+                                   ( unsigned short ) nextRetryBackOff ) );
+                        Clock_SleepMs( nextRetryBackOff );
                     }
                 }
             } while( ( globalSubAckStatus == false ) && ( backoffAlgStatus == BackoffAlgorithmSuccess ) );

--- a/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
+++ b/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
@@ -123,11 +123,6 @@
  */
 #define CONNECTION_RETRY_BACKOFF_BASE_MS         ( 500U )
 
-/**
- * @brief Number of milliseconds in a second.
- */
-#define NUM_MILLISECONDS_IN_SECOND               ( 1000U )
-
 
 /**
  * @brief Timeout for receiving CONNACK packet in milli seconds.
@@ -591,8 +586,10 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
             }
             else if( backoffAlgStatus == BackoffAlgorithmSuccess )
             {
-                LogWarn( ( "Connection to the broker failed. Retrying connection after backoff." ) );
-                ( void ) sleep( nextRetryBackOff / NUM_MILLISECONDS_IN_SECOND );
+                LogWarn( ( "Connection to the broker failed. Retrying connection "
+                           "after %hu ms backoff.",
+                           ( unsigned short ) nextRetryBackOff ) );
+                Clock_SleepMs( nextRetryBackOff );
             }
         }
     } while( ( opensslStatus != OPENSSL_SUCCESS ) && ( backoffAlgStatus == BackoffAlgorithmSuccess ) );

--- a/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
+++ b/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
@@ -127,11 +127,6 @@
 #define CONNECTION_RETRY_BACKOFF_BASE_MS         ( 500U )
 
 /**
- * @brief Number of milliseconds in a second.
- */
-#define NUM_MILLISECONDS_IN_SECOND               ( 1000U )
-
-/**
  * @brief Timeout for receiving CONNACK packet in milli seconds.
  */
 #define CONNACK_RECV_TIMEOUT_MS                  ( 1000U )
@@ -412,8 +407,10 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
             }
             else if( backoffAlgStatus == BackoffAlgorithmSuccess )
             {
-                LogWarn( ( "Connection to the broker failed. Retrying connection after backoff." ) );
-                ( void ) sleep( nextRetryBackOff / NUM_MILLISECONDS_IN_SECOND );
+                LogWarn( ( "Connection to the broker failed. Retrying connection "
+                           "after %hu ms backoff.",
+                           ( unsigned short ) nextRetryBackOff ) );
+                Clock_SleepMs( nextRetryBackOff );
             }
         }
     } while( ( opensslStatus != OPENSSL_SUCCESS ) && ( backoffAlgStatus == BackoffAlgorithmSuccess ) );


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The demos calculate backoff value in milliseconds and then convert it to seconds with integer division in order to pass to posix `sleep`. Since the base backoff is 500ms, the first few backoff values are likely to yield 0, resulting in no backoff at all. This uses a millisecond sleep timer instead to avoid this issue.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
