### PR TITLE
Support hostname verification and partial writes in Openssl wrapper

### DIFF
--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -608,7 +608,8 @@ OpensslStatus_t Openssl_Connect( NetworkContext_t * pNetworkContext,
     /* Setup credentials. */
     if( returnStatus == OPENSSL_SUCCESS )
     {
-        /* Set auto retry mode for the blocking calls to SSL_read and SSL_write.
+        /* Enable partial writes for blocking calls to SSL_write to allow a
+         * payload larger than the maximum fragment length.
          * The mask returned by SSL_CTX_set_mode does not need to be checked. */
 
         /* MISRA Directive 4.6 flags the following line for using basic
@@ -616,7 +617,7 @@ OpensslStatus_t Openssl_Connect( NetworkContext_t * pNetworkContext,
         * function #SSL_CTX_set_mode takes an argument of type long. */
         /* coverity[misra_c_2012_directive_4_6_violation] */
         ( void ) SSL_CTX_set_mode( pSslContext,
-                                   ( long ) ( SSL_MODE_ENABLE_PARTIAL_WRITE ) );
+                                   ( long ) SSL_MODE_ENABLE_PARTIAL_WRITE );
 
         sslStatus = setCredentials( pSslContext,
                                     pOpensslCredentials );

--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -238,9 +238,8 @@ static OpensslStatus_t tlsHandshake( const ServerInfo_t * pServerInfo,
 
     if( sslStatus != 1 )
     {
-        LogError( ( "SSL_set1_host failed to validate the hostname "
-                    "in the server's certificate." ) );
-        returnStatus = OPENSSL_HANDSHAKE_FAILED;
+        LogError( ( "SSL_set1_host failed to set the hostname to validate." ) );
+        returnStatus = OPENSSL_API_ERROR;
     }
 
     /* Enable SSL peer verification. */

--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -230,11 +230,8 @@ static OpensslStatus_t tlsHandshake( OpensslParams_t * pOpensslParams,
     int32_t sslStatus = -1, verifyPeerCertStatus = X509_V_OK;
 
     /* Validate the hostname against the server's certificate. */
-    if( pOpensslCredentials->sniHostName != NULL )
-    {
-        sslStatus = SSL_set1_host( pOpensslParams->pSsl,
-                                   pOpensslCredentials->sniHostName );
-    }
+    sslStatus = SSL_set1_host( pOpensslParams->pSsl,
+                               pOpensslCredentials->sniHostName );
 
     if( sslStatus != 1 )
     {
@@ -753,11 +750,6 @@ int32_t Openssl_Recv( NetworkContext_t * pNetworkContext,
                  * Thus, setting the return value of this function as zero to represent that no
                  * data was received from the network. */
                 bytesReceived = 0;
-            }
-            else if( bytesReceived = 0 )
-            {
-                /* Peer has sent a close-notify alert. */
-                bytesReceived = -1;
             }
             else
             {

--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -147,12 +147,14 @@ static OpensslStatus_t convertToOpensslStatus( SocketStatus_t socketStatus );
 /**
  * @brief Establish TLS session by performing handshake with the server.
  *
+ * @param[in] pServerInfo Server connection info.
  * @param[in] pOpensslParams Parameters to perform the TLS handshake.
  * @param[in] pOpensslCredentials TLS credentials containing configurations.
  *
  * @return #OPENSSL_SUCCESS, #OPENSSL_API_ERROR, and #OPENSSL_HANDSHAKE_FAILED.
  */
-static OpensslStatus_t tlsHandshake( OpensslParams_t * pOpensslParams,
+static OpensslStatus_t tlsHandshake( const ServerInfo_t * pServerInfo,
+                                     OpensslParams_t * pOpensslParams,
                                      const OpensslCredentials_t * pOpensslCredentials );
 
 /*-----------------------------------------------------------*/
@@ -223,7 +225,8 @@ static OpensslStatus_t convertToOpensslStatus( SocketStatus_t socketStatus )
 }
 /*-----------------------------------------------------------*/
 
-static OpensslStatus_t tlsHandshake( OpensslParams_t * pOpensslParams,
+static OpensslStatus_t tlsHandshake( const ServerInfo_t * pServerInfo,
+                                     OpensslParams_t * pOpensslParams,
                                      const OpensslCredentials_t * pOpensslCredentials )
 {
     OpensslStatus_t returnStatus = OPENSSL_SUCCESS;
@@ -231,7 +234,7 @@ static OpensslStatus_t tlsHandshake( OpensslParams_t * pOpensslParams,
 
     /* Validate the hostname against the server's certificate. */
     sslStatus = SSL_set1_host( pOpensslParams->pSsl,
-                               pOpensslCredentials->sniHostName );
+                               pServerInfo->pHostName );
 
     if( sslStatus != 1 )
     {
@@ -645,7 +648,8 @@ OpensslStatus_t Openssl_Connect( NetworkContext_t * pNetworkContext,
     /* Setup the socket to use for communication. */
     if( returnStatus == OPENSSL_SUCCESS )
     {
-        returnStatus = tlsHandshake( pOpensslParams,
+        returnStatus = tlsHandshake( pServerInfo,
+                                     pOpensslParams,
                                      pOpensslCredentials );
     }
 

--- a/platform/posix/transport/utest/mocks/openssl_api.h
+++ b/platform/posix/transport/utest/mocks/openssl_api.h
@@ -107,6 +107,9 @@ extern void SSL_set_verify( SSL * s,
 extern int SSL_set_fd( SSL * s,
                        int fd );
 
+extern int SSL_set1_host( SSL * s,
+                          const char * hostname );
+
 extern int SSL_connect( SSL * ssl );
 
 extern long SSL_get_verify_result( const SSL * ssl );

--- a/platform/posix/transport/utest/openssl_utest.c
+++ b/platform/posix/transport/utest/openssl_utest.c
@@ -93,6 +93,7 @@ typedef enum FunctionNames
     SSL_CTX_use_certificate_chain_file_fn,
     SSL_CTX_use_PrivateKey_file_fn,
     SSL_new_fn,
+    SSL_set1_host_fn,
     SSL_set_fd_fn,
     SSL_set_alpn_protos_fn,
     SSL_set_max_send_fragment_fn,
@@ -333,6 +334,16 @@ static OpensslStatus_t failFunctionFrom_Openssl_Connect( FunctionNames_t functio
     {
         SSL_new_ExpectAnyArgsAndReturn( &ssl );
         sslCreated = true;
+    }
+
+    if( functionToFail == SSL_set1_host_fn )
+    {
+        SSL_set1_host_ExpectAnyArgsAndReturn( 0 );
+        returnStatus = OPENSSL_HANDSHAKE_FAILED;
+    }
+    else if( returnStatus == OPENSSL_SUCCESS )
+    {
+        SSL_set1_host_ExpectAnyArgsAndReturn( 1 );
     }
 
     if( returnStatus == OPENSSL_SUCCESS )
@@ -585,7 +596,7 @@ void test_Openssl_Connect_Handshake_Fails( void )
     OpensslStatus_t returnStatus, expectedStatus;
     FunctionNames_t connectFunctions[] =
     {
-        SSL_connect_fn, SSL_get_verify_result_fn
+        SSL_set1_host_fn, SSL_connect_fn, SSL_get_verify_result_fn
     };
     uint16_t i;
 

--- a/platform/posix/transport/utest/openssl_utest.c
+++ b/platform/posix/transport/utest/openssl_utest.c
@@ -232,6 +232,13 @@ static OpensslStatus_t failFunctionFrom_Openssl_Connect( FunctionNames_t functio
         sslCtxCreated = true;
     }
 
+    /* SSL_CTX_set_mode is actually what the API uses, but CMock expects the	
+     * actual method rather than the macro wrapper. */	
+    if( returnStatus == OPENSSL_SUCCESS )	
+    {	
+        SSL_CTX_ctrl_ExpectAnyArgsAndReturn( 1 );	
+    }
+
     /* Path to Root CA must be set for handshake to succeed. */
     if( opensslCredentials.pRootCaPath == NULL )
     {

--- a/platform/posix/transport/utest/openssl_utest.c
+++ b/platform/posix/transport/utest/openssl_utest.c
@@ -339,7 +339,7 @@ static OpensslStatus_t failFunctionFrom_Openssl_Connect( FunctionNames_t functio
     if( functionToFail == SSL_set1_host_fn )
     {
         SSL_set1_host_ExpectAnyArgsAndReturn( 0 );
-        returnStatus = OPENSSL_HANDSHAKE_FAILED;
+        returnStatus = OPENSSL_API_ERROR;
     }
     else if( returnStatus == OPENSSL_SUCCESS )
     {

--- a/platform/posix/transport/utest/openssl_utest.c
+++ b/platform/posix/transport/utest/openssl_utest.c
@@ -232,11 +232,11 @@ static OpensslStatus_t failFunctionFrom_Openssl_Connect( FunctionNames_t functio
         sslCtxCreated = true;
     }
 
-    /* SSL_CTX_set_mode is actually what the API uses, but CMock expects the	
-     * actual method rather than the macro wrapper. */	
-    if( returnStatus == OPENSSL_SUCCESS )	
-    {	
-        SSL_CTX_ctrl_ExpectAnyArgsAndReturn( 1 );	
+    /* SSL_CTX_set_mode is actually what the API uses, but CMock expects the
+     * actual method rather than the macro wrapper. */
+    if( returnStatus == OPENSSL_SUCCESS )
+    {
+        SSL_CTX_ctrl_ExpectAnyArgsAndReturn( 1 );
     }
 
     /* Path to Root CA must be set for handshake to succeed. */


### PR DESCRIPTION
When the SNI hostname is set, we need to use `SSL_set1_host` to verify the hostname against the server's certificate. Also, when the payload was too large, OpenSSL would just return `SSL_WANT_WRITE` instead of trying to write as many bytes as it could, potentially causing an infinite loop in libraries. The `SSL_MODE_ENABLE_PARTIAL_WRITE` flag allows OpenSSL to support partial writes so that less bytes than the expected payload can be returned.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
