### PR TITLE
Initialize the MQTTPublishInfo_t local structure

### DIFF
--- a/demos/ota/ota_demo_core_http/ota_demo_core_http.c
+++ b/demos/ota/ota_demo_core_http/ota_demo_core_http.c
@@ -1629,7 +1629,7 @@ static OtaMqttStatus_t mqttPublish( const char * const pTopic,
     OtaMqttStatus_t otaRet = OtaMqttSuccess;
 
     MQTTStatus_t mqttStatus = MQTTBadParameter;
-    MQTTPublishInfo_t publishInfo;
+    MQTTPublishInfo_t publishInfo = { 0 };
     MQTTContext_t * pMqttContext = &mqttContext;
 
     /* Set the required publish parameters. */

--- a/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
+++ b/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
@@ -1285,7 +1285,7 @@ static OtaMqttStatus_t mqttPublish( const char * const pacTopic,
     OtaMqttStatus_t otaRet = OtaMqttSuccess;
 
     MQTTStatus_t mqttStatus = MQTTBadParameter;
-    MQTTPublishInfo_t publishInfo;
+    MQTTPublishInfo_t publishInfo = { 0 };
     MQTTContext_t * pMqttContext = &mqttContext;
 
     /* Set the required publish parameters. */


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change internalizes the MQTTPublishInfo_t to zero , which if not cleared can cause issues with connecting to broker.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
