### PR TITLE
Update OTA over MQTT and HTTP demo config

### DIFF
--- a/demos/ota/ota_demo_core_http/ota_config.h
+++ b/demos/ota/ota_demo_core_http/ota_config.h
@@ -58,7 +58,7 @@
  *
  * 10 bits yields a data block size of 1KB.
  */
-#define otaconfigLOG2_FILE_BLOCK_SIZE          10UL
+#define otaconfigLOG2_FILE_BLOCK_SIZE          14UL
 
 /**
  * @brief Size of the file data block message (excluding the header).
@@ -118,7 +118,7 @@
  * This configurations parameter sets the maximum number of static data buffers used by
  * the OTA agent for job and file data blocks received.
  */
-#define otaconfigMAX_NUM_OTA_DATA_BUFFERS      1U
+#define otaconfigMAX_NUM_OTA_DATA_BUFFERS      2U
 
 /**
  * @brief Allow update to same or lower version.

--- a/demos/ota/ota_demo_core_mqtt/ota_config.h
+++ b/demos/ota/ota_demo_core_mqtt/ota_config.h
@@ -58,7 +58,7 @@
  *
  * 10 bits yields a data block size of 1KB.
  */
-#define otaconfigLOG2_FILE_BLOCK_SIZE    10UL
+#define otaconfigLOG2_FILE_BLOCK_SIZE    14UL
 
 
 /**
@@ -102,7 +102,7 @@
  *  @note This must be set larger than zero.
  *
  */
-#define otaconfigMAX_NUM_BLOCKS_REQUEST        1U
+#define otaconfigMAX_NUM_BLOCKS_REQUEST        8U
 
 /**
  * @brief The maximum number of requests allowed to send without a response before we abort.
@@ -119,7 +119,7 @@
  * This configurations parameter sets the maximum number of static data buffers used by
  * the OTA agent for job and file data blocks received.
  */
-#define otaconfigMAX_NUM_OTA_DATA_BUFFERS      1U
+#define otaconfigMAX_NUM_OTA_DATA_BUFFERS      10U
 
 /**
  * @brief Allow update to same or lower version.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update the OTA over MQTT and HTTP config to 

* Increase block size default to 16KB in demo

* Increase number of blocks requested and data buffers

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
