### PR TITLE
Fix assert in OTA pal posix

### DIFF
--- a/platform/lexicon.txt
+++ b/platform/lexicon.txt
@@ -141,6 +141,7 @@ otapalrxfiletoolarge
 otapalsignaturecheckfailed
 otapalsuccess
 otapaluninitialized
+otapal_closefile
 paddrinfo
 palpnprotos
 param

--- a/platform/posix/ota_pal/source/ota_pal_posix.c
+++ b/platform/posix/ota_pal/source/ota_pal_posix.c
@@ -218,7 +218,7 @@ static bool Openssl_DigestVerifyUpdate( EVP_MD_CTX * pSigContext,
 
         /* POSIX port using standard library */
         /* coverity[misra_c_2012_rule_21_6_violation] */
-        if( 0 == feof( pFile ) )
+        if( (  bytesRead < OTA_PAL_POSIX_BUF_SIZE ) && ( 0 == feof( pFile )))
         {
             break;
         }

--- a/platform/posix/ota_pal/source/ota_pal_posix.c
+++ b/platform/posix/ota_pal/source/ota_pal_posix.c
@@ -124,7 +124,7 @@ static EVP_PKEY * Openssl_GetPkeyFromCertificate( uint8_t * pCertFilePath )
         }
         else
         {
-            LogError( ( "Failed to read certificate from a file." ) );
+            LogDebug( ( "Opened certificate file." ) );
         }
     }
 

--- a/platform/posix/ota_pal/source/ota_pal_posix.c
+++ b/platform/posix/ota_pal/source/ota_pal_posix.c
@@ -210,7 +210,7 @@ static bool Openssl_DigestVerifyUpdate( EVP_MD_CTX * pSigContext,
         /* coverity[misra_c_2012_rule_21_6_violation] */
         bytesRead = fread( pBuf, 1U, OTA_PAL_POSIX_BUF_SIZE, pFile );
 
-        assert( bytesRead < OTA_PAL_POSIX_BUF_SIZE );
+        assert( bytesRead <= OTA_PAL_POSIX_BUF_SIZE );
 
         /* feof returns non-zero if end of file is reached, otherwise it returns 0. When
          * bytesRead is not equal to OTA_PAL_POSIX_BUF_SIZE, we should be reading last

--- a/platform/posix/ota_pal/source/ota_pal_posix.c
+++ b/platform/posix/ota_pal/source/ota_pal_posix.c
@@ -218,7 +218,7 @@ static bool Openssl_DigestVerifyUpdate( EVP_MD_CTX * pSigContext,
 
         /* POSIX port using standard library */
         /* coverity[misra_c_2012_rule_21_6_violation] */
-        if( (  bytesRead < OTA_PAL_POSIX_BUF_SIZE ) && ( 0 == feof( pFile )))
+        if( ( bytesRead < OTA_PAL_POSIX_BUF_SIZE ) && ( 0 == feof( pFile ) ) )
         {
             break;
         }

--- a/platform/posix/ota_pal/utest/ota_pal_posix_utest.c
+++ b/platform/posix/ota_pal/utest/ota_pal_posix_utest.c
@@ -775,8 +775,6 @@ void test_OTAPAL_CloseFile_EVP_DigestVerifyInit_fail( void )
 void test_OTAPAL_CloseFile_MaxBlockSize()
 {
     const size_t OTA_PAL_POSIX_BUF_SIZE = 4096U;
-    const int feofFailReturn = 0;
-
     OtaPalStatus_t result;
     OtaFileContext_t otaFileContext;
     Sig256_t dummySig;

--- a/platform/posix/ota_pal/utest/ota_pal_posix_utest.c
+++ b/platform/posix/ota_pal/utest/ota_pal_posix_utest.c
@@ -767,8 +767,8 @@ void test_OTAPAL_CloseFile_EVP_DigestVerifyInit_fail( void )
 }
 
 /**
- * @brief Test that CloseFile properly handles receiving fread returning data
- * that is the maximum size. The maximum size is based on the OTA PAL
+ * @brief Test that otaPal_CloseFile properly handles receiving fread returning
+ * data that is the maximum size. The maximum size is based on the OTA PAL
  * implementation. It is defined by the "OTA_PAL_POSIX_BUF_SIZE" macro in the
  * OTA posix PAL implementation .c file.
  */

--- a/platform/posix/ota_pal/utest/ota_pal_posix_utest.c
+++ b/platform/posix/ota_pal/utest/ota_pal_posix_utest.c
@@ -783,6 +783,7 @@ void test_OTAPAL_CloseFile_MaxBlockSize()
 
     otaFileContext.pSignature = &dummySig;
     otaFileContext.pFile = &dummyFile;
+
     /* Simulate the scenario where fread returns a max size block and then it
      * returns a value less than the max size. */
     fread_IgnoreAndReturn( OTA_PAL_POSIX_BUF_SIZE );


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* This change fixes an incorrect assert in the OTA pal port for POSIX.

* This change also fixes bug in signature verification.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
