### PR TITLE
Add backoffAlgorithm to README table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
         * [AWS IoT Device Shadow](#aws-iot-device-shadow)
         * [AWS IoT Jobs](#aws-iot-jobs)
         * [AWS IoT Device Defender](#aws-iot-device-defender)
+        * [backoffAlgorithm](#backoffalgorithm)
     * [AWS Collection of Metrics](#aws-collection-of-metrics)
 * [Versioning](#versioning)
 * [Releases](#releases)


### PR DESCRIPTION
Add backoffAlgorithm library to table of contents in README file that was missed in PR #1444