### PR TITLE
Remove prefix MQTT_ in OTA over HTTP demo config

### DIFF
--- a/demos/ota/ota_demo_core_http/demo_config.h
+++ b/demos/ota/ota_demo_core_http/demo_config.h
@@ -137,12 +137,12 @@
  */
 
 /**
- * @brief MQTT client identifier.
+ * @brief MQTT Client identifier.
  *
  * No two clients may use the same client identifier simultaneously.
  */
-#ifndef MQTT_CLIENT_IDENTIFIER
-    #define MQTT_CLIENT_IDENTIFIER    "testclient"
+#ifndef CLIENT_IDENTIFIER
+    #define CLIENT_IDENTIFIER    "testclient"
 #endif
 
 /**


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

* This change only removes prefix MQTT_ in OTA over HTTP demo config


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
