### PR TITLE
Add GitHub Actions job to automate source file versioning

### DIFF
--- a/.github/workflows/version-updater.yml
+++ b/.github/workflows/version-updater.yml
@@ -1,0 +1,40 @@
+name: Source File Version Updater
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Target branch for raising PR'
+        required: true
+      new_version_number:
+        description: 'New version Number (Eg, v1.1.0)'
+        required: true
+      old_version_number:
+        description: 'Old version Number (Eg, v1.0.0)'
+        required: true
+
+jobs:
+  update-version:
+    name: Update Version in source files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch }}
+      - name: Configure git identity
+        run: |
+          git config --global user.name "Version Updater"
+      - name: Update source files with new version
+        run: |
+          grep -ilr ${{ github.event.inputs.old_version_number }} . | grep -v ".git" | grep -v "CHANGELOG.md" | grep -v "README.md" | xargs sed -i s/${{ github.event.inputs.old_version_number }}/${{ github.event.inputs.new_version_number }}/g
+      - name: Commit changes and Push to remote
+        run: |
+          git checkout -b updater-job/update-to-${{ github.event.inputs.new_version_number }}
+          git commit -am 'Update versioning in file from ${{ github.event.inputs.old_version_number }} to ${{ github.event.inputs.new_version_number }}'
+          git push --set-upstream origin updater-job/update-to-${{ github.event.inputs.new_version_number }}
+      - name: Raise a Pull-Request
+        run: |
+          sudo apt-get install
+          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          gh pr create --base ${{ github.event.inputs.branch }} --title 'Update source file versioning to ${{ github.event.inputs.new_version_number }}' --body 'Updater-Job: PR to update versioning in source files from ${{ github.event.inputs.old_version_numver }} to ${{ github.event.inputs.new_version_number }}'


### PR DESCRIPTION
**Add a GitHub Actions workflow for updating versioning of source files for a new release**. 
* The job takes input parameters for **target branch**, **old version number** (that is searched through the codebase for replacement) and **new version number** (to update the source files with). 
* The job updates the versioning in source files, pushes a branch to remote and creates a PR to the target branch.

Here is a test run of the job on my fork repository: https://github.com/aggarw13/aws-iot-device-sdk-embedded-C/actions/runs/412091484
 and here is the PR it created: https://github.com/aggarw13/aws-iot-device-sdk-embedded-C/pull/5

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
