### PR TITLE
Fix/ota demo http

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
         * [AWS IoT Device Shadow](#aws-iot-device-shadow)
         * [AWS IoT Jobs](#aws-iot-jobs)
         * [AWS IoT Device Defender](#aws-iot-device-defender)
+        * [backoffAlgorithm](#backoffalgorithm)
     * [AWS Collection of Metrics](#aws-collection-of-metrics)
 * [Versioning](#versioning)
 * [Releases](#releases)

--- a/demos/lexicon.txt
+++ b/demos/lexicon.txt
@@ -446,7 +446,7 @@ ppublishinfo
 ppxslotid
 pre
 prequest
-pResponse
+presponse
 presigned
 prf
 printf

--- a/demos/lexicon.txt
+++ b/demos/lexicon.txt
@@ -446,6 +446,7 @@ ppublishinfo
 ppxslotid
 pre
 prequest
+pResponse
 presigned
 prf
 printf

--- a/demos/ota/ota_demo_core_http/ota_demo_core_http.c
+++ b/demos/ota/ota_demo_core_http/ota_demo_core_http.c
@@ -204,8 +204,13 @@
  */
 #define CONNECTION_RETRY_MAX_ATTEMPTS    ( 5U )
 
+/**
+ * @brief The maximum size of the HTTP header.
+ */
+#define HTTP_HEADER_SIZE_MAX             ( 1024U )
+
 /* HTTP buffers used for http request and response. */
-#define HTTP_USER_BUFFER_LENGTH          ( otaconfigFILE_BLOCK_SIZE + 1024 )
+#define HTTP_USER_BUFFER_LENGTH          ( otaconfigFILE_BLOCK_SIZE + HTTP_HEADER_SIZE_MAX )
 
 /**
  * @brief The MQTT metrics string expected by AWS IoT.
@@ -802,7 +807,7 @@ static void mqttJobCallback( MQTTContext_t * pContext,
     }
     else
     {
-        LogError( ( "Error: No OTA data buffers available.\r\n" ) );
+        LogError( ( "Error: No OTA data buffers available." ) );
     }
 }
 
@@ -1193,10 +1198,10 @@ static void disconnect( void )
             /* Disconnect MQTT session. */
             MQTT_Disconnect( &mqttContext );
 
-            pthread_mutex_unlock( &mqttMutex );
-
             /* Clear the mqtt session flag. */
             mqttSessionEstablished = false;
+
+            pthread_mutex_unlock( &mqttMutex );
         }
         else
         {
@@ -1312,7 +1317,7 @@ static OtaHttpStatus_t handleHttpResponse( const HTTPResponse_t * pResponse )
             }
             else
             {
-                LogError( ( "Error: No OTA data buffers available.\r\n" ) );
+                LogError( ( "Error: No OTA data buffers available." ) );
 
                 ret = OtaHttpRequestFailed;
             }

--- a/demos/ota/ota_demo_core_http/ota_demo_core_http.c
+++ b/demos/ota/ota_demo_core_http/ota_demo_core_http.c
@@ -204,20 +204,18 @@
  */
 #define CONNECTION_RETRY_MAX_ATTEMPTS    ( 5U )
 
-/* Check that size of the user buffer is defined. */
-#ifndef USER_BUFFER_LENGTH
-    #define USER_BUFFER_LENGTH    ( 2048 )
-#endif
+/* HTTP buffers used for http request and response. */
+#define HTTP_USER_BUFFER_LENGTH          ( otaconfigFILE_BLOCK_SIZE + 1024 )
 
 /**
  * @brief The MQTT metrics string expected by AWS IoT.
  */
-#define METRICS_STRING           "?SDK=" OS_NAME "&Version=" OS_VERSION "&Platform=" HARDWARE_PLATFORM_NAME "&OTALib=" OTA_LIB
+#define METRICS_STRING                   "?SDK=" OS_NAME "&Version=" OS_VERSION "&Platform=" HARDWARE_PLATFORM_NAME "&OTALib=" OTA_LIB
 
 /**
  * @brief The length of the MQTT metrics string expected by AWS IoT.
  */
-#define METRICS_STRING_LENGTH    ( ( uint16_t ) ( sizeof( METRICS_STRING ) - 1 ) )
+#define METRICS_STRING_LENGTH            ( ( uint16_t ) ( sizeof( METRICS_STRING ) - 1 ) )
 
 
 #ifdef CLIENT_USERNAME
@@ -299,7 +297,7 @@ static char serverHost[ 256 ];
  * response after the HTTP request is sent out. However, the user can also
  * decide to use separate buffers for storing the HTTP request and response.
  */
-static uint8_t userBuffer[ USER_BUFFER_LENGTH ];
+static uint8_t httpUserBuffer[ HTTP_USER_BUFFER_LENGTH ];
 
 /* The transport layer interface used by the HTTP Client library. */
 TransportInterface_t transportInterfaceHttp;
@@ -1370,8 +1368,8 @@ static OtaHttpStatus_t httpRequest( uint32_t rangeStart,
     requestInfo.reqFlags = HTTP_REQUEST_KEEP_ALIVE_FLAG;
 
     /* Set the buffer used for storing request headers. */
-    requestHeaders.pBuffer = userBuffer;
-    requestHeaders.bufferLen = USER_BUFFER_LENGTH;
+    requestHeaders.pBuffer = httpUserBuffer;
+    requestHeaders.bufferLen = HTTP_USER_BUFFER_LENGTH;
 
     httpStatus = HTTPClient_InitializeRequestHeaders( &requestHeaders,
                                                       &requestInfo );
@@ -1382,8 +1380,8 @@ static OtaHttpStatus_t httpRequest( uint32_t rangeStart,
     {
         /* Initialize the response object. The same buffer used for storing
          * request headers is reused here. */
-        response.pBuffer = userBuffer;
-        response.bufferLen = USER_BUFFER_LENGTH;
+        response.pBuffer = httpUserBuffer;
+        response.bufferLen = HTTP_USER_BUFFER_LENGTH;
 
         /* Send the request and receive the response. */
         httpStatus = HTTPClient_Send( &transportInterfaceHttp,

--- a/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
+++ b/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
@@ -610,11 +610,10 @@ static void otaAppCallback( OtaJobEvent_t event,
         OTA_ActivateNewImage();
 
         /* We should never get here as new image activation must reset the device.*/
-        LogError( ( "New image activation failed." ) );
+        LogError( ( "New image activation failed, exiting." ) );
 
-        for( ; ; )
-        {
-        }
+        /* Exit this application.*/
+        exit( EXIT_SUCCESS );
     }
     else if( event == OtaJobEventFail )
     {

--- a/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
+++ b/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
@@ -677,7 +677,7 @@ static void mqttJobCallback( MQTTContext_t * pContext,
     }
     else
     {
-        LogError( ( "No OTA data buffers available.\r\n" ) );
+        LogError( ( "No OTA data buffers available." ) );
     }
 }
 
@@ -710,7 +710,7 @@ static void mqttDataCallback( MQTTContext_t * pContext,
     }
     else
     {
-        LogError( ( "No OTA data buffers available.\r\n" ) );
+        LogError( ( "No OTA data buffers available." ) );
     }
 }
 
@@ -1078,10 +1078,10 @@ static void disconnect( void )
             /* Disconnect MQTT session. */
             MQTT_Disconnect( &mqttContext );
 
-            pthread_mutex_unlock( &mqttMutex );
-
             /* Clear the mqtt session flag. */
             mqttSessionEstablished = false;
+
+            pthread_mutex_unlock( &mqttMutex );
         }
         else
         {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Speed up OTA over HTTP demo by checking connection close flag and connecting before sending request 

* Fix issues where buffer was directly used instead of calling get buffer function.

* Added handling of expired url.

* Added exit function to both OTA over MQTT and HTT demos


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
