### PR TITLE
Fix OTA PAL unit test mock

### DIFF
--- a/platform/lexicon.txt
+++ b/platform/lexicon.txt
@@ -235,6 +235,7 @@ unistd
 utest
 utils
 v1
+variadic
 vtaskdelay
 writesize
 www

--- a/platform/posix/ota_pal/utest/mocks/stdio_api.h
+++ b/platform/posix/ota_pal/utest/mocks/stdio_api.h
@@ -44,7 +44,9 @@ extern _STDIO_FILE_TYPE * fopen( const char * __filename,
 /* Close STREAM. */
 extern int fclose( _STDIO_FILE_TYPE * __stream );
 
-extern int snprintf( char * s,
+/* CMock doesn't support variadic functions. This alias replaces the original
+ * function name to get around this issue. */
+extern int snprintf_alias( char * s,
                      size_t n,
                      const char * format,
                      ... );

--- a/platform/posix/ota_pal/utest/mocks/stdio_api.h
+++ b/platform/posix/ota_pal/utest/mocks/stdio_api.h
@@ -47,9 +47,9 @@ extern int fclose( _STDIO_FILE_TYPE * __stream );
 /* CMock doesn't support variadic functions. This alias replaces the original
  * function name to get around this issue. */
 extern int snprintf_alias( char * s,
-                     size_t n,
-                     const char * format,
-                     ... );
+                           size_t n,
+                           const char * format,
+                           ... );
 
 extern size_t fread( void * ptr,
                      size_t size,

--- a/platform/posix/ota_pal/utest/mocks/stdio_api.h
+++ b/platform/posix/ota_pal/utest/mocks/stdio_api.h
@@ -44,7 +44,7 @@ extern _STDIO_FILE_TYPE * fopen( const char * __filename,
 /* Close STREAM. */
 extern int fclose( _STDIO_FILE_TYPE * __stream );
 
-/* CMock doesn't support variadic functions. This alias replaces the original
+/* CMock does not support variadic functions. This alias replaces the original
  * function name to get around this issue. */
 extern int snprintf_alias( char * s,
                            size_t n,

--- a/platform/posix/ota_pal/utest/ota_config.h
+++ b/platform/posix/ota_pal/utest/ota_config.h
@@ -167,7 +167,7 @@
  * "fwrite". The function declaration for this alias is in "stdio_api.h". */
 #define fwrite                             fwrite_alias
 
-/* CMock doesn't support variadic functions. This alias replaces the original
+/* CMock does not support variadic functions. This alias replaces the original
  * function name to get around this issue. */
 #define snprintf                           snprintf_alias
 

--- a/platform/posix/ota_pal/utest/ota_config.h
+++ b/platform/posix/ota_pal/utest/ota_config.h
@@ -167,4 +167,8 @@
  * "fwrite". The function declaration for this alias is in "stdio_api.h". */
 #define fwrite                             fwrite_alias
 
+/* CMock doesn't support variadic functions. This alias replaces the original
+ * function name to get around this issue. */
+#define snprintf                           snprintf_alias
+
 #endif /* _OTA_CONFIG_H_ */

--- a/platform/posix/ota_pal/utest/ota_pal_posix_utest.c
+++ b/platform/posix/ota_pal/utest/ota_pal_posix_utest.c
@@ -316,7 +316,7 @@ static void OTA_PAL_FailSingleMock_stdio( MockFunctionNames_t funcToFail,
     fopen_IgnoreAndReturn( fopen_return );
 
     snprintf_return = ( funcToFail == snprintf_fn ) ? snprintf_failure : snprintf_success;
-    snprintf_IgnoreAndReturn( snprintf_return );
+    snprintf_alias_IgnoreAndReturn( snprintf_return );
 
     fread_return = ( funcToFail == fread_fn ) ? fread_failure : fread_success;
     fread_IgnoreAndReturn( fread_return );
@@ -1045,7 +1045,7 @@ void test_OTAPAL_GetPlatformImageState_fclose_fails( void )
     const int fclose_fail_val = EOF;
 
     /* Predefine what functions are expected to be called. */
-    snprintf_ExpectAnyArgsAndReturn( snprintf_success_val );
+    snprintf_alias_ExpectAnyArgsAndReturn( snprintf_success_val );
     fopen_ExpectAnyArgsAndReturn( fopen_success_val );
     fread_ExpectAnyArgsAndReturn( fread_success_val );
     fclose_ExpectAnyArgsAndReturn( fclose_fail_val );
@@ -1085,7 +1085,7 @@ void test_OTAPAL_GetPlatformImageState_ValidStates( void )
     /* Test the scenario where the platform state is OtaImageStateTesting. */
     freadResultingState = OtaImageStateTesting;
     /* Predefine what functions are expected to be called. */
-    snprintf_ExpectAnyArgsAndReturn( snprintf_success_val );
+    snprintf_alias_ExpectAnyArgsAndReturn( snprintf_success_val );
     fopen_ExpectAnyArgsAndReturn( fopen_success_val );
     fread_ExpectAnyArgsAndReturn( fread_success_val );
     fread_ReturnThruPtr_ptr( &freadResultingState );
@@ -1097,7 +1097,7 @@ void test_OTAPAL_GetPlatformImageState_ValidStates( void )
     /* Test the scenario where the platform state is OtaImageStateAccepted. */
     freadResultingState = OtaImageStateAccepted;
     /* Predefine what functions are expected to be called. */
-    snprintf_ExpectAnyArgsAndReturn( snprintf_success_val );
+    snprintf_alias_ExpectAnyArgsAndReturn( snprintf_success_val );
     fopen_ExpectAnyArgsAndReturn( fopen_success_val );
     fread_ExpectAnyArgsAndReturn( fread_success_val );
     fread_ReturnThruPtr_ptr( &freadResultingState );
@@ -1109,7 +1109,7 @@ void test_OTAPAL_GetPlatformImageState_ValidStates( void )
     /* Test the scenario where the platform state is an unexpected value. */
     freadResultingState = invalidImageState;
     /* Predefine what functions are expected to be called. */
-    snprintf_ExpectAnyArgsAndReturn( snprintf_success_val );
+    snprintf_alias_ExpectAnyArgsAndReturn( snprintf_success_val );
     fopen_ExpectAnyArgsAndReturn( fopen_success_val );
     fread_ExpectAnyArgsAndReturn( fread_success_val );
     fread_ReturnThruPtr_ptr( &freadResultingState );


### PR DESCRIPTION
CMock doesn't support variadic functions. Use an alias to replace the original function as a workaround to this issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
