### PR TITLE
Fix incorrect section hierarchy in building.dox

### DIFF
--- a/docs/doxygen/building.dox
+++ b/docs/doxygen/building.dox
@@ -111,24 +111,22 @@ Note: A pre-signed GET URL is required for all HTTP S3 demos. For upload demos, 
 @section configuring_ota_demos Configuring the Over-The-Air Update Demos
 @brief Configurations and Prerequisites for the OTA Demo
 
-### Prerequisites:
+## Requirements for OTA demo
+
+### Prerequisites
 <ol>
 	<li> To perform a successful OTA update you would need to complete the prerequisites mentioned here: https://docs.aws.amazon.com/freertos/latest/userguide/ota-prereqs.html </li>
 	<li> A Code-Signing profile can be created using: https://docs.aws.amazon.com/freertos/latest/userguide/ota-code-sign-cert-esp.html </li>
 </ol>
 
-### Configuration:
-
+### Configuration
 You will need to specify the following parameters in the file demo_config.h (located in `demos/ota_demo_[mqtt/http]/`)
+
 <ol>
-<li> AWS_IOT_ENDPOINT:
-     This is the endpoint for your account. The endpoint should be for the region that your thing was created in. This can be found by going to the AWS IoT Core console, pressing the “Settings” tab on the left hand side of the page. It is under the section labeled “Custom endpoint”. </li>
-<li> CLIENT_CERT_PATH:
-    This is the client certificate that was downloaded when you created your thing. The path specified needs to be either an absolute path, or a path that is relative to the “cloned-repo-root-dir/build/bin" directory where the demo will be ran from.</li>
-<li> CLIENT_PRIVATE_KEY_PATH:
-    This is the client private key that was downloaded when you created your thing. The path specified needs to be either an absolute path, or a path that is relative to the “cloned-repo-root-dir/build/bin" directory where the demo will be ran from.</li>
-<li> CLIENT_IDENTIFER:
-    This is the name of the thing you created during the OTA Prerequisites section.</li>
+<li> AWS_IOT_ENDPOINT: This is the endpoint for your account. The endpoint should be for the region that your thing was created in. This can be found by going to the AWS IoT Core console, pressing the “Settings” tab on the left hand side of the page. It is under the section labeled “Custom endpoint”. </li>
+<li> CLIENT_CERT_PATH: This is the client certificate that was downloaded when you created your thing. The path specified needs to be either an absolute path, or a path that is relative to the “cloned-repo-root-dir/build/bin" directory where the demo will be ran from.</li>
+<li> CLIENT_PRIVATE_KEY_PATH: This is the client private key that was downloaded when you created your thing. The path specified needs to be either an absolute path, or a path that is relative to the “cloned-repo-root-dir/build/bin" directory where the demo will be ran from.</li>
+<li> CLIENT_IDENTIFER: This is the name of the thing you created during the OTA Prerequisites section.</li>
 </ol>
 
 An example expected output:
@@ -139,7 +137,7 @@ An example expected output:
 #define CLIENT_IDENTIFIER          "testclient"
 @endcode
 
-### Scheduling an OTA Update Job:
+### Scheduling an OTA Update Job
 After you build and run the initial executable you will have to create another executable and schedule an OTA update job with this image.
 <ol>
 	<li> Increase the version of the application by setting macro `APP_VERSION_BUILD` in demos/ota_demo_core_[mqtt/http]/demo_config.h to a different version than what is running.</li>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fixed incorrect indexing of subsections of OTA requirements in building documents.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
