### PR TITLE
Add comment about handling S3 request limits to S3 download demos

### DIFF
--- a/demos/http/http_demo_s3_download/http_demo_s3_download.c
+++ b/demos/http/http_demo_s3_download/http_demo_s3_download.c
@@ -385,11 +385,11 @@ static bool downloadS3ObjectFile( const TransportInterface_t * pTransportInterfa
  * (located in located in demos/http/common/src) to generate these URLs. For
  * detailed instructions, see the accompanied README.md.
  *
- * @note If your file requires more than 99 range requests to S3 (depending on the
- * size of the file and the length specified in democonfigRANGE_REQUEST_LENGTH),
- * your connection may be dropped by S3. In this case, either increase the
- * buffer size and range request length (if feasible), to reduce the number of
- * requests required, or re-establish the connection with S3 after receiving a
+ * @note If your file requires more than 99 range requests to S3 (depending on
+ * the size of the file and the length specified in RANGE_REQUEST_LENGTH), your
+ * connection may be dropped by S3. In this case, either increase the buffer
+ * size and range request length (if feasible), to reduce the number of requests
+ * required, or re-establish the connection with S3 after receiving a
  * "Connection: close" response header.
  */
 int main( int argc,

--- a/demos/http/http_demo_s3_download/http_demo_s3_download.c
+++ b/demos/http/http_demo_s3_download/http_demo_s3_download.c
@@ -380,6 +380,17 @@ static bool downloadS3ObjectFile( const TransportInterface_t * pTransportInterfa
  *
  * @note This example is single-threaded and uses statically allocated memory.
  *
+ * @note This demo requires user-generated pre-signed URLs to be pasted into
+ * demo_config.h. Please use the provided script "presigned_urls_gen.py"
+ * (located in located in demos/http/common/src) to generate these URLs. For
+ * detailed instructions, see the accompanied README.md.
+ *
+ * @note If your file requires more than 99 range requests to S3 (depending on the
+ * size of the file and the length specified in democonfigRANGE_REQUEST_LENGTH),
+ * your connection may be dropped by S3. In this case, either increase the
+ * buffer size and range request length (if feasible), to reduce the number of
+ * requests required, or re-establish the connection with S3 after receiving a
+ * "Connection: close" response header.
  */
 int main( int argc,
           char ** argv )

--- a/demos/http/http_demo_s3_download_multithreaded/http_demo_s3_download_multithreaded.c
+++ b/demos/http/http_demo_s3_download_multithreaded/http_demo_s3_download_multithreaded.c
@@ -828,6 +828,17 @@ void tearDown( pid_t httpThread,
  *
  * @note This example is multi-threaded and uses statically allocated memory.
  *
+ * @note This demo requires user-generated pre-signed URLs to be pasted into
+ * demo_config.h. Please use the provided script "presigned_urls_gen.py"
+ * (located in located in demos/http/common/src) to generate these URLs. For
+ * detailed instructions, see the accompanied README.md.
+ *
+ * @note If your file requires more than 99 range requests to S3 (depending on the
+ * size of the file and the length specified in democonfigRANGE_REQUEST_LENGTH),
+ * your connection may be dropped by S3. In this case, either increase the
+ * buffer size and range request length (if feasible), to reduce the number of
+ * requests required, or re-establish the connection with S3 after receiving a
+ * "Connection: close" response header.
  */
 int main( int argc,
           char ** argv )

--- a/demos/http/http_demo_s3_download_multithreaded/http_demo_s3_download_multithreaded.c
+++ b/demos/http/http_demo_s3_download_multithreaded/http_demo_s3_download_multithreaded.c
@@ -833,11 +833,11 @@ void tearDown( pid_t httpThread,
  * (located in located in demos/http/common/src) to generate these URLs. For
  * detailed instructions, see the accompanied README.md.
  *
- * @note If your file requires more than 99 range requests to S3 (depending on the
- * size of the file and the length specified in democonfigRANGE_REQUEST_LENGTH),
- * your connection may be dropped by S3. In this case, either increase the
- * buffer size and range request length (if feasible), to reduce the number of
- * requests required, or re-establish the connection with S3 after receiving a
+ * @note If your file requires more than 99 range requests to S3 (depending on
+ * the size of the file and the length specified in RANGE_REQUEST_LENGTH), your
+ * connection may be dropped by S3. In this case, either increase the buffer
+ * size and range request length (if feasible), to reduce the number of requests
+ * required, or re-establish the connection with S3 after receiving a
  * "Connection: close" response header.
  */
 int main( int argc,


### PR DESCRIPTION
Adding a comment to the top of S3 download and multi-threaded download demo source code files, to explain how to handle S3 request limits. This is done to prevent users from treating this case as a bug.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
