### PR TITLE
Block until all data has been read or written in mbedTLS port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AWS IoT Device SDK for Embedded C
 
-This tag [3.1.3](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/v3.1.3) contains the v3 version of AWS IoT Device SDK for Embedded C. No new features will be added to this tag; instead, only bug fixes will be made and minimally tested.
+This tag [3.1.4](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/v3.1.4) contains the v3 version of AWS IoT Device SDK for Embedded C. No new features will be added to this tag; instead, only bug fixes will be made and minimally tested.
 
 
 ## Overview

--- a/platform/linux/mbedtls/network_mbedtls_wrapper.c
+++ b/platform/linux/mbedtls/network_mbedtls_wrapper.c
@@ -270,7 +270,7 @@ IoT_Error_t iot_tls_connect(Network *pNetwork, TLSConnectParams *params) {
 	}
 
 #ifdef ENABLE_IOT_DEBUG
-	if (mbedtls_ssl_get_peer_cert(&(tlsDataParams->ssl)) != NULL) {
+	if(mbedtls_ssl_get_peer_cert(&(tlsDataParams->ssl)) != NULL) {
 		IOT_DEBUG("  . Peer certificate information    ...\n");
 		mbedtls_x509_crt_info((char *) buf, sizeof(buf) - 1, "      ", mbedtls_ssl_get_peer_cert(&(tlsDataParams->ssl)));
 		IOT_DEBUG("%s\n", buf);
@@ -307,7 +307,7 @@ IoT_Error_t iot_tls_write(Network *pNetwork, unsigned char *pMsg, size_t len, Ti
 	init_timer(&writeTimer);
 	countdown_ms(&writeTimer, IOT_SSL_WRITE_RETRY_TIMEOUT_MS);
 
-	while (len > 0) {
+	while(len > 0) {
 		ret = mbedtls_ssl_write(pSsl, pMsg, len);
 
 		if(ret > 0) {
@@ -362,11 +362,11 @@ IoT_Error_t iot_tls_read(Network *pNetwork, unsigned char *pMsg, size_t len, Tim
 	init_timer(&readTimer);
 	countdown_ms(&readTimer, IOT_SSL_READ_RETRY_TIMEOUT_MS);
 
-	while (len > 0) {
+	while(len > 0) {
 		/* This read will timeout after IOT_SSL_READ_TIMEOUT if there's no data to be read */
 		ret = mbedtls_ssl_read(pSsl, pMsg, len);
 
-		if (ret > 0) {
+		if(ret > 0) {
 			if((size_t) ret > len) {
 				IOT_ERROR("More bytes read than requested\n\n");
 				return NETWORK_SSL_WRITE_ERROR;
@@ -379,11 +379,11 @@ IoT_Error_t iot_tls_read(Network *pNetwork, unsigned char *pMsg, size_t len, Tim
 			rxLen += ret;
 			pMsg += ret;
 			len -= ret;
-		} else if (ret == MBEDTLS_ERR_SSL_WANT_READ || 
+		} else if(ret == MBEDTLS_ERR_SSL_WANT_READ || 
 				ret == MBEDTLS_ERR_SSL_WANT_WRITE ||
 				ret == MBEDTLS_ERR_SSL_TIMEOUT) {
 			if(has_timer_expired(&readTimer)) {
-				if (rxLen == 0) {
+				if(rxLen == 0) {
 					return NETWORK_SSL_NOTHING_TO_READ;
 				} else {
 					return NETWORK_SSL_READ_TIMEOUT_ERROR;

--- a/platform/linux/mbedtls/network_mbedtls_wrapper.c
+++ b/platform/linux/mbedtls/network_mbedtls_wrapper.c
@@ -31,7 +31,9 @@ extern "C" {
 
 
 /* This is the value used for ssl read timeout */
-#define IOT_SSL_READ_TIMEOUT 10
+#ifndef IOT_SSL_READ_TIMEOUT
+	#define IOT_SSL_READ_TIMEOUT 10
+#endif
 
 /* This defines the value of the debug buffer that gets allocated.
  * The value can be altered based on memory constraints
@@ -289,7 +291,9 @@ IoT_Error_t iot_tls_connect(Network *pNetwork, TLSConnectParams *params) {
 /* When this much time has elapsed after receiving MBEDTLS_ERR_SSL_WANT_READ
  * or MBEDTLS_ERR_SSL_WANT_WRITE, then iot_tls_write will return
  * NETWORK_SSL_WRITE_TIMEOUT_ERROR. */
-#define IOT_SSL_WRITE_RETRY_TIMEOUT_MS 10
+#ifndef IOT_SSL_WRITE_RETRY_TIMEOUT_MS
+	#define IOT_SSL_WRITE_RETRY_TIMEOUT_MS 10
+#endif
 
 IoT_Error_t iot_tls_write(Network *pNetwork, unsigned char *pMsg, size_t len, Timer *timer, size_t *written_len) {
 	mbedtls_ssl_context *pSsl = &(pNetwork->tlsDataParams.ssl);
@@ -343,7 +347,9 @@ IoT_Error_t iot_tls_write(Network *pNetwork, unsigned char *pMsg, size_t len, Ti
 /* When this much time has elapsed after receiving MBEDTLS_ERR_SSL_WANT_READ,
  * MBEDTLS_ERR_SSL_WANT_WRITE, or MBEDTLS_ERR_SSL_TIMEOUT, then iot_tls_read
  * will return NETWORK_SSL_READ_TIMEOUT_ERROR. */
-#define IOT_SSL_READ_RETRY_TIMEOUT_MS 10
+#ifndef IOT_SSL_READ_RETRY_TIMEOUT_MS
+	#define IOT_SSL_READ_RETRY_TIMEOUT_MS 10
+#endif
 
 IoT_Error_t iot_tls_read(Network *pNetwork, unsigned char *pMsg, size_t len, Timer *timer, size_t *read_len) {
 	mbedtls_ssl_context *pSsl = &(pNetwork->tlsDataParams.ssl);

--- a/platform/linux/mbedtls/network_mbedtls_wrapper.c
+++ b/platform/linux/mbedtls/network_mbedtls_wrapper.c
@@ -31,8 +31,8 @@ extern "C" {
 
 
 /* This is the value used for ssl read timeout */
-#ifndef IOT_SSL_READ_TIMEOUT
-	#define IOT_SSL_READ_TIMEOUT 3
+#ifndef IOT_SSL_READ_TIMEOUT_MS
+	#define IOT_SSL_READ_TIMEOUT_MS 3
 #endif
 
 /* This defines the value of the debug buffer that gets allocated.
@@ -279,7 +279,7 @@ IoT_Error_t iot_tls_connect(Network *pNetwork, TLSConnectParams *params) {
 	}
 #endif
 
-	mbedtls_ssl_conf_read_timeout(&(tlsDataParams->conf), IOT_SSL_READ_TIMEOUT);
+	mbedtls_ssl_conf_read_timeout(&(tlsDataParams->conf), IOT_SSL_READ_TIMEOUT_MS);
 
 #ifdef IOT_SSL_SOCKET_NON_BLOCKING
 	mbedtls_net_set_nonblock(&(tlsDataParams->server_fd));
@@ -369,7 +369,7 @@ IoT_Error_t iot_tls_read(Network *pNetwork, unsigned char *pMsg, size_t len, Tim
 	countdown_ms(&readTimer, IOT_SSL_READ_RETRY_TIMEOUT_MS);
 
 	while(len > 0U) {
-		/* This read will timeout after IOT_SSL_READ_TIMEOUT if there's no data to be read */
+		/* This read will timeout after IOT_SSL_READ_TIMEOUT_MS if there's no data to be read */
 		ret = mbedtls_ssl_read(pSsl, pMsg, len);
 
 		if(ret > 0) {

--- a/platform/linux/mbedtls/network_mbedtls_wrapper.c
+++ b/platform/linux/mbedtls/network_mbedtls_wrapper.c
@@ -307,7 +307,7 @@ IoT_Error_t iot_tls_write(Network *pNetwork, unsigned char *pMsg, size_t len, Ti
 	init_timer(&writeTimer);
 	countdown_ms(&writeTimer, IOT_SSL_WRITE_RETRY_TIMEOUT_MS);
 
-	while(len > 0) {
+	while(len > 0U) {
 		ret = mbedtls_ssl_write(pSsl, pMsg, len);
 
 		if(ret > 0) {
@@ -362,7 +362,7 @@ IoT_Error_t iot_tls_read(Network *pNetwork, unsigned char *pMsg, size_t len, Tim
 	init_timer(&readTimer);
 	countdown_ms(&readTimer, IOT_SSL_READ_RETRY_TIMEOUT_MS);
 
-	while(len > 0) {
+	while(len > 0U) {
 		/* This read will timeout after IOT_SSL_READ_TIMEOUT if there's no data to be read */
 		ret = mbedtls_ssl_read(pSsl, pMsg, len);
 
@@ -375,7 +375,7 @@ IoT_Error_t iot_tls_read(Network *pNetwork, unsigned char *pMsg, size_t len, Tim
 			/* Successfully received data, so reset the timeout */
 			init_timer(&readTimer);
 			countdown_ms(&readTimer, IOT_SSL_READ_RETRY_TIMEOUT_MS);
-			
+
 			rxLen += ret;
 			pMsg += ret;
 			len -= ret;
@@ -383,7 +383,7 @@ IoT_Error_t iot_tls_read(Network *pNetwork, unsigned char *pMsg, size_t len, Tim
 				ret == MBEDTLS_ERR_SSL_WANT_WRITE ||
 				ret == MBEDTLS_ERR_SSL_TIMEOUT) {
 			if(has_timer_expired(&readTimer)) {
-				if(rxLen == 0) {
+				if(rxLen == 0U) {
 					return NETWORK_SSL_NOTHING_TO_READ;
 				} else {
 					return NETWORK_SSL_READ_TIMEOUT_ERROR;

--- a/platform/linux/mbedtls/network_mbedtls_wrapper.c
+++ b/platform/linux/mbedtls/network_mbedtls_wrapper.c
@@ -333,7 +333,6 @@ IoT_Error_t iot_tls_write(Network *pNetwork, unsigned char *pMsg, size_t len, Ti
 			/* All other negative return values indicate connection needs to be reset.
 			 * Will be caught in ping request so ignored here */
 			return NETWORK_SSL_WRITE_ERROR;
-			break;
 		}
 	}
 

--- a/platform/linux/mbedtls/network_mbedtls_wrapper.c
+++ b/platform/linux/mbedtls/network_mbedtls_wrapper.c
@@ -300,6 +300,9 @@ IoT_Error_t iot_tls_write(Network *pNetwork, unsigned char *pMsg, size_t len, Ti
 	 * Timeout is specified by IOT_SSL_READ_RETRY_TIMEOUT_MS. */
 	Timer writeTimer;
 
+	/* This variable is unused */
+	(void) timer;
+
 	/* The timer must be started in case no bytes are written on the first try */
 	init_timer(&writeTimer);
 	countdown_ms(&writeTimer, IOT_SSL_WRITE_RETRY_TIMEOUT_MS);
@@ -308,7 +311,7 @@ IoT_Error_t iot_tls_write(Network *pNetwork, unsigned char *pMsg, size_t len, Ti
 		ret = mbedtls_ssl_write(pSsl, pMsg, len);
 
 		if(ret > 0) {
-			if((size_t)ret > len) {
+			if((size_t) ret > len) {
 				IOT_ERROR("More bytes written than requested\n\n");
 				return NETWORK_SSL_WRITE_ERROR;
 			}
@@ -326,7 +329,7 @@ IoT_Error_t iot_tls_write(Network *pNetwork, unsigned char *pMsg, size_t len, Ti
 				return NETWORK_SSL_WRITE_TIMEOUT_ERROR;
 			}
 		} else {
-			IOT_ERROR(" failed\n  ! mbedtls_ssl_write returned -0x%x\n\n", (unsigned int)-ret);
+			IOT_ERROR(" failed\n  ! mbedtls_ssl_write returned -0x%x\n\n", (unsigned int) -ret);
 			/* All other negative return values indicate connection needs to be reset.
 			 * Will be caught in ping request so ignored here */
 			return NETWORK_SSL_WRITE_ERROR;
@@ -352,6 +355,9 @@ IoT_Error_t iot_tls_read(Network *pNetwork, unsigned char *pMsg, size_t len, Tim
 	 * mbedtls_ssl_read. Timeout is specified by IOT_SSL_READ_RETRY_TIMEOUT_MS. */
 	Timer readTimer;
 
+	/* This variable is unused */
+	(void) timer;
+
 	/* The timer must be started in case no bytes are read on the first try */
 	init_timer(&readTimer);
 	countdown_ms(&readTimer, IOT_SSL_READ_RETRY_TIMEOUT_MS);
@@ -361,7 +367,7 @@ IoT_Error_t iot_tls_read(Network *pNetwork, unsigned char *pMsg, size_t len, Tim
 		ret = mbedtls_ssl_read(pSsl, pMsg, len);
 
 		if (ret > 0) {
-			if((size_t)ret > len) {
+			if((size_t) ret > len) {
 				IOT_ERROR("More bytes read than requested\n\n");
 				return NETWORK_SSL_WRITE_ERROR;
 			}
@@ -384,7 +390,7 @@ IoT_Error_t iot_tls_read(Network *pNetwork, unsigned char *pMsg, size_t len, Tim
 				}
 			}
 		} else {
-			IOT_ERROR("Failed\n  ! mbedtls_ssl_read returned -0x%x\n\n", (unsigned int)-ret);
+			IOT_ERROR("Failed\n  ! mbedtls_ssl_read returned -0x%x\n\n", (unsigned int) -ret);
 			return NETWORK_SSL_READ_ERROR;
 		}
 	}

--- a/platform/linux/mbedtls/network_mbedtls_wrapper.c
+++ b/platform/linux/mbedtls/network_mbedtls_wrapper.c
@@ -35,6 +35,20 @@ extern "C" {
 	#define IOT_SSL_READ_TIMEOUT_MS 3
 #endif
 
+/* When this much time has elapsed after receiving MBEDTLS_ERR_SSL_WANT_READ
+ * or MBEDTLS_ERR_SSL_WANT_WRITE, then iot_tls_write will return
+ * NETWORK_SSL_WRITE_TIMEOUT_ERROR. */
+#ifndef IOT_SSL_WRITE_RETRY_TIMEOUT_MS
+	#define IOT_SSL_WRITE_RETRY_TIMEOUT_MS 10
+#endif
+
+/* When this much time has elapsed after receiving MBEDTLS_ERR_SSL_WANT_READ,
+ * MBEDTLS_ERR_SSL_WANT_WRITE, or MBEDTLS_ERR_SSL_TIMEOUT, then iot_tls_read
+ * will return NETWORK_SSL_READ_TIMEOUT_ERROR. */
+#ifndef IOT_SSL_READ_RETRY_TIMEOUT_MS
+	#define IOT_SSL_READ_RETRY_TIMEOUT_MS 10
+#endif
+
 /* This defines the value of the debug buffer that gets allocated.
  * The value can be altered based on memory constraints
  */
@@ -288,13 +302,6 @@ IoT_Error_t iot_tls_connect(Network *pNetwork, TLSConnectParams *params) {
 	return (IoT_Error_t) ret;
 }
 
-/* When this much time has elapsed after receiving MBEDTLS_ERR_SSL_WANT_READ
- * or MBEDTLS_ERR_SSL_WANT_WRITE, then iot_tls_write will return
- * NETWORK_SSL_WRITE_TIMEOUT_ERROR. */
-#ifndef IOT_SSL_WRITE_RETRY_TIMEOUT_MS
-	#define IOT_SSL_WRITE_RETRY_TIMEOUT_MS 10
-#endif
-
 IoT_Error_t iot_tls_write(Network *pNetwork, unsigned char *pMsg, size_t len, Timer *timer, size_t *written_len) {
 	mbedtls_ssl_context *pSsl = &(pNetwork->tlsDataParams.ssl);
 	size_t txLen = 0U;
@@ -344,13 +351,6 @@ IoT_Error_t iot_tls_write(Network *pNetwork, unsigned char *pMsg, size_t len, Ti
 	*written_len = txLen;
 	return SUCCESS;
 }
-
-/* When this much time has elapsed after receiving MBEDTLS_ERR_SSL_WANT_READ,
- * MBEDTLS_ERR_SSL_WANT_WRITE, or MBEDTLS_ERR_SSL_TIMEOUT, then iot_tls_read
- * will return NETWORK_SSL_READ_TIMEOUT_ERROR. */
-#ifndef IOT_SSL_READ_RETRY_TIMEOUT_MS
-	#define IOT_SSL_READ_RETRY_TIMEOUT_MS 10
-#endif
 
 IoT_Error_t iot_tls_read(Network *pNetwork, unsigned char *pMsg, size_t len, Timer *timer, size_t *read_len) {
 	mbedtls_ssl_context *pSsl = &(pNetwork->tlsDataParams.ssl);

--- a/platform/linux/mbedtls/network_mbedtls_wrapper.c
+++ b/platform/linux/mbedtls/network_mbedtls_wrapper.c
@@ -32,7 +32,7 @@ extern "C" {
 
 /* This is the value used for ssl read timeout */
 #ifndef IOT_SSL_READ_TIMEOUT
-	#define IOT_SSL_READ_TIMEOUT 10
+	#define IOT_SSL_READ_TIMEOUT 3
 #endif
 
 /* This defines the value of the debug buffer that gets allocated.
@@ -330,6 +330,7 @@ IoT_Error_t iot_tls_write(Network *pNetwork, unsigned char *pMsg, size_t len, Ti
 		} else if(ret == MBEDTLS_ERR_SSL_WANT_READ ||
 				ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
 			if(has_timer_expired(&writeTimer)) {
+				*written_len = txLen;
 				return NETWORK_SSL_WRITE_TIMEOUT_ERROR;
 			}
 		} else {
@@ -388,6 +389,7 @@ IoT_Error_t iot_tls_read(Network *pNetwork, unsigned char *pMsg, size_t len, Tim
 				ret == MBEDTLS_ERR_SSL_WANT_WRITE ||
 				ret == MBEDTLS_ERR_SSL_TIMEOUT) {
 			if(has_timer_expired(&readTimer)) {
+				*read_len = rxLen;
 				if(rxLen == 0U) {
 					return NETWORK_SSL_NOTHING_TO_READ;
 				} else {

--- a/platform/linux/mbedtls/network_mbedtls_wrapper.c
+++ b/platform/linux/mbedtls/network_mbedtls_wrapper.c
@@ -297,7 +297,7 @@ IoT_Error_t iot_tls_write(Network *pNetwork, unsigned char *pMsg, size_t len, Ti
 	int ret = 0;
 	/* This timer checks for a timeout whenever MBEDTLS_ERR_SSL_WANT_READ
 	 * or MBEDTLS_ERR_SSL_WANT_WRITE are returned by mbedtls_ssl_write.
-	 * Timeout is specified by IOT_SSL_READ_RETRY_TIMEOUT_MS. */
+	 * Timeout is specified by IOT_SSL_WRITE_RETRY_TIMEOUT_MS. */
 	Timer writeTimer;
 
 	/* This variable is unused */

--- a/samples/linux/jobs_sample/aws_iot_config.h
+++ b/samples/linux/jobs_sample/aws_iot_config.h
@@ -70,4 +70,9 @@
 
 #define DISABLE_METRICS false ///< Disable the collection of metrics by setting this to true
 
+// TLS configs
+#define IOT_SSL_READ_TIMEOUT 10 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
+#define IOT_SSL_READ_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_read when pending data has not yet been received
+#define IOT_SSL_WRITE_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_write when pending data has not yet been written
+
 #endif /* SRC_JOBS_IOT_JOB_CONFIG_H_ */

--- a/samples/linux/jobs_sample/aws_iot_config.h
+++ b/samples/linux/jobs_sample/aws_iot_config.h
@@ -71,7 +71,7 @@
 #define DISABLE_METRICS false ///< Disable the collection of metrics by setting this to true
 
 // TLS configs
-#define IOT_SSL_READ_TIMEOUT 10 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
+#define IOT_SSL_READ_TIMEOUT 3 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
 #define IOT_SSL_READ_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_read when pending data has not yet been received
 #define IOT_SSL_WRITE_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_write when pending data has not yet been written
 

--- a/samples/linux/jobs_sample/aws_iot_config.h
+++ b/samples/linux/jobs_sample/aws_iot_config.h
@@ -71,7 +71,7 @@
 #define DISABLE_METRICS false ///< Disable the collection of metrics by setting this to true
 
 // TLS configs
-#define IOT_SSL_READ_TIMEOUT 3 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
+#define IOT_SSL_READ_TIMEOUT_MS 3 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
 #define IOT_SSL_READ_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_read when pending data has not yet been received
 #define IOT_SSL_WRITE_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_write when pending data has not yet been written
 

--- a/samples/linux/shadow_sample/aws_iot_config.h
+++ b/samples/linux/shadow_sample/aws_iot_config.h
@@ -55,4 +55,9 @@
 
 #define DISABLE_METRICS false ///< Disable the collection of metrics by setting this to true
 
+// TLS configs
+#define IOT_SSL_READ_TIMEOUT 10 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
+#define IOT_SSL_READ_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_read when pending data has not yet been received
+#define IOT_SSL_WRITE_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_write when pending data has not yet been written
+
 #endif /* SRC_SHADOW_IOT_SHADOW_CONFIG_H_ */

--- a/samples/linux/shadow_sample/aws_iot_config.h
+++ b/samples/linux/shadow_sample/aws_iot_config.h
@@ -56,7 +56,7 @@
 #define DISABLE_METRICS false ///< Disable the collection of metrics by setting this to true
 
 // TLS configs
-#define IOT_SSL_READ_TIMEOUT 3 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
+#define IOT_SSL_READ_TIMEOUT_MS 3 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
 #define IOT_SSL_READ_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_read when pending data has not yet been received
 #define IOT_SSL_WRITE_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_write when pending data has not yet been written
 

--- a/samples/linux/shadow_sample/aws_iot_config.h
+++ b/samples/linux/shadow_sample/aws_iot_config.h
@@ -56,7 +56,7 @@
 #define DISABLE_METRICS false ///< Disable the collection of metrics by setting this to true
 
 // TLS configs
-#define IOT_SSL_READ_TIMEOUT 10 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
+#define IOT_SSL_READ_TIMEOUT 3 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
 #define IOT_SSL_READ_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_read when pending data has not yet been received
 #define IOT_SSL_WRITE_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_write when pending data has not yet been written
 

--- a/samples/linux/shadow_sample_console_echo/aws_iot_config.h
+++ b/samples/linux/shadow_sample_console_echo/aws_iot_config.h
@@ -55,4 +55,9 @@
 
 #define DISABLE_METRICS false ///< Disable the collection of metrics by setting this to true
 
+// TLS configs
+#define IOT_SSL_READ_TIMEOUT 10 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
+#define IOT_SSL_READ_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_read when pending data has not yet been received
+#define IOT_SSL_WRITE_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_write when pending data has not yet been written
+
 #endif /* SRC_SHADOW_IOT_SHADOW_CONFIG_H_ */

--- a/samples/linux/shadow_sample_console_echo/aws_iot_config.h
+++ b/samples/linux/shadow_sample_console_echo/aws_iot_config.h
@@ -56,7 +56,7 @@
 #define DISABLE_METRICS false ///< Disable the collection of metrics by setting this to true
 
 // TLS configs
-#define IOT_SSL_READ_TIMEOUT 3 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
+#define IOT_SSL_READ_TIMEOUT_MS 3 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
 #define IOT_SSL_READ_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_read when pending data has not yet been received
 #define IOT_SSL_WRITE_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_write when pending data has not yet been written
 

--- a/samples/linux/shadow_sample_console_echo/aws_iot_config.h
+++ b/samples/linux/shadow_sample_console_echo/aws_iot_config.h
@@ -56,7 +56,7 @@
 #define DISABLE_METRICS false ///< Disable the collection of metrics by setting this to true
 
 // TLS configs
-#define IOT_SSL_READ_TIMEOUT 10 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
+#define IOT_SSL_READ_TIMEOUT 3 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
 #define IOT_SSL_READ_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_read when pending data has not yet been received
 #define IOT_SSL_WRITE_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_write when pending data has not yet been written
 

--- a/samples/linux/subscribe_publish_library_sample/aws_iot_config.h
+++ b/samples/linux/subscribe_publish_library_sample/aws_iot_config.h
@@ -55,4 +55,9 @@
 
 #define DISABLE_METRICS false ///< Disable the collection of metrics by setting this to true
 
+// TLS configs
+#define IOT_SSL_READ_TIMEOUT 10 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
+#define IOT_SSL_READ_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_read when pending data has not yet been received
+#define IOT_SSL_WRITE_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_write when pending data has not yet been written
+
 #endif /* SRC_SHADOW_IOT_SHADOW_CONFIG_H_ */

--- a/samples/linux/subscribe_publish_library_sample/aws_iot_config.h
+++ b/samples/linux/subscribe_publish_library_sample/aws_iot_config.h
@@ -56,7 +56,7 @@
 #define DISABLE_METRICS false ///< Disable the collection of metrics by setting this to true
 
 // TLS configs
-#define IOT_SSL_READ_TIMEOUT 3 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
+#define IOT_SSL_READ_TIMEOUT_MS 3 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
 #define IOT_SSL_READ_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_read when pending data has not yet been received
 #define IOT_SSL_WRITE_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_write when pending data has not yet been written
 

--- a/samples/linux/subscribe_publish_library_sample/aws_iot_config.h
+++ b/samples/linux/subscribe_publish_library_sample/aws_iot_config.h
@@ -56,7 +56,7 @@
 #define DISABLE_METRICS false ///< Disable the collection of metrics by setting this to true
 
 // TLS configs
-#define IOT_SSL_READ_TIMEOUT 10 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
+#define IOT_SSL_READ_TIMEOUT 3 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
 #define IOT_SSL_READ_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_read when pending data has not yet been received
 #define IOT_SSL_WRITE_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_write when pending data has not yet been written
 

--- a/samples/linux/subscribe_publish_sample/aws_iot_config.h
+++ b/samples/linux/subscribe_publish_sample/aws_iot_config.h
@@ -55,4 +55,9 @@
 
 #define DISABLE_METRICS false ///< Disable the collection of metrics by setting this to true
 
+// TLS configs
+#define IOT_SSL_READ_TIMEOUT 10 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
+#define IOT_SSL_READ_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_read when pending data has not yet been received
+#define IOT_SSL_WRITE_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_write when pending data has not yet been written
+
 #endif /* SRC_SHADOW_IOT_SHADOW_CONFIG_H_ */

--- a/samples/linux/subscribe_publish_sample/aws_iot_config.h
+++ b/samples/linux/subscribe_publish_sample/aws_iot_config.h
@@ -56,7 +56,7 @@
 #define DISABLE_METRICS false ///< Disable the collection of metrics by setting this to true
 
 // TLS configs
-#define IOT_SSL_READ_TIMEOUT 3 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
+#define IOT_SSL_READ_TIMEOUT_MS 3 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
 #define IOT_SSL_READ_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_read when pending data has not yet been received
 #define IOT_SSL_WRITE_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_write when pending data has not yet been written
 

--- a/samples/linux/subscribe_publish_sample/aws_iot_config.h
+++ b/samples/linux/subscribe_publish_sample/aws_iot_config.h
@@ -56,7 +56,7 @@
 #define DISABLE_METRICS false ///< Disable the collection of metrics by setting this to true
 
 // TLS configs
-#define IOT_SSL_READ_TIMEOUT 10 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
+#define IOT_SSL_READ_TIMEOUT 3 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
 #define IOT_SSL_READ_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_read when pending data has not yet been received
 #define IOT_SSL_WRITE_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_write when pending data has not yet been written
 

--- a/src/aws_iot_mqtt_client.c
+++ b/src/aws_iot_mqtt_client.c
@@ -142,9 +142,9 @@ IoT_Error_t aws_iot_mqtt_set_client_state(AWS_IoT_Client *pClient, ClientState e
 	}
 
 #ifdef _ENABLE_THREAD_SUPPORT_
-	rc = aws_iot_mqtt_client_lock_mutex(pClient, &(pClient->clientData.state_change_mutex));
-	if(SUCCESS != rc) {
-		return rc;
+	threadRc = aws_iot_mqtt_client_lock_mutex(pClient, &(pClient->clientData.state_change_mutex));
+	if(SUCCESS != threadRc) {
+		return threadRc;
 	}
 #endif
 	if(expectedCurrentState == aws_iot_mqtt_get_client_state(pClient)) {

--- a/tests/integration/include/aws_iot_config.h
+++ b/tests/integration/include/aws_iot_config.h
@@ -66,7 +66,7 @@
 #define DISABLE_METRICS false ///< Disable the collection of metrics by setting this to true
 
 // TLS configs
-#define IOT_SSL_READ_TIMEOUT 10 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
+#define IOT_SSL_READ_TIMEOUT 3 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
 #define IOT_SSL_READ_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_read when pending data has not yet been received
 #define IOT_SSL_WRITE_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_write when pending data has not yet been written
 

--- a/tests/integration/include/aws_iot_config.h
+++ b/tests/integration/include/aws_iot_config.h
@@ -66,7 +66,7 @@
 #define DISABLE_METRICS false ///< Disable the collection of metrics by setting this to true
 
 // TLS configs
-#define IOT_SSL_READ_TIMEOUT 3 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
+#define IOT_SSL_READ_TIMEOUT_MS 3 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
 #define IOT_SSL_READ_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_read when pending data has not yet been received
 #define IOT_SSL_WRITE_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_write when pending data has not yet been written
 

--- a/tests/integration/include/aws_iot_config.h
+++ b/tests/integration/include/aws_iot_config.h
@@ -65,4 +65,9 @@
 
 #define DISABLE_METRICS false ///< Disable the collection of metrics by setting this to true
 
+// TLS configs
+#define IOT_SSL_READ_TIMEOUT 10 ///< Timeout associated with underlying socket of TLS connection (set by mbedtls_ssl_conf_read_timeout)
+#define IOT_SSL_READ_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_read when pending data has not yet been received
+#define IOT_SSL_WRITE_RETRY_TIMEOUT_MS 10 ///< Minimum elapsed time before returning from iot_tls_write when pending data has not yet been written
+
 #endif /* SRC_SHADOW_IOT_SHADOW_CONFIG_H_ */


### PR DESCRIPTION
- `iot_tls_write` and `iot_tls_read` used to return an error when the actual number of sent/received bytes did not match the requested bytes. As such, an appropriate update is made to update these functions to block until the entire payload has been sent or received. This requires allocating new timers with configurable timeouts, `IOT_SSL_WRITE_RETRY_TIMEOUT_MS` and `IOT_SSL_READ_RETRY_TIMEOUT_MS`. Keep in mind that the dependency on the old yield timer is removed so that we never break out of the loop even though the yield timer has expired.
    - `iot_tls_write`: When the write timer expires and`MBEDTLS_ERR_SSL_WANT_WRITE` or `MBEDTLS_ERR_SSL_TIMEOUT` are returned by `mbedtls_ssl_write`.  `NETWORK_SSL_WRITE_TIMEOUT_ERROR` is appropriately returned by `iot_tls_write`.
    - `iot_tls_read`: When the read timer expires and `MBEDTLS_ERR_SSL_WANT_READ`, `MBEDTLS_ERR_SSL_WANT_WRITE`, or `MBEDTLS_ERR_SSL_TIMEOUT` are returned by `mbedtls_ssl_read`. `NETWORK_SSL_READ_TIMEOUT_ERROR` is appropriately returned by `iot_tls_read`.
- Another change is made so that when the number of sent/received bytes is larger than the number of requested bytes, then `NETWORK_SSL_WRITE_ERROR` or `NETWORK_SSL_READ_ERROR` is appropriately returned.
- In `aws_iot_mqtt_set_client_state`, whenever `_ENABLE_THREAD_SUPPORT_` was defined, `aws_iot_mqtt_client_lock_mutex` would return its status to `rc` rather than `threadRc`. While this won't make any difference in terms of functionality, this fix needs to be made for consistency and code hygiene.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
