### PR TITLE
Add instructions about OTA, Jobs, PKCS11 demos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
         * [Prerequisites for the AWS Over-The-Air Update (OTA) demos](#prerequisites-for-the-aws-over-the-air-update-ota-demos)
         * [Scheduling an OTA Update Job](#scheduling-an-ota-update-job)
         * [Build Steps](#build-steps)
+        * [Running corePKCS11 demos](#running-corepkcs11-demos)
         * [Alternative option of Docker containers for running demos locally](#alternative-option-of-docker-containers-for-running-demos-locally)
             * [Installing Mosquitto to run MQTT demos locally](#installing-mosquitto-to-run-mqtt-demos-locally)
             * [Installing httpbin to run HTTP demos locally](#installing-httpbin-to-run-http-demos-locally)
@@ -389,6 +390,15 @@ After you build and run the initial executable you will have to create another e
 * Run *cmake* while inside build directory: `cmake ..`
 * Run this command to build the demos: `make`
 * Go to the `build/bin` directory and run any demo executables from there.
+
+#### Running corePKCS11 demos
+
+The corePKCS11 demos do not require any AWS IoT resources setup, and are standalone. The demos build upon each other to introduce concepts in PKCS #11 sequentially. Below is the recommended order.
+1. `pkcs11_demo_managaement_and_rng`
+1. `pkcs11_demo_mechanisms_and_digests`
+1. `pkcs11_demo_objects`
+1. `pkcs11_demo_sign_and_verify`
+    1. Please note that this demo requires the private and public key generated from `pkcs11_demo_objects` to be in the directory the demo is executed from.
 
 #### Alternative option of Docker containers for running demos locally
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@
         * [AWS IoT Account Setup](#aws-iot-account-setup)
         * [Configuring the mutual auth demos](#configuring-the-mutual-auth-demos)
         * [Configuring the S3 demos](#configuring-the-s3-demos)
+        * [Setup for AWS IoT Jobs demo](#setup-for-aws-iot-jobs-demo)
+        * [Prerequisites for the AWS Over-The-Air Update (OTA) demos](#prerequisites-for-the-aws-over-the-air-update-ota-demos)
+        * [Scheduling an OTA Update Job](#scheduling-an-ota-update-job)
         * [Build Steps](#build-steps)
         * [Alternative option of Docker containers for running demos locally](#alternative-option-of-docker-containers-for-running-demos-locally)
             * [Installing Mosquitto to run MQTT demos locally](#installing-mosquitto-to-run-mqtt-demos-locally)
@@ -329,7 +332,7 @@ You can generate the presigned urls using [demos/http/common/src/presigned_urls_
 
 #### Setup for AWS IoT Jobs demo
 
-1. The demo requires the Linux platform to contain curl and libmosquitto which can be installed with:
+1. The demo requires the Linux platform to contain curl and libmosquitto. On a Debian platform, these dependencies can be installed with:
 
 ```
     apt install curl libmosquitto-dev

--- a/README.md
+++ b/README.md
@@ -284,7 +284,8 @@ Dependency | Version | Usage
 
 #### AWS IoT Account Setup
 
-You need to setup an AWS account and access the AWS IoT console for running the AWS IoT Device Shadow library, AWS IoT Device Defender library, AWS IoT Jobs library and coreHTTP S3 download demos. 
+You need to setup an AWS account and access the AWS IoT console for running the AWS IoT Device Shadow library, AWS IoT Device Defender library, AWS IoT Jobs library, 
+AWS IoT OTA library and coreHTTP S3 download demos. 
 Also, the AWS account can be used for running the MQTT mutual auth demo can be run against AWS IoT broker.
 Also, running the AWS IoT Device Defender, AWS IoT Jobs and AWS IoT Device Shadow library demos require the setup of a Thing Name resource for the device running the
 demo.

--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ You can generate the presigned urls using [demos/http/common/src/presigned_urls_
 ```
     apt install curl libmosquitto-dev
 ```
+If the platform does not contain the `libmosquitto` library, the demo will build the library from source.
 
 `libmosquitto` 1.4.10 or any later version of the first major release is required to run this demo.
 

--- a/docs/doxygen/building.dox
+++ b/docs/doxygen/building.dox
@@ -39,11 +39,11 @@ cmake .. -DAWS_IOT_ENDPOINT="aws-iot-endpoint" -DROOT_CA_CERT_PATH="root-ca-path
 
 	- Set `AWS_IOT_ENDPOINT` to your custom endpoint. This is found on the *Settings* page of the AWS IoT Console and has a format of `ABCDEFG1234567.iot.us-east-2.amazonaws.com`.
 
-	- Set `ROOT_CA_CERT_PATH` to the path of the root CA certificate downloaded when setting up the device certificate (or Provisioning Claim for Fleet Provisioning) in [AWS IoT Account Setup](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/main#aws-iot-account-setup).
+	- Set `ROOT_CA_CERT_PATH` to the path of the root CA certificate downloaded when setting up the device certificate in [AWS IoT Account Setup](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/main#aws-iot-account-setup).
 
-	- Set `CLIENT_CERT_PATH` to the path of the client certificate downloaded when setting up the device certificate (or Provisioning Claim for Fleet Provisioning) in [AWS IoT Account Setup](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/main#aws-iot-account-setup).
+	- Set `CLIENT_CERT_PATH` to the path of the client certificate downloaded when setting up the device certificate in [AWS IoT Account Setup](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/main#aws-iot-account-setup).
 
-	- Set `CLIENT_PRIVATE_KEY_PATH` to the path of the private key downloaded when setting up the device certificate (or Provisioning Claim for Fleet Provisioning) in [AWS IoT Account Setup](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/main#aws-iot-account-setup).
+	- Set `CLIENT_PRIVATE_KEY_PATH` to the path of the private key downloaded when setting up the device certificate in [AWS IoT Account Setup](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/main#aws-iot-account-setup).
 
 @section configuring_s3_demos Configuring the HTTP S3 Demos
 @brief Generating pre-signed URLs and passing configuration settings to run the S3 upload, download, and multi-threaded download demos.


### PR DESCRIPTION
Update README with instructions for OTA and Jobs demos along with link to setup a **Thing resource** in their AWS account (required for AWS specific libraries)