### PR TITLE
Add README.md for generate_docs.py script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ The Doxygen references were created using Doxygen version 1.8.20. To generate th
 ```sh
 cd <CSDK_ROOT>
 git submodule update --init --recursive --checkout
-python3 tools/doxygen/generate_docs.py --root .
+python3 tools/doxygen/generate_docs.py
 ```
 
 The generated documentation landing page is located at `docs/doxygen/output/html/index.html`.

--- a/tools/doxygen/README.md
+++ b/tools/doxygen/README.md
@@ -10,13 +10,13 @@
 This script generates all of the Doxygen documentation for the CSDK and its
 library spoke repos.
 Any Doxygen warnings from generation will print out to the console.
-Optionally one can also choose to zip up the generated Doxygen documentation.
+Optionally, one can also choose to zip up the generated Doxygen documentation.
 
 ## Usage
 
 ### Preliminary
 
-Ensure that all of the library spoke repos are cloned before running this script.
+Ensure that all of the library spoke repositories are cloned before running this script.
 
 ```console
 cd aws-iot-device-sdk-embedded-C

--- a/tools/doxygen/README.md
+++ b/tools/doxygen/README.md
@@ -7,9 +7,10 @@
 
 ## Output
 
-This script generate all of the Doxygen for the CSDK and its library spoke repos.
+This script generates all of the Doxygen documentation for the CSDK and its
+library spoke repos.
 Any Doxygen warnings from generation will print out to the console.
-Optionally one can also choose to zip up the generated Doxygen as well.
+Optionally one can also choose to zip up the generated Doxygen documentation.
 
 ## Usage
 
@@ -23,6 +24,8 @@ git submodule update --init --checkout libraries/standard libraries/aws
 ```
 
 ### Generate Doxygen
+
+You can run this script from anywhere with the path to the CSDK repo root.
 
 ```console
 python3 generate_docs.py --root <CSDK_REPO_ROOT>

--- a/tools/doxygen/README.md
+++ b/tools/doxygen/README.md
@@ -1,0 +1,45 @@
+# Generate all Doxygen
+
+## Prerequisites
+
+- [Git](https://git-scm.com/downloads/)
+- [Python 3+](https://www.python.org/downloads/)
+
+## Output
+
+This script generate all of the Doxygen for the CSDK and its library spoke repos.
+Any Doxygen warnings from generation will print out to the console.
+Optionally one can also choose to zip up the generated Doxygen as well.
+
+## Usage
+
+### Preliminary
+
+Ensure that all of the library spoke repos are cloned before running this script.
+
+```console
+cd aws-iot-device-sdk-embedded-C
+git submodule update --init --checkout libraries/standard libraries/aws
+```
+
+### Generate Doxygen
+
+```console
+python3 generate_docs.py --root <CSDK_REPO_ROOT>
+```
+
+If the `--root` option is not given, then the script assumes the current working
+directory is the CSDK repo root.
+
+```console
+python3 tools/doxygen/generate_docs.py
+```
+
+### Generate Doxygen Zipfile
+
+Pass the `--zip` or `-z` option to create a zip file named "**doxygen.zip**" in the
+current working directory.
+
+```console
+python3 tools/doxygen/generate_docs.py --zip
+```

--- a/tools/doxygen/generate_docs.py
+++ b/tools/doxygen/generate_docs.py
@@ -48,11 +48,15 @@ def main():
     Generate documentation and optionally zip it up.
     """
     parser = argparse.ArgumentParser(description="Generate all doxygen and optionally zip it.")
-    parser.add_argument("-r", "--root", action="store", required=True, dest="root", help="CSDK repo root path.")
-    parser.add_argument("-z", "--zip", action="store_true", required=False, help="Zip all doxygen output")
+    parser.add_argument("-r", "--root", action="store", required=False, dest="root", help="CSDK repo root path. This defaults to the current working directory.")
+    parser.add_argument("-z", "--zip", action="store_true", required=False, help="Zip all doxygen output.")
     args = parser.parse_args()
     sdk_root = args.root
     doZip = args.zip
+
+    # If the root folder is not give, use the current working directory.
+    if( sdk_root == None ):
+        sdk_root = os.getcwd()
 
     # Get the absolute paths to all of the libraries in the CSDK.
     abs_sdk_root = os.path.abspath(sdk_root)


### PR DESCRIPTION
For consistency with other Python scripts in this repo, I add a README.md for generate all of the docs.
I also update the script to use the CWD as the CSDK root if --root is not given as a parameter.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
