### PR TITLE
Always reset resubscribe flags on disconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AWS IoT Device SDK for Embedded C
 
-This tag [3.1.4](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/v3.1.4) contains the v3 version of AWS IoT Device SDK for Embedded C. No new features will be added to this tag; instead, only bug fixes will be made and minimally tested.
+This tag [3.1.5](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/v3.1.5) contains the v3 version of AWS IoT Device SDK for Embedded C. No new features will be added to this tag; instead, only bug fixes will be made and minimally tested.
 
 
 ## Overview

--- a/src/aws_iot_mqtt_client_yield.c
+++ b/src/aws_iot_mqtt_client_yield.c
@@ -241,6 +241,11 @@ static IoT_Error_t _aws_iot_mqtt_internal_yield(AWS_IoT_Client *pClient, uint32_
 
 		if(NETWORK_DISCONNECTED_ERROR == yieldRc) {
 			pClient->clientData.counterNetworkDisconnected++;
+			/* Always clear resubscribe flags. */
+			for(itr = 0; itr < AWS_IOT_MQTT_NUM_SUBSCRIBE_HANDLERS; itr++) {
+				pClient->clientData.messageHandlers[itr].resubscribed = 0;
+			}
+
 			if(1 == pClient->clientStatus.isAutoReconnectEnabled) {
 				yieldRc = aws_iot_mqtt_set_client_state(pClient, CLIENT_STATE_DISCONNECTED_ERROR,
 														CLIENT_STATE_PENDING_RECONNECT);
@@ -250,10 +255,6 @@ static IoT_Error_t _aws_iot_mqtt_internal_yield(AWS_IoT_Client *pClient, uint32_
 
 				pClient->clientData.currentReconnectWaitInterval = AWS_IOT_MQTT_MIN_RECONNECT_WAIT_INTERVAL;
 				countdown_ms(&(pClient->reconnectDelayTimer), pClient->clientData.currentReconnectWaitInterval);
-
-				for(itr = 0; itr < AWS_IOT_MQTT_NUM_SUBSCRIBE_HANDLERS; itr++) {
-					pClient->clientData.messageHandlers[itr].resubscribed = 0;
-				}
 
 				/* Depending on timer values, it is possible that yield timer has expired
 				 * Set to rc to attempting reconnect to inform client that autoreconnect


### PR DESCRIPTION
*Issue #, if available:*
#1510

*Description of changes:*
On disconnect, resets the resubscribe flags so that topics will be resubscribed to when `aws_iot_mqtt_attempt_reconnect` is manually invoked.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
