### PR TITLE
Upload doxygen output artifact in CI checks for mainline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,8 +191,7 @@ jobs:
           python-version: '3.x'
       - name: Generate doxygen output
         run: |
-          echo $GITHUB_REF
-          if [[ "$GITHUB_REF" == "refs/head/main" ]]; then
+          if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
             echo 'Generate ZIP artifact of doxygen output'
             python3 tools/doxygen/generate_docs.py --root . --zip
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,23 +185,25 @@ jobs:
         run: |
           wget -qO- "http://doxygen.nl/files/doxygen-1.8.20.linux.bin.tar.gz" | sudo tar --strip-components=1 -xz -C /usr/local
           sudo apt-get install -y libclang-9-dev graphviz
-      - name: Run Doxygen on all library submodules
+      - name: Install Python3
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Generate doxygen output
         run: |
-          ROOT=$PWD
-          for lib in $(find libraries/aws libraries/standard -maxdepth 1 -mindepth 1)
-          do
-            cd $lib
-            if [ ! -d docs/doxygen/ ]; then
-              echo "$lib has no Doxygen documentation."
-            else
-              doxygen docs/doxygen/config.doxyfile
-            fi
-            cd $ROOT
-          done
-      - name: Run Doxygen on CSDK and verify stdout is empty
-        run: |
-          doxygen docs/doxygen/config.doxyfile 2>&1 | tee doxyoutput.txt
-          if [[ "$(wc -c < doxyoutput.txt | bc)" = "0" ]]; then exit 0; else exit 1; fi
+          echo $GITHUB_REF
+          if [[ "$GITHUB_REF" == "refs/head/main" ]]; then
+            echo 'Generate ZIP artifact of doxygen output'
+            python3 tools/doxygen/generate_docs.py --root . --zip
+          else
+            python3 tools/doxygen/generate_docs.py --root .
+          fi
+      - name: Upload doxygen artifact if main branch
+        if: success() && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v2
+        with:
+          name: doxygen.zip
+          path: ./doxygen.zip
   git-secrets:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,7 @@ jobs:
         with:
           name: doxygen.zip
           path: ./doxygen.zip
+          retention-days: 2
   git-secrets:
     runs-on: ubuntu-latest
     steps:

--- a/tools/doxygen/generate_docs.py
+++ b/tools/doxygen/generate_docs.py
@@ -97,9 +97,9 @@ def main():
 
     # Return failure exit code if doxygen generation resulted in warnings.
     if doxygen_warnings_flag == False:
-        sys.exit(1)
-    else:
         sys.exit(0)
+    else:
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/tools/doxygen/generate_docs.py
+++ b/tools/doxygen/generate_docs.py
@@ -5,7 +5,8 @@ import argparse
 import os
 import zipfile
 
-
+# Executes the passed command in a shell subprocess.
+# Returns True if any output is received from the shell process.
 def run_cmd(cmd):
     """
     Execute the input command on the shell.
@@ -22,7 +23,7 @@ def run_cmd(cmd):
             timeout=180,
         )
         print( result.stdout )
-        return result.stdout
+        return (len(result.stdout) > 0)
     except subprocess.CalledProcessError as e:
         result = e.stdout
         return result
@@ -62,6 +63,7 @@ def main():
     abs_sdk_root = os.path.abspath(sdk_root)
     abs_lib_paths = get_lib_paths(abs_sdk_root)
     abs_doxy_paths = []
+    doxygen_warnings_flag = False
 
     # Generate the doxygen for all of the libraries.
     for abs_lib_path in abs_lib_paths:
@@ -69,17 +71,18 @@ def main():
         if os.path.exists(abs_doxy_path):
             os.chdir(abs_lib_path)
             print(abs_lib_path)
-            run_cmd("doxygen docs/doxygen/config.doxyfile")
+            # If there is something printed by doxygen, then it represents a warning.
+            doxygen_warnings_flag = run_cmd("doxygen docs/doxygen/config.doxyfile") or doxygen_warnings_flag
             abs_doxy_paths.append(abs_doxy_path)
 
     # Generate the doxygen for the CSDK last to use the tags from the libraries.
     os.chdir(abs_sdk_root)
     print(abs_sdk_root)
-    run_cmd("doxygen docs/doxygen/config.doxyfile")
+    doxygen_warnings_flag = run_cmd("doxygen docs/doxygen/config.doxyfile") or doxygen_warnings_flag
     abs_doxy_paths.append(os.path.join(abs_sdk_root, "docs", "doxygen"))
 
     # Zip up if desired.
-    if doZip:
+    if not(doxygen_warnings_flag) and doZip:
         print(f"Zipping up to {abs_sdk_root}{os.path.sep}doxygen.zip...")
         doxy_zip = zipfile.ZipFile("doxygen.zip", mode="w")
         try:
@@ -92,6 +95,11 @@ def main():
         finally:
             doxy_zip.close()
 
+    # Return failure exit code if doxygen generation resulted in warnings.
+    if doxygen_warnings_flag == False:
+        sys.exit(1)
+    else:
+        sys.exit(0)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
**Update the existing doxygen step of the ci.yml workflow to upload the doxygen output artifact when CI checks run on the mainline branch.** 
This helps automate the activity of generating doxygen manual for the repository for releases. 
This PR also performs the _hygiene_ task of updating the doxygen step to invoke the existing `generate_doxygen.py` script to test doxygen generation as well generate the ZIP output.

Example run of the job for `main` branch (on my fork):
https://github.com/aggarw13/aws-iot-device-sdk-embedded-C/actions/runs/436778585
**Note that the `doxygen` job creates and uploads ZIP artifact ONLY for the `main` branch**


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
