### PR TITLE
Wait for OTA Agent thread to terminate in demos

### DIFF
--- a/demos/ota/ota_demo_core_http/ota_demo_core_http.c
+++ b/demos/ota/ota_demo_core_http/ota_demo_core_http.c
@@ -2007,7 +2007,7 @@ static int startOTADemo( void )
                                otaStatistics.otaPacketsDropped ) );
 
                     /* Delay if mqtt process loop is set to zero.*/
-                    if( !( MQTT_PROCESS_LOOP_TIMEOUT_MS > 0 ) )
+                    if( MQTT_PROCESS_LOOP_TIMEOUT_MS > 0 )
                     {
                         Clock_SleepMs( OTA_EXAMPLE_LOOP_SLEEP_PERIOD_MS );
                     }
@@ -2045,6 +2045,17 @@ static int startOTADemo( void )
                 }
             }
         }
+    }
+
+    /****************************** Wait for OTA Thread. ******************************/
+
+    returnStatus = pthread_join( threadHandle, NULL );
+
+    if( returnStatus != 0 )
+    {
+        LogError( ( "Failed to join thread"
+                    ",error code = %d",
+                    returnStatus ) );
     }
 
     return returnStatus;

--- a/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
+++ b/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
@@ -1575,7 +1575,7 @@ static int startOTADemo( void )
                                otaStatistics.otaPacketsDropped ) );
 
                     /* Delay if mqtt process loop is set to zero.*/
-                    if( !( MQTT_PROCESS_LOOP_TIMEOUT_MS > 0 ) )
+                    if( MQTT_PROCESS_LOOP_TIMEOUT_MS > 0 )
                     {
                         Clock_SleepMs( OTA_EXAMPLE_LOOP_SLEEP_PERIOD_MS );
                     }
@@ -1610,6 +1610,16 @@ static int startOTADemo( void )
                 }
             }
         }
+    }
+
+    /****************************** Wait for OTA Thread. ******************************/
+
+    returnStatus = pthread_join( threadHandle, NULL );
+    if( returnStatus != 0 )
+    {
+        LogError( ( "Failed to join thread"
+                    ",errno=%d",
+                    returnStatus ) );
     }
 
     return returnStatus;

--- a/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
+++ b/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
@@ -1615,10 +1615,11 @@ static int startOTADemo( void )
     /****************************** Wait for OTA Thread. ******************************/
 
     returnStatus = pthread_join( threadHandle, NULL );
+
     if( returnStatus != 0 )
     {
         LogError( ( "Failed to join thread"
-                    ",errno=%d",
+                    ",error code = %d",
                     returnStatus ) );
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Add pthread join to the OTA over MQTT and HTTP demos 
* Remove incorrect condition when setting the OTA demo task to sleep


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
