### PR TITLE
Remove unused packet timeout

### DIFF
--- a/include/aws_iot_mqtt_client.h
+++ b/include/aws_iot_mqtt_client.h
@@ -266,6 +266,7 @@ typedef struct _ClientStatus {
 typedef struct _ClientData {
 	uint16_t nextPacketId; ///< Packet ID to use for the next generated packet
 
+	/* Packet timeout is unused. See https://github.com/aws/aws-iot-device-sdk-embedded-C/pull/1475 */
 	uint32_t packetTimeoutMs; ///< Timeout for reading incoming packets from the network
 	uint32_t commandTimeoutMs; ///< Timeout for processing outgoing MQTT packets
 	uint16_t keepAliveInterval; ///< Maximum interval between control packets

--- a/src/aws_iot_mqtt_client_common_internal.c
+++ b/src/aws_iot_mqtt_client_common_internal.c
@@ -428,9 +428,6 @@ static IoT_Error_t _aws_iot_mqtt_internal_read_packet(AWS_IoT_Client *pClient, T
 	IoT_Error_t rc;
     size_t offset = 0;
 	MQTTHeader header = {0};
-	Timer packetTimer;
-	init_timer(&packetTimer);
-	countdown_ms(&packetTimer, pClient->clientData.packetTimeoutMs);
 
 	rem_len = 0;
 	total_bytes_read = 0;


### PR DESCRIPTION
*Issue #, if available:*
#1517
*Description of changes:*
The packet receive timeout from `pClient->clientData.packetTimeoutMs` was not being used when receiving packets. This seems to be due to #177, which had removed the assignment of `&packetTimer` to `pTimer` before decoding the remaining length. However, due to #1475, the read timeout is instead controlled by `IOT_SSL_READ_RETRY_TIMEOUT_MS`, so the unused timer implementation is removed to avoid confusion

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
