### PR TITLE
Fix Defender Demo warnings

### DIFF
--- a/demos/defender/defender_demo_json/metrics_collector.c
+++ b/demos/defender/defender_demo_json/metrics_collector.c
@@ -87,10 +87,10 @@ static MetricsCollectorStatus_t getOpenPorts( const char * pProcFile,
     {
         LogError( ( "Invalid parameters. pProcFile: %p, pOutPortsArray: %p,"
                     " portsArrayLength: %u, pOutNumOpenPorts: %p.",
-                    pProcFile,
-                    pOutPortsArray,
+                    ( void * ) pProcFile,
+                    ( void * ) pOutPortsArray,
                     portsArrayLength,
-                    pOutNumOpenPorts ) );
+                    ( void * ) pOutNumOpenPorts ) );
         status = MetricsCollectorBadParameter;
     }
 
@@ -181,7 +181,7 @@ MetricsCollectorStatus_t GetNetworkStats( NetworkStats_t * pOutNetworkStats )
 
     if( pOutNetworkStats == NULL )
     {
-        LogError( ( "Invalid parameter. pOutNetworkStats: %p.", pOutNetworkStats ) );
+        LogError( ( "Invalid parameter. pOutNetworkStats: %p.", ( void * ) pOutNetworkStats ) );
         status = MetricsCollectorBadParameter;
     }
 
@@ -288,9 +288,9 @@ MetricsCollectorStatus_t GetEstablishedConnections( Connection_t * pOutConnectio
     {
         LogError( ( "Invalid parameters. pOutConnectionsArray: %p,"
                     " connectionsArrayLength: %u, pOutNumEstablishedConnections: %p.",
-                    pOutConnectionsArray,
+                    ( void * ) pOutConnectionsArray,
                     connectionsArrayLength,
-                    pOutNumEstablishedConnections ) );
+                    ( void * ) pOutNumEstablishedConnections ) );
         status = MetricsCollectorBadParameter;
     }
 

--- a/demos/defender/defender_demo_json/mqtt_operations.c
+++ b/demos/defender/defender_demo_json/mqtt_operations.c
@@ -654,7 +654,7 @@ bool EstablishMqttSession( MQTTPublishCallback_t publishCallback )
 
     /* Initialize the mqtt context and network context. */
     ( void ) memset( pMqttContext, 0U, sizeof( MQTTContext_t ) );
-    ( void ) memset( pMqttContext, 0U, sizeof( NetworkContext_t ) );
+    ( void ) memset( pNetworkContext, 0U, sizeof( NetworkContext_t ) );
 
     returnStatus = connectToBrokerWithBackoffRetries( pNetworkContext );
 

--- a/demos/defender/defender_demo_json/report_builder.c
+++ b/demos/defender/defender_demo_json/report_builder.c
@@ -326,10 +326,10 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
     {
         LogError( ( "Invalid parameters. pBuffer: %p, bufferLength: %u"
                     " pMetrics: %p, pOutReprotLength: %p.",
-                    pBuffer,
+                    ( void * ) pBuffer,
                     bufferLength,
-                    pMetrics,
-                    pOutReprotLength ) );
+                    ( void * ) pMetrics,
+                    ( void * ) pOutReprotLength ) );
         status = ReportBuilderBadParameter;
     }
 

--- a/demos/defender/defender_demo_json/report_builder.c
+++ b/demos/defender/defender_demo_json/report_builder.c
@@ -312,7 +312,7 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
                                           uint32_t majorReportVersion,
                                           uint32_t minorReportVersion,
                                           uint32_t reportId,
-                                          uint32_t * pOutReprotLength )
+                                          uint32_t * pOutReportLength )
 {
     char * pCurrentWritePos = pBuffer;
     uint32_t remainingBufferLength = bufferLength, bufferWritten;
@@ -322,14 +322,14 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
     if( ( pBuffer == NULL ) ||
         ( bufferLength == 0 ) ||
         ( pMetrics == NULL ) ||
-        ( pOutReprotLength == NULL ) )
+        ( pOutReportLength == NULL ) )
     {
         LogError( ( "Invalid parameters. pBuffer: %p, bufferLength: %u"
-                    " pMetrics: %p, pOutReprotLength: %p.",
+                    " pMetrics: %p, pOutReportLength: %p.",
                     ( void * ) pBuffer,
                     bufferLength,
                     ( void * ) pMetrics,
-                    ( void * ) pOutReprotLength ) );
+                    ( void * ) pOutReportLength ) );
         status = ReportBuilderBadParameter;
     }
 
@@ -481,7 +481,7 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
 
     if( status == ReportBuilderSuccess )
     {
-        *pOutReprotLength = bufferLength - remainingBufferLength;
+        *pOutReportLength = bufferLength - remainingBufferLength;
     }
 
     return status;

--- a/demos/defender/defender_demo_json/report_builder.h
+++ b/demos/defender/defender_demo_json/report_builder.h
@@ -60,7 +60,7 @@ typedef struct ReportMetrics
  * @param[in] majorReportVersion Major version of the report.
  * @param[in] minorReportVersion Minor version of the report.
  * @param[in] reportId Value to be used as the reportId in the generated report.
- * @param[out] pOutReprotLength The length of the generated report.
+ * @param[out] pOutReportLength The length of the generated report.
  *
  * @return #ReportBuilderSuccess if the report is successfully generated;
  * #ReportBuilderBadParameter if invalid parameters are passed;
@@ -72,6 +72,6 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
                                           uint32_t majorReportVersion,
                                           uint32_t minorReportVersion,
                                           uint32_t reportId,
-                                          uint32_t * pOutReprotLength );
+                                          uint32_t * pOutReportLength );
 
 #endif /* ifndef REPORT_BUILDER_H_ */

--- a/demos/lexicon.txt
+++ b/demos/lexicon.txt
@@ -428,7 +428,6 @@ poutnumtcpopenports
 poutnumudpopenports
 poutportsarray
 poutreportlength
-poutreprotlength
 pouttcpportsarray
 poutudpportsarray
 poweron


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes warnings for the defender demo when building with clang, and fixes one incorrect memset. I also corrected one typo in a variable name

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
