### PR TITLE
Fix shadow demo thing name size example. Thing name must be an array so sizeof givse the array size, instead of the char pointer size.

### DIFF
--- a/demos/shadow/shadow_demo_main/shadow_demo_main.c
+++ b/demos/shadow/shadow_demo_main/shadow_demo_main.c
@@ -772,7 +772,7 @@ int main( int argc,
              * char topicBuffer[ SHADOW_TOPIC_MAX_LENGTH ] = { 0 };
              * uint16_t bufferSize = SHADOW_TOPIC_MAX_LENGTH;
              * uint16_t outLength = 0;
-             * const char * thingName = "TestThingName";
+             * const char thingName[] = "TestThingName";
              * uint16_t thingNameLength  = ( sizeof( thingName ) - 1U );
              *
              * shadowStatus = Shadow_GetTopicString( ShadowTopicStringTypeUpdateDelta,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
