### PR TITLE
Fix Doxygen CI link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
           submodules: recursive
       - name: Install Doxygen
         run: |
-          wget -qO- "http://doxygen.nl/files/doxygen-1.8.20.linux.bin.tar.gz" | sudo tar --strip-components=1 -xz -C /usr/local
+          wget -qO- "https://sourceforge.net/projects/doxygen/files/rel-1.8.20/doxygen-1.8.20.linux.bin.tar.gz/download" | sudo tar --strip-components=1 -xz -C /usr/local
           sudo apt-get install -y libclang-9-dev graphviz
       - name: Run Doxygen on all library submodules
         run: |


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Doxygen's download link has been moved to sourceforge.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
