### PR TITLE
Make periodic jobs service requests disabled by default

### DIFF
--- a/demos/jobs/jobs_demo_mosquitto/demo_config.h
+++ b/demos/jobs/jobs_demo_mosquitto/demo_config.h
@@ -53,14 +53,10 @@
 #define MQTT_WAIT_TIME          ( 10U * 1000U )
 
 /**
- * @brief How often in seconds to ask for a new job.
+ * @brief Maximum interval in seconds for pollinv and updateinv command line arguments.
+ * (arbitrarily chosen to be a week; must be less than LONG_MAX)
  */
-#define PROMPT_INTERVAL         ( 120U )
-
-/**
- * @brief How often in seconds to send updates for a running job.
- */
-#define UPDATE_INTERVAL         ( 10U )
+#define INTERVAL_MAX            ( 60U * 60U * 24U * 7U )
 
 /**
  * @brief Parent directory to contain download directories and files.

--- a/demos/jobs/jobs_demo_mosquitto/jobs_demo_mosquitto.c
+++ b/demos/jobs/jobs_demo_mosquitto/jobs_demo_mosquitto.c
@@ -141,9 +141,10 @@ static void usage( const char * programName )
              "--keyfile   : client private key for authentication in PEM format.\n",
              DEFAULT_CA_DIRECTORY );
     fprintf( stderr,
-             "--pollinv   : after this many idle seconds, request a job.  Default is not to poll.\n"
+             "--pollinv   : after this many idle seconds, request a job.\n"
+             "              Without this option and a positive value, no polling is done.\n"
              "--updateinv : after this many seconds running a job, resend the current status to the jobs service.\n"
-             "              Default is not to resend.\n\n"
+             "              Without this option and a positive value, status is not resent.\n\n"
              );
 }
 
@@ -175,8 +176,8 @@ typedef struct
     char * capath;
     char * certfile;
     char * keyfile;
-    uint32_t pollinv;
-    uint32_t updateinv;
+    uint32_t pollinv;   /* 0 (default) disables polling for new jobs */
+    uint32_t updateinv; /* 0 (default) disables periodic resending of status */
     /* flags */
     bool runOnce;
     /* callback-populated values */

--- a/demos/lexicon.txt
+++ b/demos/lexicon.txt
@@ -414,6 +414,7 @@ pmqttcontext
 pmsg
 pmsg
 pnetworkcontext
+pollinv
 poly
 popenportsarray
 portsarraylength
@@ -602,6 +603,7 @@ ulslotcount
 unix
 unsub
 unsuback
+updateinv
 updatejobexecution
 urandom
 uri


### PR DESCRIPTION
To avoid possible throttling when scaling up code based on this demo, jobs polling and repeated job updates are tied to command line arguments and disabled by default.  This PR also drops redundant subscriptions.