### PR TITLE
Use Jobs_Describe() instead of Jobs_StartNext()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-check-demos:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
           make -C build/ help | grep demo | tr -d '. ' | xargs make -C build/
           make -C demos/jobs/jobs_demo_mosquitto
   build-check-system-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v2
@@ -68,7 +68,7 @@ jobs:
       - name: Build System Tests
         run: make -C build/ help | grep system | tr -d '. ' | xargs make -C build/
   build-check-install:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v2
@@ -123,7 +123,7 @@ jobs:
           # Each line of install_manifest.txt contains the location of an installed library or header
           done <install_manifest.txt
   unittest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v2
@@ -175,7 +175,7 @@ jobs:
           fi
           exit $RESULT
   complexity:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup
@@ -185,7 +185,7 @@ jobs:
           find platform/ \( -iname '*.c' ! -wholename '*test*' \) |\
           xargs complexity --scores --threshold=0 --horrid-threshold=8
   spell-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Install spell
@@ -204,7 +204,7 @@ jobs:
             fi
           done
   formatting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Install Uncrustify
@@ -261,7 +261,7 @@ jobs:
           path: ./doxygen.zip
           retention-days: 2
   git-secrets:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -279,7 +279,7 @@ jobs:
           git-secrets --register-aws
           git-secrets --scan
   link-verifier:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/demos/lexicon.txt
+++ b/demos/lexicon.txt
@@ -129,6 +129,7 @@ defendersuccess
 deinitialize
 der
 des
+describejobexecution
 deserialize
 deserialized
 deserializer


### PR DESCRIPTION
This PR addresses additional feedback related to scaling by using Jobs_Describe() with $next instead of Jobs_StartNext().  The cases where Jobs_Describe() is called have been reduced to three: at startup, when a job is "force" canceled, or when polling is enabled.