### PR TITLE
Move include(CheckSymbolExists) to set_macro_definitions definition

### DIFF
--- a/demos/defender/defender_demo_json/CMakeLists.txt
+++ b/demos/defender/defender_demo_json/CMakeLists.txt
@@ -1,5 +1,3 @@
-include( CheckSymbolExists )
-
 set( DEMO_NAME "defender_demo" )
 
 # Include MQTT library's source and header path variables.

--- a/demos/http/http_demo_mutual_auth/CMakeLists.txt
+++ b/demos/http/http_demo_mutual_auth/CMakeLists.txt
@@ -1,5 +1,3 @@
-include(CheckSymbolExists)
-
 set( DEMO_NAME "http_demo_mutual_auth" )
 
 # Include HTTP library's source and header path variables.

--- a/demos/mqtt/mqtt_demo_mutual_auth/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_mutual_auth/CMakeLists.txt
@@ -1,4 +1,3 @@
-include(CheckSymbolExists)
 set( DEMO_NAME "mqtt_demo_mutual_auth" )
 
 # Include MQTT library's source and header path variables.

--- a/demos/mqtt/mqtt_demo_subscription_manager/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_subscription_manager/CMakeLists.txt
@@ -1,5 +1,3 @@
-include(CheckSymbolExists)
-
 # Include CMake configuration for subscriptipn manager library.
 add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/subscription-manager )
 

--- a/demos/shadow/shadow_demo_main/CMakeLists.txt
+++ b/demos/shadow/shadow_demo_main/CMakeLists.txt
@@ -1,5 +1,3 @@
-include(CheckSymbolExists)
-
 set( DEMO_NAME "shadow_demo_main" )
 
 # Include MQTT library's source and header path variables.

--- a/integration-test/http/CMakeLists.txt
+++ b/integration-test/http/CMakeLists.txt
@@ -82,4 +82,6 @@ set_macro_definitions(TARGETS ${stest_name}
                       REQUIRED
                         "ROOT_CA_CERT_PATH"
                         "SERVER_HOST"
-                        "HTTPS_PORT")
+                        "HTTPS_PORT"
+                      FILES_TO_CHECK
+                        "test_config.h")

--- a/integration-test/mqtt/CMakeLists.txt
+++ b/integration-test/mqtt/CMakeLists.txt
@@ -66,4 +66,6 @@ set_macro_definitions(TARGETS ${stest_name}
                         "CLIENT_PRIVATE_KEY_PATH"
                         "CLIENT_IDENTIFIER"
                         "BROKER_ENDPOINT"
-                        "BROKER_PORT")
+                        "BROKER_PORT"
+                      FILES_TO_CHECK
+                        "test_config.h")

--- a/tools/cmake/utility.cmake
+++ b/tools/cmake/utility.cmake
@@ -1,3 +1,5 @@
+include(CheckSymbolExists)
+
 function(set_macro_definitions)
     set(multiValueArgs TARGETS REQUIRED OPTIONAL FILES_TO_CHECK)
     cmake_parse_arguments(MACRO_DEFINITIONS "" "" "${multiValueArgs}" ${ARGN})


### PR DESCRIPTION
Because the code has been refactored out into its own function, the include is removed from the demos and placed into the file that defines the function.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
