### PR TITLE
Blocklist certificate files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ build/
 *.gcda
 *.gcno
 *.gcov
+
+# Ignore certificate files
+*.pem
+*.crt


### PR DESCRIPTION
Add certificate file extensions to **.gitignore** to prevent certificate files from being accidentally checked in the repository.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
