### PR TITLE
Update OTA_Shutdown API calls

### DIFF
--- a/demos/ota/ota_demo_core_http/ota_demo_core_http.c
+++ b/demos/ota/ota_demo_core_http/ota_demo_core_http.c
@@ -747,7 +747,7 @@ static void otaAppCallback( OtaJobEvent_t event,
             /* Activate the new firmware image. */
             OTA_ActivateNewImage();
 
-            /* Shutdown OTA Agent, if it is required that the unsubscribe operations are
+            /* Shutdown OTA Agent, if it is required that the unsubscribe operations are not
              * performed while shutting down please set the second paramter to 0 instead of 1. */
             OTA_Shutdown( 0, 1 );
 
@@ -797,7 +797,7 @@ static void otaAppCallback( OtaJobEvent_t event,
              * new image downloaded failed.*/
             LogError( ( "Self-test failed, shutting down OTA Agent." ) );
 
-            /* Shutdown OTA Agent, if it is required that the unsubscribe operations are
+            /* Shutdown OTA Agent, if it is required that the unsubscribe operations are not
              * performed while shutting down please set the second paramter to 0 instead of 1. */
             OTA_Shutdown( 0, 1 );
 

--- a/demos/ota/ota_demo_core_http/ota_demo_core_http.c
+++ b/demos/ota/ota_demo_core_http/ota_demo_core_http.c
@@ -748,7 +748,7 @@ static void otaAppCallback( OtaJobEvent_t event,
             OTA_ActivateNewImage();
 
             /* Shutdown OTA Agent, if it is required that the unsubscribe operations are not
-             * performed while shutting down please set the second paramter to 0 instead of 1. */
+             * performed while shutting down please set the second parameter to 0 instead of 1. */
             OTA_Shutdown( 0, 1 );
 
             /* Requires manual activation of new image.*/
@@ -798,7 +798,7 @@ static void otaAppCallback( OtaJobEvent_t event,
             LogError( ( "Self-test failed, shutting down OTA Agent." ) );
 
             /* Shutdown OTA Agent, if it is required that the unsubscribe operations are not
-             * performed while shutting down please set the second paramter to 0 instead of 1. */
+             * performed while shutting down please set the second parameter to 0 instead of 1. */
             OTA_Shutdown( 0, 1 );
 
 

--- a/demos/ota/ota_demo_core_http/ota_demo_core_http.c
+++ b/demos/ota/ota_demo_core_http/ota_demo_core_http.c
@@ -747,8 +747,9 @@ static void otaAppCallback( OtaJobEvent_t event,
             /* Activate the new firmware image. */
             OTA_ActivateNewImage();
 
-            /* Shutdown OTA Agent. */
-            OTA_Shutdown( 0 );
+            /* Shutdown OTA Agent, if it is required that the unsubscribe operations are
+             * performed while shutting down please set the second paramter to 0 instead of 1. */
+            OTA_Shutdown( 0, 1 );
 
             /* Requires manual activation of new image.*/
             LogError( ( "New image activation failed." ) );
@@ -796,8 +797,9 @@ static void otaAppCallback( OtaJobEvent_t event,
              * new image downloaded failed.*/
             LogError( ( "Self-test failed, shutting down OTA Agent." ) );
 
-            /* Shutdown OTA Agent. */
-            OTA_Shutdown( 0 );
+            /* Shutdown OTA Agent, if it is required that the unsubscribe operations are
+             * performed while shutting down please set the second paramter to 0 instead of 1. */
+            OTA_Shutdown( 0, 1 );
 
 
             break;

--- a/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
+++ b/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
@@ -616,8 +616,9 @@ static void otaAppCallback( OtaJobEvent_t event,
             /* Activate the new firmware image. */
             OTA_ActivateNewImage();
 
-            /* Shutdown OTA Agent. */
-            OTA_Shutdown( 0 );
+            /* Shutdown OTA Agent, if it is required that the unsubscribe operations are
+             * performed while shutting down please set the second paramter to 0 instead of 1. */
+            OTA_Shutdown( 0, 1 );
 
             /* Requires manual activation of new image.*/
             LogError( ( "New image activation failed." ) );
@@ -665,9 +666,9 @@ static void otaAppCallback( OtaJobEvent_t event,
              * new image downloaded failed.*/
             LogError( ( "Self-test failed, shutting down OTA Agent." ) );
 
-            /* Shutdown OTA Agent. */
-            OTA_Shutdown( 0 );
-
+            /* Shutdown OTA Agent, if it is required that the unsubscribe operations are
+             * performed while shutting down please set the second paramter to 0 instead of 1. */
+            OTA_Shutdown( 0, 1 );
 
             break;
 

--- a/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
+++ b/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
@@ -617,7 +617,7 @@ static void otaAppCallback( OtaJobEvent_t event,
             OTA_ActivateNewImage();
 
             /* Shutdown OTA Agent, if it is required that the unsubscribe operations are not
-             * performed while shutting down please set the second paramter to 0 instead of 1. */
+             * performed while shutting down please set the second parameter to 0 instead of 1. */
             OTA_Shutdown( 0, 1 );
 
             /* Requires manual activation of new image.*/
@@ -667,7 +667,7 @@ static void otaAppCallback( OtaJobEvent_t event,
             LogError( ( "Self-test failed, shutting down OTA Agent." ) );
 
             /* Shutdown OTA Agent, if it is required that the unsubscribe operations are not
-             * performed while shutting down please set the second paramter to 0 instead of 1. */
+             * performed while shutting down please set the second parameter to 0 instead of 1. */
             OTA_Shutdown( 0, 1 );
 
             break;

--- a/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
+++ b/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
@@ -616,7 +616,7 @@ static void otaAppCallback( OtaJobEvent_t event,
             /* Activate the new firmware image. */
             OTA_ActivateNewImage();
 
-            /* Shutdown OTA Agent, if it is required that the unsubscribe operations are
+            /* Shutdown OTA Agent, if it is required that the unsubscribe operations are not
              * performed while shutting down please set the second paramter to 0 instead of 1. */
             OTA_Shutdown( 0, 1 );
 
@@ -666,7 +666,7 @@ static void otaAppCallback( OtaJobEvent_t event,
              * new image downloaded failed.*/
             LogError( ( "Self-test failed, shutting down OTA Agent." ) );
 
-            /* Shutdown OTA Agent, if it is required that the unsubscribe operations are
+            /* Shutdown OTA Agent, if it is required that the unsubscribe operations are not
              * performed while shutting down please set the second paramter to 0 instead of 1. */
             OTA_Shutdown( 0, 1 );
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change updates the OTA_Shutdown calls by adding a new parameter for unsubscribe flag.
The change is in both OTA demos - MQTT and HTTP

Dependency for this change is https://github.com/aws/ota-for-aws-iot-embedded-sdk/pull/154

OTA Submodule is updated in this PR which has above dependency.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
