### PR TITLE
Suppress stringop-truncation warning for HTTP demos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-check-demos:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
           make -C build/ help | grep demo | tr -d '. ' | xargs make -C build/
           make -C demos/jobs/jobs_demo_mosquitto
   build-check-system-tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v2
@@ -68,7 +68,7 @@ jobs:
       - name: Build System Tests
         run: make -C build/ help | grep system | tr -d '. ' | xargs make -C build/
   build-check-install:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v2
@@ -123,7 +123,7 @@ jobs:
           # Each line of install_manifest.txt contains the location of an installed library or header
           done <install_manifest.txt
   unittest:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v2
@@ -175,7 +175,7 @@ jobs:
           fi
           exit $RESULT
   complexity:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Setup
@@ -185,7 +185,7 @@ jobs:
           find platform/ \( -iname '*.c' ! -wholename '*test*' \) |\
           xargs complexity --scores --threshold=0 --horrid-threshold=8
   spell-check:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Install spell
@@ -204,7 +204,7 @@ jobs:
             fi
           done
   formatting:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Install Uncrustify
@@ -261,7 +261,7 @@ jobs:
           path: ./doxygen.zip
           retention-days: 2
   git-secrets:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
@@ -279,7 +279,7 @@ jobs:
           git-secrets --register-aws
           git-secrets --scan
   link-verifier:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/demos/http/http_demo_basic_tls/CMakeLists.txt
+++ b/demos/http/http_demo_basic_tls/CMakeLists.txt
@@ -35,7 +35,7 @@ target_include_directories(
 
 target_compile_options(
     ${DEMO_NAME}
-    PRIVATE
+    PUBLIC
         -Wno-stringop-truncation
 )
 

--- a/demos/http/http_demo_basic_tls/CMakeLists.txt
+++ b/demos/http/http_demo_basic_tls/CMakeLists.txt
@@ -33,6 +33,12 @@ target_include_directories(
         ${LOGGING_INCLUDE_DIRS}
 )
 
+target_compile_options(
+    ${DEMO_NAME}
+    PRIVATE
+        -Wno-stringop-truncation
+)
+
 set_macro_definitions(TARGETS ${DEMO_NAME}
                       REQUIRED
                         "SERVER_HOST"

--- a/demos/http/http_demo_mutual_auth/CMakeLists.txt
+++ b/demos/http/http_demo_mutual_auth/CMakeLists.txt
@@ -35,7 +35,7 @@ target_include_directories(
 
 target_compile_options(
     ${DEMO_NAME}
-    PRIVATE
+    PUBLIC
         -Wno-stringop-truncation
 )
 

--- a/demos/http/http_demo_mutual_auth/CMakeLists.txt
+++ b/demos/http/http_demo_mutual_auth/CMakeLists.txt
@@ -33,18 +33,12 @@ target_include_directories(
         ${LOGGING_INCLUDE_DIRS}
 )
 
-if(ROOT_CA_CERT_PATH)
-    target_compile_definitions(
-        ${DEMO_NAME} PRIVATE
-            ROOT_CA_CERT_PATH="${ROOT_CA_CERT_PATH}"
-    )
-endif()
-if(AWS_HTTPS_PORT)
-    target_compile_definitions(
-        ${DEMO_NAME} PRIVATE
-            AWS_HTTPS_PORT=${AWS_HTTPS_PORT}
-    )
-endif()
+target_compile_options(
+    ${DEMO_NAME}
+    PRIVATE
+        -Wno-stringop-truncation
+)
+
 set_macro_definitions(TARGETS ${DEMO_NAME}
                       REQUIRED
                         "SERVER_HOST"

--- a/demos/http/http_demo_plaintext/CMakeLists.txt
+++ b/demos/http/http_demo_plaintext/CMakeLists.txt
@@ -35,7 +35,7 @@ target_include_directories(
 
 target_compile_options(
     ${DEMO_NAME}
-    PRIVATE
+    PUBLIC
         -Wno-stringop-truncation
 )
 

--- a/demos/http/http_demo_plaintext/CMakeLists.txt
+++ b/demos/http/http_demo_plaintext/CMakeLists.txt
@@ -33,6 +33,12 @@ target_include_directories(
         ${LOGGING_INCLUDE_DIRS}
 )
 
+target_compile_options(
+    ${DEMO_NAME}
+    PRIVATE
+        -Wno-stringop-truncation
+)
+
 set_macro_definitions(TARGETS ${DEMO_NAME}
                       OPTIONAL
                         "SERVER_HOST"

--- a/demos/http/http_demo_s3_download/CMakeLists.txt
+++ b/demos/http/http_demo_s3_download/CMakeLists.txt
@@ -37,7 +37,7 @@ target_include_directories(
 
 target_compile_options(
     ${DEMO_NAME}
-    PRIVATE
+    PUBLIC
         -Wno-stringop-truncation
 )
 

--- a/demos/http/http_demo_s3_download/CMakeLists.txt
+++ b/demos/http/http_demo_s3_download/CMakeLists.txt
@@ -35,6 +35,12 @@ target_include_directories(
         ${LOGGING_INCLUDE_DIRS}
 )
 
+target_compile_options(
+    ${DEMO_NAME}
+    PRIVATE
+        -Wno-stringop-truncation
+)
+
 set_macro_definitions(TARGETS ${DEMO_NAME}
                       REQUIRED
                         "S3_PRESIGNED_GET_URL"

--- a/demos/http/http_demo_s3_download_multithreaded/CMakeLists.txt
+++ b/demos/http/http_demo_s3_download_multithreaded/CMakeLists.txt
@@ -38,7 +38,7 @@ target_include_directories(
 
 target_compile_options(
     ${DEMO_NAME}
-    PRIVATE
+    PUBLIC
         -Wno-stringop-truncation
 )
 

--- a/demos/http/http_demo_s3_download_multithreaded/CMakeLists.txt
+++ b/demos/http/http_demo_s3_download_multithreaded/CMakeLists.txt
@@ -36,6 +36,12 @@ target_include_directories(
         ${LOGGING_INCLUDE_DIRS}
 )
 
+target_compile_options(
+    ${DEMO_NAME}
+    PRIVATE
+        -Wno-stringop-truncation
+)
+
 set_macro_definitions(TARGETS ${DEMO_NAME}
                       REQUIRED
                         "S3_PRESIGNED_GET_URL"

--- a/demos/http/http_demo_s3_upload/CMakeLists.txt
+++ b/demos/http/http_demo_s3_upload/CMakeLists.txt
@@ -37,7 +37,7 @@ target_include_directories(
 
 target_compile_options(
     ${DEMO_NAME}
-    PRIVATE
+    PUBLIC
         -Wno-stringop-truncation
 )
 

--- a/demos/http/http_demo_s3_upload/CMakeLists.txt
+++ b/demos/http/http_demo_s3_upload/CMakeLists.txt
@@ -35,6 +35,12 @@ target_include_directories(
         ${LOGGING_INCLUDE_DIRS}
 )
 
+target_compile_options(
+    ${DEMO_NAME}
+    PRIVATE
+        -Wno-stringop-truncation
+)
+
 set_macro_definitions(TARGETS ${DEMO_NAME}
                       REQUIRED
                         "S3_PRESIGNED_PUT_URL"

--- a/demos/ota/ota_demo_core_http/CMakeLists.txt
+++ b/demos/ota/ota_demo_core_http/CMakeLists.txt
@@ -48,6 +48,12 @@ target_include_directories(
         ${HTTP_INCLUDE_PUBLIC_DIRS}
 )
 
+target_compile_options(
+    ${DEMO_NAME}
+    PRIVATE
+        -Wno-stringop-truncation
+)
+
 set_macro_definitions(TARGETS ${DEMO_NAME}
                       REQUIRED
                         "AWS_IOT_ENDPOINT"

--- a/demos/ota/ota_demo_core_http/CMakeLists.txt
+++ b/demos/ota/ota_demo_core_http/CMakeLists.txt
@@ -50,7 +50,7 @@ target_include_directories(
 
 target_compile_options(
     ${DEMO_NAME}
-    PRIVATE
+    PUBLIC
         -Wno-stringop-truncation
 )
 

--- a/integration-test/http/CMakeLists.txt
+++ b/integration-test/http/CMakeLists.txt
@@ -78,6 +78,12 @@ create_test(${stest_name}
             "${test_include_directories}"
         )
 
+target_compile_options(
+    ${stest_name}
+    PRIVATE
+        -Wno-stringop-truncation
+)
+
 set_macro_definitions(TARGETS ${stest_name}
                       REQUIRED
                         "ROOT_CA_CERT_PATH"

--- a/integration-test/http/CMakeLists.txt
+++ b/integration-test/http/CMakeLists.txt
@@ -80,7 +80,7 @@ create_test(${stest_name}
 
 target_compile_options(
     ${stest_name}
-    PRIVATE
+    PUBLIC
         -Wno-stringop-truncation
 )
 


### PR DESCRIPTION
The coreHTTP library uses `strncpy`, causing a warning in the HTTP demos that utilize NULL-terminated strings. This change suppresses that warning for those demos, enabling us to use `ubuntu-latest` for Github Actions.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
