### PR TITLE
Update the version of the OTA PAL

### DIFF
--- a/platform/posix/ota_pal/source/include/ota_pal_posix.h
+++ b/platform/posix/ota_pal/source/include/ota_pal_posix.h
@@ -1,5 +1,5 @@
 /*
- * OTA PAL V2.0.0 (Release Candidate) for POSIX
+ * OTA PAL V3.0.0 for POSIX
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/platform/posix/ota_pal/source/ota_pal_posix.c
+++ b/platform/posix/ota_pal/source/ota_pal_posix.c
@@ -1,5 +1,5 @@
 /*
- * OTA PAL V2.0.0 (Release Candidate) for POSIX
+ * OTA PAL V3.0.0 for POSIX
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/platform/posix/ota_pal/utest/mocks/openssl_api.h
+++ b/platform/posix/ota_pal/utest/mocks/openssl_api.h
@@ -1,5 +1,5 @@
 /*
- * OTA PAL V2.0.0 (Release Candidate) for POSIX
+ * OTA PAL V3.0.0 for POSIX
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/platform/posix/ota_pal/utest/mocks/stdio_api.h
+++ b/platform/posix/ota_pal/utest/mocks/stdio_api.h
@@ -1,5 +1,5 @@
 /*
- * OTA PAL V2.0.0 (Release Candidate) for POSIX
+ * OTA PAL V3.0.0 for POSIX
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/platform/posix/ota_pal/utest/mocks/unistd_api.h
+++ b/platform/posix/ota_pal/utest/mocks/unistd_api.h
@@ -1,5 +1,5 @@
 /*
- * OTA PAL V2.0.0 (Release Candidate) for POSIX
+ * OTA PAL V3.0.0 for POSIX
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/platform/posix/ota_pal/utest/ota_config.h
+++ b/platform/posix/ota_pal/utest/ota_config.h
@@ -1,5 +1,5 @@
 /*
- * OTA PAL V2.0.0 (Release Candidate) for POSIX
+ * OTA PAL V3.0.0 for POSIX
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/platform/posix/ota_pal/utest/ota_pal_posix_utest.c
+++ b/platform/posix/ota_pal/utest/ota_pal_posix_utest.c
@@ -1,5 +1,5 @@
 /*
- * OTA PAL V2.0.0 (Release Candidate) for POSIX
+ * OTA PAL V3.0.0 for POSIX
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
In all of the PAL *.c and *.h files, change "OTA PAL V2.0.0 (Release Candidate) for POSIX" to "OTA PAL V3.0.0 for POSIX"

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
