### PR TITLE
Update CHANGELOG.md for the OTA library for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Major Changes
 
-- This release introduces the **AWS IoT Over-the-air Update** library(Release Candidate), **backoffAlgorithm** library, and **PKCS #11** library.
+- This release introduces the **AWS IoT Over-the-air Update** library, **backoffAlgorithm** library, and **PKCS #11** library.
 These libraries have gone through code quality checks including verification that no function has a [GNU Complexity](https://www.gnu.org/software/complexity/manual/complexity.html) score greater than 8, checks against deviations from the mandatory rules in the [MISRA coding standard](https://www.misra.org.uk/MISRAHome/MISRAC2012/tabid/196/Default.aspx), and static code analysis from [Coverity statical analysis](https://scan.coverity.com/). In addition, PKCS11 library has also undergone validation of memory safety through the [CBMC automated reasoning tool](http://www.cs.cmu.edu/~modelcheck/cbmc/).
 
 - This release uses submodule references to the following new individual repositories for the AWS IoT Over-the-air Update, backoffAlgorithm, and PKCS11 libraries under the `libraries` folder:


### PR DESCRIPTION
* Update the terminology of the OTA library name in the changelog
  to be consistent with the rest of the libraries.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
