### PR TITLE
Validate Github tags and releases of spoke repos in release verification script

### DIFF
--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -15,6 +15,7 @@ This script checks that:
     - All jobs pass in <JENKINS_CI_URL>/view/CSDK%20Jobs/job/csdk/
     - Only the main branch exists in library repos.
     - Only the main branch and v4_beta_deprecated exist in the CSDK.
+    - Each library repo has a tag and release labeled with the version specified in the config.
     - manifest.yml has all libraries and versions expected in this script's config.yml
     - There are no pending PRs on the main branch.
 

--- a/tools/release/release-verify.py
+++ b/tools/release/release-verify.py
@@ -135,7 +135,6 @@ def validate_checks(configs) -> list:
     repo_paths.append(f"{CSDK_ORG}/{CSDK_REPO}")
     return repo_paths
 
-
 def validate_ci():
     """
     Validates that all CSDK jobs in the Jenkins CI passed.
@@ -172,6 +171,37 @@ def validate_branches(repo_paths):
             if branch_name not in valid_branches:
                 log_error(f"Invalid branch {branch_name} found in {repo_path}.")
 
+def validate_tags_and_releases(repo_paths, lib_versions):
+    """
+    Validates that each library repo has a release and tag for the specified version number.
+    Args:
+        repo_paths (dict): Paths to all library repos in the CSDK, including their org.
+        lib_versions (dict): A dictionary containing the new versions of each library.
+    """
+    # Verify that all repos have a release and tag for the version specified in the config.
+    for repo_path in repo_paths:
+        library = repo_path.split("/")[-1].casefold()
+        # Only need to verify for spoke repos because CSDK is the library being released.
+        if library == CSDK_REPO:
+            continue
+        # Check that a release exists with the same name as the version.
+        git_releases_resp = requests.get(f"{GITHUB_API_URL}/repos/{repo_path}/releases", headers=GITHUB_AUTH_HEADER)
+        found_release_for_verison = False
+        for release in git_releases_resp.json():
+            if release["name"] == lib_versions[library] and release["tag_name"] == lib_versions[library]:
+                found_release_for_verison = True
+                break
+        if not found_release_for_verison:
+            log_error(f"Could not find release {lib_versions[library]} for {repo_path}.")
+        # Check that a tag exists with the same name as the version.
+        git_tags_resp = requests.get(f"{GITHUB_API_URL}/repos/{repo_path}/tags", headers=GITHUB_AUTH_HEADER)
+        found_tag_for_version = False
+        for tag in git_tags_resp.json():
+            if tag["name"] == lib_versions[library]:
+                found_tag_for_version = True
+                break
+        if not found_tag_for_version:
+            log_error(f"Could not find tag {lib_versions[library]} for {repo_path}.")
 
 def validate_main_branch():
     """
@@ -185,7 +215,6 @@ def validate_main_branch():
     for pr in git_resp.json():
         pr_url = pr["url"]
         log_error(f"Pull request to main {pr_url}.")
-
 
 def set_globals(configs):
     """
@@ -324,6 +353,9 @@ def main():
 
     # Check that only qualified branches exist in each library repo.
     validate_branches(repo_paths)
+
+    # Check that library repos have a tag and release for each specified version.
+    validate_tags_and_releases(repo_paths, configs)
 
     # Verify there are no pending PRs to the CSDK main branch.
     validate_main_branch()

--- a/tools/release/release-verify.py
+++ b/tools/release/release-verify.py
@@ -29,6 +29,7 @@ JENKINS_CSDK_DEMOS_PATH = "job/csdk/job/demo_pipeline/lastCompletedBuild"
 JENKINS_CSDK_TESTS_PATH = "job/csdk/job/nightly/lastCompletedBuild"
 JENKINS_API_PATH = "api/json"
 JENKINS_SERVER_VERIFY = True
+GITHUB_RELEASES_TAGS_VERIFY = True
 
 # Errors found in this run.
 errors = 0
@@ -178,6 +179,8 @@ def validate_tags_and_releases(repo_paths, lib_versions):
         repo_paths (dict): Paths to all library repos in the CSDK, including their org.
         lib_versions (dict): A dictionary containing the new versions of each library.
     """
+    if not GITHUB_RELEASES_TAGS_VERIFY:
+        return
     # Verify that all repos have a release and tag for the version specified in the config.
     for repo_path in repo_paths:
         library = repo_path.split("/")[-1].casefold()
@@ -224,6 +227,7 @@ def set_globals(configs):
     """
     global GITHUB_ACCESS_TOKEN
     global GITHUB_AUTH_HEADER
+    global GITHUB_RELEASES_TAGS_VERIFY
     global JENKINS_API_URL
     global JENKINS_USERNAME
     global JENKINS_PASSWORD
@@ -263,6 +267,7 @@ def set_globals(configs):
     JENKINS_PASSWORD = jenkins_password
     JENKINS_API_URL = jenkins_api_url
     JENKINS_SERVER_VERIFY = False if configs["disable_jenkins_server_verify"] else True
+    GITHUB_RELEASES_TAGS_VERIFY = False if configs["disable_github_release_tag_verify"] else True
 
 
 def get_configs() -> dict:
@@ -298,6 +303,14 @@ def get_configs() -> dict:
         default=False,
         dest="disable_jenkins_server_verify",
         help="Disable server verification for the Jenkins API calls if your system doesn't have the certificate in its store.",
+    )
+    parser.add_argument(
+        "--disable-github-release-tag-verify",
+        action="store_true",
+        required=False,
+        default=False,
+        dest="disable_github_release_tag_verify",
+        help="Disable verifying that there are Github releases and tags named after the versions of the spoke repos.",
     )
     parser.add_argument(
         "--disable-cbmc-checks-for",


### PR DESCRIPTION
Since all spoke repos are being tagged and released before execution of the MCM, this updates the script to verify that each of the individual spoke repos has a release and tag named after the version specified in the config.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
