### PR TITLE
Fix issue in upload-release workflow

### DIFF
--- a/.github/workflows/upload-release.yml
+++ b/.github/workflows/upload-release.yml
@@ -36,7 +36,7 @@ jobs:
           github_token: ${{secrets.GITHUB_TOKEN}}
           # Required, workflow file name or ID
           workflow: ${{ github.event.inputs.workflow_name }}.yml
-          run_id: ${{ github.event.inputs.run_id }}
+          run_id: ${{ github.event.inputs.workflow_id }}
           name: aws-iot-device-sdk-embedded-C-${{ github.event.inputs.version_number }}.zip
       - name: Upload Release Asset
         id: upload-release-asset


### PR DESCRIPTION
The `upload-release.yml` release automation workflow has an issue when downloading the ZIP artifact for a `tag-and-zip.yml` release workflow run. This PR fixes the issue of the incorrect workflow ID parameter passed to the GitHub Action for downloading artifact used in the workflow.

The fix has been verified on my fork repository in this run: https://github.com/aggarw13/aws-iot-device-sdk-embedded-C/actions/runs/615188641
The workflow run (of `tag-and-zip.yml`) used for obtaining the ZIP artifact is https://github.com/aggarw13/aws-iot-device-sdk-embedded-C/actions/runs/615025395
The test workflow run of `upload-release.yml` created a release for `release-v1` here: https://github.com/aggarw13/aws-iot-device-sdk-embedded-C/releases/tag/release-v1