### PR TITLE
Fix issue of inability to configure THING_NAME in Shadow demo from CLI

### DIFF
--- a/demos/shadow/shadow_demo_main/CMakeLists.txt
+++ b/demos/shadow/shadow_demo_main/CMakeLists.txt
@@ -49,6 +49,7 @@ set_macro_definitions(TARGETS ${DEMO_NAME}
                         "CLIENT_CERT_PATH"
                         "CLIENT_PRIVATE_KEY_PATH"
                         "CLIENT_IDENTIFIER"
+                        "THING_NAME"
                         "CLIENT_USERNAME"
                         "CLIENT_PASSWORD"
                         "OS_NAME"


### PR DESCRIPTION
With recent changes in #1596 for aliasing `THING_NAME` and `CLIENT_IDENTIFIER` (for the Best practice of using the Client ID as THing Name when connecting to AWS IoT), there is an issue of not being able to configure the `THING_NAME` macro when `THING_NAME` is passed as a CMake variable. 

The following is the build log which shows the issue of missing `THING_NAME` configuration for the Shadow demo:

```
Using values in demo_config.h to define the following macros for shadow_demo_main:
OS_NAME
OS_VERSION
HARDWARE_PLATFORM_NAME
Using the passed CMake arguments to define the following macros for shadow_demo_main:
AWS_IOT_ENDPOINT = <REDACTED>
ROOT_CA_CERT_PATH = /home/ubuntu/AWS_Certificates/Amazon_Root_CA_1.txt
CLIENT_CERT_PATH = /home/ubuntu/AWS_Certificates/<REDACTED>
CLIENT_PRIVATE_KEY_PATH = /home/ubuntu/AWS_Certificates/<REDACTED>
CLIENT_IDENTIFIER = Test_Thing
Found the following definitions for shadow_demo_main: AWS_IOT_ENDPOINT, ROOT_CA_CERT_PATH, CLIENT_CERT_PATH, CLIENT_PRIVATE_KEY_PATH, CLIENT_IDENTIFIER, THING_NAME, OS_NAME, OS_VERSION, HARDWARE_PLATFORM_NAME
WARNING: shadow_demo_main missing definitions for macros: CLIENT_USERNAME, CLIENT_PASSWORD
To run shadow_demo_main, define required macros in shadow_demo_main/demo_config.h.
``` 

This PR fixes the issue for enabling `THING_NAME` configuration from CMake CLI command: 

```
Using values in demo_config.h to define the following macros for shadow_demo_main:
OS_NAME
OS_VERSION
HARDWARE_PLATFORM_NAME
Using the passed CMake arguments to define the following macros for shadow_demo_main:
AWS_IOT_ENDPOINT = <REDACTED>
ROOT_CA_CERT_PATH = /home/ubuntu/AWS_Certificates/Amazon_Root_CA_1.txt
CLIENT_CERT_PATH = /home/ubuntu/AWS_Certificates/<REDACTED>
CLIENT_PRIVATE_KEY_PATH = /home/ubuntu/AWS_Certificates/<REDACTED>
CLIENT_IDENTIFIER = Test_Thing
THING_NAME = Test_Thing
Found the following definitions for shadow_demo_main: AWS_IOT_ENDPOINT, ROOT_CA_CERT_PATH, CLIENT_CERT_PATH, CLIENT_PRIVATE_KEY_PATH, CLIENT_IDENTIFIER, THING_NAME, OS_NAME, OS_VERSION, HARDWARE_PLATFORM_NAME
WARNING: shadow_demo_main missing definitions for macros: CLIENT_USERNAME, CLIENT_PASSWORD
To run shadow_demo_main, define required macros in shadow_demo_main/demo_config.h.
```