### PR TITLE
Fix memory allocation error when no. of device config entries is zero

### DIFF
--- a/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
@@ -629,9 +629,10 @@ AwsIotProvisioningError_t _AwsIotProvisioning_ParseRegisterThingResponse( AwsIot
                     IOT_SET_AND_GOTO_CLEANUP( AWS_IOT_PROVISIONING_INTERNAL_FAILURE );
                 }
 
-                if ( numOfDeviceConfigurationEntries > 0) {
-                     pDeviceConfigurationList = AwsIotProvisioning_MallocDeviceConfigurationList( numOfDeviceConfigurationEntries *
-                                                                                             sizeof( AwsIotProvisioningResponseDeviceConfigurationEntry_t ) );
+                if( numOfDeviceConfigurationEntries > 0 )
+                {
+                    pDeviceConfigurationList = AwsIotProvisioning_MallocDeviceConfigurationList( numOfDeviceConfigurationEntries *
+                                                                                                 sizeof( AwsIotProvisioningResponseDeviceConfigurationEntry_t ) );
 
                     if( pDeviceConfigurationList == NULL )
                     {

--- a/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
@@ -636,7 +636,7 @@ AwsIotProvisioningError_t _AwsIotProvisioning_ParseRegisterThingResponse( AwsIot
                     if( pDeviceConfigurationList == NULL )
                     {
                         IotLogError( "Failure in allocating memory for device configuration data in response payload of %s operation",
-                                 REGISTER_THING_OPERATION_LOG );
+                                     REGISTER_THING_OPERATION_LOG );
                         IOT_SET_AND_GOTO_CLEANUP( AWS_IOT_PROVISIONING_NO_MEMORY );
                     }
 

--- a/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
@@ -629,17 +629,20 @@ AwsIotProvisioningError_t _AwsIotProvisioning_ParseRegisterThingResponse( AwsIot
                     IOT_SET_AND_GOTO_CLEANUP( AWS_IOT_PROVISIONING_INTERNAL_FAILURE );
                 }
 
-                pDeviceConfigurationList = AwsIotProvisioning_MallocDeviceConfigurationList( numOfDeviceConfigurationEntries *
+                if ( numOfDeviceConfigurationEntries > 0) {
+                     pDeviceConfigurationList = AwsIotProvisioning_MallocDeviceConfigurationList( numOfDeviceConfigurationEntries *
                                                                                              sizeof( AwsIotProvisioningResponseDeviceConfigurationEntry_t ) );
 
-                if( pDeviceConfigurationList == NULL )
-                {
-                    IotLogError( "Failure in allocating memory for device configuration data in response payload of %s operation",
+                    if( pDeviceConfigurationList == NULL )
+                    {
+                        IotLogError( "Failure in allocating memory for device configuration data in response payload of %s operation",
                                  REGISTER_THING_OPERATION_LOG );
-                    IOT_SET_AND_GOTO_CLEANUP( AWS_IOT_PROVISIONING_NO_MEMORY );
-                }
+                        IOT_SET_AND_GOTO_CLEANUP( AWS_IOT_PROVISIONING_NO_MEMORY );
+                    }
 
-                configurationListAllocated = true;
+                    configurationListAllocated = true;
+                }
+               
 
                 /* Iterate over the contents of the device configuration to decode the list of configuration entries to
                  * pass to the user-callback.*/


### PR DESCRIPTION
*Description of changes:*
Added a conditional check to allocate memory for device configuration list in provisioning parser only if the 
configuration entries is greater than zero. 


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
