### PR TITLE
Updating OTA OS Timer interface method names

### DIFF
--- a/demos/ota/ota_demo_core_http/ota_demo_core_http.c
+++ b/demos/ota/ota_demo_core_http/ota_demo_core_http.c
@@ -1882,9 +1882,9 @@ static void setOtaInterfaces( OtaInterfaces_t * pOtaInterfaces )
     pOtaInterfaces->os.event.send = Posix_OtaSendEvent;
     pOtaInterfaces->os.event.recv = Posix_OtaReceiveEvent;
     pOtaInterfaces->os.event.deinit = Posix_OtaDeinitEvent;
-    pOtaInterfaces->os.timer.start = Posix_OtaStartTimer;
-    pOtaInterfaces->os.timer.stop = Posix_OtaStopTimer;
-    pOtaInterfaces->os.timer.delete = Posix_OtaDeleteTimer;
+    pOtaInterfaces->os.timer.startTimer = Posix_OtaStartTimer;
+    pOtaInterfaces->os.timer.stopTimer = Posix_OtaStopTimer;
+    pOtaInterfaces->os.timer.deleteTimer = Posix_OtaDeleteTimer;
     pOtaInterfaces->os.mem.malloc = STDC_Malloc;
     pOtaInterfaces->os.mem.free = STDC_Free;
 

--- a/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
+++ b/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
@@ -1435,9 +1435,9 @@ static void setOtaInterfaces( OtaInterfaces_t * pOtaInterfaces )
     pOtaInterfaces->os.event.send = Posix_OtaSendEvent;
     pOtaInterfaces->os.event.recv = Posix_OtaReceiveEvent;
     pOtaInterfaces->os.event.deinit = Posix_OtaDeinitEvent;
-    pOtaInterfaces->os.timer.start = Posix_OtaStartTimer;
-    pOtaInterfaces->os.timer.stop = Posix_OtaStopTimer;
-    pOtaInterfaces->os.timer.delete = Posix_OtaDeleteTimer;
+    pOtaInterfaces->os.timer.startTimer = Posix_OtaStartTimer;
+    pOtaInterfaces->os.timer.stopTimer = Posix_OtaStopTimer;
+    pOtaInterfaces->os.timer.deleteTimer = Posix_OtaDeleteTimer;
     pOtaInterfaces->os.mem.malloc = STDC_Malloc;
     pOtaInterfaces->os.mem.free = STDC_Free;
 


### PR DESCRIPTION
*Issue:*
[Build error in C ++ projects issue](https://github.com/aws/ota-for-aws-iot-embedded-sdk/issues/201)

*Description of changes:*
Changing the OS method names for C ++ compiler
* deleteTimer
* startTimer
* stopTimer

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
