### PR TITLE
Patch makefile common

### DIFF
--- a/cbmc/proofs/IotMqtt_Wait/Makefile
+++ b/cbmc/proofs/IotMqtt_Wait/Makefile
@@ -39,7 +39,6 @@ LOOP += valid_IotMqttSubscriptionList.0:$(SUBSCRIPTION_COUNT_MAX)
 LOOP += valid_IotMqttOperationList.0:$(SUBSCRIPTION_COUNT_MAX)
 LOOP += IotListDouble_RemoveAllMatches.0:$(SUBSCRIPTION_COUNT_MAX)
 LOOP += IotListDouble_FindFirstMatch.0:$(SUBSCRIPTION_COUNT_MAX)
-LOOP += IotListDouble_FindFirstMatch.0:$(SUBSCRIPTION_COUNT_MAX)
 LOOP += IotListDouble_RemoveAllMatches\$$link1.0:$(SUBSCRIPTION_COUNT_MAX)
 LOOP += IotListDouble_FindFirstMatch\$$link2.0:$(SUBSCRIPTION_COUNT_MAX)
 

--- a/cbmc/proofs/IotMqtt_Wait/Makefile
+++ b/cbmc/proofs/IotMqtt_Wait/Makefile
@@ -38,6 +38,10 @@ DEF += -DTOPIC_LENGTH_MAX=$(TOPIC_LENGTH_MAX)
 LOOP += valid_IotMqttSubscriptionList.0:$(SUBSCRIPTION_COUNT_MAX)
 LOOP += valid_IotMqttOperationList.0:$(SUBSCRIPTION_COUNT_MAX)
 LOOP += IotListDouble_RemoveAllMatches.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += IotListDouble_FindFirstMatch.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += IotListDouble_FindFirstMatch.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += IotListDouble_RemoveAllMatches\$$link1.0:$(SUBSCRIPTION_COUNT_MAX)
+LOOP += IotListDouble_FindFirstMatch\$$link2.0:$(SUBSCRIPTION_COUNT_MAX)
 
 UNWINDING += --unwind 1
 UNWINDING += --unwindset '$(shell echo $(LOOP) | sed 's/ /,/g')'

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -74,7 +74,14 @@ $(GOTO_DIR)/%.goto: ./%.c
 	mkdir -p $(dir $@)
 	$(GOTO_CC) -o $@ $(CFLAGS) $<
 
-$(MQTT)/build:
+# Do 'make cmake' to build configuration files before 'make report'.
+#
+# When running proofs concurrently, build the configuration files once
+# with 'make cmake' and then run the proofs concurrently with concurrent
+# invocations of 'make report'. Do not add 'cmake' as a 'report'
+# dependency or the concurrent proofs will fail to run correctly.
+#
+cmake:
 	(mkdir -p $(MQTT)/build; cd $(MQTT)/build; cmake ..) \
 	       > $(ENTRY)0.txt 2>&1
 
@@ -115,7 +122,6 @@ CHECKFLAGS += \
 	--malloc-may-fail \
 	--nan-check \
 	--pointer-check \
-	--pointer-overflow-check \
 	--pointer-primitive-check \
 	--signed-overflow-check \
 	--undefined-shift-check \

--- a/cbmc/proofs/run-cbmc-proofs.py
+++ b/cbmc/proofs/run-cbmc-proofs.py
@@ -98,6 +98,11 @@ def set_up_logging(verbose):
     logging.basicConfig(
         format="run-cbmc-proofs: %(message)s", level=level)
 
+def task_pool_size():
+    ret = os.cpu_count()
+    if ret is None or ret < 3:
+        return 1
+    return ret - 2
 
 def print_counter(counter):
     print(
@@ -310,7 +315,8 @@ def main():
                 [str(f) for f in counter["fail"]]))
 
     if not args.no_standalone:
-        run_build(litani, args.parallel_jobs)
+        jobs = min(args.parallel_jobs or task_pool_size(), 8)
+        run_build(litani, jobs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request depends on #1636 

For CBMC proofs, this pull request updates litanti to the latest release 1.7.1, fixes a concurrency bug in Makefile.common, and restricts concurrency to 8 concurrent jobs to avoid memory exhaustion.



By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
