### PR TITLE
Update CMake install target to support static libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,21 +74,20 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Configure CMake build for custom install location
+      - name: Configure CMake for installation of shared libraries at custom location
         run: |
-          mkdir installed-headers-dir installed-libs-dir
           curl https://cmake.org/files/v3.2/cmake-3.2.0-Linux-x86_64.tar.gz -o cmake.tar.gz
           tar -xf cmake.tar.gz
           mkdir build && cd build
           ../cmake-3.2.0-Linux-x86_64/bin/cmake .. \
           -DBUILD_DEMOS=0 -DBUILD_TESTS=0 \
-          -DCSDK_HEADER_INSTALL_PATH="$PWD/../installed-headers-dir" -DCSDK_LIB_INSTALL_PATH="$PWD/../installed-headers-dir"
-      - name: Install libraries and verify custom install location
+          -DCSDK_HEADER_INSTALL_PATH="$PWD/../shared-libs-headers-install-dir" -DCSDK_LIB_INSTALL_PATH="$PWD/../shared-libs-install-dir"
+      - name: Install shared libraries and verify custom install location
         run: |
           cd build && sudo make install
           while IFS="" read -r p || [ -n "$p" ]
           do
-            if [[ $p != "$PWD/../installed-headers-dir"* ]] && [[ $p != "$PWD/../installed-libs-dir"* ]]; then
+            if [[ $p != "$PWD/../shared-libs-headers-install-dir"* ]] && [[ $p != "$PWD/../shared-libs-install-dir"* ]]; then
               exit 1
             fi
           # Each line of install_manifest.txt contains the location of an installed library or header
@@ -96,6 +95,28 @@ jobs:
           # Uninstall and reset build.
           sudo xargs rm < install_manifest.txt || echo "transport_interface.h is installed twice because of duplicate copies in spoke repos."
           rm -rf *
+      - name: Configure CMake for installation of static libraries at custom location
+        run: |
+          curl https://cmake.org/files/v3.2/cmake-3.2.0-Linux-x86_64.tar.gz -o cmake.tar.gz
+          tar -xf cmake.tar.gz
+          mkdir build && cd build
+          ../cmake-3.2.0-Linux-x86_64/bin/cmake .. \
+          -DBUILD_SHARED_LIBRARIES=OFF \
+          -DBUILD_DEMOS=0 -DBUILD_TESTS=0 \
+          -DCSDK_HEADER_INSTALL_PATH="$PWD/../static-libs-headers-install-dir" -DCSDK_LIB_INSTALL_PATH="$PWD/../static-libs-install-dir"
+      - name: Install static libraries and verify custom install location
+        run: |
+          cd build && sudo make install
+          while IFS="" read -r p || [ -n "$p" ]
+          do
+            if [[ $p != "$PWD/../static-libs-headers-install-dir"* ]] && [[ $p != "$PWD/../static-libs-install-dir"* ]]; then
+              exit 1
+            fi
+          # Each line of install_manifest.txt contains the location of an installed library or header
+          done <install_manifest.txt
+          # Uninstall and reset build.
+          sudo xargs rm < install_manifest.txt || echo "transport_interface.h is installed twice because of duplicate copies in spoke repos."
+          rm -rf *          
       - name: Configure CMake build for system install location and selective installation
         run: |
           cd build
@@ -232,7 +253,7 @@ jobs:
             exit 0
           fi
   doxygen:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
@@ -240,7 +261,7 @@ jobs:
       - name: Install Doxygen
         run: |
           wget -qO- "https://sourceforge.net/projects/doxygen/files/rel-1.8.20/doxygen-1.8.20.linux.bin.tar.gz/download" | sudo tar --strip-components=1 -xz -C /usr/local
-          sudo apt-get install -y libclang-9-dev graphviz
+          sudo apt-get install -y libclang-9-dev libclang-cpp9 graphviz
       - name: Install Python3
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,7 @@ jobs:
           rm -rf *
       - name: Configure CMake for installation of static libraries at custom location
         run: |
-          curl https://cmake.org/files/v3.2/cmake-3.2.0-Linux-x86_64.tar.gz -o cmake.tar.gz
-          tar -xf cmake.tar.gz
-          mkdir build && cd build
+          cd build
           ../cmake-3.2.0-Linux-x86_64/bin/cmake .. \
           -DBUILD_SHARED_LIBRARIES=OFF \
           -DBUILD_DEMOS=0 -DBUILD_TESTS=0 \
@@ -116,7 +114,7 @@ jobs:
           done <install_manifest.txt
           # Uninstall and reset build.
           sudo xargs rm < install_manifest.txt || echo "transport_interface.h is installed twice because of duplicate copies in spoke repos."
-          rm -rf *          
+          rm -rf *
       - name: Configure CMake build for system install location and selective installation
         run: |
           cd build

--- a/platform/posix/CMakeLists.txt
+++ b/platform/posix/CMakeLists.txt
@@ -9,11 +9,13 @@ target_include_directories( clock_posix
                               PRIVATE
                                 ${PLATFORM_DIR}/include )
 
-# Install clock abstraction as library.
+# Install clock abstraction as library of both static archive and shared type.
 if(INSTALL_PLATFORM_ABSTRACTIONS)
     install(TARGETS
       clock_posix
-      LIBRARY DESTINATION "${CSDK_LIB_INSTALL_PATH}")
+      LIBRARY DESTINATION "${CSDK_LIB_INSTALL_PATH}"
+      ARCHIVE DESTINATION "${CSDK_LIB_INSTALL_PATH}"
+      )
 endif()
 
 if(BUILD_TESTS)

--- a/platform/posix/transport/CMakeLists.txt
+++ b/platform/posix/transport/CMakeLists.txt
@@ -40,13 +40,14 @@ target_link_libraries( openssl_posix
                           # requires explicit linking.
                           ${CMAKE_DL_LIBS} )
 
-# Install transport implementations as libraries.
+# Install transport implementations as both shared and static libraries.
 if(INSTALL_PLATFORM_ABSTRACTIONS)
     install(TARGETS
       openssl_posix
       plaintext_posix
       sockets_posix
-      LIBRARY DESTINATION "${CSDK_LIB_INSTALL_PATH}")
+      LIBRARY DESTINATION "${CSDK_LIB_INSTALL_PATH}"
+      ARCHIVE DESTINATION "${CSDK_LIB_INSTALL_PATH}")
 endif()
 
 if( BUILD_TESTS )

--- a/tools/cmake/install.cmake
+++ b/tools/cmake/install.cmake
@@ -127,9 +127,9 @@ foreach(library_prefix ${LIBRARY_PREFIXES})
     endif()
 
     # Install the library target and support both static archive and shared library builds.
-    install(TARGETS "${library_name}" 
-            LIBRARY DESTINATION "${CSDK_LIB_INSTALL_PATH}" 
-            ARCHIVE DESTINATION "${CSDK_LIB_INSTALL_PATH}") 
+    install(TARGETS "${library_name}"
+            LIBRARY DESTINATION "${CSDK_LIB_INSTALL_PATH}"
+            ARCHIVE DESTINATION "${CSDK_LIB_INSTALL_PATH}")
 endforeach()
 
 # Install platform abstractions as shared libraries if enabled.
@@ -146,8 +146,8 @@ if(INSTALL_PLATFORM_ABSTRACTIONS)
                                         ${OTA_INCLUDE_PUBLIC_DIRS}
                                         ${OTA_INCLUDE_OS_POSIX_DIRS})
         target_compile_definitions(ota_posix PRIVATE -DOTA_DO_NOT_USE_CUSTOM_CONFIG)
-        install(TARGETS ota_posix 
-                LIBRARY DESTINATION "${CSDK_LIB_INSTALL_PATH}" 
+        install(TARGETS ota_posix
+                LIBRARY DESTINATION "${CSDK_LIB_INSTALL_PATH}"
                 ARCHIVE DESTINATION "${CSDK_LIB_INSTALL_PATH}")
         list(APPEND PLATFORM_DIRECTORIES ${OTA_INCLUDE_OS_POSIX_DIRS})
     endif()

--- a/tools/cmake/install.cmake
+++ b/tools/cmake/install.cmake
@@ -126,8 +126,10 @@ foreach(library_prefix ${LIBRARY_PREFIXES})
                                     PRIVATE ${${library_prefix}_INCLUDE_PRIVATE_DIRS})
     endif()
 
-    # Install the library target.
-    install(TARGETS "${library_name}" LIBRARY DESTINATION "${CSDK_LIB_INSTALL_PATH}")
+    # Install the library target and support both static archive and shared library builds.
+    install(TARGETS "${library_name}" 
+            LIBRARY DESTINATION "${CSDK_LIB_INSTALL_PATH}" 
+            ARCHIVE DESTINATION "${CSDK_LIB_INSTALL_PATH}") 
 endforeach()
 
 # Install platform abstractions as shared libraries if enabled.
@@ -144,7 +146,9 @@ if(INSTALL_PLATFORM_ABSTRACTIONS)
                                         ${OTA_INCLUDE_PUBLIC_DIRS}
                                         ${OTA_INCLUDE_OS_POSIX_DIRS})
         target_compile_definitions(ota_posix PRIVATE -DOTA_DO_NOT_USE_CUSTOM_CONFIG)
-        install(TARGETS ota_posix LIBRARY DESTINATION "${CSDK_LIB_INSTALL_PATH}")
+        install(TARGETS ota_posix 
+                LIBRARY DESTINATION "${CSDK_LIB_INSTALL_PATH}" 
+                ARCHIVE DESTINATION "${CSDK_LIB_INSTALL_PATH}")
         list(APPEND PLATFORM_DIRECTORIES ${OTA_INCLUDE_OS_POSIX_DIRS})
     endif()
     foreach(platform_dir ${PLATFORM_DIRECTORIES})


### PR DESCRIPTION
Update the `install` target of the build infrastructure to support installation of `.a` (static archive) libraries when `BUILD_SHARED_LIBRARIES=OFF` parameter is passed in the CMake configuration command.

Associated Issue: https://github.com/aws/aws-iot-device-sdk-embedded-C/issues/1637