### PR TITLE
Fix Mosquitto setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,10 +519,10 @@ sh get-docker.sh
 
 The following instructions have been tested on an Ubuntu 18.04 environment with Docker and OpenSSL installed.
 
-1. Download the official Docker image for Mosquitto.
+1. Download the official Docker image for Mosquitto 1.6.14.
 
     ```sh
-    docker pull eclipse-mosquitto:latest
+    docker pull eclipse-mosquitto:1.6.14
     ```
 
 1. If a Mosquitto broker with TLS communication needs to be run, ignore this step and proceed to the next step. A Mosquitto broker with plain text communication can be run by executing the command below.

--- a/docs/doxygen/building.dox
+++ b/docs/doxygen/building.dox
@@ -197,10 +197,10 @@ sh get-docker.sh
 
 The following instructions have been tested on an Ubuntu 18.04 environment with Docker and OpenSSL installed.
 <ol>
-<li>Download the official Docker image for Mosquitto.</li>
+<li>Download the official Docker image for Mosquitto 1.6.14.</li>
 
 @code{sh}
-docker pull eclipse-mosquitto:latest
+docker pull eclipse-mosquitto:1.6.14
 @endcode
 
 <li>`BROKER_ENDPOINT` defined in `demos/mqtt/mqtt_demo_basic_tls/demo_config.h` can now be set to `localhost`.</li>


### PR DESCRIPTION
Because Mosquitto V2 requires an unprivileged user to run the broker:
```
If Mosquitto is run on as root on a unix like system, it will attempt to drop privileges as soon as the configuration file has been read. This is in contrast to the previous behaviour where elevated privileges were only dropped after listeners had been started (and hence TLS certificates loaded) and logging had been started. The change means that clients will never be able to connect to the broker when it is running as root, unless the user explicitly sets it to run as root, which is not advised. It also means that all locations that the broker needs to access must be available to the unprivileged user. In particular those people using TLS certificates from Lets Encrypt will need to do something to allow Mosquitto to access those certificates. An example deploy renewal hook script to help with this is at misc/letsencrypt/mosquitto-copy.s
```
We need to update the instructions to use `docker pull eclipse-mosquitto:1.6.14` rather than `docker pull eclipse-mosquitto:latest`. Otherwise, you get the following error when trying to connect to the broker:
```
1621740462: Client <unknown> disconnected, not authorised.
1621740477: New connection from 172.18.0.1:59296 on port 8883.
1621740477: Client <unknown> disconnected, not authorised.
1621740576: New connection from 172.18.0.1:59444 on port 8883.
1621740576: Client <unknown> disconnected, not authorised.
```
Updating the instructions to utilize V2 may also be possible, but reverting to the Mosquitto version used while writing these instructions should also fix the problem for the time being.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
