### PR TITLE
Fix version of eclipse-mosquitto in remaining areas of documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,8 @@ sh get-docker.sh
 
 The following instructions have been tested on an Ubuntu 18.04 environment with Docker and OpenSSL installed.
 
-1. Download the official Docker image for Mosquitto 1.6.14.
+1. Download the official Docker image for Mosquitto 1.6.14. This version is deliberately chosen so that the Docker container can load certificates from the host system.
+Any version after 1.6.14 will drop privileges as soon as the configuration file has been read (before TLS certificates are loaded).
 
     ```sh
     docker pull eclipse-mosquitto:1.6.14

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ The following instructions have been tested on an Ubuntu 18.04 environment with 
 1. If a Mosquitto broker with TLS communication needs to be run, ignore this step and proceed to the next step. A Mosquitto broker with plain text communication can be run by executing the command below.
 
     ```
-    docker run -it -p 1883:1883 --name mosquitto-plain-text eclipse-mosquitto:latest
+    docker run -it -p 1883:1883 --name mosquitto-plain-text eclipse-mosquitto:1.6.14
     ```
 
 1. Set `BROKER_ENDPOINT` defined in `demos/mqtt/mqtt_demo_plaintext/demo_config.h` to `localhost`.
@@ -568,7 +568,7 @@ The following instructions have been tested on an Ubuntu 18.04 environment with 
 1. Run the docker container from the local directory containing the generated credential and mosquitto.conf files.
 
     ```sh
-    docker run -it -p 8883:8883 -v $(pwd):/mosquitto/config/ --name mosquitto-basic-tls eclipse-mosquitto:latest
+    docker run -it -p 8883:8883 -v $(pwd):/mosquitto/config/ --name mosquitto-basic-tls eclipse-mosquitto:1.6.14
     ```
 
 1. Update `demos/mqtt/mqtt_demo_basic_tls/demo_config.h` to the following:  

--- a/docs/doxygen/building.dox
+++ b/docs/doxygen/building.dox
@@ -197,7 +197,8 @@ sh get-docker.sh
 
 The following instructions have been tested on an Ubuntu 18.04 environment with Docker and OpenSSL installed.
 <ol>
-<li>Download the official Docker image for Mosquitto 1.6.14.</li>
+<li>Download the official Docker image for Mosquitto 1.6.14. This version is deliberately chosen so that the Docker container can load certificates from the host system.
+Any version after 1.6.14 will drop privileges as soon as the configuration file has been read (before TLS certificates are loaded).</li>
 
 @code{sh}
 docker pull eclipse-mosquitto:1.6.14

--- a/docs/doxygen/building.dox
+++ b/docs/doxygen/building.dox
@@ -239,7 +239,7 @@ tls_version tlsv1.2
 <li>Run the docker container from the local directory containing the generated credential and mosquitto.conf files.</li>
 
 @code{sh}
-docker run -it -p 8883:8883 -v $(pwd):/mosquitto/config/ --name mosquitto-basic-tls eclipse-mosquitto:latest
+docker run -it -p 8883:8883 -v $(pwd):/mosquitto/config/ --name mosquitto-basic-tls eclipse-mosquitto:1.6.14
 @endcode
 
 <li>Set `ROOT_CA_CERT_PATH` to the absolute path of the CA certificate created in step 3. for the local Mosquitto server.</li>


### PR DESCRIPTION
This is a follow-up to PR #1642 since I had forgotten a few places that still used `eclipse-mosquitto:latest` instead of `eclipse-mosquitto:1.6.14`.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
