### PR TITLE
Cleaned up report_builder in defender_demo_json

### DIFF
--- a/demos/defender/defender_demo_json/report_builder.c
+++ b/demos/defender/defender_demo_json/report_builder.c
@@ -45,53 +45,53 @@
 #define SNPRINTF_SUCCESS( retVal, bufLen )    ( ( retVal > 0 ) && ( ( uint32_t ) retVal < bufLen ) )
 
 /* Formats used to generate the JSON report. */
-#define JSON_PORT_OBJECT_FORMAT \
-    "{"                         \
-    "\"%s\": %u"                \
+#define JSON_PORT_OBJECT_FORMAT          \
+    "{"                                  \
+    "\""DEFENDER_REPORT_PORT_KEY"\": %u" \
     "},"
 
-#define JSON_CONNECTION_OBJECT_FORMAT \
-    "{"                               \
-    "\"%s\": %u,"                     \
-    "\"%s\": \"%u.%u.%u.%u:%u\""      \
+#define JSON_CONNECTION_OBJECT_FORMAT                           \
+    "{"                                                         \
+    "\""DEFENDER_REPORT_LOCAL_PORT_KEY"\": %u,"                 \
+    "\""DEFENDER_REPORT_REMOTE_ADDR_KEY"\": \"%u.%u.%u.%u:%u\"" \
     "},"
 
-#define JSON_REPORT_FORMAT_PART1 \
-    "{"                          \
-    "\"%s\": {"                  \
-    "\"%s\": %u,"                \
-    "\"%s\": \"%u.%u\""          \
-    "},"                         \
-    "\"%s\": {"                  \
-    "\"%s\": {"                  \
-    "\"%s\": "
+#define JSON_REPORT_FORMAT_PART1                       \
+    "{"                                                \
+    "\""DEFENDER_REPORT_HEADER_KEY"\": {"              \
+    "\""DEFENDER_REPORT_ID_KEY"\": %u,"                \
+    "\""DEFENDER_REPORT_VERSION_KEY"\": \"%u.%u\""     \
+    "},"                                               \
+    "\""DEFENDER_REPORT_METRICS_KEY"\": {"             \
+    "\""DEFENDER_REPORT_TCP_LISTENING_PORTS_KEY"\": {" \
+    "\""DEFENDER_REPORT_PORTS_KEY"\": "
 
-#define JSON_REPORT_FORMAT_PART2 \
-    ","                          \
-    "\"%s\": %u"                 \
-    "},"                         \
-    "\"%s\": {"                  \
-    "\"%s\": "
+#define JSON_REPORT_FORMAT_PART2                       \
+    ","                                                \
+    "\""DEFENDER_REPORT_TOTAL_KEY"\": %u"              \
+    "},"                                               \
+    "\""DEFENDER_REPORT_UDP_LISTENING_PORTS_KEY"\": {" \
+    "\""DEFENDER_REPORT_PORTS_KEY"\": "
 
-#define JSON_REPORT_FORMAT_PART3 \
-    ","                          \
-    "\"%s\": %u"                 \
-    "},"                         \
-    "\"%s\": {"                  \
-    "\"%s\": %u,"                \
-    "\"%s\": %u,"                \
-    "\"%s\": %u,"                \
-    "\"%s\": %u"                 \
-    "},"                         \
-    "\"%s\": {"                  \
-    "\"%s\": {"                  \
-    "\"%s\": "
+#define JSON_REPORT_FORMAT_PART3                           \
+    ","                                                    \
+    "\""DEFENDER_REPORT_TOTAL_KEY"\": %u"                  \
+    "},"                                                   \
+    "\""DEFENDER_REPORT_NETWORK_STATS_KEY"\": {"           \
+    "\""DEFENDER_REPORT_BYTES_IN_KEY"\": %u,"              \
+    "\""DEFENDER_REPORT_BYTES_OUT_KEY"\": %u,"             \
+    "\""DEFENDER_REPORT_PKTS_IN_KEY"\": %u,"               \
+    "\""DEFENDER_REPORT_PKTS_OUT_KEY"\": %u"               \
+    "},"                                                   \
+    "\""DEFENDER_REPORT_TCP_CONNECTIONS_KEY"\": {"         \
+    "\""DEFENDER_REPORT_ESTABLISHED_CONNECTIONS_KEY"\": {" \
+    "\""DEFENDER_REPORT_CONNECTIONS_KEY"\": "
 
-#define JSON_REPORT_FORMAT_PART4 \
-    ","                          \
-    "\"%s\": %u"                 \
-    "}"                          \
-    "}"                          \
+#define JSON_REPORT_FORMAT_PART4          \
+    ","                                   \
+    "\""DEFENDER_REPORT_TOTAL_KEY"\": %u" \
+    "}"                                   \
+    "}"                                   \
     "},"
 
 /**
@@ -220,7 +220,6 @@ static ReportBuilderStatus_t writePortsArray( char * pBuffer,
         charactersWritten = snprintf( pCurrentWritePos,
                                       remainingBufferLength,
                                       JSON_PORT_OBJECT_FORMAT,
-                                      DEFENDER_REPORT_PORT_KEY,
                                       pOpenPortsArray[ i ] );
 
         if( !SNPRINTF_SUCCESS( charactersWritten, remainingBufferLength ) )
@@ -302,9 +301,7 @@ static ReportBuilderStatus_t writeConnectionsArray( char * pBuffer,
         charactersWritten = snprintf( pCurrentWritePos,
                                       remainingBufferLength,
                                       JSON_CONNECTION_OBJECT_FORMAT,
-                                      DEFENDER_REPORT_LOCAL_PORT_KEY,
                                       pConn->localPort,
-                                      DEFENDER_REPORT_REMOTE_ADDR_KEY,
                                       ( pConn->remoteIp >> 24 ) & 0xFF,
                                       ( pConn->remoteIp >> 16 ) & 0xFF,
                                       ( pConn->remoteIp >> 8 ) & 0xFF,
@@ -388,15 +385,9 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
         charactersWritten = snprintf( pCurrentWritePos,
                                       remainingBufferLength,
                                       JSON_REPORT_FORMAT_PART1,
-                                      DEFENDER_REPORT_HEADER_KEY,
-                                      DEFENDER_REPORT_ID_KEY,
                                       reportId,
-                                      DEFENDER_REPORT_VERSION_KEY,
                                       majorReportVersion,
-                                      minorReportVersion,
-                                      DEFENDER_REPORT_METRICS_KEY,
-                                      DEFENDER_REPORT_TCP_LISTENING_PORTS_KEY,
-                                      DEFENDER_REPORT_PORTS_KEY );
+                                      minorReportVersion );
 
         if( !SNPRINTF_SUCCESS( charactersWritten, remainingBufferLength ) )
         {
@@ -436,10 +427,7 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
         charactersWritten = snprintf( pCurrentWritePos,
                                       remainingBufferLength,
                                       JSON_REPORT_FORMAT_PART2,
-                                      DEFENDER_REPORT_TOTAL_KEY,
-                                      pMetrics->openTcpPortsArrayLength,
-                                      DEFENDER_REPORT_UDP_LISTENING_PORTS_KEY,
-                                      DEFENDER_REPORT_PORTS_KEY );
+                                      pMetrics->openTcpPortsArrayLength );
 
         if( !SNPRINTF_SUCCESS( charactersWritten, remainingBufferLength ) )
         {
@@ -479,20 +467,11 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
         charactersWritten = snprintf( pCurrentWritePos,
                                       remainingBufferLength,
                                       JSON_REPORT_FORMAT_PART3,
-                                      DEFENDER_REPORT_TOTAL_KEY,
                                       pMetrics->openUdpPortsArrayLength,
-                                      DEFENDER_REPORT_NETWORK_STATS_KEY,
-                                      DEFENDER_REPORT_BYTES_IN_KEY,
                                       pMetrics->pNetworkStats->bytesReceived,
-                                      DEFENDER_REPORT_BYTES_OUT_KEY,
                                       pMetrics->pNetworkStats->bytesSent,
-                                      DEFENDER_REPORT_PKTS_IN_KEY,
                                       pMetrics->pNetworkStats->packetsReceived,
-                                      DEFENDER_REPORT_PKTS_OUT_KEY,
-                                      pMetrics->pNetworkStats->packetsSent,
-                                      DEFENDER_REPORT_TCP_CONNECTIONS_KEY,
-                                      DEFENDER_REPORT_ESTABLISHED_CONNECTIONS_KEY,
-                                      DEFENDER_REPORT_CONNECTIONS_KEY );
+                                      pMetrics->pNetworkStats->packetsSent );
 
         if( !SNPRINTF_SUCCESS( charactersWritten, remainingBufferLength ) )
         {
@@ -532,7 +511,6 @@ ReportBuilderStatus_t GenerateJsonReport( char * pBuffer,
         charactersWritten = snprintf( pCurrentWritePos,
                                       remainingBufferLength,
                                       JSON_REPORT_FORMAT_PART4,
-                                      DEFENDER_REPORT_TOTAL_KEY,
                                       pMetrics->establishedConnectionsArrayLength );
 
         if( !SNPRINTF_SUCCESS( charactersWritten, remainingBufferLength ) )

--- a/demos/defender/defender_demo_json/report_builder.c
+++ b/demos/defender/defender_demo_json/report_builder.c
@@ -45,6 +45,7 @@
 #define SNPRINTF_SUCCESS( retVal, bufLen )    ( ( retVal > 0 ) && ( ( uint32_t ) retVal < bufLen ) )
 
 /* Formats used to generate the JSON report. */
+/* *INDENT-OFF* */
 #define JSON_PORT_OBJECT_FORMAT          \
     "{"                                  \
     "\""DEFENDER_REPORT_PORT_KEY"\": %u" \
@@ -93,6 +94,8 @@
     "}"                                   \
     "}"                                   \
     "},"
+
+/* *INDENT-ON* */
 
 /**
  * @brief The format for custom metrics of CPU usage time


### PR DESCRIPTION
With the parentheses in `DEFENDER_REPORT_SELECT_KEY` removed, json key macros from `defender.h` can now be used as strings to concatenate with other strings at build time. This PR cleans up `report_builder` in `defender_demo_json` by replacing "%s" in json formatting strings with appropriate key macros from `defender.h`.

This PR is tested by building defender_demo_json and running it. By default without `DEFENDER_USE_LONG_KEYS` defined, the json report is as follow:
```
{"hed": {"rid": 1625700661,"v": "1.0"},"met": {"tp": {"pts": [{"pt": 53},{"pt": 22},{"pt": 1883}],"t": 3},"up": {"pts": [],"t": 0},"ns": {"bi": 1932335905,"bo": 147230817,"pi": 1872689,"po": 940337},"tc": {"ec": {"cs": [{"lp": 39216,"rad": "34.212.105.174:8883"},{"lp": 59284,"rad": "52.94.212.197:443"},{"lp": 40854,"rad": "52.119.161.149:443"},{"lp": 22,"rad": "205.251.233.52:20714"}],"t": 4}}},"cmet":{"cpu-usage": [{"number_list": [1313090, 10499958]}],"memory-info": [{"string_list": ["15807620kB","15052772kB"]}]}}
```
With `DEFENDER_USE_LONG_KEYS` defined to 1, the report is as follow:
```
{"header": {"report_id": 1625700736,"version": "1.0"},"metrics": {"listening_tcp_ports": {"ports": [{"port": 53},{"port": 22},{"port": 1883}],"total": 3},"listening_udp_ports": {"ports": [],"total": 0},"network_stats": {"bytes_in": 1932414997,"bytes_out": 147530502,"packets_in": 1873332,"packets_out": 940903},"tcp_connections": {"established_connections": {"connections": [{"local_port": 49454,"remote_addr": "52.34.21.9:8883"},{"local_port": 40854,"remote_addr": "52.119.161.149:443"},{"local_port": 22,"remote_addr": "205.251.233.52:20714"},{"local_port": 36418,"remote_addr": "52.94.210.188:443"}],"total": 4}}},"custom_metrics":{"cpu-usage": [{"number_list": [1313164, 10500553]}],"memory-info": [{"string_list": ["15807620kB","15051816kB"]}]}}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
