### PR TITLE
Poll socket before attempting a speculative read or write

### DIFF
--- a/platform/lexicon.txt
+++ b/platform/lexicon.txt
@@ -186,6 +186,8 @@ platformimagestate
 plisthead
 pnetworkcontext
 png
+pollin
+pollpri
 popensslcredentials
 popensslparams
 posix
@@ -249,6 +251,7 @@ transportpage
 transportsectionimplementation
 transportsectionoverview
 transportstruct
+tx
 txt
 ulblockindex
 ulblocksize

--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -25,15 +25,15 @@
 #include <assert.h>
 #include <string.h>
 
-/* POSIX socket include. */
+/* POSIX socket includes. */
 #include <unistd.h>
+#include <poll.h>
 
 /* Transport interface include. */
 #include "transport_interface.h"
 
 #include "openssl_posix.h"
 #include <openssl/err.h>
-#include <poll.h>
 
 /*-----------------------------------------------------------*/
 
@@ -738,8 +738,10 @@ int32_t Openssl_Recv( NetworkContext_t * pNetworkContext,
         struct pollfd pollFds;
         pOpensslParams = pNetworkContext->pParams;
 
-        /* Initialize the file descriptor. */
-        pollFds.events = POLLIN | POLLPRI | POLLHUP | POLLERR;
+        /* Initialize the file descriptor.
+         * #POLLPRI corresponds to high-priority data while #POLLIN corresponds
+         * to any other data that may be read. */
+        pollFds.events = POLLIN | POLLPRI;
         pollFds.revents = 0;
         /* Set the file descriptor for poll. */
         pollFds.fd = pOpensslParams->socketDescriptor;
@@ -838,7 +840,7 @@ int32_t Openssl_Send( NetworkContext_t * pNetworkContext,
         pOpensslParams = pNetworkContext->pParams;
 
         /* Initialize the file descriptor. */
-        pollFds.events = POLLOUT | POLLPRI | POLLHUP | POLLERR;
+        pollFds.events = POLLOUT;
         pollFds.revents = 0;
         /* Set the file descriptor for poll. */
         pollFds.fd = pOpensslParams->socketDescriptor;

--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -856,7 +856,10 @@ int32_t Openssl_Send( NetworkContext_t * pNetworkContext,
         /* Set the file descriptor for poll. */
         pollFds.fd = pOpensslParams->socketDescriptor;
 
-        /* `poll` checks if the socket is ready to send data. */
+        /* `poll` checks if the socket is ready to send data. 
+         * Note: This is done to avoid blocking on SSL_write()
+         * when TCP socket is not ready to accept more data for
+         * network transmission (possibly due to a full TX buffer). */
         pollStatus = poll( &pollFds, 1, 0 );
 
         if( pollStatus > 0 )

--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -856,7 +856,7 @@ int32_t Openssl_Send( NetworkContext_t * pNetworkContext,
         /* Set the file descriptor for poll. */
         pollFds.fd = pOpensslParams->socketDescriptor;
 
-        /* `poll` checks if the socket is ready to send data. 
+        /* `poll` checks if the socket is ready to send data.
          * Note: This is done to avoid blocking on SSL_write()
          * when TCP socket is not ready to accept more data for
          * network transmission (possibly due to a full TX buffer). */

--- a/platform/posix/transport/src/plaintext_posix.c
+++ b/platform/posix/transport/src/plaintext_posix.c
@@ -207,7 +207,7 @@ int32_t Plaintext_Send( NetworkContext_t * pNetworkContext,
 
     /* Check if data can be written to the socket.
      * Note: This is done to avoid blocking on send() when
-     * the socket is not ready to accept more data for network 
+     * the socket is not ready to accept more data for network
      * transmission (possibly due to a full TX buffer). */
     pollStatus = poll( &pollFds, 1, 0 );
 

--- a/platform/posix/transport/src/plaintext_posix.c
+++ b/platform/posix/transport/src/plaintext_posix.c
@@ -125,8 +125,10 @@ int32_t Plaintext_Recv( NetworkContext_t * pNetworkContext,
     /* Get receive timeout from the socket to use as the timeout for #select. */
     pPlaintextParams = pNetworkContext->pParams;
 
-    /* Initialize the file descriptor. */
-    pollFds.events = POLLIN | POLLPRI | POLLHUP | POLLERR;
+    /* Initialize the file descriptor.
+     * #POLLPRI corresponds to high-priority data while #POLLIN corresponds
+     * to any other data that may be read. */
+    pollFds.events = POLLIN | POLLPRI;
     pollFds.revents = 0;
     /* Set the file descriptor for poll. */
     pollFds.fd = pPlaintextParams->socketDescriptor;
@@ -194,7 +196,7 @@ int32_t Plaintext_Send( NetworkContext_t * pNetworkContext,
     pPlaintextParams = pNetworkContext->pParams;
 
     /* Initialize the file descriptor. */
-    pollFds.events = POLLOUT | POLLPRI | POLLHUP | POLLERR;
+    pollFds.events = POLLOUT;
     pollFds.revents = 0;
     /* Set the file descriptor for poll. */
     pollFds.fd = pPlaintextParams->socketDescriptor;

--- a/platform/posix/transport/src/plaintext_posix.c
+++ b/platform/posix/transport/src/plaintext_posix.c
@@ -115,7 +115,7 @@ int32_t Plaintext_Recv( NetworkContext_t * pNetworkContext,
                         size_t bytesToRecv )
 {
     PlaintextParams_t * pPlaintextParams = NULL;
-    int32_t bytesReceived = -1, pollStatus = -1;
+    int32_t bytesReceived = -1, pollStatus = 1;
     struct pollfd pollFds;
 
     assert( pNetworkContext != NULL && pNetworkContext->pParams != NULL );
@@ -131,8 +131,12 @@ int32_t Plaintext_Recv( NetworkContext_t * pNetworkContext,
     /* Set the file descriptor for poll. */
     pollFds.fd = pPlaintextParams->socketDescriptor;
 
-    /* Check if there is data to read from the socket. */
-    pollStatus = poll( &pollFds, 1, 0 );
+    /* Speculative read for the start of a payload. */
+    if( bytesToRecv == 1U )
+    {
+        /* Check if there is data to read from the socket. */
+        pollStatus = poll( &pollFds, 1, 0 );
+    }
 
     if( pollStatus > 0 )
     {

--- a/platform/posix/transport/src/plaintext_posix.c
+++ b/platform/posix/transport/src/plaintext_posix.c
@@ -207,8 +207,8 @@ int32_t Plaintext_Send( NetworkContext_t * pNetworkContext,
 
     /* Check if data can be written to the socket.
      * Note: This is done to avoid blocking on send() when
-     * the socket is ready to accept more data for network transmission
-     * (possibly due to a full TX buffer). */
+     * the socket is not ready to accept more data for network 
+     * transmission (possibly due to a full TX buffer). */
     pollStatus = poll( &pollFds, 1, 0 );
 
     if( pollStatus > 0 )

--- a/platform/posix/transport/utest/CMakeLists.txt
+++ b/platform/posix/transport/utest/CMakeLists.txt
@@ -16,10 +16,10 @@ list(APPEND mock_list
             /usr/include/arpa/inet.h
             /usr/include/x86_64-linux-gnu/sys/socket.h
             /usr/include/netdb.h
+            /usr/include/x86_64-linux-gnu/sys/poll.h
             ${CMAKE_CURRENT_LIST_DIR}/mocks/unistd_api.h
             ${CMAKE_CURRENT_LIST_DIR}/mocks/openssl_api.h
             ${CMAKE_CURRENT_LIST_DIR}/mocks/stdio_api.h
-            ${CMAKE_CURRENT_LIST_DIR}/mocks/select_api.h
             ${PLATFORM_DIR}/posix/transport/include/sockets_posix.h
         )
 # list the directories your mocks need

--- a/platform/posix/transport/utest/mocks/openssl_api.h
+++ b/platform/posix/transport/utest/mocks/openssl_api.h
@@ -146,6 +146,8 @@ extern int SSL_write( SSL * ssl,
                       const void * buf,
                       int num );
 
+extern int SSL_pending( const SSL * ssl );
+
 const char * ERR_reason_error_string( unsigned long e );
 
 void X509_free( X509 * a );

--- a/platform/posix/transport/utest/openssl_utest.c
+++ b/platform/posix/transport/utest/openssl_utest.c
@@ -849,9 +849,10 @@ void test_Openssl_Recv_All_Bytes_Received_Successfully( void )
     TEST_ASSERT_EQUAL( BYTES_TO_RECV, bytesReceived );
 
     /* Pending data from last read. */
-    SSL_read_ExpectAnyArgsAndReturn( BYTES_TO_RECV );
-    bytesReceived = Openssl_Recv( &networkContext, opensslBuffer, BYTES_TO_RECV );
-    TEST_ASSERT_EQUAL( BYTES_TO_RECV, bytesReceived );
+    SSL_pending_ExpectAnyArgsAndReturn( BYTES_TO_RECV );
+    SSL_read_ExpectAnyArgsAndReturn( 1U );
+    bytesReceived = Openssl_Recv( &networkContext, opensslBuffer, 1U );
+    TEST_ASSERT_EQUAL( 1U, bytesReceived );
 }
 
 /**
@@ -875,10 +876,9 @@ void test_Openssl_Recv_Network_Error( void )
     TEST_ASSERT_TRUE( bytesReceived < 0 );
 
     /* Test that a non-retryable zero error code is converted to -1 by the API. */
-    SSL_pending_ExpectAnyArgsAndReturn( 1 );
     SSL_read_ExpectAnyArgsAndReturn( 0 );
     SSL_get_error_ExpectAnyArgsAndReturn( SSL_ERROR_ZERO_RETURN );
-    bytesReceived = Openssl_Recv( &networkContext, opensslBuffer, 1U );
+    bytesReceived = Openssl_Recv( &networkContext, opensslBuffer, BYTES_TO_RECV );
     TEST_ASSERT_EQUAL( -1, bytesReceived );
 
     /* Test that a poll error results in the function under test returning -1. */

--- a/platform/posix/transport/utest/plaintext_utest.c
+++ b/platform/posix/transport/utest/plaintext_utest.c
@@ -183,7 +183,6 @@ void test_Plaintext_Recv_All_Bytes_Received_Successfully( void )
 {
     int32_t bytesReceived;
 
-    poll_ExpectAnyArgsAndReturn( 1 );
     recv_ExpectAnyArgsAndReturn( BYTES_TO_RECV );
     bytesReceived = Plaintext_Recv( &networkContext,
                                     plaintextBuffer,
@@ -199,7 +198,6 @@ void test_Plaintext_Recv_Zero_Bytes_Received( void )
 {
     int32_t bytesReceived;
 
-    poll_ExpectAnyArgsAndReturn( 1 );
     recv_ExpectAnyArgsAndReturn( 0 );
     bytesReceived = Plaintext_Recv( &networkContext,
                                     plaintextBuffer,
@@ -217,7 +215,7 @@ void test_Plaintext_Recv_Socket_Timeout( void )
     poll_ExpectAnyArgsAndReturn( 0 );
     bytesReceived = Plaintext_Recv( &networkContext,
                                     plaintextBuffer,
-                                    BYTES_TO_RECV );
+                                    1U );
     TEST_ASSERT_EQUAL( 0, bytesReceived );
 }
 
@@ -232,7 +230,7 @@ void test_Plaintext_Recv_Poll_Error( void )
     poll_ExpectAnyArgsAndReturn( -1 );
     bytesReceived = Plaintext_Recv( &networkContext,
                                     plaintextBuffer,
-                                    BYTES_TO_RECV );
+                                    1U );
     TEST_ASSERT_EQUAL( SEND_RECV_ERROR, bytesReceived );
 }
 
@@ -247,7 +245,6 @@ void test_Plaintext_Recv_Network_Error( void )
 
     for( i = 0; i < sizeof( errorNumbers ); i++ )
     {
-        poll_ExpectAnyArgsAndReturn( 1 );
         recv_ExpectAnyArgsAndReturn( SEND_RECV_ERROR );
         errno = errorNumbers[ i ];
         bytesReceived = Plaintext_Recv( &networkContext,

--- a/platform/posix/transport/utest/plaintext_utest.c
+++ b/platform/posix/transport/utest/plaintext_utest.c
@@ -32,7 +32,7 @@
 
 #include "mock_sockets_posix.h"
 #include "mock_stdio_api.h"
-#include "mock_select_api.h"
+#include "mock_poll.h"
 #include "mock_socket.h"
 
 /* The send and receive timeout to set for the socket. */
@@ -183,8 +183,7 @@ void test_Plaintext_Recv_All_Bytes_Received_Successfully( void )
 {
     int32_t bytesReceived;
 
-    getsockopt_ExpectAnyArgsAndReturn( 0 );
-    select_ExpectAnyArgsAndReturn( 1 );
+    poll_ExpectAnyArgsAndReturn( 1 );
     recv_ExpectAnyArgsAndReturn( BYTES_TO_RECV );
     bytesReceived = Plaintext_Recv( &networkContext,
                                     plaintextBuffer,
@@ -200,8 +199,7 @@ void test_Plaintext_Recv_Zero_Bytes_Received( void )
 {
     int32_t bytesReceived;
 
-    getsockopt_ExpectAnyArgsAndReturn( -1 );
-    select_ExpectAnyArgsAndReturn( 1 );
+    poll_ExpectAnyArgsAndReturn( 1 );
     recv_ExpectAnyArgsAndReturn( 0 );
     bytesReceived = Plaintext_Recv( &networkContext,
                                     plaintextBuffer,
@@ -216,8 +214,7 @@ void test_Plaintext_Recv_Socket_Timeout( void )
 {
     int32_t bytesReceived;
 
-    getsockopt_ExpectAnyArgsAndReturn( 0 );
-    select_ExpectAnyArgsAndReturn( 0 );
+    poll_ExpectAnyArgsAndReturn( 0 );
     bytesReceived = Plaintext_Recv( &networkContext,
                                     plaintextBuffer,
                                     BYTES_TO_RECV );
@@ -232,8 +229,7 @@ void test_Plaintext_Recv_Poll_Error( void )
 {
     int32_t bytesReceived;
 
-    getsockopt_ExpectAnyArgsAndReturn( 0 );
-    select_ExpectAnyArgsAndReturn( -1 );
+    poll_ExpectAnyArgsAndReturn( -1 );
     bytesReceived = Plaintext_Recv( &networkContext,
                                     plaintextBuffer,
                                     BYTES_TO_RECV );
@@ -251,8 +247,7 @@ void test_Plaintext_Recv_Network_Error( void )
 
     for( i = 0; i < sizeof( errorNumbers ); i++ )
     {
-        getsockopt_ExpectAnyArgsAndReturn( 0 );
-        select_ExpectAnyArgsAndReturn( 1 );
+        poll_ExpectAnyArgsAndReturn( 1 );
         recv_ExpectAnyArgsAndReturn( SEND_RECV_ERROR );
         errno = errorNumbers[ i ];
         bytesReceived = Plaintext_Recv( &networkContext,
@@ -271,8 +266,7 @@ void test_Plaintext_Send_All_Bytes_Sent_Successfully( void )
 {
     int32_t bytesSent;
 
-    getsockopt_ExpectAnyArgsAndReturn( 0 );
-    select_ExpectAnyArgsAndReturn( 1 );
+    poll_ExpectAnyArgsAndReturn( 1 );
     send_ExpectAnyArgsAndReturn( BYTES_TO_SEND );
     bytesSent = Plaintext_Send( &networkContext,
                                 plaintextBuffer,
@@ -291,8 +285,7 @@ void test_Plaintext_Send_Network_Error( void )
 
     for( i = 0; i < sizeof( errorNumbers ); i++ )
     {
-        getsockopt_ExpectAnyArgsAndReturn( 0 );
-        select_ExpectAnyArgsAndReturn( 1 );
+        poll_ExpectAnyArgsAndReturn( 1 );
         send_ExpectAnyArgsAndReturn( SEND_RECV_ERROR );
         errno = errorNumbers[ i ];
         bytesSent = Plaintext_Send( &networkContext,
@@ -311,8 +304,7 @@ void test_Plaintext_Send_Zero_Bytes_Received( void )
 {
     int32_t bytesSent;
 
-    getsockopt_ExpectAnyArgsAndReturn( -1 );
-    select_ExpectAnyArgsAndReturn( 1 );
+    poll_ExpectAnyArgsAndReturn( 1 );
     send_ExpectAnyArgsAndReturn( 0 );
     bytesSent = Plaintext_Send( &networkContext,
                                 plaintextBuffer,
@@ -327,8 +319,7 @@ void test_Plaintext_Send_Socket_Timeout( void )
 {
     int32_t bytesSent;
 
-    getsockopt_ExpectAnyArgsAndReturn( 0 );
-    select_ExpectAnyArgsAndReturn( 0 );
+    poll_ExpectAnyArgsAndReturn( 0 );
     bytesSent = Plaintext_Send( &networkContext,
                                 plaintextBuffer,
                                 BYTES_TO_SEND );
@@ -343,8 +334,7 @@ void test_Plaintext_Send_Poll_Error( void )
 {
     int32_t bytesSent;
 
-    getsockopt_ExpectAnyArgsAndReturn( 0 );
-    select_ExpectAnyArgsAndReturn( -1 );
+    poll_ExpectAnyArgsAndReturn( -1 );
     bytesSent = Plaintext_Send( &networkContext,
                                 plaintextBuffer,
                                 BYTES_TO_SEND );


### PR DESCRIPTION
This addresses the problem from issue #1634. Specifically, the POSIX transport implementation is updated to match what is specified in the [transport_interface.h documentation for handling speculative reads](https://github.com/FreeRTOS/coreMQTT/blob/main/source/interface/transport_interface.h#L94-L172).

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
