### PR TITLE
Configure HMAC & CMAC keys as empty strings for demo

### DIFF
--- a/demos/pkcs11/common/include/core_pkcs11_config.h
+++ b/demos/pkcs11/common/include/core_pkcs11_config.h
@@ -146,13 +146,21 @@
 
 /**
  * @brief The PKCS #11 label for the object to be used for HMAC operations.
+ * 
+ * @note The PKCS #11 does create a CMAC object but can be modified to do so
+ * by using the following definition:
+ * #define pkcs11configLABEL_CMAC_KEY                         "HMAC Key"
  */
-#define pkcs11configLABEL_HMAC_KEY                         "HMAC Key"
+#define pkcs11configLABEL_HMAC_KEY                         ""
 
 /**
  * @brief The PKCS #11 label for the object to be used for CMAC operations.
+ * 
+ * @note The PKCS #11 does create a CMAC object but can be modified to do so
+ * by using the following definition:
+ * #define pkcs11configLABEL_CMAC_KEY                         "CMAC Key"
  */
-#define pkcs11configLABEL_CMAC_KEY                         "CMAC Key"
+#define pkcs11configLABEL_CMAC_KEY                         ""
 
 /**
  * @brief The PKCS #11 label for the object to be used for code verification.


### PR DESCRIPTION
The demo currently does not support HMAC or CMAC, causing `pkcs11_sign_and_verify` demo to fail. Define these as empty strings but leave a note in case a customer would like to update the demo to create HMAC or CMAC objects.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
