### PR TITLE
Update corePKCS11 demo to read the public key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Minor Changes
 
+- [#1670](https://github.com/aws/aws-iot-device-sdk-embedded-C/pull/1670) Update corePKCS11 demo to read the public key as the private key was being used to both sign and verify
 - [#1596](https://github.com/aws/aws-iot-device-sdk-embedded-C/pull/1596) Make `THING_NAME` an alias for `CLIENT_IDENTIFIER` in MQTT-related demos
 - [#1593](https://github.com/aws/aws-iot-device-sdk-embedded-C/pull/1593) Initialize MQTT status return code in OTA demos mqtt_publish
 - [#1599](https://github.com/aws/aws-iot-device-sdk-embedded-C/pull/1599) Checking execution status of demo loop before calling pthread_join in OTA demos

--- a/demos/pkcs11/pkcs11_demo_objects/pkcs11_demo_objects.c
+++ b/demos/pkcs11/pkcs11_demo_objects/pkcs11_demo_objects.c
@@ -336,8 +336,8 @@ static CK_RV objectGeneration( void )
 
     /* Labels are application defined strings that are used to identify an
      * object. It should not be NULL terminated. */
-    CK_BYTE publicKeyLabel[] = { pkcs11demoPRIVATE_KEY_LABEL };
-    CK_BYTE privateKeyLabel[] = { pkcs11demoPUBLIC_KEY_LABEL };
+    CK_BYTE publicKeyLabel[] = { pkcs11demoPUBLIC_KEY_LABEL };
+    CK_BYTE privateKeyLabel[] = { pkcs11demoPRIVATE_KEY_LABEL };
 
     /* CK_ATTTRIBUTE's contain an attribute type, a value, and the length of
      * the value. An array of CK_ATTRIBUTEs is called a template. They are used

--- a/demos/pkcs11/pkcs11_demo_sign_and_verify/pkcs11_demo_sign_and_verify.c
+++ b/demos/pkcs11/pkcs11_demo_sign_and_verify/pkcs11_demo_sign_and_verify.c
@@ -155,7 +155,7 @@ CK_RV PKCS11SignVerifyDemo( void )
     {
         result = xFindObjectWithLabelAndClass( session,
                                                pkcs11demoPRIVATE_KEY_LABEL,
-                                               sizeof( pkcs11demoPRIVATE_KEY_LABEL ),
+                                               sizeof( pkcs11demoPRIVATE_KEY_LABEL ) - 1,
                                                CKO_PRIVATE_KEY,
                                                &privateKeyHandle );
     }
@@ -166,8 +166,8 @@ CK_RV PKCS11SignVerifyDemo( void )
     {
         result = xFindObjectWithLabelAndClass( session,
                                                pkcs11demoPUBLIC_KEY_LABEL,
-                                               sizeof( pkcs11demoPUBLIC_KEY_LABEL ),
-                                               CKO_PRIVATE_KEY,
+                                               sizeof( pkcs11demoPUBLIC_KEY_LABEL ) - 1,
+                                               CKO_PUBLIC_KEY,
                                                &publicKeyHandle );
     }
 


### PR DESCRIPTION
Update the demo so that it doesn't treat the public key as a private key

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
