### PR TITLE
Add Sigv4 library as a submodule in C-SDK

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,3 +46,6 @@
 [submodule "libraries/3rdparty/tinycbor"]
 	path = libraries/3rdparty/tinycbor
 	url = https://github.com/intel/tinycbor
+[submodule "libraries/aws/sigv4-for-aws-iot-embedded-sdk"]
+	path = libraries/aws/sigv4-for-aws-iot-embedded-sdk
+	url = https://github.com/aws/SigV4-for-AWS-IoT-embedded-sdk.git

--- a/manifest.yml
+++ b/manifest.yml
@@ -57,4 +57,9 @@ dependencies:
     repository:
       type: "git"
       url: "https://github.com/aws/Fleet-Provisioning-for-AWS-IoT-embedded-sdk"
+  - name: "sigv4-for-AWS-IoT-embedded-sdk"
+    version: "2e4bd59"
+    repository:
+      type: "git"
+      url: "https://github.com/aws/SigV4-for-AWS-IoT-embedded-sdk"
 license: "MIT"


### PR DESCRIPTION
THIS PR adds Sigv4 library as a submodule in C-SDK