### PR TITLE
Add build checks for C++ linkage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           make -C build/ help | grep demo | tr -d '. ' | xargs make -C build/
           make -C demos/jobs/jobs_demo_mosquitto
   build-check-demos-cpp:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v2
@@ -90,7 +90,6 @@ jobs:
       - name: Build Demos
         run: |
           make -C build/ help | grep demo | tr -d '. ' | xargs make -C build/
-          make -C demos/jobs/jobs_demo_mosquitto
   build-check-system-tests:
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,46 @@ jobs:
         run: |
           make -C build/ help | grep demo | tr -d '. ' | xargs make -C build/
           make -C demos/jobs/jobs_demo_mosquitto
+  build-check-demos-cpp-mqtt:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Clone This Repo
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Rename source files
+        run: |
+          for source in demos/mqtt/mqtt*/*.c; do mv -- "$source" "${source%.c}.cpp"; done
+      - name: Configure CMake build
+        run: |
+          sudo apt-get install -y libmosquitto-dev
+          curl https://cmake.org/files/v3.2/cmake-3.2.0-Linux-x86_64.tar.gz -o cmake.tar.gz
+          tar -xf cmake.tar.gz
+          mkdir build && cd build
+          ../cmake-3.2.0-Linux-x86_64/bin/cmake .. \
+          -G "Unix Makefiles" \
+          -DBUILD_DEMOS=1 \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_C_FLAGS='-Wall -Wextra' \
+          -DAWS_IOT_ENDPOINT="aws-iot-endpoint" \
+          -DBROKER_ENDPOINT="broker-endpoint" \
+          -DCLIENT_CERT_PATH="cert/path" \
+          -DROOT_CA_CERT_PATH="cert/path" \
+          -DCLIENT_PRIVATE_KEY_PATH="key/path" \
+          -DCLIENT_IDENTIFIER="ci-identifier" \
+          -DTHING_NAME="thing-name" \
+          -DS3_PRESIGNED_GET_URL="get-url" \
+          -DS3_PRESIGNED_PUT_URL="put-url" \
+          -DCLAIM_CERT_PATH="cert/path" \
+          -DCLAIM_PRIVATE_KEY_PATH="key/path" \
+          -DPROVISIONING_TEMPLATE_NAME="template-name" \
+          -DPROVISIONING_CSR_PATH="csr/path" \
+          -DPROVISIONING_PRIVATE_KEY_PATH="key/path" \
+          -DPROVISIONING_CERT_PATH="cert/path"
+      - name: Build Demos
+        run: |
+          make -C build/ help | grep demo | tr -d '. ' | xargs make -C build/
+          make -C demos/jobs/jobs_demo_mosquitto
   build-check-system-tests:
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           make -C build/ help | grep demo | tr -d '. ' | xargs make -C build/
           make -C demos/jobs/jobs_demo_mosquitto
-  build-check-demos-cpp-mqtt:
+  build-check-demos-cpp:
     runs-on: ubuntu-18.04
     steps:
       - name: Clone This Repo
@@ -54,9 +54,13 @@ jobs:
           submodules: recursive
       - name: Rename source files
         run: |
-          for source in demos/mqtt/mqtt*/*.c; do mv -- "$source" "${source%.c}.cpp"; done
-          for source in demos/http/http*/*.c; do mv -- "$source" "${source%.c}.cpp"; done
-          for source in demos/shadow/shadow_demo_main/*.c; do mv -- "$source" "${source%.c}.cpp"; done
+          for demo in mqtt http shadow defender
+          do
+              for source in demos/$demo/*/*.c
+              do
+                  mv -- "$source" "${source%.c}.cpp"
+              done
+          done
       - name: Configure CMake build
         run: |
           sudo apt-get install -y libmosquitto-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
       - name: Rename source files
         run: |
           for source in demos/mqtt/mqtt*/*.c; do mv -- "$source" "${source%.c}.cpp"; done
+          for source in demos/http/http*/*.c; do mv -- "$source" "${source%.c}.cpp"; done
+          for source in demos/shadow/shadow_demo_main/*.c; do mv -- "$source" "${source%.c}.cpp"; done
       - name: Configure CMake build
         run: |
           sudo apt-get install -y libmosquitto-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required( VERSION 3.2.0 )
 project( AwsIotDeviceSdkEmbeddedC
          VERSION 202103.00
-         LANGUAGES C )
+         LANGUAGES C CXX )
 
 # Allow the project to be organized into folders.
 set_property( GLOBAL PROPERTY USE_FOLDERS ON )

--- a/demos/defender/defender_demo_json/CMakeLists.txt
+++ b/demos/defender/defender_demo_json/CMakeLists.txt
@@ -12,12 +12,11 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreJSON/jsonFilePaths.cmake )
 # Include Defender library's source and header path variables.
 include( ${CMAKE_SOURCE_DIR}/libraries/aws/device-defender-for-aws-iot-embedded-sdk/defenderFilePaths.cmake )
 
+file( GLOB DEMO_SRCS "*.c*" )
+
 # Demo target.
 add_executable( ${DEMO_NAME}
-                "defender_demo.c"
-                "metrics_collector.c"
-                "mqtt_operations.c"
-                "report_builder.c"
+                ${DEMO_SRCS}
                 ${MQTT_SOURCES}
                 ${MQTT_SERIALIZER_SOURCES}
                 ${BACKOFF_ALGORITHM_SOURCES}

--- a/demos/defender/defender_demo_json/CMakeLists.txt
+++ b/demos/defender/defender_demo_json/CMakeLists.txt
@@ -12,6 +12,7 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreJSON/jsonFilePaths.cmake )
 # Include Defender library's source and header path variables.
 include( ${CMAKE_SOURCE_DIR}/libraries/aws/device-defender-for-aws-iot-embedded-sdk/defenderFilePaths.cmake )
 
+# CPP files are searched for supporting CI build checks that verify C++ linkage of the Device Defender library
 file( GLOB DEMO_SRCS "*.c*" )
 
 # Demo target.

--- a/demos/defender/defender_demo_json/defender_demo.c
+++ b/demos/defender/defender_demo_json/defender_demo.c
@@ -323,7 +323,7 @@ static void publishCallback( MQTTPublishInfo_t * pPublishInfo,
         if( api == DefenderJsonReportAccepted )
         {
             /* Check if the response is valid and is for the report we published. */
-            validationResult = validateDefenderResponse( pPublishInfo->pPayload,
+            validationResult = validateDefenderResponse( ( const char * ) pPublishInfo->pPayload,
                                                          pPublishInfo->payloadLength );
 
             if( validationResult == true )
@@ -337,7 +337,7 @@ static void publishCallback( MQTTPublishInfo_t * pPublishInfo,
         else if( api == DefenderJsonReportRejected )
         {
             /* Check if the response is valid and is for the report we published. */
-            validationResult = validateDefenderResponse( pPublishInfo->pPayload,
+            validationResult = validateDefenderResponse( ( const char * ) pPublishInfo->pPayload,
                                                          pPublishInfo->payloadLength );
 
             if( validationResult == true )

--- a/demos/http/common/include/http_demo_utils.h
+++ b/demos/http/common/include/http_demo_utils.h
@@ -20,9 +20,18 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#ifndef HTTP_DEMO_UTILS_H_
+#define HTTP_DEMO_UTILS_H_
+
 /* Standard includes. */
 #include <stdlib.h>
 #include <stdbool.h>
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
 
 /* Transport interface include. */
 #include "transport_interface.h"
@@ -113,3 +122,11 @@ HTTPStatus_t getUrlAddress( const char * pUrl,
                             size_t urlLen,
                             const char ** pAddress,
                             size_t * pAddressLen );
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    }
+#endif
+/* *INDENT-ON* */
+
+#endif /* ifndef HTTP_DEMO_UTILS_H_ */

--- a/demos/http/http_demo_basic_tls/CMakeLists.txt
+++ b/demos/http/http_demo_basic_tls/CMakeLists.txt
@@ -8,12 +8,13 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorith
 
 # CPP files are searched for supporting CI build checks that verify C++ linkage of the coreHTTP library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
+file( GLOB DEMO_UTILS "${DEMOS_DIR}/http/common/src/*.c*" )
 
 # Demo target.
 add_executable(
     ${DEMO_NAME}
         "${DEMO_FILE}"
-        "${DEMOS_DIR}/http/common/src/http_demo_utils.c"
+        ${DEMO_UTILS}
         ${HTTP_SOURCES}
         ${HTTP_THIRD_PARTY_SOURCES}
         ${BACKOFF_ALGORITHM_SOURCES}

--- a/demos/http/http_demo_basic_tls/CMakeLists.txt
+++ b/demos/http/http_demo_basic_tls/CMakeLists.txt
@@ -6,10 +6,12 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 # Include backoffAlgorithm library file path configuration.
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
+file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
+
 # Demo target.
 add_executable(
     ${DEMO_NAME}
-        "${DEMO_NAME}.c"
+        "${DEMO_FILE}"
         "${DEMOS_DIR}/http/common/src/http_demo_utils.c"
         ${HTTP_SOURCES}
         ${HTTP_THIRD_PARTY_SOURCES}

--- a/demos/http/http_demo_basic_tls/CMakeLists.txt
+++ b/demos/http/http_demo_basic_tls/CMakeLists.txt
@@ -6,6 +6,7 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 # Include backoffAlgorithm library file path configuration.
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
+# CPP files are searched for supporting CI build checks that verify C++ linkage of the coreHTTP library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
 
 # Demo target.

--- a/demos/http/http_demo_mutual_auth/CMakeLists.txt
+++ b/demos/http/http_demo_mutual_auth/CMakeLists.txt
@@ -8,12 +8,13 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorith
 
 # CPP files are searched for supporting CI build checks that verify C++ linkage of the coreHTTP library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
+file( GLOB DEMO_UTILS "${DEMOS_DIR}/http/common/src/*.c*" )
 
 # Demo target.
 add_executable(
     ${DEMO_NAME}
         "${DEMO_FILE}"
-        "${DEMOS_DIR}/http/common/src/http_demo_utils.c"
+        ${DEMO_UTILS}
         ${HTTP_SOURCES}
         ${HTTP_THIRD_PARTY_SOURCES}
         ${BACKOFF_ALGORITHM_SOURCES}

--- a/demos/http/http_demo_mutual_auth/CMakeLists.txt
+++ b/demos/http/http_demo_mutual_auth/CMakeLists.txt
@@ -6,10 +6,12 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 # Include backoffAlgorithm library file path configuration.
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
+file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
+
 # Demo target.
 add_executable(
     ${DEMO_NAME}
-        "${DEMO_NAME}.c"
+        "${DEMO_FILE}"
         "${DEMOS_DIR}/http/common/src/http_demo_utils.c"
         ${HTTP_SOURCES}
         ${HTTP_THIRD_PARTY_SOURCES}

--- a/demos/http/http_demo_mutual_auth/CMakeLists.txt
+++ b/demos/http/http_demo_mutual_auth/CMakeLists.txt
@@ -6,6 +6,7 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 # Include backoffAlgorithm library file path configuration.
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
+# CPP files are searched for supporting CI build checks that verify C++ linkage of the coreHTTP library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
 
 # Demo target.

--- a/demos/http/http_demo_plaintext/CMakeLists.txt
+++ b/demos/http/http_demo_plaintext/CMakeLists.txt
@@ -8,12 +8,13 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorith
 
 # CPP files are searched for supporting CI build checks that verify C++ linkage of the coreHTTP library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
+file( GLOB DEMO_UTILS "${DEMOS_DIR}/http/common/src/*.c*" )
 
 # Demo target.
 add_executable(
     ${DEMO_NAME}
         "${DEMO_FILE}"
-        "${DEMOS_DIR}/http/common/src/http_demo_utils.c"
+        ${DEMO_UTILS}
         ${HTTP_SOURCES}
         ${HTTP_THIRD_PARTY_SOURCES}
         ${BACKOFF_ALGORITHM_SOURCES}

--- a/demos/http/http_demo_plaintext/CMakeLists.txt
+++ b/demos/http/http_demo_plaintext/CMakeLists.txt
@@ -6,10 +6,12 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 # Include backoffAlgorithm library file path configuration.
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
+file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
+
 # Demo target.
 add_executable(
     ${DEMO_NAME}
-        "${DEMO_NAME}.c"
+        "${DEMO_FILE}"
         "${DEMOS_DIR}/http/common/src/http_demo_utils.c"
         ${HTTP_SOURCES}
         ${HTTP_THIRD_PARTY_SOURCES}

--- a/demos/http/http_demo_plaintext/CMakeLists.txt
+++ b/demos/http/http_demo_plaintext/CMakeLists.txt
@@ -6,6 +6,7 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 # Include backoffAlgorithm library file path configuration.
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
+# CPP files are searched for supporting CI build checks that verify C++ linkage of the coreHTTP library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
 
 # Demo target.

--- a/demos/http/http_demo_s3_download/CMakeLists.txt
+++ b/demos/http/http_demo_s3_download/CMakeLists.txt
@@ -8,12 +8,13 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorith
 
 # CPP files are searched for supporting CI build checks that verify C++ linkage of the coreHTTP library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
+file( GLOB DEMO_UTILS "${DEMOS_DIR}/http/common/src/*.c*" )
 
 # Demo target.
 add_executable(
     ${DEMO_NAME}
         "${DEMO_FILE}"
-        "${DEMOS_DIR}/http/common/src/http_demo_utils.c"
+        ${DEMO_UTILS}
         ${HTTP_SOURCES}
         ${HTTP_THIRD_PARTY_SOURCES}
         ${BACKOFF_ALGORITHM_SOURCES}

--- a/demos/http/http_demo_s3_download/CMakeLists.txt
+++ b/demos/http/http_demo_s3_download/CMakeLists.txt
@@ -6,10 +6,12 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 # Include backoffAlgorithm library file path configuration.
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
+file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
+
 # Demo target.
 add_executable(
     ${DEMO_NAME}
-        "${DEMO_NAME}.c"
+        "${DEMO_FILE}"
         "${DEMOS_DIR}/http/common/src/http_demo_utils.c"
         ${HTTP_SOURCES}
         ${HTTP_THIRD_PARTY_SOURCES}

--- a/demos/http/http_demo_s3_download/CMakeLists.txt
+++ b/demos/http/http_demo_s3_download/CMakeLists.txt
@@ -6,6 +6,7 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 # Include backoffAlgorithm library file path configuration.
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
+# CPP files are searched for supporting CI build checks that verify C++ linkage of the coreHTTP library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
 
 # Demo target.

--- a/demos/http/http_demo_s3_download_multithreaded/CMakeLists.txt
+++ b/demos/http/http_demo_s3_download_multithreaded/CMakeLists.txt
@@ -8,12 +8,13 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorith
 
 # CPP files are searched for supporting CI build checks that verify C++ linkage of the coreHTTP library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
+file( GLOB DEMO_UTILS "${DEMOS_DIR}/http/common/src/*.c*" )
 
 # Demo target.
 add_executable(
     ${DEMO_NAME}
         "${DEMO_FILE}"
-        "${DEMOS_DIR}/http/common/src/http_demo_utils.c"
+        ${DEMO_UTILS}
         ${HTTP_SOURCES}
         ${HTTP_THIRD_PARTY_SOURCES}
         ${BACKOFF_ALGORITHM_SOURCES}

--- a/demos/http/http_demo_s3_download_multithreaded/CMakeLists.txt
+++ b/demos/http/http_demo_s3_download_multithreaded/CMakeLists.txt
@@ -6,10 +6,12 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 # Include backoffAlgorithm library file path configuration.
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
+file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
+
 # Demo target.
 add_executable(
     ${DEMO_NAME}
-        "${DEMO_NAME}.c"
+        "${DEMO_FILE}"
         "${DEMOS_DIR}/http/common/src/http_demo_utils.c"
         ${HTTP_SOURCES}
         ${HTTP_THIRD_PARTY_SOURCES}

--- a/demos/http/http_demo_s3_download_multithreaded/CMakeLists.txt
+++ b/demos/http/http_demo_s3_download_multithreaded/CMakeLists.txt
@@ -6,6 +6,7 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 # Include backoffAlgorithm library file path configuration.
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
+# CPP files are searched for supporting CI build checks that verify C++ linkage of the coreHTTP library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
 
 # Demo target.

--- a/demos/http/http_demo_s3_upload/CMakeLists.txt
+++ b/demos/http/http_demo_s3_upload/CMakeLists.txt
@@ -8,12 +8,13 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorith
 
 # CPP files are searched for supporting CI build checks that verify C++ linkage of the coreHTTP library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
+file( GLOB DEMO_UTILS "${DEMOS_DIR}/http/common/src/*.c*" )
 
 # Demo target.
 add_executable(
     ${DEMO_NAME}
         "${DEMO_FILE}"
-        "${DEMOS_DIR}/http/common/src/http_demo_utils.c"
+        ${DEMO_UTILS}
         ${HTTP_SOURCES}
         ${HTTP_THIRD_PARTY_SOURCES}
         ${BACKOFF_ALGORITHM_SOURCES}

--- a/demos/http/http_demo_s3_upload/CMakeLists.txt
+++ b/demos/http/http_demo_s3_upload/CMakeLists.txt
@@ -6,10 +6,12 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 # Include backoffAlgorithm library file path configuration.
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
+file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
+
 # Demo target.
 add_executable(
     ${DEMO_NAME}
-        "${DEMO_NAME}.c"
+        "${DEMO_FILE}"
         "${DEMOS_DIR}/http/common/src/http_demo_utils.c"
         ${HTTP_SOURCES}
         ${HTTP_THIRD_PARTY_SOURCES}

--- a/demos/http/http_demo_s3_upload/CMakeLists.txt
+++ b/demos/http/http_demo_s3_upload/CMakeLists.txt
@@ -6,6 +6,7 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 # Include backoffAlgorithm library file path configuration.
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
+# CPP files are searched for supporting CI build checks that verify C++ linkage of the coreHTTP library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
 
 # Demo target.

--- a/demos/mqtt/mqtt_demo_basic_tls/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_basic_tls/CMakeLists.txt
@@ -6,10 +6,12 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 # Include backoffAlgorithm library file path configuration.
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
+file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
+
 # Demo target.
 add_executable(
     ${DEMO_NAME}
-        "${DEMO_NAME}.c"
+        "${DEMO_FILE}"
         ${MQTT_SOURCES}
         ${MQTT_SERIALIZER_SOURCES}
         ${BACKOFF_ALGORITHM_SOURCES}

--- a/demos/mqtt/mqtt_demo_basic_tls/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_basic_tls/CMakeLists.txt
@@ -6,6 +6,7 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 # Include backoffAlgorithm library file path configuration.
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
+# CPP files are searched for supporting CI build checks that verify C++ linkage of the coreMQTT library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
 
 # Demo target.

--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -748,7 +748,7 @@ static void updateSubAckStatus( MQTTPacketInfo_t * pPacketInfo )
     ( void ) mqttStatus;
 
     /* Demo only subscribes to one topic, so only one status code is returned. */
-    globalSubAckStatus = pPayload[ 0 ];
+    globalSubAckStatus = ( MQTTSubAckStatus_t ) pPayload[ 0 ];
 }
 
 /*-----------------------------------------------------------*/

--- a/demos/mqtt/mqtt_demo_mutual_auth/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_mutual_auth/CMakeLists.txt
@@ -6,10 +6,12 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 # Include backoffAlgorithm library file path configuration.
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
+file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
+
 # Demo target.
 add_executable(
     ${DEMO_NAME}
-        "${DEMO_NAME}.c"
+        "${DEMO_FILE}"
         ${MQTT_SOURCES}
         ${MQTT_SERIALIZER_SOURCES}
         ${BACKOFF_ALGORITHM_SOURCES}

--- a/demos/mqtt/mqtt_demo_mutual_auth/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_mutual_auth/CMakeLists.txt
@@ -6,6 +6,7 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 # Include backoffAlgorithm library file path configuration.
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
+# CPP files are searched for supporting CI build checks that verify C++ linkage of the coreMQTT library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
 
 # Demo target.

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -877,7 +877,7 @@ static void updateSubAckStatus( MQTTPacketInfo_t * pPacketInfo )
     ( void ) mqttStatus;
 
     /* Demo only subscribes to one topic, so only one status code is returned. */
-    globalSubAckStatus = pPayload[ 0 ];
+    globalSubAckStatus = ( MQTTSubAckStatus_t ) pPayload[ 0 ];
 }
 
 /*-----------------------------------------------------------*/

--- a/demos/mqtt/mqtt_demo_plaintext/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_plaintext/CMakeLists.txt
@@ -6,10 +6,12 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 # Include backoffAlgorithm library file path configuration.
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
+file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
+
 # Demo target.
 add_executable(
     ${DEMO_NAME}
-        "${DEMO_NAME}.c"
+        "${DEMO_FILE}"
         ${MQTT_SOURCES}
         ${MQTT_SERIALIZER_SOURCES}
         ${BACKOFF_ALGORITHM_SOURCES}

--- a/demos/mqtt/mqtt_demo_plaintext/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_plaintext/CMakeLists.txt
@@ -6,6 +6,7 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 # Include backoffAlgorithm library file path configuration.
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
+# CPP files are searched for supporting CI build checks that verify C++ linkage of the coreMQTT library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
 
 # Demo target.

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
@@ -479,7 +479,7 @@ static void updateSubAckStatus( MQTTPacketInfo_t * pPacketInfo )
     ( void ) mqttStatus;
 
     /* Demo only subscribes to one topic, so only one status code is returned. */
-    globalSubAckStatus = pPayload[ 0 ];
+    globalSubAckStatus = ( MQTTSubAckStatus_t ) pPayload[ 0 ];
 }
 
 /*-----------------------------------------------------------*/

--- a/demos/mqtt/mqtt_demo_serializer/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_serializer/CMakeLists.txt
@@ -6,10 +6,12 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 # Include backoffAlgorithm library file path configuration.
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
+file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
+
 # Demo target.
 add_executable(
     ${DEMO_NAME}
-        "${DEMO_NAME}.c"
+        "${DEMO_FILE}"
         ${MQTT_SERIALIZER_SOURCES}
         ${BACKOFF_ALGORITHM_SOURCES}
 )

--- a/demos/mqtt/mqtt_demo_serializer/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_serializer/CMakeLists.txt
@@ -6,6 +6,7 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 # Include backoffAlgorithm library file path configuration.
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
+# CPP files are searched for supporting CI build checks that verify C++ linkage of the coreMQTT library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
 
 # Demo target.

--- a/demos/mqtt/mqtt_demo_subscription_manager/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_subscription_manager/CMakeLists.txt
@@ -9,10 +9,12 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorith
 
 set( DEMO_NAME "mqtt_demo_subscription_manager" )
 
+file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
+
 # Demo target.
 add_executable(
     ${DEMO_NAME}
-        "${DEMO_NAME}.c"
+        "${DEMO_FILE}"
         ${MQTT_SOURCES}
         ${MQTT_SERIALIZER_SOURCES}
         ${BACKOFF_ALGORITHM_SOURCES}

--- a/demos/mqtt/mqtt_demo_subscription_manager/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_subscription_manager/CMakeLists.txt
@@ -9,6 +9,7 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorith
 
 set( DEMO_NAME "mqtt_demo_subscription_manager" )
 
+# CPP files are searched for supporting CI build checks that verify C++ linkage of the coreMQTT library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )
 
 # Demo target.

--- a/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
+++ b/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
@@ -950,7 +950,7 @@ static int subscribeToAndRegisterTopicFilter( MQTTContext_t * pContext,
                                               SubscriptionManagerCallback_t callback )
 {
     int returnStatus = EXIT_SUCCESS;
-    SubscriptionManagerStatus_t managerStatus = 0u;
+    SubscriptionManagerStatus_t managerStatus = ( SubscriptionManagerStatus_t ) 0u;
 
     /* Register the topic filter and its callback with subscription manager.
      * On an incoming PUBLISH message whose topic name that matches the topic filter
@@ -1045,10 +1045,12 @@ static int publishToTopicAndProcessIncomingMessage( MQTTContext_t * pMqttContext
     int returnStatus = EXIT_SUCCESS;
 
     MQTTStatus_t mqttStatus = MQTTSuccess;
-    MQTTPublishInfo_t publishInfo = { 0 };
+    MQTTPublishInfo_t publishInfo;
     uint16_t pubPacketId = MQTT_PACKET_ID_INVALID;
 
     assert( pMqttContext != NULL );
+
+    ( void ) memset( &publishInfo, 0x00, sizeof( MQTTPublishInfo_t ) );
 
     if( returnStatus == EXIT_FAILURE )
     {

--- a/demos/mqtt/mqtt_demo_subscription_manager/subscription-manager/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_subscription_manager/subscription-manager/CMakeLists.txt
@@ -5,9 +5,12 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
 set( LIBRARY_NAME "mqtt_subscription_manager" )
+
+# CPP files are searched for supporting CI build checks that verify C++ linkage of the coreMQTT library
+file( GLOB LIBRARY_SRCS "${LIBRARY_NAME}.c*" )
 # Library target.
 add_library( ${LIBRARY_NAME}
-            "${LIBRARY_NAME}.c" )
+             ${LIBRARY_SRCS} )
 
 target_include_directories(
     ${LIBRARY_NAME}

--- a/demos/mqtt/mqtt_demo_subscription_manager/subscription-manager/mqtt_subscription_manager.h
+++ b/demos/mqtt/mqtt_demo_subscription_manager/subscription-manager/mqtt_subscription_manager.h
@@ -54,6 +54,12 @@
 
 /************ End of logging configuration ****************/
 
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
+
 /* Include MQTT library. */
 #include "core_mqtt.h"
 
@@ -139,5 +145,11 @@ SubscriptionManagerStatus_t SubscriptionManager_RegisterCallback( const char * p
 void SubscriptionManager_RemoveCallback( const char * pTopicFilter,
                                          uint16_t topicFilterLength );
 
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    }
+#endif
+/* *INDENT-ON* */
 
 #endif /* ifndef MQTT_SUBSCRIPTION_MANAGER_H_ */

--- a/demos/shadow/shadow_demo_main/CMakeLists.txt
+++ b/demos/shadow/shadow_demo_main/CMakeLists.txt
@@ -12,11 +12,12 @@ include( ${CMAKE_SOURCE_DIR}/libraries/aws/device-shadow-for-aws-iot-embedded-sd
 # Include JSON library's source and header path variables.
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreJSON/jsonFilePaths.cmake )
 
+file( GLOB DEMO_SRCS "*.c*" )
+
 # Demo target.
 add_executable(
     ${DEMO_NAME}
-        "${DEMO_NAME}.c"
-        "shadow_demo_helpers.c"
+        ${DEMO_SRCS}
         ${MQTT_SOURCES}
         ${MQTT_SERIALIZER_SOURCES}
         ${BACKOFF_ALGORITHM_SOURCES}

--- a/demos/shadow/shadow_demo_main/CMakeLists.txt
+++ b/demos/shadow/shadow_demo_main/CMakeLists.txt
@@ -12,6 +12,7 @@ include( ${CMAKE_SOURCE_DIR}/libraries/aws/device-shadow-for-aws-iot-embedded-sd
 # Include JSON library's source and header path variables.
 include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreJSON/jsonFilePaths.cmake )
 
+# CPP files are searched for supporting CI build checks that verify C++ linkage of the Device Shadow library
 file( GLOB DEMO_SRCS "*.c*" )
 
 # Demo target.

--- a/demos/shadow/shadow_demo_main/shadow_demo_main.c
+++ b/demos/shadow/shadow_demo_main/shadow_demo_main.c
@@ -298,7 +298,7 @@ static void deleteRejectedHandler( MQTTPublishInfo_t * pPublishInfo )
      */
 
     /* Make sure the payload is a valid json document. */
-    result = JSON_Validate( pPublishInfo->pPayload,
+    result = JSON_Validate( ( const char * ) pPublishInfo->pPayload,
                             pPublishInfo->payloadLength );
 
     if( result == JSONSuccess )
@@ -372,7 +372,7 @@ static void updateDeltaHandler( MQTTPublishInfo_t * pPublishInfo )
      */
 
     /* Make sure the payload is a valid json document. */
-    result = JSON_Validate( pPublishInfo->pPayload,
+    result = JSON_Validate( ( const char * ) pPublishInfo->pPayload,
                             pPublishInfo->payloadLength );
 
     if( result == JSONSuccess )
@@ -499,7 +499,7 @@ static void updateAcceptedHandler( MQTTPublishInfo_t * pPublishInfo )
      */
 
     /* Make sure the payload is a valid json document. */
-    result = JSON_Validate( pPublishInfo->pPayload,
+    result = JSON_Validate( ( const char * ) pPublishInfo->pPayload,
                             pPublishInfo->payloadLength );
 
     if( result == JSONSuccess )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Makes a few changes to the MQTT, HTTP, Shadow, and Defender demos to be able to compile as C++, and then build these demos as a CI check to ensure that the C library functions can be linked into a C++ project. The `-Werror` flag is not passed, as this code was not written with C++ in mind and we don't need to fix warnings that arise from using C++.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
