### PR TITLE
Add more C++ linkage checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           submodules: recursive
       - name: Rename source files
         run: |
-          for demo in mqtt http shadow defender
+          for demo in mqtt http shadow defender pkcs11 fleet_provisioning
           do
               for source in demos/$demo/*/*.c
               do

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/CMakeLists.txt
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/CMakeLists.txt
@@ -10,11 +10,12 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorith
 include(
     ${CMAKE_SOURCE_DIR}/libraries/aws/fleet-provisioning-for-aws-iot-embedded-sdk/fleetprovisioningFilePaths.cmake )
 
+# CPP files are searched for supporting CI build checks that verify C++ linkage of the Fleet Provisioning library
+file( GLOB DEMO_SRCS "*.c*" )
+
 # Demo target.
 add_executable( ${DEMO_NAME}
-                "fleet_provisioning_with_csr_demo.c"
-                "fleet_provisioning_serializer.c"
-                "mqtt_operations.c"
+                ${DEMO_SRCS}
                 ${MQTT_SOURCES}
                 ${MQTT_SERIALIZER_SOURCES}
                 ${BACKOFF_ALGORITHM_SOURCES}

--- a/demos/lexicon.txt
+++ b/demos/lexicon.txt
@@ -80,6 +80,7 @@ chacha
 chachapoly
 chinese
 chunked
+ci
 ciphersuite
 ciphersuites
 ciphertext
@@ -134,6 +135,7 @@ currentversion
 customisation
 cybertrust
 dat
+datalength
 dd
 debian
 dec
@@ -673,7 +675,6 @@ udp
 udpportsarraylength
 uint
 ulblocksize
-uldatalength
 uldigestlength
 uloffset
 ulong

--- a/demos/logging-stack/logging_stack.h
+++ b/demos/logging-stack/logging_stack.h
@@ -101,28 +101,28 @@
 #else
     #if LIBRARY_LOG_LEVEL == LOG_DEBUG
         /* All log level messages will logged. */
-        #define LogError( message )    SdkLog( ( "[ERROR] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
-        #define LogWarn( message )     SdkLog( ( "[WARN] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
-        #define LogInfo( message )     SdkLog( ( "[INFO] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
-        #define LogDebug( message )    SdkLog( ( "[DEBUG] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogError( message )    SdkLog( ( "[ERROR] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogWarn( message )     SdkLog( ( "[WARN] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogInfo( message )     SdkLog( ( "[INFO] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogDebug( message )    SdkLog( ( "[DEBUG] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
 
     #elif LIBRARY_LOG_LEVEL == LOG_INFO
         /* Only INFO, WARNING and ERROR messages will be logged. */
-        #define LogError( message )    SdkLog( ( "[ERROR] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
-        #define LogWarn( message )     SdkLog( ( "[WARN] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
-        #define LogInfo( message )     SdkLog( ( "[INFO] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogError( message )    SdkLog( ( "[ERROR] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogWarn( message )     SdkLog( ( "[WARN] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogInfo( message )     SdkLog( ( "[INFO] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
         #define LogDebug( message )
 
     #elif LIBRARY_LOG_LEVEL == LOG_WARN
         /* Only WARNING and ERROR messages will be logged.*/
-        #define LogError( message )    SdkLog( ( "[ERROR] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
-        #define LogWarn( message )     SdkLog( ( "[WARN] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogError( message )    SdkLog( ( "[ERROR] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogWarn( message )     SdkLog( ( "[WARN] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
         #define LogInfo( message )
         #define LogDebug( message )
 
     #elif LIBRARY_LOG_LEVEL == LOG_ERROR
         /* Only ERROR messages will be logged. */
-        #define LogError( message )    SdkLog( ( "[ERROR] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogError( message )    SdkLog( ( "[ERROR] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
         #define LogWarn( message )
         #define LogInfo( message )
         #define LogDebug( message )
@@ -148,7 +148,7 @@
  * This macro is only enabled for #LOG_DEBUG level configuration in this
  * logging stack implementation.
  */
-    #define LogDebug( message )    SdkLog( ( "[DEBUG] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+    #define LogDebug( message )    SdkLog( ( "[DEBUG] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
 
 /**
  * @brief Definition of logging interface macro that logs messages at the "Info"
@@ -157,7 +157,7 @@
  * This macro is only enabled for #LOG_DEBUG and #LOG_INFO level configurations
  * in this logging stack implementation.
  */
-    #define LogInfo( message )     SdkLog( ( "[INFO] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+    #define LogInfo( message )     SdkLog( ( "[INFO] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
 
 /**
  * @brief Definition of logging interface macro that logs messages at the "Warning"
@@ -166,7 +166,7 @@
  * This macro is only enabled for #LOG_DEBUG, #LOG_INFO and #LOG_WARN level
  * configurations in this logging stack implementation.
  */
-    #define LogWarn( message )     SdkLog( ( "[WARN] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+    #define LogWarn( message )     SdkLog( ( "[WARN] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
 
 /**
  * @brief Definition of logging interface macro that logs messages at the "Error"
@@ -175,7 +175,7 @@
  * This macro is only enabled for all logging level configurations
  * unless except the #LOG_NONE configuration.
  */
-    #define LogError( message )    SdkLog( ( "[ERROR] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+    #define LogError( message )    SdkLog( ( "[ERROR] " LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
 
 #endif /* ifdef DOXYGEN */
 

--- a/demos/pkcs11/common/include/demo_helpers.h
+++ b/demos/pkcs11/common/include/demo_helpers.h
@@ -22,6 +22,12 @@
 #ifndef _DEMO_HELPER_FUNCTIONS_
 #define _DEMO_HELPER_FUNCTIONS_
 
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
+
 /**
  * @file demo_helpers.h
  * @brief Common functions used between the PKCS #11 demos.
@@ -77,15 +83,15 @@ void end( CK_SESSION_HANDLE session,
 
 /*
  * @brief This function is simply a helper function to print the raw hex values
- * of an EC public key. It's explanation is not within the scope of the demos
+ * of an EC public key. Its explanation is not within the scope of the demos
  * and is sparsely commented.
  *
- * @param[in] pcDescription         Description message
- * @param[in] pucData               Hex contents to print (Public key)
- * @param[in] ulDataLength          Length of pucData
+ * @param[in] description         Description message
+ * @param[in] data                Hex contents to print (Public key)
+ * @param[in] dataLength          Length of data
  *
  */
-void writeHexBytesToConsole( char * description,
+void writeHexBytesToConsole( const char * description,
                              CK_BYTE * data,
                              CK_ULONG dataLength );
 /*-----------------------------------------------------------*/
@@ -100,5 +106,11 @@ CK_RV exportPublicKey( CK_SESSION_HANDLE session,
                        CK_BYTE ** derPublicKey,
                        CK_ULONG * derPublicKeyLength );
 /*-----------------------------------------------------------*/
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    }
+#endif
+/* *INDENT-ON* */
 
 #endif /* _DEMO_HELPER_FUNCTIONS_ */

--- a/demos/pkcs11/common/src/demo_helpers.c
+++ b/demos/pkcs11/common/src/demo_helpers.c
@@ -130,12 +130,12 @@ void end( CK_SESSION_HANDLE session,
 }
 /*-----------------------------------------------------------*/
 
-void writeHexBytesToConsole( char * description,
+void writeHexBytesToConsole( const char * description,
                              CK_BYTE * data,
                              CK_ULONG dataLength )
 {
     /* This function is simply a helper function to print the raw hex values
-     * of an EC public key. It's explanation is not within the scope of the demos
+     * of an EC public key. Its explanation is not within the scope of the demos
      * and is sparsely commented. */
     char byteRow[ 1 + ( BYTES_TO_DISPLAY_PER_ROW * 2 ) + ( BYTES_TO_DISPLAY_PER_ROW / 2 ) ];
     char * nextChar = byteRow;

--- a/demos/pkcs11/pkcs11_demo_management_and_rng/CMakeLists.txt
+++ b/demos/pkcs11/pkcs11_demo_management_and_rng/CMakeLists.txt
@@ -12,10 +12,12 @@ list(APPEND PKCS_SOURCES
     "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils/mbedtls_utils.c"
 )
 
+file( GLOB DEMO_SRCS "*.c*" )
+
 # Demo target.
 add_executable(
     ${DEMO_NAME}
-    "${DEMO_NAME}.c"
+    ${DEMO_SRCS}
     ${PKCS_SOURCES}
 )
 

--- a/demos/pkcs11/pkcs11_demo_management_and_rng/pkcs11_demo_management_and_rng.c
+++ b/demos/pkcs11/pkcs11_demo_management_and_rng/pkcs11_demo_management_and_rng.c
@@ -136,7 +136,7 @@ CK_RV PKCS11ManagementAndRNGDemo( void )
      * slot ids. */
     if( result == CKR_OK )
     {
-        slotId = malloc( sizeof( CK_SLOT_ID ) * ( slotCount ) );
+        slotId = ( CK_SLOT_ID * ) malloc( sizeof( CK_SLOT_ID ) * ( slotCount ) );
 
         if( slotId == NULL )
         {

--- a/demos/pkcs11/pkcs11_demo_mechanisms_and_digests/CMakeLists.txt
+++ b/demos/pkcs11/pkcs11_demo_mechanisms_and_digests/CMakeLists.txt
@@ -13,10 +13,12 @@ list(APPEND PKCS_SOURCES
             "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils/mbedtls_utils.c"
             )
 
+file( GLOB DEMO_SRCS "*.c*" )
+
 # Demo target.
 add_executable(
     ${DEMO_NAME}
-    "${DEMO_NAME}.c"
+    ${DEMO_SRCS}
     ${PKCS_SOURCES}
 )
 

--- a/demos/pkcs11/pkcs11_demo_objects/CMakeLists.txt
+++ b/demos/pkcs11/pkcs11_demo_objects/CMakeLists.txt
@@ -14,10 +14,12 @@ list(APPEND PKCS_SOURCES
             "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils/mbedtls_utils.c"
             )
 
+file( GLOB DEMO_SRCS "*.c*" )
+
 # Demo target.
 add_executable(
     ${DEMO_NAME}
-    "${DEMO_NAME}.c"
+    ${DEMO_SRCS}
     ${PKCS_SOURCES}
 )
 

--- a/demos/pkcs11/pkcs11_demo_objects/pkcs11_demo_objects.c
+++ b/demos/pkcs11/pkcs11_demo_objects/pkcs11_demo_objects.c
@@ -87,6 +87,14 @@
     "xg07nhvDeydwB48xXrPQ1KutrRyh\n"                                     \
     "-----END CERTIFICATE-----"
 
+/* Add C++ guards for C linkage in case this file is being compiled as C++
+ * for a CI check. */
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
+
 /* This function can be found in
  * corePKCS11/source/dependency/3rdparty/mbedtls_utils/mbedtls_utils.c.
  * It will be used to convert the RSA certificate from PEM format
@@ -95,6 +103,12 @@ extern int convert_pem_to_der( const unsigned char * pucInput,
                                size_t xLen,
                                unsigned char * pucOutput,
                                size_t * pxOlen );
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    }
+#endif
+/* *INDENT-ON* */
+
 /*-----------------------------------------------------------*/
 
 
@@ -232,7 +246,7 @@ static CK_RV objectImporting( void )
     /* Convert the certificate to DER format if it was in PEM. The DER key
      * should be about 3/4 the size of the PEM key, so mallocing the PEM key
      * size is sufficient. */
-    derObject = malloc( certificateTemplate.xValue.ulValueLen );
+    derObject = ( uint8_t * ) malloc( certificateTemplate.xValue.ulValueLen );
 
     if( derObject == NULL )
     {
@@ -242,7 +256,7 @@ static CK_RV objectImporting( void )
     if( result == CKR_OK )
     {
         derLen = certificateTemplate.xValue.ulValueLen;
-        ( void ) convert_pem_to_der( certificateTemplate.xValue.pValue,
+        ( void ) convert_pem_to_der( ( unsigned char * ) certificateTemplate.xValue.pValue,
                                      certificateTemplate.xValue.ulValueLen,
                                      derObject,
                                      &derLen );
@@ -303,7 +317,7 @@ static CK_RV objectGeneration( void )
     CK_FUNCTION_LIST_PTR functionList = NULL;
     CK_BYTE * derPublicKey = NULL;
     CK_ULONG derPublicKeyLength = 0;
-    CK_BBOOL true = CK_TRUE;
+    CK_BBOOL trueVar = CK_TRUE;
 
     /* Specify the mechanism to use in the key pair generation. Mechanisms are
      * previously explained in the "mechanims_and_digests.c" demo. */
@@ -353,7 +367,7 @@ static CK_RV objectGeneration( void )
     CK_ATTRIBUTE publicKeyTemplate[] =
     {
         { CKA_KEY_TYPE,  &keyType,       sizeof( keyType )            },
-        { CKA_VERIFY,    &true,          sizeof( true )               },
+        { CKA_VERIFY,    &trueVar,       sizeof( trueVar )            },
         { CKA_EC_PARAMS, ecParams,       sizeof( ecParams )           },
         { CKA_LABEL,     publicKeyLabel, sizeof( publicKeyLabel ) - 1 }
     };
@@ -368,9 +382,9 @@ static CK_RV objectGeneration( void )
     CK_ATTRIBUTE privateKeyTemplate[] =
     {
         { CKA_KEY_TYPE, &keyType,        sizeof( keyType )             },
-        { CKA_TOKEN,    &true,           sizeof( true )                },
-        { CKA_PRIVATE,  &true,           sizeof( true )                },
-        { CKA_SIGN,     &true,           sizeof( true )                },
+        { CKA_TOKEN,    &trueVar,        sizeof( trueVar )             },
+        { CKA_PRIVATE,  &trueVar,        sizeof( trueVar )             },
+        { CKA_SIGN,     &trueVar,        sizeof( trueVar )             },
         { CKA_LABEL,    privateKeyLabel, sizeof( privateKeyLabel ) - 1 }
     };
 

--- a/demos/pkcs11/pkcs11_demo_sign_and_verify/CMakeLists.txt
+++ b/demos/pkcs11/pkcs11_demo_sign_and_verify/CMakeLists.txt
@@ -14,10 +14,12 @@ list(APPEND PKCS_SOURCES
             "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils/mbedtls_utils.c"
             )
 
+file( GLOB DEMO_SRCS "*.c*" )
+
 # Demo target.
 add_executable(
     ${DEMO_NAME}
-    "${DEMO_NAME}.c"
+    ${DEMO_SRCS}
     ${PKCS_SOURCES}
 )
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -62,7 +62,7 @@ dependencies:
       url: "https://github.com/FreeRTOS/corePKCS11"
       path: "libraries/standard/corePKCS11"
   - name: "Fleet-Provisioning-for-AWS-IoT-embedded-sdk"
-    version: "68d31ae"
+    version: "cbcb7a5"
     repository:
       type: "git"
       url: "https://github.com/aws/Fleet-Provisioning-for-AWS-IoT-embedded-sdk"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds CI checks for C++ linkage compatibility to the PKCS11 and Fleet Provisioning demos. Although the `-Werror` flag is not used (actually no flags are passed for C++) the macros in the logging header files were also fixed for C++ compatibility.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
