### PR TITLE
Update branch in gitmodules for fleet prov library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -42,6 +42,7 @@
 	url = https://github.com/eclipse/mosquitto.git
 [submodule "libraries/aws/fleet-provisioning-for-aws-iot-embedded-sdk"]
 	path = libraries/aws/fleet-provisioning-for-aws-iot-embedded-sdk
+    branch = main
 	url = https://github.com/aws/Fleet-Provisioning-for-AWS-IoT-embedded-sdk
 [submodule "libraries/3rdparty/tinycbor"]
 	path = libraries/3rdparty/tinycbor

--- a/.gitmodules
+++ b/.gitmodules
@@ -42,7 +42,7 @@
 	url = https://github.com/eclipse/mosquitto.git
 [submodule "libraries/aws/fleet-provisioning-for-aws-iot-embedded-sdk"]
 	path = libraries/aws/fleet-provisioning-for-aws-iot-embedded-sdk
-    branch = main
+	branch = main
 	url = https://github.com/aws/Fleet-Provisioning-for-AWS-IoT-embedded-sdk
 [submodule "libraries/3rdparty/tinycbor"]
 	path = libraries/3rdparty/tinycbor


### PR DESCRIPTION
*Description of changes:* Adding the branch specifier to .gitmodules for the fleet provisioning library so the CI system (and others) can accurately update the submodule to the intended branch rather than wait for submodule reference to be updated by the library authors.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
