### PR TITLE
Fix memory leaks in PKCS11 demo

### DIFF
--- a/demos/lexicon.txt
+++ b/demos/lexicon.txt
@@ -195,6 +195,7 @@ esavedagentstate
 establishmqttsession
 ethernet
 eventcallback
+exportpublickey
 extendedkeyusage
 familiy
 faqs

--- a/demos/pkcs11/pkcs11_demo_objects/pkcs11_demo_objects.c
+++ b/demos/pkcs11/pkcs11_demo_objects/pkcs11_demo_objects.c
@@ -429,6 +429,13 @@ static CK_RV objectGeneration( void )
     writeHexBytesToConsole( "Public Key in Hex Format",
                             derPublicKey,
                             derPublicKeyLength );
+
+    /* exportPublicKey allocates memory which must be freed. */
+    if( derPublicKey != NULL )
+    {
+        free( derPublicKey );
+    }
+
     LogInfo( ( "---------Finished Generating Objects---------" ) );
     end( session, slotId );
 

--- a/demos/pkcs11/pkcs11_demo_sign_and_verify/pkcs11_demo_sign_and_verify.c
+++ b/demos/pkcs11/pkcs11_demo_sign_and_verify/pkcs11_demo_sign_and_verify.c
@@ -75,8 +75,6 @@ CK_RV PKCS11SignVerifyDemo( void )
     /* Helper / previously explained variables. */
     CK_RV result = CKR_OK;
     CK_SESSION_HANDLE session = CK_INVALID_HANDLE;
-    CK_SLOT_ID * slotId = NULL;
-    CK_ULONG slotCount = 0;
     CK_ULONG index = 0;
     CK_OBJECT_HANDLE privateKeyHandle = CK_INVALID_HANDLE;
     CK_OBJECT_HANDLE publicKeyHandle = CK_INVALID_HANDLE;
@@ -128,16 +126,6 @@ CK_RV PKCS11SignVerifyDemo( void )
     if( result == CKR_OK )
     {
         result = xInitializePkcs11Token();
-    }
-
-    /* This function will:
-     * Query the Cryptoki library for the total number of slots. Malloc an array
-     * of slots. Then the slotId and slotCount variables will be updated to
-     * point to the slot array, and the total slot count.
-     */
-    if( result == CKR_OK )
-    {
-        result = xGetSlotList( &slotId, &slotCount );
     }
 
     /***************************** Find Objects *****************************/
@@ -343,6 +331,11 @@ CK_RV PKCS11SignVerifyDemo( void )
         writeHexBytesToConsole( "Public Key in Hex Format",
                                 derPublicKey,
                                 derPublicKeyLength );
+        /* exportPublicKey allocates memory which needs to be freed. */
+        if( derPublicKey != NULL )
+        {
+            free( derPublicKey );
+        }
     }
 
     /* This utility function converts the PKCS #11 signature into an ASN.1

--- a/demos/pkcs11/pkcs11_demo_sign_and_verify/pkcs11_demo_sign_and_verify.c
+++ b/demos/pkcs11/pkcs11_demo_sign_and_verify/pkcs11_demo_sign_and_verify.c
@@ -331,6 +331,7 @@ CK_RV PKCS11SignVerifyDemo( void )
         writeHexBytesToConsole( "Public Key in Hex Format",
                                 derPublicKey,
                                 derPublicKeyLength );
+
         /* exportPublicKey allocates memory which needs to be freed. */
         if( derPublicKey != NULL )
         {


### PR DESCRIPTION
This PR fixes the following 2 leaks:

1.` xGetSlotList` is not supposed to be called and doing so results in a  memory leak.
2. `exportPublicKey` allocates memory which must be freed by the caller.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
