### PR TITLE
Update CMake paths for the latest corePKCS11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,7 +367,7 @@ jobs:
       - name: Check Links
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: FreeRTOS/CI-CD-Github-Actions/link-verifier@main
+        uses: FreeRTOS/CI-CD-GitHub-Actions/link-verifier@main
         with:
           path: ./
           exclude-dirs: cmock,unity,cbmc,third-party,3rdparty,libmosquitto
@@ -384,7 +384,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Verify manifest.yml
-        uses: FreeRTOS/CI-CD-Github-Actions/manifest-verifier@main
+        uses: FreeRTOS/CI-CD-GitHub-Actions/manifest-verifier@main
         with:
           path: ./
           exclude-submodules: libraries/3rdparty/CMock,libraries/3rdparty/mbedtls,libraries/3rdparty/tinycbor,demos/jobs/jobs_demo_mosquitto/libmosquitto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,7 +367,7 @@ jobs:
       - name: Check Links
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: FreeRTOS/CI-CD-GitHub-Actions/link-verifier@main
+        uses: FreeRTOS/CI-CD-Github-Actions/link-verifier@main
         with:
           path: ./
           exclude-dirs: cmock,unity,cbmc,third-party,3rdparty,libmosquitto
@@ -384,7 +384,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Verify manifest.yml
-        uses: FreeRTOS/CI-CD-GitHub-Actions/manifest-verifier@main
+        uses: FreeRTOS/CI-CD-Github-Actions/manifest-verifier@main
         with:
           path: ./
           exclude-submodules: libraries/3rdparty/CMock,libraries/3rdparty/mbedtls,libraries/3rdparty/tinycbor,demos/jobs/jobs_demo_mosquitto/libmosquitto

--- a/demos/pkcs11/pkcs11_demo_management_and_rng/CMakeLists.txt
+++ b/demos/pkcs11/pkcs11_demo_management_and_rng/CMakeLists.txt
@@ -8,7 +8,8 @@ set(CORE_PKCS11_3RDPARTY_LOCATION "${COREPKCS11_LOCATION}/source/dependency/3rdp
 include( ${COREPKCS11_LOCATION}/pkcsFilePaths.cmake )
 
 list(APPEND PKCS_SOURCES
-    "${COREPKCS11_LOCATION}/source/portable/posix/core_pkcs11_pal.c"
+    "${COREPKCS11_LOCATION}/source/portable/os/posix/core_pkcs11_pal.c"
+    "${COREPKCS11_LOCATION}/source/portable/os/core_pkcs11_pal_utils.c"
     "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils/mbedtls_utils.c"
 )
 
@@ -34,6 +35,7 @@ target_include_directories(
         ${PKCS_INCLUDE_PUBLIC_DIRS}
         ${CMAKE_CURRENT_LIST_DIR}
         ${LOGGING_INCLUDE_DIRS}
+        "${COREPKCS11_LOCATION}/source/portable/os"
         ${CORE_PKCS11_3RDPARTY_LOCATION}/pkcs11
     PRIVATE
         ${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils

--- a/demos/pkcs11/pkcs11_demo_mechanisms_and_digests/CMakeLists.txt
+++ b/demos/pkcs11/pkcs11_demo_mechanisms_and_digests/CMakeLists.txt
@@ -9,7 +9,8 @@ include( ${COREPKCS11_LOCATION}/pkcsFilePaths.cmake )
 
 list(APPEND PKCS_SOURCES
             "${DEMOS_DIR}/pkcs11/common/src/demo_helpers.c"
-            "${COREPKCS11_LOCATION}/source/portable/posix/core_pkcs11_pal.c"
+            "${COREPKCS11_LOCATION}/source/portable/os/posix/core_pkcs11_pal.c"
+            "${COREPKCS11_LOCATION}/source/portable/os/core_pkcs11_pal_utils.c"
             "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils/mbedtls_utils.c"
             )
 
@@ -36,6 +37,7 @@ target_include_directories(
         ${CMAKE_CURRENT_LIST_DIR}
         ${LOGGING_INCLUDE_DIRS}
         "${CORE_PKCS11_3RDPARTY_LOCATION}/pkcs11"
+        "${COREPKCS11_LOCATION}/source/portable/os"
     PRIVATE
         "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils"
 )

--- a/demos/pkcs11/pkcs11_demo_objects/CMakeLists.txt
+++ b/demos/pkcs11/pkcs11_demo_objects/CMakeLists.txt
@@ -10,7 +10,8 @@ include( ${COREPKCS11_LOCATION}/pkcsFilePaths.cmake )
 
 list(APPEND PKCS_SOURCES
             "../common/src/demo_helpers.c"
-            "${COREPKCS11_LOCATION}/source/portable/posix/core_pkcs11_pal.c"
+            "${COREPKCS11_LOCATION}/source/portable/os/posix/core_pkcs11_pal.c"
+            "${COREPKCS11_LOCATION}/source/portable/os/core_pkcs11_pal_utils.c"
             "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils/mbedtls_utils.c"
             )
 
@@ -37,6 +38,7 @@ target_include_directories(
         ${CMAKE_CURRENT_LIST_DIR}
         ${LOGGING_INCLUDE_DIRS}
         "${CORE_PKCS11_3RDPARTY_LOCATION}/pkcs11"
+        "${COREPKCS11_LOCATION}/source/portable/os"
     PRIVATE
         "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils"
 )

--- a/demos/pkcs11/pkcs11_demo_sign_and_verify/CMakeLists.txt
+++ b/demos/pkcs11/pkcs11_demo_sign_and_verify/CMakeLists.txt
@@ -10,7 +10,8 @@ include( ${COREPKCS11_LOCATION}/pkcsFilePaths.cmake )
 
 list(APPEND PKCS_SOURCES
             "${DEMOS_DIR}/pkcs11/common/src/demo_helpers.c"
-            "${COREPKCS11_LOCATION}/source/portable/posix/core_pkcs11_pal.c"
+            "${COREPKCS11_LOCATION}/source/portable/os/posix/core_pkcs11_pal.c"
+            "${COREPKCS11_LOCATION}/source/portable/os/core_pkcs11_pal_utils.c"
             "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils/mbedtls_utils.c"
             )
 
@@ -37,6 +38,7 @@ target_include_directories(
         ${CMAKE_CURRENT_LIST_DIR}
         ${LOGGING_INCLUDE_DIRS}
         "${CORE_PKCS11_3RDPARTY_LOCATION}/pkcs11"
+        "${COREPKCS11_LOCATION}/source/portable/os"
     PRIVATE
         "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils"
 )

--- a/manifest.yml
+++ b/manifest.yml
@@ -56,7 +56,7 @@ dependencies:
       url: "https://github.com/FreeRTOS/backoffAlgorithm"
       path: "libraries/standard/backoffAlgorithm"
   - name: "corePKCS11"
-    version: "v3.1.0"
+    version: "309727d"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/corePKCS11"

--- a/tools/cmake/install.cmake
+++ b/tools/cmake/install.cmake
@@ -40,11 +40,13 @@ set(CORE_PKCS11_3RDPARTY_LOCATION "${COREPKCS11_LOCATION}/source/dependency/3rdp
 set(MQTT_EXTRA_SOURCES
         ${MQTT_SERIALIZER_SOURCES})
 set(PKCS_EXTRA_SOURCES
-        "${COREPKCS11_LOCATION}/source/portable/posix/core_pkcs11_pal.c"
+        "${COREPKCS11_LOCATION}/source/portable/os/posix/core_pkcs11_pal.c"
+        "${COREPKCS11_LOCATION}/source/portable/os/core_pkcs11_pal_utils.c"
         "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils/mbedtls_utils.c")
 set(PKCS_EXTRA_INCLUDE_PRIVATE_DIRS
     PRIVATE
-        "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils")
+        "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils"
+        "${COREPKCS11_LOCATION}/source/portable/os")
 set(OTA_BACKENDS "OTA_HTTP" "OTA_MQTT")
 foreach(ota_backend ${OTA_BACKENDS})
     set("${ota_backend}_EXTRA_INCLUDE_PUBLIC_DIRS"


### PR DESCRIPTION
This PR updates the corePKCS11 submodule pointer to the latest and updates the CMake paths as per the changes in this PR: https://github.com/FreeRTOS/corePKCS11/pull/123

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
