### PR TITLE
Have Fleet Provisioning Demo use MbedTLS and corePKCS11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,7 @@ jobs:
           -DCLAIM_CERT_PATH="cert/path" \
           -DCLAIM_PRIVATE_KEY_PATH="key/path" \
           -DPROVISIONING_TEMPLATE_NAME="template-name" \
-          -DPROVISIONING_CSR_PATH="csr/path" \
-          -DPROVISIONING_PRIVATE_KEY_PATH="key/path" \
-          -DPROVISIONING_CERT_PATH="cert/path"
+          -DDEVICE_SERIAL_NUMBER="00000"
       - name: Build Demos
         run: |
           make -C build/ help | grep demo | tr -d '. ' | xargs make -C build/
@@ -84,9 +82,7 @@ jobs:
           -DCLAIM_CERT_PATH="cert/path" \
           -DCLAIM_PRIVATE_KEY_PATH="key/path" \
           -DPROVISIONING_TEMPLATE_NAME="template-name" \
-          -DPROVISIONING_CSR_PATH="csr/path" \
-          -DPROVISIONING_PRIVATE_KEY_PATH="key/path" \
-          -DPROVISIONING_CERT_PATH="cert/path"
+          -DDEVICE_SERIAL_NUMBER="00000"
       - name: Build Demos
         run: |
           make -C build/ help | grep demo | tr -d '. ' | xargs make -C build/
@@ -119,9 +115,7 @@ jobs:
           -DCLAIM_CERT_PATH="cert/path" \
           -DCLAIM_PRIVATE_KEY_PATH="key/path" \
           -DPROVISIONING_TEMPLATE_NAME="template-name" \
-          -DPROVISIONING_CSR_PATH="csr/path" \
-          -DPROVISIONING_PRIVATE_KEY_PATH="key/path" \
-          -DPROVISIONING_CERT_PATH="cert/path"
+          -DDEVICE_SERIAL_NUMBER="00000"
       - name: Build System Tests
         run: make -C build/ help | grep system | tr -d '. ' | xargs make -C build/
   build-check-install:

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/CMakeLists.txt
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/CMakeLists.txt
@@ -10,6 +10,19 @@ include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorith
 include(
     ${CMAKE_SOURCE_DIR}/libraries/aws/fleet-provisioning-for-aws-iot-embedded-sdk/fleetprovisioningFilePaths.cmake )
 
+# Set path to corePKCS11 and it's third party libraries.
+set(COREPKCS11_LOCATION "${CMAKE_SOURCE_DIR}/libraries/standard/corePKCS11")
+set(CORE_PKCS11_3RDPARTY_LOCATION "${COREPKCS11_LOCATION}/source/dependency/3rdparty")
+
+# Include PKCS #11 library's source and header path variables.
+include( ${COREPKCS11_LOCATION}/pkcsFilePaths.cmake )
+
+list(APPEND PKCS_SOURCES
+    "${COREPKCS11_LOCATION}/source/portable/os/posix/core_pkcs11_pal.c"
+    "${COREPKCS11_LOCATION}/source/portable/os/core_pkcs11_pal_utils.c"
+    "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils/mbedtls_utils.c"
+)
+
 # CPP files are searched for supporting CI build checks that verify C++ linkage of the Fleet Provisioning library
 file( GLOB DEMO_SRCS "*.c*" )
 
@@ -19,19 +32,29 @@ add_executable( ${DEMO_NAME}
                 ${MQTT_SOURCES}
                 ${MQTT_SERIALIZER_SOURCES}
                 ${BACKOFF_ALGORITHM_SOURCES}
+                ${PKCS_SOURCES}
                 ${FLEET_PROVISIONING_SOURCES} )
 
 target_link_libraries( ${DEMO_NAME} PRIVATE
                        tinycbor
+                       mbedtls
                        clock_posix
-                       openssl_posix )
+                       transport_mbedtls_pkcs11_posix )
 
-target_include_directories( ${DEMO_NAME} PUBLIC
-                            ${LOGGING_INCLUDE_DIRS}
-                            ${MQTT_INCLUDE_PUBLIC_DIRS}
-                            ${BACKOFF_ALGORITHM_INCLUDE_PUBLIC_DIRS}
-                            ${FLEET_PROVISIONING_INCLUDE_PUBLIC_DIRS}
-                            ${CMAKE_CURRENT_LIST_DIR} )
+target_include_directories( ${DEMO_NAME}
+                            PUBLIC
+                              ${LOGGING_INCLUDE_DIRS}
+                              ${MQTT_INCLUDE_PUBLIC_DIRS}
+                              ${BACKOFF_ALGORITHM_INCLUDE_PUBLIC_DIRS}
+                              ${PKCS_INCLUDE_PUBLIC_DIRS}
+                              "${COREPKCS11_LOCATION}/source/portable/os"
+                              "${CORE_PKCS11_3RDPARTY_LOCATION}/pkcs11"
+                              "${FLEET_PROVISIONING_INCLUDE_PUBLIC_DIRS}"
+                              "${DEMOS_DIR}/pkcs11/common/include" # corePKCS11 config
+                              "${CMAKE_SOURCE_DIR}/platform/include"
+                              "${CMAKE_CURRENT_LIST_DIR}"
+                            PRIVATE
+                              "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils" )
 
 set_macro_definitions(TARGETS ${DEMO_NAME}
                       REQUIRED
@@ -40,9 +63,7 @@ set_macro_definitions(TARGETS ${DEMO_NAME}
                         "CLAIM_CERT_PATH"
                         "CLAIM_PRIVATE_KEY_PATH"
                         "PROVISIONING_TEMPLATE_NAME"
-                        "PROVISIONING_PRIVATE_KEY_PATH"
-                        "PROVISIONING_CSR_PATH"
-                        "PROVISIONING_CERT_PATH"
+                        "DEVICE_SERIAL_NUMBER"
                         "CLIENT_IDENTIFIER"
                         "OS_NAME"
                         "OS_VERSION"

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/core_mqtt_config.h
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/core_mqtt_config.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_INFO
+    #define LIBRARY_LOG_LEVEL    LOG_WARN
 #endif
 
 #include "logging_stack.h"

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/demo_config.h
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/demo_config.h
@@ -90,7 +90,7 @@
 #endif
 
 /**
- * @brief Path the file containing the provisioning claim certificate. This
+ * @brief Path of the file containing the provisioning claim certificate. This
  * certificate is used to connect to AWS IoT Core and use Fleet Provisioning
  * APIs to provision the client device. This is used for the "Provisioning by
  * Claim" provisioning workflow.
@@ -123,53 +123,6 @@
  */
 
 /**
- * @brief Path of the file containing the private key that the device is to be
- * provisioned with using the Fleet Provisioning APIs. This should be the key
- * used to generate the Certificate Signing Request (CSR) for certificate
- * provisioning. This key should be used to connect to IoT Core after the
- * client device has been provisioned.
- *
- * The following openssl command can be used to generate a private key and CSR:
- * openssl req -newkey rsa:2048 -keyout fpdemo_priv_key.pem -out fpdemo_csr.pem
- *
- * For information about provisioning by claim, see the following AWS documentation:
- * https://docs.aws.amazon.com/iot/latest/developerguide/provision-wo-cert.html#claim-based
- *
- * @note This private key should be PEM-encoded.
- *
- * #define PROVISIONING_PRIVATE_KEY_PATH    "...insert here..."
- */
-
-/**
- * @brief Path of the file containing the Certificate Signing Request (CSR) to
- * send to the AWS IoT Fleet Provisioning APIs for provisioning the client
- * device with a new certificate.
- *
- * The following openssl command can be used to generate a private key and CSR:
- * openssl req -newkey rsa:2048 -keyout fpdemo_priv_key.pem -out fpdemo_csr.pem
- *
- * For information about provisioning by claim, see the following AWS documentation:
- * https://docs.aws.amazon.com/iot/latest/developerguide/provision-wo-cert.html#claim-based
- *
- * @note This CSR should be PEM-encoded.
- *
- * #define PROVISIONING_CSR_PATH    "...insert here..."
- */
-
-/**
- * @brief Path to which to write the newly provisioned client certificate
- * obtained from AWS IoT Core through the Fleet Provisioning APIs.
- *
- * For information about provisioning by claim, see the following AWS documentation:
- * https://docs.aws.amazon.com/iot/latest/developerguide/provision-wo-cert.html#claim-based
- *
- * For information about client certificates, see the following AWS documentation:
- * https://docs.aws.amazon.com/iot/latest/developerguide/x509-client-certs.html
- *
- * #define PROVISIONING_CERT_PATH    "...insert here..."
- */
-
-/**
  * @brief Name of the provisioning template to use for the RegisterThing
  * portion of the Fleet Provisioning workflow.
  *
@@ -185,7 +138,16 @@
  * @note The provisioning template MUST be created in AWS IoT before running the
  * demo.
  *
- *  #define PROVISIONING_TEMPLATE_NAME    "...insert here..."
+ * #define PROVISIONING_TEMPLATE_NAME    "...insert here..."
+ */
+
+/**
+ * @brief Serial number sent as part of the RegisterThing request.
+ *
+ * This is sent as a parameter to the provisioning template, which uses it to
+ * generate a unique Thing name. This should be unique per device.
+ *
+ * #define DEVICE_SERIAL_NUMBER    "...insert here..."
  */
 
 /**
@@ -199,7 +161,7 @@
  * However, it is not required for the demo to run.
  */
 #ifndef CLIENT_IDENTIFIER
-    #define CLIENT_IDENTIFIER    THING_NAME
+    #define CLIENT_IDENTIFIER    DEVICE_SERIAL_NUMBER
 #endif
 
 /**

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/demo_config.h
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/demo_config.h
@@ -142,13 +142,21 @@
  */
 
 /**
- * @brief Serial number sent as part of the RegisterThing request.
+ * @brief Serial number to send in the request to the Fleet Provisioning
+ * RegisterThing API.
  *
  * This is sent as a parameter to the provisioning template, which uses it to
  * generate a unique Thing name. This should be unique per device.
  *
  * #define DEVICE_SERIAL_NUMBER    "...insert here..."
  */
+
+/**
+ * @brief Subject name to use when creating the certificate signing request (CSR).
+ *
+ * This is passed to MbedTLS; see https://tls.mbed.org/api/x509__csr_8h.html#a954eae166b125cea2115b7db8c896e90
+ */
+#define SUBJECT_NAME    "CN=Fleet Provisioning Demo"
 
 /**
  * @brief MQTT client identifier.

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/demo_config.h
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/demo_config.h
@@ -152,7 +152,9 @@
  */
 
 /**
- * @brief Subject name to use when creating the certificate signing request (CSR).
+ * @brief Subject name to use when creating the certificate signing request (CSR)
+ * for provisioning the demo client with using the Fleet Provisioning
+ * CreateCertificateFromCsr APIs.
  *
  * This is passed to MbedTLS; see https://tls.mbed.org/api/x509__csr_8h.html#a954eae166b125cea2115b7db8c896e90
  */

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/fleet_provisioning_with_csr_demo.c
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/fleet_provisioning_with_csr_demo.c
@@ -490,7 +490,11 @@ int main( int argc,
         else
         {
             /* Insert the claim credentials into the PKCS #11 module */
-            status = loadClaimCredentials( p11Session );
+            status = loadClaimCredentials( p11Session,
+                                           CLAIM_CERT_PATH,
+                                           pkcs11configLABEL_CLAIM_CERTIFICATE,
+                                           CLAIM_PRIVATE_KEY_PATH,
+                                           pkcs11configLABEL_CLAIM_PRIVATE_KEY );
 
             if( status == false )
             {
@@ -543,7 +547,12 @@ int main( int argc,
         if( status == true )
         {
             /* Create a new key and CSR. */
-            status = generateKeyAndCsr( p11Session, csr, CSR_BUFFER_LENGTH, &csrLength );
+            status = generateKeyAndCsr( p11Session,
+                                        pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS,
+                                        pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS,
+                                        csr,
+                                        CSR_BUFFER_LENGTH,
+                                        &csrLength );
         }
 
         if( status == true )
@@ -601,7 +610,10 @@ int main( int argc,
         if( status == true )
         {
             /* Save the certificate into PKCS #11. */
-            status = loadCertificate( p11Session, certificate, certificateLength );
+            status = loadCertificate( p11Session,
+                                      certificate,
+                                      pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS,
+                                      certificateLength );
         }
 
         if( status == true )

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/mqtt_operations.c
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/mqtt_operations.c
@@ -47,8 +47,8 @@
 /* Interface include. */
 #include "mqtt_operations.h"
 
-/* OpenSSL sockets transport implementation. */
-#include "openssl_posix.h"
+/* MbedTLS sockets transport implementation. */
+#include "mbedtls_pkcs11_posix.h"
 
 /*Include backoff algorithm header for retry logic.*/
 #include "backoff_algorithm.h"
@@ -157,7 +157,7 @@
 /**
  * @brief Timeout in milliseconds for transport send and receive.
  */
-#define TRANSPORT_SEND_RECV_TIMEOUT_MS           ( 100 )
+#define TRANSPORT_SEND_RECV_TIMEOUT_MS           ( 100U )
 
 /**
  * @brief The MQTT metrics string expected by AWS IoT MQTT Broker.
@@ -190,7 +190,7 @@ typedef struct PublishPackets
 /* Each compilation unit must define the NetworkContext struct. */
 struct NetworkContext
 {
-    OpensslParams_t * pParams;
+    MbedtlsPkcs11Context_t * pParams;
 };
 /*-----------------------------------------------------------*/
 
@@ -229,14 +229,14 @@ static uint8_t buffer[ NETWORK_BUFFER_SIZE ];
 static MQTTContext_t mqttContext = { 0 };
 
 /**
- * @brief The network context used for Openssl operation.
+ * @brief The network context used for MbedTLS operation.
  */
 static NetworkContext_t networkContext = { 0 };
 
 /**
- * @brief The parameters for Openssl operation.
+ * @brief The parameters for MbedTLS operation.
  */
-static OpensslParams_t opensslParams = { 0 };
+static MbedtlsPkcs11Context_t tlsContext = { 0 };
 
 /**
  * @brief The flag to indicate that the mqtt session is established.
@@ -266,14 +266,16 @@ static uint32_t generateRandomNumber( void );
  * of attempts are exhausted.
  *
  * @param[out] pNetworkContext The created network context.
- * @param[in] pClientCertPath The client certificate path to use.
- * @param[in] pPrivateKeyPath The private key path for the client certificate.
+ * @param[in] p11Session The PKCS #11 session to use.
+ * @param[in] pClientCertLabel The client certificate PKCS #11 label to use.
+ * @param[in] pPrivateKeyLabel The private key PKCS #11 label for the client certificate.
  *
  * @return false on failure; true on successful connection.
  */
 static bool connectToBrokerWithBackoffRetries( NetworkContext_t * pNetworkContext,
-                                               const char * pClientCertPath,
-                                               const char * pPrivateKeyPath );
+                                               CK_SESSION_HANDLE p11Session,
+                                               char * pClientCertLabel,
+                                               char * pPrivateKeyLabel );
 
 /**
  * @brief Get the free index in the #outgoingPublishPackets array at which an
@@ -301,6 +303,7 @@ static void cleanupOutgoingPublishes( void );
 
 /**
  * @brief Clean up the publish packet with the given packet id. in the
+ *                                             CK_SESSION_HANDLE p11Session,
  * #outgoingPublishPackets array.
  *
  * @param[in] packetId Packet id of the packet to be clean.
@@ -340,32 +343,34 @@ static uint32_t generateRandomNumber()
 /*-----------------------------------------------------------*/
 
 static bool connectToBrokerWithBackoffRetries( NetworkContext_t * pNetworkContext,
-                                               const char * pClientCertPath,
-                                               const char * pPrivateKeyPath )
+                                               CK_SESSION_HANDLE p11Session,
+                                               char * pClientCertLabel,
+                                               char * pPrivateKeyLabel )
 {
     bool returnStatus = false;
     BackoffAlgorithmStatus_t backoffAlgStatus = BackoffAlgorithmSuccess;
-    OpensslStatus_t opensslStatus = OPENSSL_SUCCESS;
+    MbedtlsPkcs11Status_t tlsStatus = MBEDTLS_PKCS11_SUCCESS;
     BackoffAlgorithmContext_t reconnectParams;
-    ServerInfo_t serverInfo;
-    OpensslCredentials_t opensslCredentials;
+    MbedtlsPkcs11Credentials_t tlsCredentials = { 0 };
     uint16_t nextRetryBackOff = 0U;
-    struct timespec tp;
+    const char * alpn[] = { ALPN_PROTOCOL_NAME, NULL };
 
     /* Set the pParams member of the network context with desired transport. */
-    pNetworkContext->pParams = &opensslParams;
-
-    /* Initialize information to connect to the MQTT broker. */
-    serverInfo.pHostName = AWS_IOT_ENDPOINT;
-    serverInfo.hostNameLength = AWS_IOT_ENDPOINT_LENGTH;
-    serverInfo.port = AWS_MQTT_PORT;
+    pNetworkContext->pParams = &tlsContext;
 
     /* Initialize credentials for establishing TLS session. */
-    ( void ) memset( &opensslCredentials, 0, sizeof( OpensslCredentials_t ) );
-    opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
-    opensslCredentials.pClientCertPath = pClientCertPath;
-    opensslCredentials.pPrivateKeyPath = pPrivateKeyPath;
-    opensslCredentials.sniHostName = AWS_IOT_ENDPOINT;
+    tlsCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
+    tlsCredentials.pClientCertLabel = pClientCertLabel;
+    tlsCredentials.pPrivateKeyLabel = pPrivateKeyLabel;
+    tlsCredentials.p11Session = p11Session;
+
+    /* AWS IoT requires devices to send the Server Name Indication (SNI)
+     * extension to the Transport Layer Security (TLS) protocol and provide
+     * the complete endpoint address in the host_name field. Details about
+     * SNI for AWS IoT can be found in the link below.
+     * https://docs.aws.amazon.com/iot/latest/developerguide/transport-security.html
+     */
+    tlsCredentials.disableSni = false;
 
     if( AWS_MQTT_PORT == 443 )
     {
@@ -374,18 +379,8 @@ static bool connectToBrokerWithBackoffRetries( NetworkContext_t * pNetworkContex
          * in the link below.
          * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
          */
-        opensslCredentials.pAlpnProtos = ALPN_PROTOCOL_NAME;
-        opensslCredentials.alpnProtosLen = ALPN_PROTOCOL_NAME_LENGTH;
+        tlsCredentials.pAlpnProtos = alpn;
     }
-
-    /* Seed pseudo random number generator used in the demo for
-     * backoff period calculation when retrying failed network operations
-     * with broker. */
-
-    /* Get current time to seed pseudo random number generator. */
-    ( void ) clock_gettime( CLOCK_REALTIME, &tp );
-    /* Seed pseudo random number generator with nanoseconds. */
-    srand( ( unsigned int ) tp.tv_nsec );
 
     /* Initialize reconnect attempts and interval */
     BackoffAlgorithm_InitializeParams( &reconnectParams,
@@ -393,47 +388,48 @@ static bool connectToBrokerWithBackoffRetries( NetworkContext_t * pNetworkContex
                                        CONNECTION_RETRY_MAX_BACKOFF_DELAY_MS,
                                        CONNECTION_RETRY_MAX_ATTEMPTS );
 
-    /* Attempt to connect to MQTT broker. If connection fails, retry after
-     * a timeout. Timeout value will exponentially increase until maximum
-     * attempts are reached. */
-    do
+    if( tlsStatus == MBEDTLS_PKCS11_SUCCESS )
     {
-        /* Establish a TLS session with the MQTT broker. This example connects
-         * to the MQTT broker as specified in AWS_IOT_ENDPOINT and AWS_MQTT_PORT
-         * at the demo config header. */
-        LogDebug( ( "Establishing a TLS session to %.*s:%d.",
-                    AWS_IOT_ENDPOINT_LENGTH,
-                    AWS_IOT_ENDPOINT,
-                    AWS_MQTT_PORT ) );
-        opensslStatus = Openssl_Connect( pNetworkContext,
-                                         &serverInfo,
-                                         &opensslCredentials,
-                                         TRANSPORT_SEND_RECV_TIMEOUT_MS,
-                                         TRANSPORT_SEND_RECV_TIMEOUT_MS );
-
-        if( opensslStatus == OPENSSL_SUCCESS )
+        do
         {
-            /* Connection successful. */
-            returnStatus = true;
-        }
-        else
-        {
-            /* Generate a random number and get back-off value (in milliseconds) for the next connection retry. */
-            backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams, generateRandomNumber(), &nextRetryBackOff );
+            /* Establish a TLS session with the MQTT broker. This example connects
+             * to the MQTT broker as specified in AWS_IOT_ENDPOINT and AWS_MQTT_PORT
+             * at the demo config header. */
+            LogDebug( ( "Establishing a TLS session to %.*s:%d.",
+                        AWS_IOT_ENDPOINT_LENGTH,
+                        AWS_IOT_ENDPOINT,
+                        AWS_MQTT_PORT ) );
 
-            if( backoffAlgStatus == BackoffAlgorithmRetriesExhausted )
+            tlsStatus = Mbedtls_Pkcs11_Connect( pNetworkContext,
+                                                AWS_IOT_ENDPOINT,
+                                                AWS_MQTT_PORT,
+                                                &tlsCredentials,
+                                                TRANSPORT_SEND_RECV_TIMEOUT_MS );
+
+            if( tlsStatus == MBEDTLS_PKCS11_SUCCESS )
             {
-                LogError( ( "Connection to the broker failed, all attempts exhausted." ) );
+                /* Connection successful. */
+                returnStatus = true;
             }
-            else if( backoffAlgStatus == BackoffAlgorithmSuccess )
+            else
             {
-                LogWarn( ( "Connection to the broker failed. Retrying connection "
-                           "after %hu ms backoff.",
-                           ( unsigned short ) nextRetryBackOff ) );
-                Clock_SleepMs( nextRetryBackOff );
+                /* Generate a random number and get back-off value (in milliseconds) for the next connection retry. */
+                backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams, generateRandomNumber(), &nextRetryBackOff );
+
+                if( backoffAlgStatus == BackoffAlgorithmRetriesExhausted )
+                {
+                    LogError( ( "Connection to the broker failed, all attempts exhausted." ) );
+                }
+                else if( backoffAlgStatus == BackoffAlgorithmSuccess )
+                {
+                    LogWarn( ( "Connection to the broker failed. Retrying connection "
+                               "after %hu ms backoff.",
+                               ( unsigned short ) nextRetryBackOff ) );
+                    Clock_SleepMs( nextRetryBackOff );
+                }
             }
-        }
-    } while( ( opensslStatus != OPENSSL_SUCCESS ) && ( backoffAlgStatus == BackoffAlgorithmSuccess ) );
+        } while( ( tlsStatus != MBEDTLS_PKCS11_SUCCESS ) && ( backoffAlgStatus == BackoffAlgorithmSuccess ) );
+    }
 
     return returnStatus;
 }
@@ -638,8 +634,9 @@ static bool handlePublishResend( MQTTContext_t * pMqttContext )
 /*-----------------------------------------------------------*/
 
 bool EstablishMqttSession( MQTTPublishCallback_t publishCallback,
-                           const char * pClientCertPath,
-                           const char * pPrivateKeyPath )
+                           CK_SESSION_HANDLE p11Session,
+                           char * pClientCertLabel,
+                           char * pPrivateKeyLabel )
 {
     bool returnStatus = false;
     MQTTStatus_t mqttStatus;
@@ -659,8 +656,9 @@ bool EstablishMqttSession( MQTTPublishCallback_t publishCallback,
     ( void ) memset( pNetworkContext, 0U, sizeof( NetworkContext_t ) );
 
     returnStatus = connectToBrokerWithBackoffRetries( pNetworkContext,
-                                                      pClientCertPath,
-                                                      pPrivateKeyPath );
+                                                      p11Session,
+                                                      pClientCertLabel,
+                                                      pPrivateKeyLabel );
 
     if( returnStatus != true )
     {
@@ -676,8 +674,8 @@ bool EstablishMqttSession( MQTTPublishCallback_t publishCallback,
          * For this demo, TCP sockets are used to send and receive data
          * from the network. pNetworkContext is an SSL context for OpenSSL.*/
         transport.pNetworkContext = pNetworkContext;
-        transport.send = Openssl_Send;
-        transport.recv = Openssl_Recv;
+        transport.send = Mbedtls_Pkcs11_Send;
+        transport.recv = Mbedtls_Pkcs11_Recv;
 
         /* Fill the values for network buffer. */
         networkBuffer.pBuffer = buffer;
@@ -814,7 +812,7 @@ bool DisconnectMqttSession( void )
     }
 
     /* End TLS session, then close TCP connection. */
-    ( void ) Openssl_Disconnect( pNetworkContext );
+    ( void ) Mbedtls_Pkcs11_Disconnect( pNetworkContext );
 
     return returnStatus;
 }

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/mqtt_operations.h
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/mqtt_operations.h
@@ -26,6 +26,9 @@
 /* MQTT API header. */
 #include "core_mqtt.h"
 
+/* corePKCS11 include. */
+#include "core_pkcs11.h"
+
 /**
  * @brief Application callback type to handle the incoming publishes.
  *
@@ -40,15 +43,17 @@ typedef void (* MQTTPublishCallback_t )( MQTTPublishInfo_t * pPublishInfo,
  *
  * @param[in] publishCallback The callback function to receive incoming
  * publishes from the MQTT broker.
- * @param[in] pClientCertPath The client certificate path to use.
- * @param[in] pPrivateKeyPath The private key path for the client certificate.
+ * @param[in] p11Session The PKCS #11 session to use.
+ * @param[in] pClientCertLabel The client certificate PKCS #11 label to use.
+ * @param[in] pPrivateKeyLabel The private key PKCS #11 label for the client certificate.
  *
  * @return true if an MQTT session is established;
  * false otherwise.
  */
 bool EstablishMqttSession( MQTTPublishCallback_t publishCallback,
-                           const char * pClientCertPath,
-                           const char * pPrivateKeyPath );
+                           CK_SESSION_HANDLE p11Session,
+                           char * pClientCertLabel,
+                           char * pPrivateKeyLabel );
 
 /**
  * @brief Disconnect the MQTT connection.

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/pkcs11_operations.c
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/pkcs11_operations.c
@@ -255,7 +255,7 @@ static int32_t privateKeySigningCallback( void * pContext,
                                           size_t hashLen,
                                           unsigned char * pSig,
                                           size_t * pSigLen,
-                                          int ( * pRng )( void *, unsigned char *, size_t ),
+                                          int ( *pRng )( void *, unsigned char *, size_t ),
                                           void * pRngContext );
 
 /**
@@ -912,7 +912,7 @@ static int32_t privateKeySigningCallback( void * pContext,
                                           size_t hashLen,
                                           unsigned char * pSig,
                                           size_t * pSigLen,
-                                          int ( * pRng )( void *, unsigned char *, size_t ),
+                                          int ( *pRng )( void *, unsigned char *, size_t ),
                                           void * pRngContext )
 {
     CK_RV ret = CKR_OK;

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/pkcs11_operations.c
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/pkcs11_operations.c
@@ -497,13 +497,13 @@ static CK_RV provisionPrivateECKey( CK_SESSION_HANDLE session,
     {
         CK_ATTRIBUTE privateKeyTemplate[] =
         {
-            { CKA_CLASS,     NULL /* &privateKeyClass*/, sizeof( CK_OBJECT_CLASS )                     },
-            { CKA_KEY_TYPE,  NULL /* &privateKeyType*/,  sizeof( CK_KEY_TYPE )                         },
+            { CKA_CLASS,     NULL /* &privateKeyClass*/, sizeof( CK_OBJECT_CLASS )    },
+            { CKA_KEY_TYPE,  NULL /* &privateKeyType*/,  sizeof( CK_KEY_TYPE )        },
             { CKA_LABEL,     ( void * ) label,           ( CK_ULONG ) strlen( label ) },
-            { CKA_TOKEN,     NULL /* &trueObject*/,      sizeof( CK_BBOOL )                            },
-            { CKA_SIGN,      NULL /* &trueObject*/,      sizeof( CK_BBOOL )                            },
-            { CKA_EC_PARAMS, NULL /* ecParamsPtr*/,      EC_PARAMS_LENGTH                              },
-            { CKA_VALUE,     NULL /* DPtr*/,             EC_D_LENGTH                                   }
+            { CKA_TOKEN,     NULL /* &trueObject*/,      sizeof( CK_BBOOL )           },
+            { CKA_SIGN,      NULL /* &trueObject*/,      sizeof( CK_BBOOL )           },
+            { CKA_EC_PARAMS, NULL /* ecParamsPtr*/,      EC_PARAMS_LENGTH             },
+            { CKA_VALUE,     NULL /* DPtr*/,             EC_D_LENGTH                  }
         };
 
         /* Aggregate initializers must not use the address of an automatic variable. */
@@ -597,19 +597,19 @@ static CK_RV provisionPrivateRSAKey( CK_SESSION_HANDLE session,
 
         CK_ATTRIBUTE privateKeyTemplate[] =
         {
-            { CKA_CLASS,            NULL /* &privateKeyClass */, sizeof( CK_OBJECT_CLASS )                     },
-            { CKA_KEY_TYPE,         NULL /* &privateKeyType */,  sizeof( CK_KEY_TYPE )                         },
-            { CKA_LABEL,            ( void * ) label,            ( CK_ULONG ) strlen( label )                  },
-            { CKA_TOKEN,            NULL /* &trueObject */,      sizeof( CK_BBOOL )                            },
-            { CKA_SIGN,             NULL /* &trueObject */,      sizeof( CK_BBOOL )                            },
-            { CKA_MODULUS,          rsaParams->modulus + 1,      MODULUS_LENGTH                                },
-            { CKA_PRIVATE_EXPONENT, rsaParams->d + 1,            D_LENGTH                                      },
-            { CKA_PUBLIC_EXPONENT,  rsaParams->e + 1,            E_LENGTH                                      },
-            { CKA_PRIME_1,          rsaParams->prime1 + 1,       PRIME_1_LENGTH                                },
-            { CKA_PRIME_2,          rsaParams->prime2 + 1,       PRIME_2_LENGTH                                },
-            { CKA_EXPONENT_1,       rsaParams->exponent1 + 1,    EXPONENT_1_LENGTH                             },
-            { CKA_EXPONENT_2,       rsaParams->exponent2 + 1,    EXPONENT_2_LENGTH                             },
-            { CKA_COEFFICIENT,      rsaParams->coefficient + 1,  COEFFICIENT_LENGTH                            }
+            { CKA_CLASS,            NULL /* &privateKeyClass */, sizeof( CK_OBJECT_CLASS )    },
+            { CKA_KEY_TYPE,         NULL /* &privateKeyType */,  sizeof( CK_KEY_TYPE )        },
+            { CKA_LABEL,            ( void * ) label,            ( CK_ULONG ) strlen( label ) },
+            { CKA_TOKEN,            NULL /* &trueObject */,      sizeof( CK_BBOOL )           },
+            { CKA_SIGN,             NULL /* &trueObject */,      sizeof( CK_BBOOL )           },
+            { CKA_MODULUS,          rsaParams->modulus + 1,      MODULUS_LENGTH               },
+            { CKA_PRIVATE_EXPONENT, rsaParams->d + 1,            D_LENGTH                     },
+            { CKA_PUBLIC_EXPONENT,  rsaParams->e + 1,            E_LENGTH                     },
+            { CKA_PRIME_1,          rsaParams->prime1 + 1,       PRIME_1_LENGTH               },
+            { CKA_PRIME_2,          rsaParams->prime2 + 1,       PRIME_2_LENGTH               },
+            { CKA_EXPONENT_1,       rsaParams->exponent1 + 1,    EXPONENT_1_LENGTH            },
+            { CKA_EXPONENT_2,       rsaParams->exponent2 + 1,    EXPONENT_2_LENGTH            },
+            { CKA_COEFFICIENT,      rsaParams->coefficient + 1,  COEFFICIENT_LENGTH           }
         };
 
         /* Aggregate initializers must not use the address of an automatic variable. */
@@ -733,7 +733,7 @@ static CK_RV provisionCertificate( CK_SESSION_HANDLE session,
 
         if( result != CKR_OK )
         {
-        LogError( ( "Could not get a PKCS #11 function pointer." ) );
+            LogError( ( "Could not get a PKCS #11 function pointer." ) );
         }
     }
 
@@ -1033,10 +1033,10 @@ static CK_RV generateKeyPairEC( CK_SESSION_HANDLE session,
     CK_BBOOL trueObject = CK_TRUE;
     CK_ATTRIBUTE publicKeyTemplate[] =
     {
-        { CKA_KEY_TYPE,  NULL /* &keyType */,    sizeof( keyType )                         },
-        { CKA_VERIFY,    NULL /* &trueObject */, sizeof( trueObject )                      },
-        { CKA_EC_PARAMS, NULL /* ecParams */,    sizeof( ecParams )                        },
-        { CKA_LABEL,     (void *) publicKeyLabel,         strlen( publicKeyLabel ) }
+        { CKA_KEY_TYPE,  NULL /* &keyType */,       sizeof( keyType )        },
+        { CKA_VERIFY,    NULL /* &trueObject */,    sizeof( trueObject )     },
+        { CKA_EC_PARAMS, NULL /* ecParams */,       sizeof( ecParams )       },
+        { CKA_LABEL,     ( void * ) publicKeyLabel, strlen( publicKeyLabel ) }
     };
 
     /* Aggregate initializers must not use the address of an automatic variable. */
@@ -1046,11 +1046,11 @@ static CK_RV generateKeyPairEC( CK_SESSION_HANDLE session,
 
     CK_ATTRIBUTE privateKeyTemplate[] =
     {
-        { CKA_KEY_TYPE, NULL /* &keyType */,    sizeof( keyType )                          },
-        { CKA_TOKEN,    NULL /* &trueObject */, sizeof( trueObject )                       },
-        { CKA_PRIVATE,  NULL /* &trueObject */, sizeof( trueObject )                       },
-        { CKA_SIGN,     NULL /* &trueObject */, sizeof( trueObject )                       },
-        { CKA_LABEL,    ( void *) privateKeyLabel,        strlen( privateKeyLabel ) }
+        { CKA_KEY_TYPE, NULL /* &keyType */,        sizeof( keyType )         },
+        { CKA_TOKEN,    NULL /* &trueObject */,     sizeof( trueObject )      },
+        { CKA_PRIVATE,  NULL /* &trueObject */,     sizeof( trueObject )      },
+        { CKA_SIGN,     NULL /* &trueObject */,     sizeof( trueObject )      },
+        { CKA_LABEL,    ( void * ) privateKeyLabel, strlen( privateKeyLabel ) }
     };
 
     /* Aggregate initializers must not use the address of an automatic variable. */

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/pkcs11_operations.c
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/pkcs11_operations.c
@@ -1,0 +1,1162 @@
+/*
+ * AWS IoT Device SDK for Embedded C 202103.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file pkcs11_operations.c
+ *
+ * @brief This file provides wrapper functions for PKCS11 operations.
+ */
+
+/* Standard includes. */
+#include <errno.h>
+
+/* Config include. */
+#include "demo_config.h"
+
+/* Interface include. */
+#include "pkcs11_operations.h"
+
+/* PKCS #11 include. */
+#include "core_pkcs11_config.h"
+#include "core_pki_utils.h"
+
+/* MbedTLS include. */
+#include "mbedtls/ctr_drbg.h"
+#include "mbedtls/entropy.h"
+#include "mbedtls/entropy_poll.h"
+#include "mbedtls/error.h"
+#include "mbedtls/oid.h"
+#include "mbedtls/pk.h"
+#include "mbedtls/pk_internal.h"
+#include "mbedtls/sha256.h"
+#include "mbedtls/x509_crt.h"
+#include "mbedtls/x509_csr.h"
+
+/**
+ * @brief Size of buffer in which to hold the certificate signing request (CSR).
+ */
+#define CLAIM_CERT_BUFFER_LENGTH           2048
+
+/**
+ * @brief Size of buffer in which to hold the certificate signing request (CSR).
+ */
+#define CLAIM_PRIVATE_KEY_BUFFER_LENGTH    2048
+
+/**
+ * @brief Represents string to be logged when mbedTLS returned error
+ * does not contain a high-level code.
+ */
+static const char * pNoHighLevelMbedTlsCodeStr = "<No-High-Level-Code>";
+
+/**
+ * @brief Represents string to be logged when mbedTLS returned error
+ * does not contain a low-level code.
+ */
+static const char * pNoLowLevelMbedTlsCodeStr = "<No-Low-Level-Code>";
+
+/**
+ * @brief Utility for converting the high-level code in an mbedTLS error to
+ * string, if the code-contains a high-level code; otherwise, using a default
+ * string.
+ */
+#define mbedtlsHighLevelCodeOrDefault( mbedTlsCode )     \
+    ( mbedtls_high_level_strerr( mbedTlsCode ) != NULL ) \
+    ? mbedtls_high_level_strerr( mbedTlsCode )           \
+    : pNoHighLevelMbedTlsCodeStr
+
+/**
+ * @brief Utility for converting the level-level code in an mbedTLS error to
+ * string, if the code-contains a level-level code; otherwise, using a default
+ * string.
+ */
+#define mbedtlsLowLevelCodeOrDefault( mbedTlsCode )     \
+    ( mbedtls_low_level_strerr( mbedTlsCode ) != NULL ) \
+    ? mbedtls_low_level_strerr( mbedTlsCode )           \
+    : pNoLowLevelMbedTlsCodeStr
+
+/* Length parameters for importing RSA-2048 private keys. */
+#define MODULUS_LENGTH        pkcs11RSA_2048_MODULUS_BITS / 8
+#define E_LENGTH              3
+#define D_LENGTH              pkcs11RSA_2048_MODULUS_BITS / 8
+#define PRIME_1_LENGTH        128
+#define PRIME_2_LENGTH        128
+#define EXPONENT_1_LENGTH     128
+#define EXPONENT_2_LENGTH     128
+#define COEFFICIENT_LENGTH    128
+
+#define EC_PARAMS_LENGTH      10
+#define EC_D_LENGTH           32
+
+/**
+ * @brief Struct for holding parsed RSA-2048 private keys.
+ */
+typedef struct RsaParams_t
+{
+    CK_BYTE modulus[ MODULUS_LENGTH + 1 ];
+    CK_BYTE e[ E_LENGTH + 1 ];
+    CK_BYTE d[ D_LENGTH + 1 ];
+    CK_BYTE prime1[ PRIME_1_LENGTH + 1 ];
+    CK_BYTE prime2[ PRIME_2_LENGTH + 1 ];
+    CK_BYTE exponent1[ EXPONENT_1_LENGTH + 1 ];
+    CK_BYTE exponent2[ EXPONENT_2_LENGTH + 1 ];
+    CK_BYTE coefficient[ COEFFICIENT_LENGTH + 1 ];
+} RsaParams_t;
+
+/**
+ * @brief Struct containing parameters needed by the signing callback.
+ */
+typedef struct SigningCallbackContext
+{
+    CK_SESSION_HANDLE p11Session;
+    CK_OBJECT_HANDLE p11PrivateKey;
+} SigningCallbackContext_t;
+
+/**
+ * @brief Parameters for the signing callback. This needs to be global as
+ * MbedTLS passes the key context to the signing function, so we cannot pass
+ * our own.
+ */
+static SigningCallbackContext_t signingContext = { 0 };
+
+/* Defined in
+ * libraries/standard/corePKCS11/source/dependency/3rdparty/mbedtls_utils/mbedtls_utils.c
+ */
+extern int convert_pem_to_der( const unsigned char * pucInput,
+                               size_t xLen,
+                               unsigned char * pucOutput,
+                               size_t * pxOlen );
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Reads a file into the given buffer.
+ *
+ * @param[in] path Path of the file.
+ * @param[out] pBuffer Buffer to read file contents into.
+ * @param[in] bufferLength Length of #pBuffer.
+ * @param[out] pOutWrittenLength Length of contents written to #pBuffer.
+ */
+static bool readFile( const char * path,
+                      char * pBuffer,
+                      size_t bufferLength,
+                      size_t * pOutWrittenLength );
+
+/**
+ * @brief Delete the specified crypto object from storage.
+ *
+ * @param[in] session The PKCS #11 session.
+ * @param[in] pkcsLabelsPtr The list of labels to remove.
+ * @param[in] pClass The list of corresponding classes.
+ * @param[in] count The length of #pkcsLabelsPtr and #pClass.
+ */
+static CK_RV destroyProvidedObjects( CK_SESSION_HANDLE session,
+                                     CK_BYTE_PTR * pkcsLabelsPtr,
+                                     CK_OBJECT_CLASS * pClass,
+                                     CK_ULONG count );
+
+
+/**
+ * @brief Import the specified ECDSA private key into storage.
+ *
+ * @param[in] session The PKCS #11 session.
+ * @param[in] label The label to store the key.
+ * @param[in] mbedPkContext The private key to store.
+ */
+static CK_RV provisionPrivateECKey( CK_SESSION_HANDLE session,
+                                    uint8_t * label,
+                                    mbedtls_pk_context * mbedPkContext );
+
+
+
+/**
+ * @brief Import the specified RSA private key into storage.
+ *
+ * @param[in] session The PKCS #11 session.
+ * @param[in] label The label to store the key.
+ * @param[in] mbedPkContext The private key to store.
+ */
+static CK_RV provisionPrivateRSAKey( CK_SESSION_HANDLE session,
+                                     uint8_t * label,
+                                     mbedtls_pk_context * mbedPkContext );
+
+
+/**
+ * @brief Import the specified private key into storage.
+ *
+ * @param[in] session The PKCS #11 session.
+ * @param[in] privateKey The private key to store, in PEM format.
+ * @param[in] privateKeyLength The length of the key, including null terminator.
+ * @param[in] label The label to store the key.
+ */
+static CK_RV provisionPrivateKey( CK_SESSION_HANDLE session,
+                                  uint8_t * privateKey,
+                                  size_t privateKeyLength,
+                                  uint8_t * label );
+
+/**
+ * @brief Import the specified X.509 client certificate into storage.
+ *
+ * @param[in] session The PKCS #11 session.
+ * @param[in] certificate The certificate to store, in PEM format.
+ * @param[in] certificateLength The length of the certificate, including null terminator.
+ * @param[in] label The label to store the certificate.
+ */
+static CK_RV provisionCertificate( CK_SESSION_HANDLE session,
+                                   uint8_t * certificate,
+                                   size_t certificateLength,
+                                   uint8_t * label );
+
+/**
+ * @brief Read the specified ECDSA public key into the MbedTLS ECDSA context.
+ *
+ * @param[in] p11Session The PKCS #11 session.
+ * @param[in] pEcdsaContext The context in which to store the key.
+ * @param[in] publicKey The public key to read.
+ */
+static int extractEcPublicKey( CK_SESSION_HANDLE p11Session,
+                               mbedtls_ecdsa_context * pEcdsaContext,
+                               CK_OBJECT_HANDLE publicKey );
+
+/**
+ * @brief MbedTLS callback for signing using the provisioned private key. Used for
+ * signing the CSR.
+ *
+ * @param[in] pContext Unused.
+ * @param[in] mdAlg Unused.
+ * @param[in] pHash Data to sign.
+ * @param[in] hashLen Length of #pHash.
+ * @param[out] pSig The signature
+ * @param[out] pSigLen The length of the signature.
+ * @param[in] pRng Unused.
+ * @param[in] pRngContext Unused.
+ */
+static int32_t privateKeySigningCallback( void * pContext,
+                                          mbedtls_md_type_t mdAlg,
+                                          const unsigned char * pHash,
+                                          size_t hashLen,
+                                          unsigned char * pSig,
+                                          size_t * pSigLen,
+                                          int ( *pRng )( void *, unsigned char *, size_t ),
+                                          void * pRngContext );
+
+/**
+ * @brief MbedTLS random generation callback to generate random values with
+ * PKCS #11.
+ *
+ * @param[in] pCtx Pointer to the PKCS #11 session handle.
+ * @param[out] pRandom Buffer to write random data to.
+ * @param[in] randomLength Length of random data to write.
+ */
+static int randomCallback( void * pCtx,
+                           unsigned char * pRandom,
+                           size_t randomLength );
+
+/**
+ * @brief Generate a new ECDSA key pair using PKCS #11.
+ *
+ * @param[in] session The PKCS #11 session.
+ * @param[in] privateKeyLabel The label to store the private key.
+ * @param[in] publicKeyLabel The label to store the public key.
+ * @param[out] privateKeyHandlePtr The handle of the private key.
+ * @param[out] publicKeyHandlePtr The handle of the public key.
+ */
+static CK_RV generateKeyPairEC( CK_SESSION_HANDLE session,
+                                uint8_t * privateKeyLabel,
+                                uint8_t * publicKeyLabel,
+                                CK_OBJECT_HANDLE_PTR privateKeyHandlePtr,
+                                CK_OBJECT_HANDLE_PTR publicKeyHandlePtr );
+
+/*-----------------------------------------------------------*/
+
+static bool readFile( const char * path,
+                      char * pBuffer,
+                      size_t bufferLength,
+                      size_t * pOutWrittenLength )
+{
+    FILE * file;
+    size_t length = 0;
+    bool status = true;
+
+    /* Get the file descriptor for the CSR file. */
+    file = fopen( path, "rb" );
+
+    if( file == NULL )
+    {
+        LogError( ( "Error opening file at path: %s. Error: %s.",
+                    path, strerror( errno ) ) );
+        status = false;
+    }
+    else
+    {
+        int result;
+        /* Seek to the end of the file, so that we can get the file size. */
+        result = fseek( file, 0L, SEEK_END );
+
+        if( result == -1 )
+        {
+            LogError( ( "Failed while moving to end of file. Path: %s. Error: %s.",
+                        path, strerror( errno ) ) );
+            status = false;
+        }
+        else
+        {
+            long lenResult = -1;
+            /* Get the current position which is the file size. */
+            lenResult = ftell( file );
+
+            if( lenResult == -1 )
+            {
+                LogError( ( "Failed to get length of file. Path: %s. Error: %s.", path,
+                            strerror( errno ) ) );
+                status = false;
+            }
+            else
+            {
+                length = ( size_t ) lenResult;
+            }
+        }
+
+        if( status == true )
+        {
+            if( length > bufferLength )
+            {
+                LogError( ( "Buffer too small for file. Buffer size: %ld. Required size: %ld.",
+                            bufferLength, length ) );
+                status = false;
+            }
+        }
+
+        if( status == true )
+        {
+            /* Return to the beginning of the file. */
+            result = fseek( file, 0L, SEEK_SET );
+
+            if( result == -1 )
+            {
+                LogError( ( "Failed to move to beginning of file. Path: %s. Error: %s.",
+                            path, strerror( errno ) ) );
+                status = false;
+            }
+        }
+
+        if( status == true )
+        {
+            size_t written = 0;
+            /* Read the CSR into our buffer. */
+            written = fread( pBuffer, 1, length, file );
+
+            if( written != length )
+            {
+                LogError( ( "Failed reading file. Path: %s. Error: %s.", path,
+                            strerror( errno ) ) );
+                status = false;
+            }
+            else
+            {
+                *pOutWrittenLength = length;
+            }
+        }
+
+        fclose( file );
+    }
+
+    return status;
+}
+
+/*-----------------------------------------------------------*/
+
+static CK_RV destroyProvidedObjects( CK_SESSION_HANDLE session,
+                                     CK_BYTE_PTR * pkcsLabelsPtr,
+                                     CK_OBJECT_CLASS * pClass,
+                                     CK_ULONG count )
+{
+    CK_RV result;
+    CK_FUNCTION_LIST_PTR functionList;
+    CK_OBJECT_HANDLE objectHandle;
+    CK_BYTE * labelPtr;
+    CK_ULONG index = 0;
+
+    result = C_GetFunctionList( &functionList );
+
+    for( index = 0; index < count; index++ )
+    {
+        labelPtr = pkcsLabelsPtr[ index ];
+
+        result = xFindObjectWithLabelAndClass( session, ( char * ) labelPtr,
+                                               strlen( ( char * ) labelPtr ),
+                                               pClass[ index ], &objectHandle );
+
+        while( ( result == CKR_OK ) && ( objectHandle != CK_INVALID_HANDLE ) )
+        {
+            result = functionList->C_DestroyObject( session, objectHandle );
+
+            /* PKCS #11 allows a module to maintain multiple objects with the same
+             * label and type. The intent of this loop is to try to delete all of
+             * them. However, to avoid getting stuck, we won't try to find another
+             * object of the same label/type if the previous delete failed. */
+            if( result == CKR_OK )
+            {
+                result = xFindObjectWithLabelAndClass( session, ( char * ) labelPtr,
+                                                       strlen( ( char * ) labelPtr ),
+                                                       pClass[ index ], &objectHandle );
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        if( result == CKR_FUNCTION_NOT_SUPPORTED )
+        {
+            break;
+        }
+    }
+
+    return result;
+}
+
+/*-----------------------------------------------------------*/
+
+static CK_RV provisionPrivateECKey( CK_SESSION_HANDLE session,
+                                    uint8_t * label,
+                                    mbedtls_pk_context * mbedPkContext )
+{
+    CK_RV result = CKR_OK;
+    CK_FUNCTION_LIST_PTR functionList = NULL;
+    CK_BYTE * DPtr;               /* Private value D. */
+    CK_BYTE * ecParamsPtr = NULL; /* DER-encoding of an ANSI X9.62 Parameters value */
+    int mbedResult = 0;
+    CK_BBOOL trueObject = CK_TRUE;
+    CK_KEY_TYPE privateKeyType = CKK_EC;
+    CK_OBJECT_CLASS privateKeyClass = CKO_PRIVATE_KEY;
+    CK_OBJECT_HANDLE objectHandle = CK_INVALID_HANDLE;
+    mbedtls_ecp_keypair * keyPair = ( mbedtls_ecp_keypair * ) mbedPkContext->pk_ctx;
+
+    result = C_GetFunctionList( &functionList );
+
+    DPtr = ( CK_BYTE * ) malloc( EC_D_LENGTH );
+
+    if( DPtr == NULL )
+    {
+        result = CKR_HOST_MEMORY;
+    }
+
+    if( result == CKR_OK )
+    {
+        mbedResult = mbedtls_mpi_write_binary( &( keyPair->d ), DPtr, EC_D_LENGTH );
+
+        if( mbedResult != 0 )
+        {
+            LogError( ( "Failed to parse EC private key components." ) );
+            result = CKR_ATTRIBUTE_VALUE_INVALID;
+        }
+    }
+
+    if( result == CKR_OK )
+    {
+        if( keyPair->grp.id == MBEDTLS_ECP_DP_SECP256R1 )
+        {
+            ecParamsPtr = ( CK_BYTE * ) ( "\x06\x08" MBEDTLS_OID_EC_GRP_SECP256R1 );
+        }
+        else
+        {
+            result = CKR_CURVE_NOT_SUPPORTED;
+        }
+    }
+
+    if( result == CKR_OK )
+    {
+        CK_ATTRIBUTE privateKeyTemplate[] =
+        {
+            { CKA_CLASS,     NULL /* &privateKeyClass*/, sizeof( CK_OBJECT_CLASS )                     },
+            { CKA_KEY_TYPE,  NULL /* &privateKeyType*/,  sizeof( CK_KEY_TYPE )                         },
+            { CKA_LABEL,     label,                      ( CK_ULONG ) strlen( ( const char * ) label ) },
+            { CKA_TOKEN,     NULL /* &trueObject*/,      sizeof( CK_BBOOL )                            },
+            { CKA_SIGN,      NULL /* &trueObject*/,      sizeof( CK_BBOOL )                            },
+            { CKA_EC_PARAMS, NULL /* ecParamsPtr*/,      EC_PARAMS_LENGTH                              },
+            { CKA_VALUE,     NULL /* DPtr*/,             EC_D_LENGTH                                   }
+        };
+
+        /* Aggregate initializers must not use the address of an automatic variable. */
+        privateKeyTemplate[ 0 ].pValue = &privateKeyClass;
+        privateKeyTemplate[ 1 ].pValue = &privateKeyType;
+        privateKeyTemplate[ 3 ].pValue = &trueObject;
+        privateKeyTemplate[ 4 ].pValue = &trueObject;
+        privateKeyTemplate[ 5 ].pValue = ecParamsPtr;
+        privateKeyTemplate[ 6 ].pValue = DPtr;
+
+        result = functionList->C_CreateObject( session,
+                                               ( CK_ATTRIBUTE_PTR ) &privateKeyTemplate,
+                                               sizeof( privateKeyTemplate ) / sizeof( CK_ATTRIBUTE ),
+                                               &objectHandle );
+    }
+
+    if( DPtr != NULL )
+    {
+        free( DPtr );
+    }
+
+    return result;
+}
+
+/*-----------------------------------------------------------*/
+
+static CK_RV provisionPrivateRSAKey( CK_SESSION_HANDLE session,
+                                     uint8_t * label,
+                                     mbedtls_pk_context * mbedPkContext )
+{
+    CK_RV result = CKR_OK;
+    CK_FUNCTION_LIST_PTR functionList = NULL;
+    int mbedResult = 0;
+    CK_KEY_TYPE privateKeyType = CKK_RSA;
+    mbedtls_rsa_context * rsaContext = ( mbedtls_rsa_context * ) mbedPkContext->pk_ctx;
+    CK_OBJECT_CLASS privateKeyClass = CKO_PRIVATE_KEY;
+    RsaParams_t * rsaParams = NULL;
+    CK_BBOOL trueObject = CK_TRUE;
+    CK_OBJECT_HANDLE objectHandle = CK_INVALID_HANDLE;
+
+    result = C_GetFunctionList( &functionList );
+
+    rsaParams = ( RsaParams_t * ) malloc( sizeof( RsaParams_t ) );
+
+    if( rsaParams == NULL )
+    {
+        result = CKR_HOST_MEMORY;
+    }
+
+    if( result == CKR_OK )
+    {
+        memset( rsaParams, 0, sizeof( RsaParams_t ) );
+
+        mbedResult = mbedtls_rsa_export_raw( rsaContext,
+                                             rsaParams->modulus, MODULUS_LENGTH + 1,
+                                             rsaParams->prime1, PRIME_1_LENGTH + 1,
+                                             rsaParams->prime2, PRIME_2_LENGTH + 1,
+                                             rsaParams->d, D_LENGTH + 1,
+                                             rsaParams->e, E_LENGTH + 1 );
+
+        if( mbedResult != 0 )
+        {
+            LogError( ( "Failed to parse RSA private key components." ) );
+            result = CKR_ATTRIBUTE_VALUE_INVALID;
+        }
+
+        /* Export Exponent 1, Exponent 2, Coefficient. */
+        mbedResult |= mbedtls_mpi_write_binary( ( mbedtls_mpi const * ) &rsaContext->DP, rsaParams->exponent1, EXPONENT_1_LENGTH + 1 );
+        mbedResult |= mbedtls_mpi_write_binary( ( mbedtls_mpi const * ) &rsaContext->DQ, rsaParams->exponent2, EXPONENT_2_LENGTH + 1 );
+        mbedResult |= mbedtls_mpi_write_binary( ( mbedtls_mpi const * ) &rsaContext->QP, rsaParams->coefficient, COEFFICIENT_LENGTH + 1 );
+
+        if( mbedResult != 0 )
+        {
+            LogError( ( "Failed to parse RSA private key Chinese Remainder Theorem variables." ) );
+            result = CKR_ATTRIBUTE_VALUE_INVALID;
+        }
+    }
+
+    if( result == CKR_OK )
+    {
+        /* When importing the fields, the pointer is incremented by 1
+         * to remove the leading 0 padding (if it existed) and the original field
+         * length is used */
+
+        CK_ATTRIBUTE privateKeyTemplate[] =
+        {
+            { CKA_CLASS,            NULL /* &privateKeyClass */, sizeof( CK_OBJECT_CLASS )                     },
+            { CKA_KEY_TYPE,         NULL /* &privateKeyType */,  sizeof( CK_KEY_TYPE )                         },
+            { CKA_LABEL,            label,                       ( CK_ULONG ) strlen( ( const char * ) label ) },
+            { CKA_TOKEN,            NULL /* &trueObject */,      sizeof( CK_BBOOL )                            },
+            { CKA_SIGN,             NULL /* &trueObject */,      sizeof( CK_BBOOL )                            },
+            { CKA_MODULUS,          rsaParams->modulus + 1,      MODULUS_LENGTH                                },
+            { CKA_PRIVATE_EXPONENT, rsaParams->d + 1,            D_LENGTH                                      },
+            { CKA_PUBLIC_EXPONENT,  rsaParams->e + 1,            E_LENGTH                                      },
+            { CKA_PRIME_1,          rsaParams->prime1 + 1,       PRIME_1_LENGTH                                },
+            { CKA_PRIME_2,          rsaParams->prime2 + 1,       PRIME_2_LENGTH                                },
+            { CKA_EXPONENT_1,       rsaParams->exponent1 + 1,    EXPONENT_1_LENGTH                             },
+            { CKA_EXPONENT_2,       rsaParams->exponent2 + 1,    EXPONENT_2_LENGTH                             },
+            { CKA_COEFFICIENT,      rsaParams->coefficient + 1,  COEFFICIENT_LENGTH                            }
+        };
+
+        /* Aggregate initializers must not use the address of an automatic variable. */
+        privateKeyTemplate[ 0 ].pValue = &privateKeyClass;
+        privateKeyTemplate[ 1 ].pValue = &privateKeyType;
+        privateKeyTemplate[ 3 ].pValue = &trueObject;
+        privateKeyTemplate[ 4 ].pValue = &trueObject;
+
+        result = functionList->C_CreateObject( session,
+                                               ( CK_ATTRIBUTE_PTR ) &privateKeyTemplate,
+                                               sizeof( privateKeyTemplate ) / sizeof( CK_ATTRIBUTE ),
+                                               &objectHandle );
+    }
+
+    if( NULL != rsaParams )
+    {
+        free( rsaParams );
+    }
+
+    return result;
+}
+
+/*-----------------------------------------------------------*/
+
+static CK_RV provisionPrivateKey( CK_SESSION_HANDLE session,
+                                  uint8_t * privateKey,
+                                  size_t privateKeyLength,
+                                  uint8_t * label )
+{
+    CK_RV result = CKR_OK;
+    mbedtls_pk_type_t mbedKeyType = MBEDTLS_PK_NONE;
+    int mbedResult = 0;
+    mbedtls_pk_context mbedPkContext = { 0 };
+
+    mbedtls_pk_init( &mbedPkContext );
+    mbedResult = mbedtls_pk_parse_key( &mbedPkContext, privateKey,
+                                       privateKeyLength, NULL, 0 );
+
+    if( mbedResult != 0 )
+    {
+        LogError( ( "Unable to parse private key." ) );
+        result = CKR_ARGUMENTS_BAD;
+    }
+
+    /* Determine whether the key to be imported is RSA or EC. */
+    if( result == CKR_OK )
+    {
+        mbedKeyType = mbedtls_pk_get_type( &mbedPkContext );
+
+        if( mbedKeyType == MBEDTLS_PK_RSA )
+        {
+            result = provisionPrivateRSAKey( session, label, &mbedPkContext );
+        }
+        else if( ( mbedKeyType == MBEDTLS_PK_ECDSA ) ||
+                 ( mbedKeyType == MBEDTLS_PK_ECKEY ) ||
+                 ( mbedKeyType == MBEDTLS_PK_ECKEY_DH ) )
+        {
+            result = provisionPrivateECKey( session, label, &mbedPkContext );
+        }
+        else
+        {
+            LogError( ( "Invalid private key type provided. RSA-2048 and EC P-256 keys "
+                        "are supported." ) );
+            result = CKR_ARGUMENTS_BAD;
+        }
+    }
+
+    mbedtls_pk_free( &mbedPkContext );
+
+    return result;
+}
+
+/*-----------------------------------------------------------*/
+
+static CK_RV provisionCertificate( CK_SESSION_HANDLE session,
+                                   uint8_t * certificate,
+                                   size_t certificateLength,
+                                   uint8_t * label )
+{
+    PKCS11_CertificateTemplate_t certificateTemplate;
+    CK_OBJECT_CLASS certificateClass = CKO_CERTIFICATE;
+    CK_CERTIFICATE_TYPE certificateType = CKC_X_509;
+    CK_FUNCTION_LIST_PTR functionList;
+    CK_RV result;
+    uint8_t * derObject = NULL;
+    int32_t conversion = 0;
+    size_t derLen = 0;
+    CK_BBOOL tokenStorage = CK_TRUE;
+    CK_BYTE subject[] = "TestSubject";
+    CK_OBJECT_HANDLE objectHandle = CK_INVALID_HANDLE;
+
+    /* Initialize the client certificate template. */
+    certificateTemplate.xObjectClass.type = CKA_CLASS;
+    certificateTemplate.xObjectClass.pValue = &certificateClass;
+    certificateTemplate.xObjectClass.ulValueLen = sizeof( certificateClass );
+    certificateTemplate.xSubject.type = CKA_SUBJECT;
+    certificateTemplate.xSubject.pValue = subject;
+    certificateTemplate.xSubject.ulValueLen = strlen( ( const char * ) subject );
+    certificateTemplate.xValue.type = CKA_VALUE;
+    certificateTemplate.xValue.pValue = ( CK_VOID_PTR ) certificate;
+    certificateTemplate.xValue.ulValueLen = ( CK_ULONG ) certificateLength;
+    certificateTemplate.xLabel.type = CKA_LABEL;
+    certificateTemplate.xLabel.pValue = ( CK_VOID_PTR ) label;
+    certificateTemplate.xLabel.ulValueLen = strlen( ( const char * ) label );
+    certificateTemplate.xCertificateType.type = CKA_CERTIFICATE_TYPE;
+    certificateTemplate.xCertificateType.pValue = &certificateType;
+    certificateTemplate.xCertificateType.ulValueLen = sizeof( CK_CERTIFICATE_TYPE );
+    certificateTemplate.xTokenObject.type = CKA_TOKEN;
+    certificateTemplate.xTokenObject.pValue = &tokenStorage;
+    certificateTemplate.xTokenObject.ulValueLen = sizeof( tokenStorage );
+
+    result = C_GetFunctionList( &functionList );
+
+    /* Test for a valid certificate: 0x2d is '-', as in ----- BEGIN CERTIFICATE. */
+    if( ( certificate == NULL ) || ( certificate[ 0 ] != 0x2d ) )
+    {
+        result = CKR_ATTRIBUTE_VALUE_INVALID;
+    }
+
+    if( result == CKR_OK )
+    {
+        /* Convert the certificate to DER format if it was in PEM. The DER key
+         * should be about 3/4 the size of the PEM key, so mallocing the PEM key
+         * size is sufficient. */
+        derObject = ( uint8_t * ) malloc( certificateTemplate.xValue.ulValueLen );
+        derLen = certificateTemplate.xValue.ulValueLen;
+
+        if( derObject != NULL )
+        {
+            conversion = convert_pem_to_der( ( unsigned char * ) certificateTemplate.xValue.pValue,
+                                             certificateTemplate.xValue.ulValueLen,
+                                             derObject, &derLen );
+
+            if( 0 != conversion )
+            {
+                result = CKR_ARGUMENTS_BAD;
+            }
+        }
+        else
+        {
+            result = CKR_HOST_MEMORY;
+        }
+    }
+
+    if( result == CKR_OK )
+    {
+        /* Set the template pointers to refer to the DER converted objects. */
+        certificateTemplate.xValue.pValue = derObject;
+        certificateTemplate.xValue.ulValueLen = derLen;
+    }
+
+    /* Best effort clean-up of the existing object, if it exists. */
+    if( result == CKR_OK )
+    {
+        destroyProvidedObjects( session, &label, &certificateClass, 1 );
+    }
+
+    /* Create an object using the encoded client certificate. */
+    if( result == CKR_OK )
+    {
+        LogInfo( ( "Writing certificate..." ) );
+
+        result = functionList->C_CreateObject( session,
+                                               ( CK_ATTRIBUTE_PTR ) &certificateTemplate,
+                                               sizeof( certificateTemplate ) / sizeof( CK_ATTRIBUTE ),
+                                               &objectHandle );
+    }
+
+    if( derObject != NULL )
+    {
+        free( derObject );
+    }
+
+    return result;
+}
+
+/*-----------------------------------------------------------*/
+
+bool loadClaimCredentials( CK_SESSION_HANDLE p11Session )
+{
+    bool status;
+    char claimCert[ CLAIM_CERT_BUFFER_LENGTH ] = { 0 };
+    size_t claimCertLength = 0;
+    char claimPrivateKey[ CLAIM_PRIVATE_KEY_BUFFER_LENGTH ] = { 0 };
+    size_t claimPrivateKeyLength = 0;
+    CK_RV ret;
+
+    status = readFile( CLAIM_CERT_PATH, claimCert, CLAIM_CERT_BUFFER_LENGTH,
+                       &claimCertLength );
+
+    if( status == true )
+    {
+        status = readFile( CLAIM_PRIVATE_KEY_PATH, claimPrivateKey,
+                           CLAIM_PRIVATE_KEY_BUFFER_LENGTH, &claimPrivateKeyLength );
+    }
+
+    if( status == true )
+    {
+        ret = provisionPrivateKey( p11Session, ( uint8_t * ) claimPrivateKey,
+                                   claimPrivateKeyLength + 1,
+                                   ( uint8_t * ) pkcs11configLABEL_CLAIM_PRIVATE_KEY );
+        status = ( ret == CKR_OK );
+    }
+
+    if( status == true )
+    {
+        ret = provisionCertificate( p11Session, ( uint8_t * ) claimCert,
+                                    claimCertLength + 1,
+                                    ( uint8_t * ) pkcs11configLABEL_CLAIM_CERTIFICATE );
+        status = ( ret == CKR_OK );
+    }
+
+    return status;
+}
+
+/*-----------------------------------------------------------*/
+
+static int extractEcPublicKey( CK_SESSION_HANDLE p11Session,
+                               mbedtls_ecdsa_context * pEcdsaContext,
+                               CK_OBJECT_HANDLE publicKey )
+{
+    CK_ATTRIBUTE ecTemplate = { 0 };
+    int mbedtlsRet = -1;
+    CK_RV pkcs11ret = CKR_OK;
+    CK_BYTE ecPoint[ 67 ] = { 0 };
+    CK_FUNCTION_LIST_PTR pP11FunctionList;
+
+    mbedtls_ecdsa_init( pEcdsaContext );
+    mbedtls_ecp_group_init( &( pEcdsaContext->grp ) );
+
+    pkcs11ret = C_GetFunctionList( &pP11FunctionList );
+
+    if( pkcs11ret != CKR_OK )
+    {
+        LogError( ( "Failed to extract EC public key. Could not get a "
+                    "PKCS #11 function pointer." ) );
+    }
+    else
+    {
+        ecTemplate.type = CKA_EC_POINT;
+        ecTemplate.pValue = ecPoint;
+        ecTemplate.ulValueLen = sizeof( ecPoint );
+        pkcs11ret = pP11FunctionList->C_GetAttributeValue( p11Session, publicKey, &ecTemplate, 1 );
+
+        if( pkcs11ret != CKR_OK )
+        {
+            LogError( ( "Failed to extract EC public key. Could not get attribute value. "
+                        "C_GetAttributeValue failed with %lu.", pkcs11ret ) );
+        }
+    }
+
+    if( pkcs11ret == CKR_OK )
+    {
+        mbedtlsRet = mbedtls_ecp_group_load( &( pEcdsaContext->grp ), MBEDTLS_ECP_DP_SECP256R1 );
+
+        if( mbedtlsRet != 0 )
+        {
+            LogError( ( "Failed creating an EC key. "
+                        "mbedtls_ecp_group_load failed: MbedTLS"
+                        "error = %s : %s.",
+                        mbedtlsHighLevelCodeOrDefault( mbedtlsRet ),
+                        mbedtlsLowLevelCodeOrDefault( mbedtlsRet ) ) );
+            pkcs11ret = CKR_FUNCTION_FAILED;
+        }
+        else
+        {
+            mbedtlsRet = mbedtls_ecp_point_read_binary( &( pEcdsaContext->grp ), &( pEcdsaContext->Q ), &ecPoint[ 2 ], ecTemplate.ulValueLen - 2 );
+
+            if( mbedtlsRet != 0 )
+            {
+                LogError( ( "Failed creating an EC key. "
+                            "mbedtls_ecp_group_load failed: MbedTLS"
+                            "error = %s : %s.",
+                            mbedtlsHighLevelCodeOrDefault( mbedtlsRet ),
+                            mbedtlsLowLevelCodeOrDefault( mbedtlsRet ) ) );
+                pkcs11ret = CKR_FUNCTION_FAILED;
+            }
+        }
+    }
+
+    return mbedtlsRet;
+}
+
+/*-----------------------------------------------------------*/
+
+static int32_t privateKeySigningCallback( void * pContext,
+                                          mbedtls_md_type_t mdAlg,
+                                          const unsigned char * pHash,
+                                          size_t hashLen,
+                                          unsigned char * pSig,
+                                          size_t * pSigLen,
+                                          int ( *pRng )( void *, unsigned char *, size_t ),
+                                          void * pRngContext )
+{
+    CK_RV ret = CKR_OK;
+    int32_t result = 0;
+    CK_MECHANISM mech = { 0 };
+    CK_BYTE toBeSigned[ 256 ];
+    CK_ULONG toBeSignedLen = sizeof( toBeSigned );
+    CK_FUNCTION_LIST_PTR functionList = NULL;
+
+    /* Unreferenced parameters. */
+    ( void ) ( pContext );
+    ( void ) ( pRng );
+    ( void ) ( pRngContext );
+    ( void ) ( mdAlg );
+
+    /* Sanity check buffer length. */
+    if( hashLen > sizeof( toBeSigned ) )
+    {
+        ret = CKR_ARGUMENTS_BAD;
+    }
+
+    mech.mechanism = CKM_ECDSA;
+    memcpy( toBeSigned, pHash, hashLen );
+    toBeSignedLen = hashLen;
+
+    if( ret == CKR_OK )
+    {
+        ret = C_GetFunctionList( &functionList );
+    }
+
+    if( ret == CKR_OK )
+    {
+        ret = functionList->C_SignInit( signingContext.p11Session, &mech,
+                                        signingContext.p11PrivateKey );
+    }
+
+    if( ret == CKR_OK )
+    {
+        *pSigLen = sizeof( toBeSigned );
+        ret = functionList->C_Sign( signingContext.p11Session, toBeSigned,
+                                    toBeSignedLen, pSig, ( CK_ULONG_PTR ) pSigLen );
+    }
+
+    if( ret == CKR_OK )
+    {
+        /* PKCS #11 for P256 returns a 64-byte signature with 32 bytes for R and 32
+         * bytes for S. This must be converted to an ASN.1 encoded array. */
+        if( *pSigLen != pkcs11ECDSA_P256_SIGNATURE_LENGTH )
+        {
+            ret = CKR_FUNCTION_FAILED;
+            LogError( ( "Failed to sign message using PKCS #11. Expected signature "
+                        "length of %lu, but received %lu.",
+                        ( unsigned long ) pkcs11ECDSA_P256_SIGNATURE_LENGTH,
+                        ( unsigned long ) *pSigLen ) );
+        }
+
+        if( ret == CKR_OK )
+        {
+            PKI_pkcs11SignatureTombedTLSSignature( pSig, pSigLen );
+        }
+    }
+
+    if( ret != CKR_OK )
+    {
+        LogError( ( "Failed to sign message using PKCS #11 with error code %lu.", ret ) );
+        result = -1;
+    }
+
+    return result;
+}
+
+/*-----------------------------------------------------------*/
+
+static int randomCallback( void * pCtx,
+                           unsigned char * pRandom,
+                           size_t randomLength )
+{
+    CK_SESSION_HANDLE * p11Session = ( CK_SESSION_HANDLE * ) pCtx;
+    CK_RV res;
+    CK_FUNCTION_LIST_PTR pP11FunctionList;
+
+    res = C_GetFunctionList( &pP11FunctionList );
+
+    if( res != CKR_OK )
+    {
+        LogError( ( "Failed to generate a random number in RNG callback. Could not get a "
+                    "PKCS #11 function pointer." ) );
+    }
+    else
+    {
+        res = pP11FunctionList->C_GenerateRandom( *p11Session, pRandom, randomLength );
+
+        if( res != CKR_OK )
+        {
+            LogError( ( "Failed to generate a random number in RNG callback. "
+                        "C_GenerateRandom failed with %lu.", res ) );
+        }
+    }
+
+    return ( int ) res;
+}
+
+/*-----------------------------------------------------------*/
+
+static CK_RV generateKeyPairEC( CK_SESSION_HANDLE session,
+                                uint8_t * privateKeyLabel,
+                                uint8_t * publicKeyLabel,
+                                CK_OBJECT_HANDLE_PTR privateKeyHandlePtr,
+                                CK_OBJECT_HANDLE_PTR publicKeyHandlePtr )
+{
+    CK_RV result;
+    CK_MECHANISM mechanism = { CKM_EC_KEY_PAIR_GEN, NULL_PTR, 0 };
+    CK_FUNCTION_LIST_PTR functionList;
+    CK_BYTE ecParams[] = pkcs11DER_ENCODED_OID_P256; /* prime256v1 */
+    CK_KEY_TYPE keyType = CKK_EC;
+
+    CK_BBOOL trueObject = CK_TRUE;
+    CK_ATTRIBUTE publicKeyTemplate[] =
+    {
+        { CKA_KEY_TYPE,  NULL /* &keyType */,    sizeof( keyType )                         },
+        { CKA_VERIFY,    NULL /* &trueObject */, sizeof( trueObject )                      },
+        { CKA_EC_PARAMS, NULL /* ecParams */,    sizeof( ecParams )                        },
+        { CKA_LABEL,     publicKeyLabel,         strlen( ( const char * ) publicKeyLabel ) }
+    };
+
+    /* Aggregate initializers must not use the address of an automatic variable. */
+    publicKeyTemplate[ 0 ].pValue = &keyType;
+    publicKeyTemplate[ 1 ].pValue = &trueObject;
+    publicKeyTemplate[ 2 ].pValue = &ecParams;
+
+    CK_ATTRIBUTE privateKeyTemplate[] =
+    {
+        { CKA_KEY_TYPE, NULL /* &keyType */,    sizeof( keyType )                          },
+        { CKA_TOKEN,    NULL /* &trueObject */, sizeof( trueObject )                       },
+        { CKA_PRIVATE,  NULL /* &trueObject */, sizeof( trueObject )                       },
+        { CKA_SIGN,     NULL /* &trueObject */, sizeof( trueObject )                       },
+        { CKA_LABEL,    privateKeyLabel,        strlen( ( const char * ) privateKeyLabel ) }
+    };
+
+    /* Aggregate initializers must not use the address of an automatic variable. */
+    privateKeyTemplate[ 0 ].pValue = &keyType;
+    privateKeyTemplate[ 1 ].pValue = &trueObject;
+    privateKeyTemplate[ 2 ].pValue = &trueObject;
+    privateKeyTemplate[ 3 ].pValue = &trueObject;
+
+    result = C_GetFunctionList( &functionList );
+
+    result = functionList->C_GenerateKeyPair( session,
+                                              &mechanism,
+                                              publicKeyTemplate,
+                                              sizeof( publicKeyTemplate ) / sizeof( CK_ATTRIBUTE ),
+                                              privateKeyTemplate, sizeof( privateKeyTemplate ) / sizeof( CK_ATTRIBUTE ),
+                                              publicKeyHandlePtr,
+                                              privateKeyHandlePtr );
+
+    return result;
+}
+
+/*-----------------------------------------------------------*/
+
+bool generateKeyAndCsr( CK_SESSION_HANDLE p11Session,
+                        char * pCsrBuffer,
+                        size_t csrBufferLength,
+                        size_t * pOutCsrLength )
+{
+    CK_OBJECT_HANDLE privKeyHandle;
+    CK_OBJECT_HANDLE pubKeyHandle;
+    CK_RV pkcs11Ret = CKR_OK;
+    mbedtls_pk_context privKey;
+    mbedtls_pk_info_t privKeyInfo;
+    mbedtls_ecdsa_context xEcdsaContext;
+    mbedtls_x509write_csr req;
+    int32_t mbedtlsRet = -1;
+    const mbedtls_pk_info_t * header = mbedtls_pk_info_from_type( MBEDTLS_PK_ECKEY );
+
+    pkcs11Ret = generateKeyPairEC( p11Session,
+                                   ( uint8_t * ) pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS,
+                                   ( uint8_t * ) pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS,
+                                   &privKeyHandle,
+                                   &pubKeyHandle );
+
+    if( pkcs11Ret == CKR_OK )
+    {
+        mbedtls_x509write_csr_init( &req );
+        mbedtls_x509write_csr_set_md_alg( &req, MBEDTLS_MD_SHA256 );
+
+        mbedtlsRet = mbedtls_x509write_csr_set_key_usage( &req, MBEDTLS_X509_KU_DIGITAL_SIGNATURE );
+
+        if( mbedtlsRet == 0 )
+        {
+            mbedtlsRet = mbedtls_x509write_csr_set_ns_cert_type( &req, MBEDTLS_X509_NS_CERT_TYPE_SSL_CLIENT );
+        }
+
+        if( mbedtlsRet == 0 )
+        {
+            mbedtlsRet = mbedtls_x509write_csr_set_subject_name( &req, ( const char * ) "CN=TestSubject" );
+        }
+
+        if( mbedtlsRet == 0 )
+        {
+            mbedtls_pk_init( &privKey );
+        }
+
+        if( mbedtlsRet == 0 )
+        {
+            mbedtlsRet = extractEcPublicKey( p11Session, &xEcdsaContext, pubKeyHandle );
+        }
+
+        if( mbedtlsRet == 0 )
+        {
+            signingContext.p11Session = p11Session;
+            signingContext.p11PrivateKey = privKeyHandle;
+
+            memcpy( &privKeyInfo, header, sizeof( mbedtls_pk_info_t ) );
+
+            privKeyInfo.sign_func = privateKeySigningCallback;
+            privKey.pk_info = &privKeyInfo;
+            privKey.pk_ctx = &xEcdsaContext;
+
+            mbedtls_x509write_csr_set_key( &req, &privKey );
+
+            mbedtlsRet = mbedtls_x509write_csr_pem( &req, ( unsigned char * ) pCsrBuffer,
+                                                    csrBufferLength, &randomCallback,
+                                                    &p11Session );
+        }
+
+        mbedtls_x509write_csr_free( &req );
+        mbedtls_ecdsa_free( &xEcdsaContext );
+        mbedtls_ecp_group_free( &( xEcdsaContext.grp ) );
+    }
+
+    *pOutCsrLength = strlen( pCsrBuffer );
+
+    return( mbedtlsRet == 0 );
+}
+
+/*-----------------------------------------------------------*/
+
+bool loadCertificate( CK_SESSION_HANDLE p11Session,
+                      char * pCertificate,
+                      size_t certificateLength )
+{
+    CK_RV ret;
+
+    ret = provisionCertificate( p11Session,
+                                ( uint8_t * ) pCertificate,
+                                certificateLength + 1,
+                                ( uint8_t * ) pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS );
+
+    return( ret == CKR_OK );
+}
+
+/*-----------------------------------------------------------*/
+
+bool pkcs11CloseSession( CK_SESSION_HANDLE p11Session )
+{
+    CK_RV result = CKR_OK;
+    CK_FUNCTION_LIST_PTR functionList = NULL;
+
+    result = C_GetFunctionList( &functionList );
+
+    if( result == CKR_OK )
+    {
+        result = functionList->C_CloseSession( p11Session );
+    }
+
+    if( result == CKR_OK )
+    {
+        result = functionList->C_Finalize( NULL );
+    }
+
+    return( result == CKR_OK );
+}
+
+/*-----------------------------------------------------------*/

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/pkcs11_operations.c
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/pkcs11_operations.c
@@ -217,7 +217,7 @@ static CK_RV provisionPrivateKey( CK_SESSION_HANDLE session,
  *
  * @param[in] session The PKCS #11 session.
  * @param[in] certificate The certificate to store, in PEM format.
- * @param[in] certificateLength The length of the certificate, including the NUL terminator.
+ * @param[in] certificateLength The length of the certificate, including the null terminator.
  * @param[in] label The label to store the certificate.
  */
 static CK_RV provisionCertificate( CK_SESSION_HANDLE session,
@@ -820,7 +820,7 @@ bool loadClaimCredentials( CK_SESSION_HANDLE p11Session,
     if( status == true )
     {
         ret = provisionPrivateKey( p11Session, claimPrivateKey,
-                                   claimPrivateKeyLength + 1, /* MbedTLS includes NUL character in length for PEM objects. */
+                                   claimPrivateKeyLength + 1, /* MbedTLS includes null character in length for PEM objects. */
                                    claimPrivKeyLabel );
         status = ( ret == CKR_OK );
     }
@@ -828,7 +828,7 @@ bool loadClaimCredentials( CK_SESSION_HANDLE p11Session,
     if( status == true )
     {
         ret = provisionCertificate( p11Session, claimCert,
-                                    claimCertLength + 1, /* MbedTLS includes NUL character in length for PEM objects. */
+                                    claimCertLength + 1, /* MbedTLS includes null character in length for PEM objects. */
                                     claimCertLabel );
         status = ( ret == CKR_OK );
     }
@@ -1170,7 +1170,7 @@ bool loadCertificate( CK_SESSION_HANDLE p11Session,
 
     ret = provisionCertificate( p11Session,
                                 pCertificate,
-                                certificateLength + 1, /* MbedTLS includes NUL character in length for PEM objects. */
+                                certificateLength + 1, /* MbedTLS includes null character in length for PEM objects. */
                                 pLabel );
 
     return( ret == CKR_OK );

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/pkcs11_operations.h
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/pkcs11_operations.h
@@ -1,6 +1,6 @@
 /*
  * AWS IoT Device SDK for Embedded C 202103.00
- * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -24,31 +24,57 @@
 #define PKCS11_OPERATIONS_H_
 
 /* Standard includes. */
+#include <stdlib.h>
 #include <stdbool.h>
 
 /* corePKCS11 include. */
 #include "core_pkcs11.h"
-#include "core_pkcs11_config.h"
 
 /**
- * @brief Loads the claim credentials into the PKCS #11 module.
+ * @brief Loads the claim credentials into the PKCS #11 module. Claim
+ * credentials are used in "Provisioning by Claim" workflow of Fleet
+ * Provisioning feature of AWS IoT Core. For more information, refer to the
+ * [AWS documentation](https://docs.aws.amazon.com/iot/latest/developerguide/provision-wo-cert.html#claim-based)
  *
  * Note: This function is for demonstration purposes, and the claim credentials
- * should be securely stored for production devices.
+ * should be securely stored in production devices. For example, the
+ * shared claim credentials could be loaded into a secure element on the devices
+ * in your fleet at the time of manufacturing.
  *
  * @param[in] p11Session The PKCS #11 session to use.
+ * @param[in] pClaimCertPath Path to the claim certificate.
+ * @param[in] pClaimCertLabel PKCS #11 label for the claim certificate.
+ * @param[in] pClaimPrivKeyPath Path to the claim private key.
+ * @param[in] pClaimPrivKeyLabel PKCS #11 label for the claim private key.
+ *
+ * @return True on success.
  */
-bool loadClaimCredentials( CK_SESSION_HANDLE p11Session );
+bool loadClaimCredentials( CK_SESSION_HANDLE p11Session,
+                           const char * pClaimCertPath,
+                           const char * pClaimCertLabel,
+                           const char * pClaimPrivKeyPath,
+                           const char * pClaimPrivKeyLabel );
 
 /**
- * @brief Generate new keys and sign a CSR for them with the PKCS #11 module.
+ * @brief Generate a new public-private key pair in the PKCS #11 module, and
+ * generate a certificate signing request (CSR) for them.
+ *
+ * This device-generated private key and CSR can be used with the
+ * CreateCertificateFromCsr API of the the Fleet Provisioning feature of AWS IoT
+ * Core in order to provision a unique client certificate.
  *
  * @param[in] p11Session The PKCS #11 session to use.
+ * @param[in] pPrivKeyLabel PKCS #11 label for the private key.
+ * @param[in] pPubKeyLabel PKCS #11 label for the public key.
  * @param[out] pCsrBuffer The buffer to write the CSR to.
  * @param[in] csrBufferLength Length of #pCsrBuffer.
  * @param[out] pOutCsrLength The length of the written CSR.
+ *
+ * @return True on success.
  */
 bool generateKeyAndCsr( CK_SESSION_HANDLE p11Session,
+                        const char * pPrivKeyLabel,
+                        const char * pPubKeyLabel,
                         char * pCsrBuffer,
                         size_t csrBufferLength,
                         size_t * pOutCsrLength );
@@ -58,16 +84,22 @@ bool generateKeyAndCsr( CK_SESSION_HANDLE p11Session,
  *
  * @param[in] p11Session The PKCS #11 session to use.
  * @param[in] pCertificate The certificate to save.
+ * @param[in] pLabel PKCS #11 label for the certificate.
  * @param[in] certificateLength Length of #pCertificate.
+ *
+ * @return True on success.
  */
 bool loadCertificate( CK_SESSION_HANDLE p11Session,
-                      char * pCertificate,
+                      const char * pCertificate,
+                      const char * pLabel,
                       size_t certificateLength );
 
 /**
  * @brief Close the PKCS #11 session.
  *
  * @param[in] p11Session The PKCS #11 session to use.
+ *
+ * @return True on success.
  */
 bool pkcs11CloseSession( CK_SESSION_HANDLE p11Session );
 

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/pkcs11_operations.h
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/pkcs11_operations.h
@@ -1,0 +1,74 @@
+/*
+ * AWS IoT Device SDK for Embedded C 202103.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef PKCS11_OPERATIONS_H_
+#define PKCS11_OPERATIONS_H_
+
+/* Standard includes. */
+#include <stdbool.h>
+
+/* corePKCS11 include. */
+#include "core_pkcs11.h"
+#include "core_pkcs11_config.h"
+
+/**
+ * @brief Loads the claim credentials into the PKCS #11 module.
+ *
+ * Note: This function is for demonstration purposes, and the claim credentials
+ * should be securely stored for production devices.
+ *
+ * @param[in] p11Session The PKCS #11 session to use.
+ */
+bool loadClaimCredentials( CK_SESSION_HANDLE p11Session );
+
+/**
+ * @brief Generate new keys and sign a CSR for them with the PKCS #11 module.
+ *
+ * @param[in] p11Session The PKCS #11 session to use.
+ * @param[out] pCsrBuffer The buffer to write the CSR to.
+ * @param[in] csrBufferLength Length of #pCsrBuffer.
+ * @param[out] pOutCsrLength The length of the written CSR.
+ */
+bool generateKeyAndCsr( CK_SESSION_HANDLE p11Session,
+                        char * pCsrBuffer,
+                        size_t csrBufferLength,
+                        size_t * pOutCsrLength );
+
+/**
+ * @brief Save the device client certificate into the PKCS #11 module.
+ *
+ * @param[in] p11Session The PKCS #11 session to use.
+ * @param[in] pCertificate The certificate to save.
+ * @param[in] certificateLength Length of #pCertificate.
+ */
+bool loadCertificate( CK_SESSION_HANDLE p11Session,
+                      char * pCertificate,
+                      size_t certificateLength );
+
+/**
+ * @brief Close the PKCS #11 session.
+ *
+ * @param[in] p11Session The PKCS #11 session to use.
+ */
+bool pkcs11CloseSession( CK_SESSION_HANDLE p11Session );
+
+#endif /* ifndef PKCS11_OPERATIONS_H_ */

--- a/demos/lexicon.txt
+++ b/demos/lexicon.txt
@@ -91,6 +91,8 @@ cka
 ckf
 ckm
 ckr
+claimcertlength
+claimprivatekeylength
 cli
 clienthello
 clienttoken
@@ -442,6 +444,10 @@ pcertificateidlength
 pcertificatelength
 pcertificateownershiptoken
 pcks
+pclaimcertlabel
+pclaimcertpath
+pclaimprivkeylabel
+pclaimprivkeypath
 pclass
 pclientcertlabel
 pclientcertpath
@@ -476,6 +482,7 @@ pkcslabelsptr
 pki
 pkparse
 pkwrite
+plabel
 plaintext
 platformimagestate
 pleace
@@ -522,8 +529,10 @@ ppayload
 ppkey
 pprivatekeylabel
 pprivatekeypath
+pprivkeylabel
 pprocfile
 ppubinfo
+ppubkeylabel
 ppublishinfo
 ppxslotid
 prandom


### PR DESCRIPTION
Converts the Fleet Provisioning demo to use MbedTLS and corePKCS11 for the transport interface, generating a new private key, and creating/signing a CSR.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
