### PR TITLE
Add documentation about special ALPN protocol format of OpenSSL

### DIFF
--- a/demos/defender/defender_demo_json/mqtt_operations.c
+++ b/demos/defender/defender_demo_json/mqtt_operations.c
@@ -104,7 +104,7 @@
  * broker. Please see more details about the ALPN protocol for AWS IoT MQTT
  * endpoint in the link below.
  * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
- * 
+ *
  * @note OpenSSL requires that the protocol string passed to it for configuration be encoded
  * with the prefix of 8-bit length information of the string. Thus, the 14 byte (0x0e) length
  * information is prefixed to the string.

--- a/demos/defender/defender_demo_json/mqtt_operations.c
+++ b/demos/defender/defender_demo_json/mqtt_operations.c
@@ -104,6 +104,10 @@
  * broker. Please see more details about the ALPN protocol for AWS IoT MQTT
  * endpoint in the link below.
  * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
+ * 
+ * @note OpenSSL requires that the protocol string passed to it for configuration be encoded
+ * with the prefix of 8-bit length information of the string. Thus, the 14 byte (0x0e) length
+ * information is prefixed to the string.
  */
 #define ALPN_PROTOCOL_NAME                       "\x0ex-amzn-mqtt-ca"
 

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/mqtt_operations.c
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/mqtt_operations.c
@@ -98,7 +98,7 @@
  * broker. Please see more details about the ALPN protocol for AWS IoT MQTT
  * endpoint in the link below.
  * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
- * 
+ *
  * @note OpenSSL requires that the protocol string passed to it for configuration be encoded
  * with the prefix of 8-bit length information of the string. Thus, the 14 byte (0x0e) length
  * information is prefixed to the string.

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/mqtt_operations.c
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/mqtt_operations.c
@@ -98,6 +98,10 @@
  * broker. Please see more details about the ALPN protocol for AWS IoT MQTT
  * endpoint in the link below.
  * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
+ * 
+ * @note OpenSSL requires that the protocol string passed to it for configuration be encoded
+ * with the prefix of 8-bit length information of the string. Thus, the 14 byte (0x0e) length
+ * information is prefixed to the string.
  */
 #define ALPN_PROTOCOL_NAME                       "\x0ex-amzn-mqtt-ca"
 

--- a/demos/http/http_demo_mutual_auth/http_demo_mutual_auth.c
+++ b/demos/http/http_demo_mutual_auth/http_demo_mutual_auth.c
@@ -74,6 +74,10 @@
  * @brief ALPN protocol name to be sent as part of the ClientHello message.
  *
  * @note When using ALPN, port 443 must be used to connect to AWS IoT Core.
+ *
+ * @note OpenSSL requires that the protocol string passed to it for configuration be encoded
+ * with the prefix of 8-bit length information of the string. Thus, the 14 byte (0x0e)
+ * length information is prefixed to the string.
  */
 #define IOT_CORE_ALPN_PROTOCOL_NAME    "\x0ex-amzn-http-ca"
 

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -153,6 +153,10 @@
  * Please see more details about the ALPN protocol for AWS IoT MQTT endpoint
  * in the link below.
  * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
+ *
+ * @note OpenSSL requires that the protocol string passed to it for configuration be encoded
+ * with the prefix of 8-bit length information of the string. Thus, the 14 byte (0x0e) length
+ * information is prefixed to the string.
  */
 #define AWS_IOT_MQTT_ALPN               "\x0ex-amzn-mqtt-ca"
 
@@ -164,6 +168,10 @@
 /**
  * @brief This is the ALPN (Application-Layer Protocol Negotiation) string
  * required by AWS IoT for password-based authentication using TCP port 443.
+ *
+ * @note OpenSSL requires that the protocol string passed to it for configuration
+ * be encoded with the prefix of 8-bit length information of the string. Thus, the
+ * 4 byte (0x04) length information is prefixed to the string.
  */
 #define AWS_IOT_PASSWORD_ALPN           "\x04mqtt"
 

--- a/demos/ota/ota_demo_core_http/ota_demo_core_http.c
+++ b/demos/ota/ota_demo_core_http/ota_demo_core_http.c
@@ -99,6 +99,10 @@
  * Please see more details about the ALPN protocol for AWS IoT MQTT endpoint
  * in the link below.
  * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
+ *
+ * @note OpenSSL requires that the protocol string passed to it for configuration be encoded
+ * with the prefix of 8-bit length information of the string. Thus, the 14 byte (0x0e) length
+ * information is prefixed to the string.
  */
 #define AWS_IOT_MQTT_ALPN                        "\x0ex-amzn-mqtt-ca"
 

--- a/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
+++ b/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
@@ -90,6 +90,10 @@
  * Please see more details about the ALPN protocol for AWS IoT MQTT endpoint
  * in the link below.
  * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
+ *
+ * @note OpenSSL requires that the protocol string passed to it for configuration be encoded
+ * with the prefix of 8-bit length information of the string. Thus, the 14 byte (0x0e) length
+ * information is prefixed to the string.
  */
 #define AWS_IOT_MQTT_ALPN                   "\x0ex-amzn-mqtt-ca"
 

--- a/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
+++ b/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
@@ -102,6 +102,10 @@
  * Please see more details about the ALPN protocol for AWS IoT MQTT endpoint
  * in the link below.
  * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
+ *
+ * @note OpenSSL requires that the protocol string passed to it for configuration be encoded
+ * with the prefix of 8-bit length information of the string. Thus, the 14 byte (0x0e) length
+ * information is prefixed to the string.
  */
 #define ALPN_PROTOCOL_NAME           "\x0ex-amzn-mqtt-ca"
 


### PR DESCRIPTION
To prevent the ALPN protocol string of `\x0e-x-amzn-mqtt-ca` and `\x0ex-amzn-http-ca` from being used as the ALPN protocol on non-OpenSSL TLS stacks, this PR adds comments that the hex string length prefix is only required by OpenSSL.