### PR TITLE
Allow configuration of demo CSR subject from CMake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
           -DCLAIM_CERT_PATH="cert/path" \
           -DCLAIM_PRIVATE_KEY_PATH="key/path" \
           -DPROVISIONING_TEMPLATE_NAME="template-name" \
-          -DDEVICE_SERIAL_NUMBER="00000"
+          -DDEVICE_SERIAL_NUMBER="00000" \
+          -DCSR_SUBJECT_NAME="CN=Fleet Provisioning Demo"
       - name: Build Demos
         run: |
           make -C build/ help | grep demo | tr -d '. ' | xargs make -C build/
@@ -82,7 +83,8 @@ jobs:
           -DCLAIM_CERT_PATH="cert/path" \
           -DCLAIM_PRIVATE_KEY_PATH="key/path" \
           -DPROVISIONING_TEMPLATE_NAME="template-name" \
-          -DDEVICE_SERIAL_NUMBER="00000"
+          -DDEVICE_SERIAL_NUMBER="00000" \
+          -DCSR_SUBJECT_NAME="CN=Fleet Provisioning Demo"
       - name: Build Demos
         run: |
           make -C build/ help | grep demo | tr -d '. ' | xargs make -C build/
@@ -115,7 +117,8 @@ jobs:
           -DCLAIM_CERT_PATH="cert/path" \
           -DCLAIM_PRIVATE_KEY_PATH="key/path" \
           -DPROVISIONING_TEMPLATE_NAME="template-name" \
-          -DDEVICE_SERIAL_NUMBER="00000"
+          -DDEVICE_SERIAL_NUMBER="00000" \
+          -DCSR_SUBJECT_NAME="CN=Fleet Provisioning Demo"
       - name: Build System Tests
         run: make -C build/ help | grep system | tr -d '. ' | xargs make -C build/
   build-check-install:

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/CMakeLists.txt
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/CMakeLists.txt
@@ -64,6 +64,7 @@ set_macro_definitions(TARGETS ${DEMO_NAME}
                         "CLAIM_PRIVATE_KEY_PATH"
                         "PROVISIONING_TEMPLATE_NAME"
                         "DEVICE_SERIAL_NUMBER"
+                        "CSR_SUBJECT_NAME"
                         "CLIENT_IDENTIFIER"
                         "OS_NAME"
                         "OS_VERSION"

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/demo_config.h
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/demo_config.h
@@ -158,7 +158,9 @@
  *
  * This is passed to MbedTLS; see https://tls.mbed.org/api/x509__csr_8h.html#a954eae166b125cea2115b7db8c896e90
  */
-#define SUBJECT_NAME    "CN=Fleet Provisioning Demo"
+#ifndef CSR_SUBJECT_NAME
+    #define CSR_SUBJECT_NAME    "CN=Fleet Provisioning Demo"
+#endif
 
 /**
  * @brief MQTT client identifier.

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/pkcs11_operations.c
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/pkcs11_operations.c
@@ -1123,7 +1123,7 @@ bool generateKeyAndCsr( CK_SESSION_HANDLE p11Session,
 
         if( mbedtlsRet == 0 )
         {
-            mbedtlsRet = mbedtls_x509write_csr_set_subject_name( &req, SUBJECT_NAME );
+            mbedtlsRet = mbedtls_x509write_csr_set_subject_name( &req, CSR_SUBJECT_NAME );
         }
 
         if( mbedtlsRet == 0 )


### PR DESCRIPTION
The Fleet Provisioning has a configuration to change the subject used in
creating the certificate signing request it uses. This changes the name
of the configuration from SUBJECT_NAME to CSR_SUBJECT_NAME and allows
overriding it from the CMake command.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
