### PR TITLE
Update corePKCS11 submodule

### DIFF
--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/CMakeLists.txt
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/CMakeLists.txt
@@ -18,8 +18,6 @@ set(CORE_PKCS11_3RDPARTY_LOCATION "${COREPKCS11_LOCATION}/source/dependency/3rdp
 include( ${COREPKCS11_LOCATION}/pkcsFilePaths.cmake )
 
 list(APPEND PKCS_SOURCES
-    "${COREPKCS11_LOCATION}/source/portable/os/posix/core_pkcs11_pal.c"
-    "${COREPKCS11_LOCATION}/source/portable/os/core_pkcs11_pal_utils.c"
     "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils/mbedtls_utils.c"
 )
 
@@ -33,6 +31,7 @@ add_executable( ${DEMO_NAME}
                 ${MQTT_SERIALIZER_SOURCES}
                 ${BACKOFF_ALGORITHM_SOURCES}
                 ${PKCS_SOURCES}
+                ${PKCS_PAL_POSIX_SOURCES}
                 ${FLEET_PROVISIONING_SOURCES} )
 
 target_link_libraries( ${DEMO_NAME} PRIVATE
@@ -47,8 +46,7 @@ target_include_directories( ${DEMO_NAME}
                               ${MQTT_INCLUDE_PUBLIC_DIRS}
                               ${BACKOFF_ALGORITHM_INCLUDE_PUBLIC_DIRS}
                               ${PKCS_INCLUDE_PUBLIC_DIRS}
-                              "${COREPKCS11_LOCATION}/source/portable/os"
-                              "${CORE_PKCS11_3RDPARTY_LOCATION}/pkcs11"
+                              ${PKCS_PAL_INCLUDE_PUBLIC_DIRS}
                               "${FLEET_PROVISIONING_INCLUDE_PUBLIC_DIRS}"
                               "${DEMOS_DIR}/pkcs11/common/include" # corePKCS11 config
                               "${CMAKE_SOURCE_DIR}/platform/include"

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/pkcs11_operations.c
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/pkcs11_operations.c
@@ -39,6 +39,7 @@
 /* PKCS #11 include. */
 #include "core_pkcs11_config.h"
 #include "core_pki_utils.h"
+#include "mbedtls_utils.h"
 
 /* MbedTLS include. */
 #include "mbedtls/ctr_drbg.h"
@@ -137,14 +138,6 @@ typedef struct SigningCallbackContext
  * our own.
  */
 static SigningCallbackContext_t signingContext = { 0 };
-
-/* Defined in
- * libraries/standard/corePKCS11/source/dependency/3rdparty/mbedtls_utils/mbedtls_utils.c
- */
-extern int convert_pem_to_der( const unsigned char * pucInput,
-                               size_t xLen,
-                               unsigned char * pucOutput,
-                               size_t * pxOlen );
 
 /*-----------------------------------------------------------*/
 

--- a/demos/pkcs11/pkcs11_demo_management_and_rng/CMakeLists.txt
+++ b/demos/pkcs11/pkcs11_demo_management_and_rng/CMakeLists.txt
@@ -8,8 +8,6 @@ set(CORE_PKCS11_3RDPARTY_LOCATION "${COREPKCS11_LOCATION}/source/dependency/3rdp
 include( ${COREPKCS11_LOCATION}/pkcsFilePaths.cmake )
 
 list(APPEND PKCS_SOURCES
-    "${COREPKCS11_LOCATION}/source/portable/os/posix/core_pkcs11_pal.c"
-    "${COREPKCS11_LOCATION}/source/portable/os/core_pkcs11_pal_utils.c"
     "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils/mbedtls_utils.c"
 )
 
@@ -20,6 +18,7 @@ add_executable(
     ${DEMO_NAME}
     ${DEMO_SRCS}
     ${PKCS_SOURCES}
+    ${PKCS_PAL_POSIX_SOURCES}
 )
 
 target_link_libraries(
@@ -33,10 +32,9 @@ target_include_directories(
     PUBLIC
         "${DEMOS_DIR}/pkcs11/common/include"
         ${PKCS_INCLUDE_PUBLIC_DIRS}
+        ${PKCS_PAL_INCLUDE_PUBLIC_DIRS}
         ${CMAKE_CURRENT_LIST_DIR}
         ${LOGGING_INCLUDE_DIRS}
-        "${COREPKCS11_LOCATION}/source/portable/os"
-        ${CORE_PKCS11_3RDPARTY_LOCATION}/pkcs11
     PRIVATE
         ${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils
 )

--- a/demos/pkcs11/pkcs11_demo_mechanisms_and_digests/CMakeLists.txt
+++ b/demos/pkcs11/pkcs11_demo_mechanisms_and_digests/CMakeLists.txt
@@ -9,8 +9,6 @@ include( ${COREPKCS11_LOCATION}/pkcsFilePaths.cmake )
 
 list(APPEND PKCS_SOURCES
             "${DEMOS_DIR}/pkcs11/common/src/demo_helpers.c"
-            "${COREPKCS11_LOCATION}/source/portable/os/posix/core_pkcs11_pal.c"
-            "${COREPKCS11_LOCATION}/source/portable/os/core_pkcs11_pal_utils.c"
             "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils/mbedtls_utils.c"
             )
 
@@ -21,6 +19,7 @@ add_executable(
     ${DEMO_NAME}
     ${DEMO_SRCS}
     ${PKCS_SOURCES}
+    ${PKCS_PAL_POSIX_SOURCES}
 )
 
 target_link_libraries(
@@ -34,10 +33,9 @@ target_include_directories(
     PUBLIC
         "${DEMOS_DIR}/pkcs11/common/include"
         ${PKCS_INCLUDE_PUBLIC_DIRS}
+        ${PKCS_PAL_INCLUDE_PUBLIC_DIRS}
         ${CMAKE_CURRENT_LIST_DIR}
         ${LOGGING_INCLUDE_DIRS}
-        "${CORE_PKCS11_3RDPARTY_LOCATION}/pkcs11"
-        "${COREPKCS11_LOCATION}/source/portable/os"
     PRIVATE
         "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils"
 )

--- a/demos/pkcs11/pkcs11_demo_objects/CMakeLists.txt
+++ b/demos/pkcs11/pkcs11_demo_objects/CMakeLists.txt
@@ -2,7 +2,6 @@ set( DEMO_NAME "pkcs11_demo_objects" )
 
 # Set path to corePKCS11 and it's third party libraries.
 set(COREPKCS11_LOCATION "${CMAKE_SOURCE_DIR}/libraries/standard/corePKCS11")
-set(3RDPARTY_LOCATION "${CMAKE_SOURCE_DIR}/libraries/source/dependency/3rdparty")
 set(CORE_PKCS11_3RDPARTY_LOCATION "${COREPKCS11_LOCATION}/source/dependency/3rdparty")
 
 # Include PKCS #11 library's source and header path variables.
@@ -10,8 +9,6 @@ include( ${COREPKCS11_LOCATION}/pkcsFilePaths.cmake )
 
 list(APPEND PKCS_SOURCES
             "../common/src/demo_helpers.c"
-            "${COREPKCS11_LOCATION}/source/portable/os/posix/core_pkcs11_pal.c"
-            "${COREPKCS11_LOCATION}/source/portable/os/core_pkcs11_pal_utils.c"
             "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils/mbedtls_utils.c"
             )
 
@@ -22,6 +19,7 @@ add_executable(
     ${DEMO_NAME}
     ${DEMO_SRCS}
     ${PKCS_SOURCES}
+    ${PKCS_PAL_POSIX_SOURCES}
 )
 
 target_link_libraries(
@@ -35,10 +33,9 @@ target_include_directories(
     PUBLIC
         "${DEMOS_DIR}/pkcs11/common/include"
         ${PKCS_INCLUDE_PUBLIC_DIRS}
+        ${PKCS_PAL_INCLUDE_PUBLIC_DIRS}
         ${CMAKE_CURRENT_LIST_DIR}
         ${LOGGING_INCLUDE_DIRS}
-        "${CORE_PKCS11_3RDPARTY_LOCATION}/pkcs11"
-        "${COREPKCS11_LOCATION}/source/portable/os"
     PRIVATE
         "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils"
 )

--- a/demos/pkcs11/pkcs11_demo_sign_and_verify/CMakeLists.txt
+++ b/demos/pkcs11/pkcs11_demo_sign_and_verify/CMakeLists.txt
@@ -2,7 +2,6 @@ set( DEMO_NAME "pkcs11_demo_sign_and_verify" )
 
 # Set path to corePKCS11 and it's third party libraries.
 set(COREPKCS11_LOCATION "${CMAKE_SOURCE_DIR}/libraries/standard/corePKCS11")
-set(3RDPARTY_LOCATION "${CMAKE_SOURCE_DIR}/libraries/source/dependency/3rdparty")
 set(CORE_PKCS11_3RDPARTY_LOCATION "${COREPKCS11_LOCATION}/source/dependency/3rdparty")
 
 # Include PKCS #11 library's source and header path variables.
@@ -10,8 +9,6 @@ include( ${COREPKCS11_LOCATION}/pkcsFilePaths.cmake )
 
 list(APPEND PKCS_SOURCES
             "${DEMOS_DIR}/pkcs11/common/src/demo_helpers.c"
-            "${COREPKCS11_LOCATION}/source/portable/os/posix/core_pkcs11_pal.c"
-            "${COREPKCS11_LOCATION}/source/portable/os/core_pkcs11_pal_utils.c"
             "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils/mbedtls_utils.c"
             )
 
@@ -22,6 +19,7 @@ add_executable(
     ${DEMO_NAME}
     ${DEMO_SRCS}
     ${PKCS_SOURCES}
+    ${PKCS_PAL_POSIX_SOURCES}
 )
 
 target_link_libraries(
@@ -35,10 +33,9 @@ target_include_directories(
     PUBLIC
         "${DEMOS_DIR}/pkcs11/common/include"
         ${PKCS_INCLUDE_PUBLIC_DIRS}
+        ${PKCS_PAL_INCLUDE_PUBLIC_DIRS}
         ${CMAKE_CURRENT_LIST_DIR}
         ${LOGGING_INCLUDE_DIRS}
-        "${CORE_PKCS11_3RDPARTY_LOCATION}/pkcs11"
-        "${COREPKCS11_LOCATION}/source/portable/os"
     PRIVATE
         "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils"
 )

--- a/manifest.yml
+++ b/manifest.yml
@@ -56,7 +56,7 @@ dependencies:
       url: "https://github.com/FreeRTOS/backoffAlgorithm"
       path: "libraries/standard/backoffAlgorithm"
   - name: "corePKCS11"
-    version: "8ea5d0d"
+    version: "2533c83"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/corePKCS11"

--- a/manifest.yml
+++ b/manifest.yml
@@ -56,7 +56,7 @@ dependencies:
       url: "https://github.com/FreeRTOS/backoffAlgorithm"
       path: "libraries/standard/backoffAlgorithm"
   - name: "corePKCS11"
-    version: "309727d"
+    version: "8ea5d0d"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/corePKCS11"


### PR DESCRIPTION
Update the corePKCS11 submodule, use the additional CMake variables, and use mbedtls_utils.h.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
