### PR TITLE
Use release tags for Fleet Provisioning and corePKCS11

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -56,13 +56,13 @@ dependencies:
       url: "https://github.com/FreeRTOS/backoffAlgorithm"
       path: "libraries/standard/backoffAlgorithm"
   - name: "corePKCS11"
-    version: "2533c83"
+    version: "v3.2.0"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/corePKCS11"
       path: "libraries/standard/corePKCS11"
   - name: "Fleet-Provisioning-for-AWS-IoT-embedded-sdk"
-    version: "cbcb7a5"
+    version: "v1.0.0"
     repository:
       type: "git"
       url: "https://github.com/aws/Fleet-Provisioning-for-AWS-IoT-embedded-sdk"


### PR DESCRIPTION
Sets the manifest versions for Fleet Provisioning and corePKCS11 to the new releases.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
