### PR TITLE
Update SigV4 S3 demo instructions and strlen usage

### DIFF
--- a/demos/http/http_demo_s3_download/README.md
+++ b/demos/http/http_demo_s3_download/README.md
@@ -26,7 +26,7 @@ aws iot create-thing --thing-name device_thing_name
 
 #### 2. Register a certificate:
 
-If your AWS IoT Thing already has a certificate attached to it, then that certificate's ARN can be used in [step 5](#5. attach-a-policy). Otherwise, you can create a certificate and attach it to the thing through IoT Core in the AWS Management Console UI. By doing any of these, you may skip to [step 3](#3--configure-an-iam-role).
+If your AWS IoT Thing already has a certificate attached to it, then that certificate's ARN can be used in [step 5](#5. attach-a-policy). Otherwise, you can create a certificate and attach it to the thing through IoT Core in the AWS Management Console UI. By doing any of these, you may skip to [step 3](#3-configure-an-iam-role).
 
 It is also possible to sign the Thing's certificate using your own Certificate Authority (CA) certificate, and register both certificates with AWS IoT before your device can authenticate to AWS IoT. If you do not already have a CA certificate, you can use OpenSSL to create a CA certificate, as described in [Use Your Own Certificate](https://docs.aws.amazon.com/iot/latest/developerguide/device-certs-your-own.html). To register your CA certificate with AWS IoT, follow the steps on [Registering Your CA Certificate](https://docs.aws.amazon.com/iot/latest/developerguide/device-certs-your-own.html#register-CA-cert).
 
@@ -108,7 +108,7 @@ Now, run the following command to attach the policy to the IAM user.
 aws iam attach-user-policy --policy-arn arn:aws:iam::<your_aws_account_id>:policy/passrolepermission --user-name <user_name>
 ```
 
-#### 4.  Create a role alias: 
+#### 4. Create a role alias: 
          
 Now that you have configured the IAM role, you will create a role alias with AWS IoT. You must provide the following pieces of information when creating a role alias:
 
@@ -120,7 +120,7 @@ Run the following command in the AWS CLI to create a role alias. Use the credent
 aws iot create-role-alias --role-alias name-s3-access-role-alias --role-arn arn:aws:iam::<your_aws_account_id>:role/s3-access-role --credential-duration-seconds 3600
 ```
 
-#### 5.  Attach a policy: 
+#### 5. Attach a policy: 
 You created and registered a certificate with AWS IoT earlier for successful authentication of your device. Now, you need to create and attach a policy to the certificate to authorize the request for the security token.
 ```
 {
@@ -190,7 +190,7 @@ The name of the AWS IoT thing for your device registered with AWS IoT core.
 The name for the role alias for S3.
 
 #### Thing_Policy_Name
-The name of the policy attached to the device certificate in [step 5](#5--attach-a-policy).
+The name of the policy attached to the device certificate in [step 5](#5-attach-a-policy).
 
 #### BUCKET_NAME
 The name of the S3 bucket from which the demo will download.

--- a/demos/http/http_demo_s3_download/README.md
+++ b/demos/http/http_demo_s3_download/README.md
@@ -183,9 +183,6 @@ The following is sample output of the describe-endpoint command. It contains the
          
 ### Parameters
 
-#### device_type_name
-The name that specifies your device type.
-
 #### device_thing_name
 The name of the AWS IoT thing for your device registered with AWS IoT core.
 

--- a/demos/http/http_demo_s3_download/README.md
+++ b/demos/http/http_demo_s3_download/README.md
@@ -26,7 +26,7 @@ aws iot create-thing --thing-name device_thing_name
 
 #### 2. Register a certificate:
 
-If your AWS IoT Thing already has a certificate attached to it, then that certificate's ARN can be used in [step 5](#5. attach-a-policy). Otherwise, you can create a certificate and attach it to the thing through IoT Core in the AWS Management Console UI. By doing any of these, you may skip to [step 3](#3. configure-an-iam-role).
+If your AWS IoT Thing already has a certificate attached to it, then that certificate's ARN can be used in [step 5](#5. attach-a-policy). Otherwise, you can create a certificate and attach it to the thing through IoT Core in the AWS Management Console UI. By doing any of these, you may skip to [step 3](#3--configure-an-iam-role).
 
 It is also possible to sign the Thing's certificate using your own Certificate Authority (CA) certificate, and register both certificates with AWS IoT before your device can authenticate to AWS IoT. If you do not already have a CA certificate, you can use OpenSSL to create a CA certificate, as described in [Use Your Own Certificate](https://docs.aws.amazon.com/iot/latest/developerguide/device-certs-your-own.html). To register your CA certificate with AWS IoT, follow the steps on [Registering Your CA Certificate](https://docs.aws.amazon.com/iot/latest/developerguide/device-certs-your-own.html#register-CA-cert).
 
@@ -190,7 +190,7 @@ The name of the AWS IoT thing for your device registered with AWS IoT core.
 The name for the role alias for S3.
 
 #### Thing_Policy_Name
-The name of the policy attached to the device certificate in [step 5](#5. attach-a-policy).
+The name of the policy attached to the device certificate in [step 5](#5--attach-a-policy).
 
 #### BUCKET_NAME
 The name of the S3 bucket from which the demo will download.

--- a/demos/http/http_demo_s3_download/http_demo_s3_download.c
+++ b/demos/http/http_demo_s3_download/http_demo_s3_download.c
@@ -200,11 +200,6 @@
 #define SIGV4_AUTH_HEADER_FIELD_NAME                  "Authorization"
 
 /**
- * @brief IS8601 formatted date length.
- */
-#define SIGV4_ISO_STRING_LEN                          16U
-
-/**
  * @brief Length of AWS HTTP Authorization header value generated using SigV4 library.
  */
 #define AWS_HTTP_AUTH_HEADER_VALUE_LEN                2048U

--- a/demos/http/http_demo_s3_download/http_demo_s3_download.c
+++ b/demos/http/http_demo_s3_download/http_demo_s3_download.c
@@ -1107,7 +1107,7 @@ static bool downloadS3ObjectFile( const TransportInterface_t * pTransportInterfa
 
         /* Get the hash of the payload. */
         sha256( ( const char * ) S3_REQUEST_EMPTY_PAYLOAD, 0, pPayloadHashDigest );
-        lowercaseHexEncode( ( const char * ) pPayloadHashDigest, sizeof( pPayloadHashDigest ), hexencoded );
+        lowercaseHexEncode( ( const char * ) pPayloadHashDigest, SHA256_HASH_DIGEST_LENGTH, hexencoded );
 
         if( returnStatus == true )
         {
@@ -1317,7 +1317,7 @@ static bool getS3ObjectFileSize( size_t * pFileSize,
 
     /* Get the hash of the payload. */
     sha256( ( const char * ) S3_REQUEST_EMPTY_PAYLOAD, 0, pPayloadHashDigest );
-    lowercaseHexEncode( ( const char * ) pPayloadHashDigest, sizeof( pPayloadHashDigest ), hexencoded );
+    lowercaseHexEncode( ( const char * ) pPayloadHashDigest, SHA256_HASH_DIGEST_LENGTH, hexencoded );
 
     if( returnStatus == true )
     {

--- a/demos/http/http_demo_s3_download/http_demo_s3_download.c
+++ b/demos/http/http_demo_s3_download/http_demo_s3_download.c
@@ -418,8 +418,7 @@ static bool downloadS3ObjectFile( const TransportInterface_t * pTransportInterfa
  * @param[out] pFileSize The size of the S3 object.
  * @param[in] pTransportInterface The transport interface for making network
  * calls.
- * @param[in] pHost The server host address. This string must be
- * null-terminated.
+ * @param[in] pHost The server host address.
  * @param[in] hostLen The length of the server host address.
  * @param[in] pPath The Request-URI to the objects of interest. This string
  * should be null-terminated.
@@ -451,17 +450,17 @@ static JSONStatus_t parseCredentials( HTTPResponse_t * response,
  * @brief Retrieve the temporary credentials from AWS IOT Credential Provider.
  *
  * @param[in] pTransportInterface The transport interface for performing network send/recv operations.
+ * @param[out] pDateISO8601 Buffer to store the ISO8601 formatted date.
  * @param[in] pDateISO8601Len Length of the buffer provided to store ISO8601 formatted date.
  * @param[in,out] response Response buffer to store the HTTP response received.
- * @param[out] pDateISO8601 Buffer to store the ISO8601 formatted date.
  * @param[out] sigvCreds Buffer to store the parsed credentials.
  *
  * @return `true` if credentials are retrieved successfully otherwise 'false`.
  */
 static bool getTemporaryCredentials( TransportInterface_t * transportInterface,
+                                     char * pDateISO8601,
                                      size_t pDateISO8601Len,
                                      HTTPResponse_t * response,
-                                     char * pDateISO8601,
                                      SigV4Credentials_t * sigvCreds );
 
 /**
@@ -555,9 +554,9 @@ static SigV4Parameters_t sigv4Params =
 /*-----------------------------------------------------------*/
 
 static bool getTemporaryCredentials( TransportInterface_t * transportInterface,
+                                     char * pDateISO8601,
                                      size_t pDateISO8601Len,
                                      HTTPResponse_t * response,
-                                     char * pDateISO8601,
                                      SigV4Credentials_t * sigvCreds )
 {
     bool returnStatus = true;
@@ -618,9 +617,9 @@ static bool getTemporaryCredentials( TransportInterface_t * transportInterface,
         /* Add AWS_IOT_THING_NAME_HEADER_FIELD header to the HTTP request headers. */
         httpStatus = HTTPClient_AddHeader( &requestHeaders,
                                            AWS_IOT_THING_NAME_HEADER_FIELD,
-                                           sizeof( AWS_IOT_THING_NAME_HEADER_FIELD ) - 1,
+                                           sizeof( AWS_IOT_THING_NAME_HEADER_FIELD ) - 1U,
                                            AWS_IOT_THING_NAME,
-                                           sizeof( AWS_IOT_THING_NAME ) );
+                                           sizeof( AWS_IOT_THING_NAME ) - 1U );
 
         if( httpStatus != HTTPSuccess )
         {
@@ -1067,7 +1066,7 @@ static bool downloadS3ObjectFile( const TransportInterface_t * pTransportInterfa
                                                ( const char * ) SIGV4_HTTP_X_AMZ_DATE_HEADER,
                                                ( size_t ) sizeof( SIGV4_HTTP_X_AMZ_DATE_HEADER ) - 1,
                                                ( const char * ) pDateISO8601,
-                                               ( size_t ) strlen( pDateISO8601 ) );
+                                               SIGV4_ISO_STRING_LEN );
 
             if( httpStatus != HTTPSuccess )
             {
@@ -1108,7 +1107,7 @@ static bool downloadS3ObjectFile( const TransportInterface_t * pTransportInterfa
 
         /* Get the hash of the payload. */
         sha256( ( const char * ) S3_REQUEST_EMPTY_PAYLOAD, 0, pPayloadHashDigest );
-        lowercaseHexEncode( ( const char * ) pPayloadHashDigest, strlen( pPayloadHashDigest ), hexencoded );
+        lowercaseHexEncode( ( const char * ) pPayloadHashDigest, sizeof( pPayloadHashDigest ), hexencoded );
 
         if( returnStatus == true )
         {
@@ -1143,7 +1142,7 @@ static bool downloadS3ObjectFile( const TransportInterface_t * pTransportInterfa
         sigv4HttpParams.pHeaders = pHeaders;
         sigv4HttpParams.headersLen = headersLen;
         sigv4HttpParams.pPayload = S3_REQUEST_EMPTY_PAYLOAD;
-        sigv4HttpParams.payloadLen = strlen( S3_REQUEST_EMPTY_PAYLOAD );
+        sigv4HttpParams.payloadLen = sizeof( S3_REQUEST_EMPTY_PAYLOAD ) - 1U;
 
         /* Initializing sigv4Params with Http parameters required for the HTTP request. */
         sigv4Params.pHttpParameters = &sigv4HttpParams;
@@ -1318,7 +1317,7 @@ static bool getS3ObjectFileSize( size_t * pFileSize,
 
     /* Get the hash of the payload. */
     sha256( ( const char * ) S3_REQUEST_EMPTY_PAYLOAD, 0, pPayloadHashDigest );
-    lowercaseHexEncode( ( const char * ) pPayloadHashDigest, strlen( pPayloadHashDigest ), hexencoded );
+    lowercaseHexEncode( ( const char * ) pPayloadHashDigest, sizeof( pPayloadHashDigest ), hexencoded );
 
     if( returnStatus == true )
     {
@@ -1327,7 +1326,7 @@ static bool getS3ObjectFileSize( size_t * pFileSize,
                                            ( const char * ) SIGV4_HTTP_X_AMZ_DATE_HEADER,
                                            ( size_t ) sizeof( SIGV4_HTTP_X_AMZ_DATE_HEADER ) - 1,
                                            ( const char * ) pDateISO8601,
-                                           ( size_t ) strlen( pDateISO8601 ) );
+                                           SIGV4_ISO_STRING_LEN );
 
         if( httpStatus != HTTPSuccess )
         {
@@ -1617,7 +1616,7 @@ int main( int argc,
         credentialResponse.pBuffer = pAwsIotHttpBuffer;
         credentialResponse.bufferLen = CREDENTIAL_BUFFER_LENGTH;
 
-        credentialStatus = getTemporaryCredentials( &transportInterface, sizeof( pDateISO8601 ), &credentialResponse, pDateISO8601, &sigvCreds );
+        credentialStatus = getTemporaryCredentials( &transportInterface, pDateISO8601, sizeof( pDateISO8601 ), &credentialResponse, &sigvCreds );
 
         returnStatus = ( credentialStatus == true ) ? EXIT_SUCCESS : EXIT_FAILURE;
 


### PR DESCRIPTION
The demo instructions are updated to state that an existing thing can be used rather than provisioning a new one with a customer certificate. Additionally, `sizeof` or macros are used in places where strings may potentially not be NUL-terminated.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
