### PR TITLE
Close demo connections only when created

### DIFF
--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -1421,6 +1421,9 @@ int main( int argc,
 
                 /* If TLS session is established, execute Subscribe/Publish loop. */
                 returnStatus = subscribePublishLoop( &mqttContext );
+
+                /* End TLS session, then close TCP connection. */
+                ( void ) Openssl_Disconnect( &networkContext );
             }
 
             if( returnStatus == EXIT_SUCCESS )
@@ -1428,9 +1431,6 @@ int main( int argc,
                 /* Log message indicating an iteration completed successfully. */
                 LogInfo( ( "Demo completed successfully." ) );
             }
-
-            /* End TLS session, then close TCP connection. */
-            ( void ) Openssl_Disconnect( &networkContext );
 
             LogInfo( ( "Short delay before starting the next iteration ....\n " ) );
             sleep( MQTT_SUBPUB_LOOP_DELAY_SECONDS );

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -1568,6 +1568,9 @@ int main( int argc,
 
                 /* If TLS session is established, execute Subscribe/Publish loop. */
                 returnStatus = subscribePublishLoop( &mqttContext );
+
+                /* End TLS session, then close TCP connection. */
+                ( void ) Openssl_Disconnect( &networkContext );
             }
 
             if( returnStatus == EXIT_SUCCESS )
@@ -1575,9 +1578,6 @@ int main( int argc,
                 /* Log message indicating an iteration completed successfully. */
                 LogInfo( ( "Demo completed successfully." ) );
             }
-
-            /* End TLS session, then close TCP connection. */
-            ( void ) Openssl_Disconnect( &networkContext );
 
             LogInfo( ( "Short delay before starting the next iteration....\n" ) );
             sleep( MQTT_SUBPUB_LOOP_DELAY_SECONDS );

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
@@ -1064,6 +1064,9 @@ int main( int argc,
         {
             /* If TCP connection is successful, execute Subscribe/Publish loop. */
             returnStatus = subscribePublishLoop( &mqttContext );
+
+            /* Close the TCP connection.  */
+            ( void ) Plaintext_Disconnect( &networkContext );
         }
 
         if( returnStatus == EXIT_SUCCESS )
@@ -1071,9 +1074,6 @@ int main( int argc,
             /* Log message indicating an iteration completed successfully. */
             LogInfo( ( "Demo completed successfully." ) );
         }
-
-        /* Close the TCP connection.  */
-        ( void ) Plaintext_Disconnect( &networkContext );
 
         LogInfo( ( "Short delay before starting the next iteration....\n" ) );
         sleep( MQTT_SUBPUB_LOOP_DELAY_SECONDS );

--- a/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
+++ b/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
@@ -1367,6 +1367,9 @@ int main( int argc,
         {
             /* If TLS session is established, execute Subscribe/Publish loop. */
             returnStatus = subscribePublishLoop( &mqttContext );
+
+            /* End TLS session, then close TCP connection. */
+            ( void ) Openssl_Disconnect( &networkContext );
         }
 
         if( returnStatus == EXIT_SUCCESS )
@@ -1374,9 +1377,6 @@ int main( int argc,
             /* Log message indicating an iteration completed successfully. */
             LogInfo( ( "Demo completed successfully." ) );
         }
-
-        /* End TLS session, then close TCP connection. */
-        ( void ) Openssl_Disconnect( &networkContext );
 
         LogInfo( ( "Short delay (of %u seconds) before starting the next iteration ....\n",
                    MQTT_SUBPUB_LOOP_DELAY_SECONDS ) );


### PR DESCRIPTION
*Issue #, if available:*
Fixes #1718

*Description of changes:*
Only close the TCP/TLS connection when it has been created, as doing otherwise can result in a segfault.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
