### PR TITLE
Create custom runner for multiple test groups

### DIFF
--- a/integration-test/custom_test_runner/custom_unity_runner.c
+++ b/integration-test/custom_test_runner/custom_unity_runner.c
@@ -1,5 +1,26 @@
 #include "custom_unity_runner.h"
 
+static int selected( const char * filter,
+                     const char * name )
+{
+    if( filter == 0 )
+    {
+        return 1;
+    }
+
+    return strstr( name, filter ) ? 1 : 0;
+}
+
+static int testSelected( const char * test )
+{
+    return selected( UnityFixture.NameFilter, test );
+}
+
+static int groupSelected( const char * group )
+{
+    return selected( UnityFixture.GroupFilter, group );
+}
+
 void CustomUnityTestRunner( unityfunction * setup,
                             unityfunction * testBody,
                             unityfunction * teardown,

--- a/integration-test/custom_test_runner/custom_unity_runner.c
+++ b/integration-test/custom_test_runner/custom_unity_runner.c
@@ -36,11 +36,6 @@ void CustomUnityTestRunner( unityfunction * setup,
         Unity.CurrentTestName = printableName;
         Unity.CurrentTestLineNumber = line;
 
-        if( !UnityFixture.Verbose )
-        {
-            UNITY_OUTPUT_CHAR( '.' );
-        }
-
         Unity.NumberOfTests++;
         UnityMalloc_StartTest();
         UnityPointer_Init();
@@ -67,6 +62,7 @@ void CustomUnityTestRunner( unityfunction * setup,
                 UnityMalloc_EndTest();
             }
         }
+
         UNITY_EXEC_TIME_STOP();
         UnityConcludeTest();
     }

--- a/integration-test/custom_test_runner/custom_unity_runner.c
+++ b/integration-test/custom_test_runner/custom_unity_runner.c
@@ -1,0 +1,52 @@
+#include "custom_unity_runner.h"
+
+void CustomUnityTestRunner( unityfunction * setup,
+                            unityfunction * testBody,
+                            unityfunction * teardown,
+                            const char * printableName,
+                            const char * group,
+                            const char * name,
+                            const char * file,
+                            unsigned int line )
+{
+    if( testSelected( name ) && groupSelected( group ) )
+    {
+        Unity.TestFile = file;
+        Unity.CurrentTestName = printableName;
+        Unity.CurrentTestLineNumber = line;
+
+        if( !UnityFixture.Verbose )
+        {
+            UNITY_OUTPUT_CHAR( '.' );
+        }
+
+        Unity.NumberOfTests++;
+        UnityMalloc_StartTest();
+        UnityPointer_Init();
+
+        UNITY_EXEC_TIME_START();
+
+        if( TEST_PROTECT() )
+        {
+            setup();
+            testBody();
+        }
+
+        if( TEST_PROTECT() )
+        {
+            teardown();
+        }
+
+        if( TEST_PROTECT() )
+        {
+            UnityPointer_UndoAllSets();
+
+            if( !Unity.CurrentTestFailed )
+            {
+                UnityMalloc_EndTest();
+            }
+        }
+        UNITY_EXEC_TIME_STOP();
+        UnityConcludeTest();
+    }
+}

--- a/integration-test/custom_test_runner/custom_unity_runner.h
+++ b/integration-test/custom_test_runner/custom_unity_runner.h
@@ -1,0 +1,59 @@
+#ifndef UNITY_RUNNER_H
+#define UNITY_RUNNER_H
+
+#include "unity.h"
+#include "unity_fixture_internals.h"
+#include <string.h>
+
+static int selected( const char * filter,
+                     const char * name )
+{
+    if( filter == 0 )
+    {
+        return 1;
+    }
+
+    return strstr( name, filter ) ? 1 : 0;
+}
+
+static int testSelected( const char * test )
+{
+    return selected( UnityFixture.NameFilter, test );
+}
+
+static int groupSelected( const char * group )
+{
+    return selected( UnityFixture.GroupFilter, group );
+}
+
+void CustomUnityTestRunner( unityfunction * setup,
+                            unityfunction * testBody,
+                            unityfunction * teardown,
+                            const char * printableName,
+                            const char * group,
+                            const char * name,
+                            const char * file,
+                            unsigned int line );
+
+/* Undefine this macro defined by unity_fixture.h so that a custom
+ * runner can be used */
+#ifdef TEST
+    #undef TEST
+
+/* Define a custom macro that will be used for our tests. */
+    #define TEST( group, name )                                  \
+    void TEST_ ## group ## _ ## name ## _( void );               \
+    void TEST_ ## group ## _ ## name ## _run( void );            \
+    void TEST_ ## group ## _ ## name ## _run( void )             \
+    {                                                            \
+        CustomUnityTestRunner( TEST_ ## group ## _SETUP,         \
+                               TEST_ ## group ## _ ## name ## _, \
+                               TEST_ ## group ## _TEAR_DOWN,     \
+                               "TEST(" # group ", " # name ")",  \
+                               TEST_GROUP_ ## group, # name,     \
+                               __FILE__, __LINE__ );             \
+    }                                                            \
+    void TEST_ ## group ## _ ## name ## _( void )
+#endif /* ifdef TEST */
+
+#endif /* ifndef UNITY_RUNNER_H */

--- a/integration-test/custom_test_runner/custom_unity_runner.h
+++ b/integration-test/custom_test_runner/custom_unity_runner.h
@@ -5,6 +5,11 @@
 #include "unity_fixture_internals.h"
 #include <string.h>
 
+/**
+ * @brief A custom runner that makes the standard output of
+ * multiple test groups match the standard output of the default
+ * runner for a single test group.
+ */
 void CustomUnityTestRunner( unityfunction * setup,
                             unityfunction * testBody,
                             unityfunction * teardown,

--- a/integration-test/custom_test_runner/custom_unity_runner.h
+++ b/integration-test/custom_test_runner/custom_unity_runner.h
@@ -5,27 +5,6 @@
 #include "unity_fixture_internals.h"
 #include <string.h>
 
-static int selected( const char * filter,
-                     const char * name )
-{
-    if( filter == 0 )
-    {
-        return 1;
-    }
-
-    return strstr( name, filter ) ? 1 : 0;
-}
-
-static int testSelected( const char * test )
-{
-    return selected( UnityFixture.NameFilter, test );
-}
-
-static int groupSelected( const char * group )
-{
-    return selected( UnityFixture.GroupFilter, group );
-}
-
 void CustomUnityTestRunner( unityfunction * setup,
                             unityfunction * testBody,
                             unityfunction * teardown,

--- a/integration-test/custom_test_runner/lexicon.txt
+++ b/integration-test/custom_test_runner/lexicon.txt
@@ -1,2 +1,0 @@
-ifdef
-undefine

--- a/integration-test/custom_test_runner/lexicon.txt
+++ b/integration-test/custom_test_runner/lexicon.txt
@@ -1,0 +1,2 @@
+ifdef
+undefine

--- a/integration-test/lexicon.txt
+++ b/integration-test/lexicon.txt
@@ -171,6 +171,7 @@ https
 hw
 ia
 ietf
+ifdef
 ifndef
 inc
 init
@@ -367,6 +368,7 @@ udbl
 udp
 uint
 un
+undefine
 unix
 unsuback
 urandom

--- a/tools/cmock/create_test.cmake
+++ b/tools/cmock/create_test.cmake
@@ -24,9 +24,9 @@ function(create_test test_name
     set(singleValueArgs "USE_CUSTOM_RUNNER")
     cmake_parse_arguments(VARGS "" "${singleValueArgs}" "" ${ARGN})
     if((DEFINED VARGS_USE_CUSTOM_RUNNER) AND (${VARGS_USE_CUSTOM_RUNNER}))
-        add_executable(${test_name} 
-                         ${test_src} 
-                         ${test_name}.c 
+        add_executable(${test_name}
+                         ${test_src}
+                         ${test_name}.c
                          ${CMAKE_SOURCE_DIR}/integration-test/custom_test_runner/custom_unity_runner.c)
         target_include_directories(${test_name}
                                      PUBLIC

--- a/tools/cmock/create_test.cmake
+++ b/tools/cmock/create_test.cmake
@@ -20,7 +20,22 @@ function(create_test test_name
     link_directories(${CMAKE_CURRENT_BINARY_DIR}
                      ${CMAKE_CURRENT_BINARY_DIR}/lib
         )
-    add_executable(${test_name} ${test_src} ${test_name}_runner.c)
+
+    set(singleValueArgs "USE_CUSTOM_RUNNER")
+    cmake_parse_arguments(VARGS "" "${singleValueArgs}" "" ${ARGN})
+    if((DEFINED VARGS_USE_CUSTOM_RUNNER) AND (${VARGS_USE_CUSTOM_RUNNER}))
+        add_executable(${test_name} 
+                         ${test_src} 
+                         ${test_name}.c 
+                         ${CMAKE_SOURCE_DIR}/integration-test/custom_test_runner/custom_unity_runner.c)
+        target_include_directories(${test_name}
+                                     PUBLIC
+                                     ${CMAKE_SOURCE_DIR}/integration-test/custom_test_runner)
+        target_compile_definitions(${test_name} PUBLIC -DUSE_CUSTOM_RUNNER=1)
+    else()
+        add_executable(${test_name} ${test_src} ${test_name}_runner.c)
+    endif()
+
     set_target_properties(${test_name} PROPERTIES
             COMPILE_FLAG "-O0 -ggdb"
             RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/tests"


### PR DESCRIPTION
This allows multiple test groups to run in the same binary similar to how it is done for `amazon-freertos` and `FreeRTOS/FreeRTOS`. Integration tests in CSDK ran using the same infrastructure used for CMock. This is fine if each test binary has a single test group but does not scale when a test needs to be split into multiple groups e.g. running against Mosquitto and running against IoT Core:
```
/**
 * @brief Test group runner for MQTT system tests that can be run against AWS IoT.
 */
TEST_GROUP_RUNNER( coreMQTT_Integration_AWS_IoT_Compatible )
{
    testingAgainstAWS = true;
    RUN_TEST_CASE( coreMQTT_Integration_AWS_IoT_Compatible, Subscribe_Publish_With_Qos_0 );
    RUN_TEST_CASE( coreMQTT_Integration_AWS_IoT_Compatible, Subscribe_Publish_With_Qos_1 );
    RUN_TEST_CASE( coreMQTT_Integration_AWS_IoT_Compatible, Connect_LWT );
    RUN_TEST_CASE( coreMQTT_Integration_AWS_IoT_Compatible, ProcessLoop_KeepAlive );
    RUN_TEST_CASE( coreMQTT_Integration_AWS_IoT_Compatible, Resend_Unacked_Publish_QoS1 );
    RUN_TEST_CASE( coreMQTT_Integration_AWS_IoT_Compatible, Restore_Session_Duplicate_Incoming_Publish_Qos1 );
}

/**
 * @brief Test group runner for MQTT system tests against an non-AWS IoT MQTT 3.1.1 broker.
 */
TEST_GROUP_RUNNER( coreMQTT_Integration )
{
    testingAgainstAWS = false;
    RUN_TEST_CASE( coreMQTT_Integration, Subscribe_Publish_With_Qos_0 );
    RUN_TEST_CASE( coreMQTT_Integration, Subscribe_Publish_With_Qos_1 );
    RUN_TEST_CASE( coreMQTT_Integration, Connect_LWT );
    RUN_TEST_CASE( coreMQTT_Integration, ProcessLoop_KeepAlive );
    RUN_TEST_CASE( coreMQTT_Integration, Resend_Unacked_Publish_QoS1 );
    RUN_TEST_CASE( coreMQTT_Integration, Restore_Session_Duplicate_Incoming_Publish_Qos1 );
    RUN_TEST_CASE( coreMQTT_Integration, Restore_Session_Resend_PubRel );
    RUN_TEST_CASE( coreMQTT_Integration, Subscribe_Publish_With_Qos_2 );
    RUN_TEST_CASE( coreMQTT_Integration, Restore_Session_Incoming_Duplicate_PubRel );
    RUN_TEST_CASE( coreMQTT_Integration, Resend_Unacked_Publish_QoS2 );
    RUN_TEST_CASE( coreMQTT_Integration, Restore_Session_Duplicate_Incoming_Publish_Qos2 );
    RUN_TEST_CASE( coreMQTT_Integration, Publish_With_Retain_Flag );
}
```
This makes it so that test cases like above can be compiled without issue and also matches the terminal output of existing tests so that CI does not need to parse the test results differently.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
