### PR TITLE
Create separate target for the AWS IoT integration test group

### DIFF
--- a/integration-test/mqtt/CMakeLists.txt
+++ b/integration-test/mqtt/CMakeLists.txt
@@ -60,7 +60,16 @@ create_test(${stest_name}
             USE_CUSTOM_RUNNER 1
         )
 
-set_macro_definitions(TARGETS ${stest_name}
+# Separate test target when testing against an IoT Core broker
+create_test(aws_iot_${stest_name}
+            ${stest_source}
+            "${stest_link_list}"
+            "${stest_dep_list}"
+            "${test_include_directories}"
+            USE_CUSTOM_RUNNER 1
+        )
+
+set_macro_definitions(TARGETS ${stest_name} aws_iot_${stest_name}
                       REQUIRED
                         "ROOT_CA_CERT_PATH"
                         "CLIENT_CERT_PATH"
@@ -70,6 +79,9 @@ set_macro_definitions(TARGETS ${stest_name}
                         "BROKER_PORT"
                       FILES_TO_CHECK
                         "test_config.h")
+
+# aws_iot_mqtt_system_test will always test against IoT Core
+target_compile_definitions(aws_iot_${stest_name} PUBLIC -DTEST_AGAINST_IOT_CORE=1)
 
 if(${TEST_AGAINST_IOT_CORE})
     target_compile_definitions(${stest_name} PUBLIC -DTEST_AGAINST_IOT_CORE=1)

--- a/integration-test/mqtt/mqtt_system_test.c
+++ b/integration-test/mqtt/mqtt_system_test.c
@@ -78,6 +78,11 @@
     #include "custom_unity_runner.h"
 #endif
 
+/* If testing against IoT Core, a subset of tests which are compatible should be used */
+#if ( !defined( TEST_AGAINST_IOT_CORE ) )
+    #define TEST_AGAINST_IOT_CORE               false
+#endif
+
 /**
  * @brief Length of MQTT server host name.
  */

--- a/integration-test/mqtt/mqtt_system_test.c
+++ b/integration-test/mqtt/mqtt_system_test.c
@@ -78,13 +78,6 @@
     #include "custom_unity_runner.h"
 #endif
 
-/* If testing against IoT Core, a subset of tests which are compatible should be used */
-#if ( defined( TEST_AGAINST_IOT_CORE ) && TEST_AGAINST_IOT_CORE )
-    #define TEST_AGAINST_IOT_CORE    true
-#else
-    #define TEST_AGAINST_IOT_CORE    false
-#endif
-
 /**
  * @brief Length of MQTT server host name.
  */

--- a/integration-test/mqtt/mqtt_system_test.c
+++ b/integration-test/mqtt/mqtt_system_test.c
@@ -80,7 +80,7 @@
 
 /* If testing against IoT Core, a subset of tests which are compatible should be used */
 #if ( !defined( TEST_AGAINST_IOT_CORE ) )
-    #define TEST_AGAINST_IOT_CORE               false
+    #define TEST_AGAINST_IOT_CORE    false
 #endif
 
 /**

--- a/tools/cmock/create_test.cmake
+++ b/tools/cmock/create_test.cmake
@@ -26,7 +26,6 @@ function(create_test test_name
     if((DEFINED VARGS_USE_CUSTOM_RUNNER) AND (${VARGS_USE_CUSTOM_RUNNER}))
         add_executable(${test_name}
                          ${test_src}
-                         ${test_name}.c
                          ${CMAKE_SOURCE_DIR}/integration-test/custom_test_runner/custom_unity_runner.c)
         target_include_directories(${test_name}
                                      PUBLIC


### PR DESCRIPTION
PR #1736 created separate test groups for IoT Core and Mosquitto brokers.

This PR creates a separate test endpoint (aws_iot_mqtt_system_test) which runs the coreMQTT_Integration_AWS_IoT_Compatible test group. This allows for better logging in CI and creates a more intuitive way for customers to test with the IoT Core group.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
