### PR TITLE
Update plaintext_poix transport interface

### DIFF
--- a/platform/posix/transport/src/plaintext_posix.c
+++ b/platform/posix/transport/src/plaintext_posix.c
@@ -135,7 +135,7 @@ int32_t Plaintext_Recv( NetworkContext_t * pNetworkContext,
     }
     else if( bytesToRecv == 0 )
     {
-        LogError( ( "Parameter check failed: bytesReceived is zero." ) );
+        LogError( ( "Parameter check failed: bytesToRecv is zero." ) );
         bytesReceived = -1;
     }
     else
@@ -244,7 +244,7 @@ int32_t Plaintext_Send( NetworkContext_t * pNetworkContext,
     }
     else if( bytesToSend == 0 )
     {
-        LogError( ( "Parameter check failed: bytesReceived is zero." ) );
+        LogError( ( "Parameter check failed: bytesToSend is zero." ) );
         bytesSent = -1;
     }
     else

--- a/platform/posix/transport/src/plaintext_posix.c
+++ b/platform/posix/transport/src/plaintext_posix.c
@@ -170,7 +170,16 @@ int32_t Plaintext_Recv( NetworkContext_t * pNetworkContext,
     }
     else if( bytesReceived < 0 )
     {
-        logTransportError( errno );
+        /* The timeout and no data is received situaition. Return zero to indicate
+         * this operation can be retried. */
+        if( ( errno == EAGAIN ) || ( errno == EWOULDBLOCK ) )
+        {
+            bytesReceived = 0;
+        }
+        else
+        {
+            logTransportError( errno );
+        }
     }
     else
     {
@@ -237,7 +246,16 @@ int32_t Plaintext_Send( NetworkContext_t * pNetworkContext,
     }
     else if( bytesSent < 0 )
     {
-        logTransportError( errno );
+        /* The timeout and no data is sent situaition. Return zero to indicate
+         * this operation can be retried. */
+        if( ( errno == EAGAIN ) || ( errno == EWOULDBLOCK ) )
+        {
+            bytesSent = 0;
+        }
+        else
+        {
+            logTransportError( errno );
+        }
     }
     else
     {

--- a/platform/posix/transport/src/plaintext_posix.c
+++ b/platform/posix/transport/src/plaintext_posix.c
@@ -135,7 +135,8 @@ int32_t Plaintext_Recv( NetworkContext_t * pNetworkContext,
     }
     else if( bytesToRecv == 0 )
     {
-        bytesReceived = 0;
+        LogError( ( "Parameter check failed: bytesReceived is zero." ) );
+        bytesReceived = -1;
     }
     else
     {
@@ -243,7 +244,8 @@ int32_t Plaintext_Send( NetworkContext_t * pNetworkContext,
     }
     else if( bytesToSend == 0 )
     {
-        bytesSent = 0;
+        LogError( ( "Parameter check failed: bytesReceived is zero." ) );
+        bytesSent = -1;
     }
     else
     {

--- a/platform/posix/transport/src/plaintext_posix.c
+++ b/platform/posix/transport/src/plaintext_posix.c
@@ -163,23 +163,37 @@ int32_t Plaintext_Recv( NetworkContext_t * pNetworkContext,
 
     /* Note: A zero value return from recv() represents
      * closure of TCP connection by the peer. */
-    if( ( pollStatus > 0 ) && ( bytesReceived == 0 ) )
+    if( pollStatus > 0 )
     {
-        /* Peer has closed the connection. Treat as an error. */
-        bytesReceived = -1;
-    }
-    else if( bytesReceived < 0 )
-    {
-        /* The socket blocked for timeout and no data is received situation.
-         * Return zero to indicate this operation can be retried. */
-        if( ( pollStatus > 0 ) && ( ( errno == EAGAIN ) || ( errno == EWOULDBLOCK ) ) )
+        if( bytesReceived == 0 )
         {
-            bytesReceived = 0;
+            /* Peer has closed the connection. Treat as an error. */
+            bytesReceived = -1;
+        }
+        else if( bytesReceived < 0 )
+        {
+            /* The socket blocked for timeout and no data is received situation.
+             * Return zero to indicate this operation can be retried. */
+            #if EAGAIN == EWOULDBLOCK
+                if( errno == EAGAIN )
+                {
+                    bytesReceived = 0;
+                }
+            #else
+                if( ( errno == EAGAIN ) || ( errno == EWOULDBLOCK ) )
+                {
+                    bytesReceived = 0;
+                }
+            #endif
         }
         else
         {
-            logTransportError( errno );
+            /* Empty else MISRA 15.7 */
         }
+    }
+    else if( bytesReceived < 0 )
+    {
+        logTransportError( errno );
     }
     else
     {
@@ -239,23 +253,37 @@ int32_t Plaintext_Send( NetworkContext_t * pNetworkContext,
         bytesSent = 0;
     }
 
-    if( ( pollStatus > 0 ) && ( bytesSent == 0 ) )
+    if( pollStatus > 0 )
     {
-        /* Peer has closed the connection. Treat as an error. */
-        bytesSent = -1;
-    }
-    else if( bytesSent < 0 )
-    {
-        /* The socket blocked for timeout and no data is sent situation.
-         * Return zero to indicate this operation can be retried. */
-        if( ( pollStatus > 0 ) && ( ( errno == EAGAIN ) || ( errno == EWOULDBLOCK ) ) )
+        if( bytesSent == 0 )
         {
-            bytesSent = 0;
+            /* Peer has closed the connection. Treat as an error. */
+            bytesSent = -1;
+        }
+        else if( bytesSent < 0 )
+        {
+            /* The socket blocked for timeout and no data is received situation.
+             * Return zero to indicate this operation can be retried. */
+            #if EAGAIN == EWOULDBLOCK
+                if( errno == EAGAIN )
+                {
+                    bytesSent = 0;
+                }
+            #else
+                if( ( errno == EAGAIN ) || ( errno == EWOULDBLOCK ) )
+                {
+                    bytesSent = 0;
+                }
+            #endif
         }
         else
         {
-            logTransportError( errno );
+            /* Empty else MISRA 15.7 */
         }
+    }
+    else if( bytesSent < 0 )
+    {
+        logTransportError( errno );
     }
     else
     {

--- a/platform/posix/transport/src/plaintext_posix.c
+++ b/platform/posix/transport/src/plaintext_posix.c
@@ -170,7 +170,7 @@ int32_t Plaintext_Recv( NetworkContext_t * pNetworkContext,
     }
     else if( bytesReceived < 0 )
     {
-        /* The timeout and no data is received situaition. Return zero to indicate
+        /* The timeout and no data is received situation. Return zero to indicate
          * this operation can be retried. */
         if( ( errno == EAGAIN ) || ( errno == EWOULDBLOCK ) )
         {
@@ -246,7 +246,7 @@ int32_t Plaintext_Send( NetworkContext_t * pNetworkContext,
     }
     else if( bytesSent < 0 )
     {
-        /* The timeout and no data is sent situaition. Return zero to indicate
+        /* The timeout and no data is sent situation. Return zero to indicate
          * this operation can be retried. */
         if( ( errno == EAGAIN ) || ( errno == EWOULDBLOCK ) )
         {

--- a/platform/posix/transport/src/plaintext_posix.c
+++ b/platform/posix/transport/src/plaintext_posix.c
@@ -290,7 +290,7 @@ int32_t Plaintext_Send( NetworkContext_t * pNetworkContext,
         }
         else if( ( pollStatus > 0 ) && ( bytesSent < 0 ) )
         {
-            /* The socket blocked for timeout and no data is received situation.
+            /* The socket blocked for timeout and no data is sent situation.
              * Return zero to indicate this operation can be retried. */
             #if EAGAIN == EWOULDBLOCK
                 if( errno == EAGAIN )

--- a/platform/posix/transport/src/plaintext_posix.c
+++ b/platform/posix/transport/src/plaintext_posix.c
@@ -172,7 +172,7 @@ int32_t Plaintext_Recv( NetworkContext_t * pNetworkContext,
     {
         /* The timeout and no data is received situation. Return zero to indicate
          * this operation can be retried. */
-        if( ( errno == EAGAIN ) || ( errno == EWOULDBLOCK ) )
+        if( ( pollStatus > 0 ) && ( ( errno == EAGAIN ) || ( errno == EWOULDBLOCK ) ) )
         {
             bytesReceived = 0;
         }
@@ -248,7 +248,7 @@ int32_t Plaintext_Send( NetworkContext_t * pNetworkContext,
     {
         /* The timeout and no data is sent situation. Return zero to indicate
          * this operation can be retried. */
-        if( ( errno == EAGAIN ) || ( errno == EWOULDBLOCK ) )
+        if( ( pollStatus > 0 ) && ( ( errno == EAGAIN ) || ( errno == EWOULDBLOCK ) ) )
         {
             bytesSent = 0;
         }

--- a/platform/posix/transport/src/plaintext_posix.c
+++ b/platform/posix/transport/src/plaintext_posix.c
@@ -170,8 +170,8 @@ int32_t Plaintext_Recv( NetworkContext_t * pNetworkContext,
     }
     else if( bytesReceived < 0 )
     {
-        /* The timeout and no data is received situation. Return zero to indicate
-         * this operation can be retried. */
+        /* The socket blocked for timeout and no data is received situation.
+         * Return zero to indicate this operation can be retried. */
         if( ( pollStatus > 0 ) && ( ( errno == EAGAIN ) || ( errno == EWOULDBLOCK ) ) )
         {
             bytesReceived = 0;
@@ -246,8 +246,8 @@ int32_t Plaintext_Send( NetworkContext_t * pNetworkContext,
     }
     else if( bytesSent < 0 )
     {
-        /* The timeout and no data is sent situation. Return zero to indicate
-         * this operation can be retried. */
+        /* The socket blocked for timeout and no data is sent situation.
+         * Return zero to indicate this operation can be retried. */
         if( ( pollStatus > 0 ) && ( ( errno == EAGAIN ) || ( errno == EWOULDBLOCK ) ) )
         {
             bytesSent = 0;

--- a/platform/posix/transport/utest/plaintext_utest.c
+++ b/platform/posix/transport/utest/plaintext_utest.c
@@ -70,9 +70,9 @@ static uint8_t plaintextBuffer[ BUFFER_LEN ] = { 0 };
  * one is used for the default case. */
 static uint8_t errorNumbers[] =
 {
-    EBADF,     ECONNRESET,  EDESTADDRREQ, EINTR,
-    EINVAL,    ENOTCONN,    ENOTSOCK,     EOPNOTSUPP,
-    ETIMEDOUT, EMSGSIZE,    EPIPE,
+    EBADF,     ECONNRESET, EDESTADDRREQ, EINTR,
+    EINVAL,    ENOTCONN,   ENOTSOCK,     EOPNOTSUPP,
+    ETIMEDOUT, EMSGSIZE,   EPIPE,
     UNKNOWN_ERRNO
 };
 
@@ -256,6 +256,31 @@ void test_Plaintext_Recv_Network_Error( void )
 }
 
 /**
+ * @brief Test that #Plaintext_Recv returns 0 bytes when the socket has blocked for
+ * timeout.
+ */
+void test_Plaintext_Recv_Socket_Timeout_Blocked( void )
+{
+    int32_t bytesReceived;
+
+    poll_ExpectAnyArgsAndReturn( 1 );
+    recv_ExpectAnyArgsAndReturn( SEND_RECV_ERROR );
+    errno = EAGAIN;
+    bytesReceived = Plaintext_Recv( &networkContext,
+                                    plaintextBuffer,
+                                    1U );
+    TEST_ASSERT_EQUAL( 0, bytesReceived );
+
+    poll_ExpectAnyArgsAndReturn( 1 );
+    recv_ExpectAnyArgsAndReturn( SEND_RECV_ERROR );
+    errno = EWOULDBLOCK;
+    bytesReceived = Plaintext_Recv( &networkContext,
+                                    plaintextBuffer,
+                                    1U );
+    TEST_ASSERT_EQUAL( 0, bytesReceived );
+}
+
+/**
  * @brief Test the happy path case when #Plaintext_Send is able to send all bytes
  * over the network stack successfully.
  */
@@ -336,4 +361,29 @@ void test_Plaintext_Send_Poll_Error( void )
                                 plaintextBuffer,
                                 BYTES_TO_SEND );
     TEST_ASSERT_EQUAL( SEND_RECV_ERROR, bytesSent );
+}
+
+/**
+ * @brief Test that #Plaintext_Send returns 0 bytes when the socket has blocked for
+ * timeout.
+ */
+void test_Plaintext_Send_Socket_Timeout_Blocked( void )
+{
+    int32_t bytesSent;
+
+    poll_ExpectAnyArgsAndReturn( 1 );
+    send_ExpectAnyArgsAndReturn( SEND_RECV_ERROR );
+    errno = EAGAIN;
+    bytesSent = Plaintext_Send( &networkContext,
+                                plaintextBuffer,
+                                BYTES_TO_SEND );
+    TEST_ASSERT_EQUAL( 0, bytesSent );
+
+    poll_ExpectAnyArgsAndReturn( 1 );
+    send_ExpectAnyArgsAndReturn( SEND_RECV_ERROR );
+    errno = EWOULDBLOCK;
+    bytesSent = Plaintext_Send( &networkContext,
+                                plaintextBuffer,
+                                BYTES_TO_SEND );
+    TEST_ASSERT_EQUAL( 0, bytesSent );
 }

--- a/platform/posix/transport/utest/plaintext_utest.c
+++ b/platform/posix/transport/utest/plaintext_utest.c
@@ -176,6 +176,30 @@ void test_Plaintext_Disconnect_Invalid_Params( void )
 }
 
 /**
+ * @brief Test that invalid parameters returns an error.
+ */
+void test_Plaintext_Recv_Invalid_Params( void )
+{
+    int32_t bytesReceived;
+    NetworkContext_t networkContext = { 0 };
+
+    bytesReceived = Plaintext_Recv( NULL, plaintextBuffer, BUFFER_LEN );
+    TEST_ASSERT_EQUAL( -1, bytesReceived );
+
+    networkContext.pParams = NULL;
+    bytesReceived = Plaintext_Recv( &networkContext, plaintextBuffer, BUFFER_LEN );
+    TEST_ASSERT_EQUAL( -1, bytesReceived );
+
+    networkContext.pParams = &plaintextParams;
+    bytesReceived = Plaintext_Recv( &networkContext, NULL, BUFFER_LEN );
+    TEST_ASSERT_EQUAL( -1, bytesReceived );
+
+    networkContext.pParams = &plaintextParams;
+    bytesReceived = Plaintext_Recv( &networkContext, plaintextBuffer, 0 );
+    TEST_ASSERT_EQUAL( 0, bytesReceived );
+}
+
+/**
  * @brief Test that #Plaintext_Recv returns an error when #recv fails to
  * receive data over the network stack.
  */
@@ -278,6 +302,29 @@ void test_Plaintext_Recv_Socket_Timeout_Blocked( void )
                                     plaintextBuffer,
                                     1U );
     TEST_ASSERT_EQUAL( 0, bytesReceived );
+}
+
+/**
+ * @brief Test that invalid parameters returns an error.
+ */
+void test_Plaintext_Send_Invalid_Params( void )
+{
+    int32_t bytesSent;
+    NetworkContext_t networkContext = { 0 };
+
+    bytesSent = Plaintext_Send( NULL, plaintextBuffer, BUFFER_LEN );
+    TEST_ASSERT_EQUAL( -1, bytesSent );
+
+    networkContext.pParams = NULL;
+    bytesSent = Plaintext_Send( &networkContext, plaintextBuffer, BUFFER_LEN );
+    TEST_ASSERT_EQUAL( -1, bytesSent );
+
+    networkContext.pParams = &plaintextParams;
+    bytesSent = Plaintext_Send( &networkContext, NULL, BUFFER_LEN );
+    TEST_ASSERT_EQUAL( -1, bytesSent );
+
+    bytesSent = Plaintext_Send( &networkContext, plaintextBuffer, 0 );
+    TEST_ASSERT_EQUAL( 0, bytesSent );
 }
 
 /**

--- a/platform/posix/transport/utest/plaintext_utest.c
+++ b/platform/posix/transport/utest/plaintext_utest.c
@@ -73,7 +73,7 @@ static uint8_t errorNumbers[] =
     EBADF,     ECONNRESET,  EDESTADDRREQ, EINTR,
     EINVAL,    ENOTCONN,    ENOTSOCK,     EOPNOTSUPP,
     ETIMEDOUT, EMSGSIZE,    EPIPE,
-    EAGAIN,    EWOULDBLOCK, UNKNOWN_ERRNO
+    UNKNOWN_ERRNO
 };
 
 /* ============================   UNITY FIXTURES ============================ */

--- a/platform/posix/transport/utest/plaintext_utest.c
+++ b/platform/posix/transport/utest/plaintext_utest.c
@@ -196,7 +196,7 @@ void test_Plaintext_Recv_Invalid_Params( void )
 
     networkContext.pParams = &plaintextParams;
     bytesReceived = Plaintext_Recv( &networkContext, plaintextBuffer, 0 );
-    TEST_ASSERT_EQUAL( 0, bytesReceived );
+    TEST_ASSERT_EQUAL( -1, bytesReceived );
 }
 
 /**
@@ -324,7 +324,7 @@ void test_Plaintext_Send_Invalid_Params( void )
     TEST_ASSERT_EQUAL( -1, bytesSent );
 
     bytesSent = Plaintext_Send( &networkContext, plaintextBuffer, 0 );
-    TEST_ASSERT_EQUAL( 0, bytesSent );
+    TEST_ASSERT_EQUAL( -1, bytesSent );
 }
 
 /**


### PR DESCRIPTION
* EAGAIN or EWOULDBLOCK should return zero to indicate this send or recv operation can be retried.
* Use error code instead of assert to check the invalid parameters.

Reference this [setsockopt document](url).

>If a receive operation has blocked for this much time without receiving additional data, it shall return with a partial count or errno set to [EAGAIN] or [EWOULDBLOCK] if no data is received.

>If a send operation has blocked for this time, it shall return with a partial count or with errno set to [EAGAIN] or [EWOULDBLOCK] if no data is sent.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
