### PR TITLE
posix: Skip setting socket send and receive timeout if unimplemented

### DIFF
--- a/platform/lexicon.txt
+++ b/platform/lexicon.txt
@@ -53,6 +53,7 @@ eagain
 ecdsa
 endcode
 endif
+enoprotoopt
 enum
 enums
 eof
@@ -256,6 +257,7 @@ sdk
 sendtimeout
 sendtimeoutms
 serverinfo
+setsockopt
 sha
 sha256
 sigalrm

--- a/platform/posix/transport/src/sockets_posix.c
+++ b/platform/posix/transport/src/sockets_posix.c
@@ -367,8 +367,15 @@ SocketStatus_t Sockets_Connect( int32_t * pTcpSocket,
 
         if( setTimeoutStatus < 0 )
         {
-            LogError( ( "Setting socket send timeout failed." ) );
-            returnStatus = retrieveError( errno );
+            if( errno == ENOPROTOOPT )
+            {
+                LogInfo( ( "Setting socket send timeout skipped." ) );
+            }
+            else
+            {
+                LogError( ( "Setting socket send timeout failed." ) );
+                returnStatus = retrieveError( errno );
+            }
         }
     }
 
@@ -386,8 +393,15 @@ SocketStatus_t Sockets_Connect( int32_t * pTcpSocket,
 
         if( setTimeoutStatus < 0 )
         {
-            LogError( ( "Setting socket receive timeout failed." ) );
-            returnStatus = retrieveError( errno );
+            if( errno == ENOPROTOOPT )
+            {
+                LogInfo( ( "Setting socket receive timeout skipped." ) );
+            }
+            else
+            {
+                LogError( ( "Setting socket receive timeout failed." ) );
+                returnStatus = retrieveError( errno );
+            }
         }
     }
 

--- a/platform/posix/transport/utest/sockets_utest.c
+++ b/platform/posix/transport/utest/sockets_utest.c
@@ -321,9 +321,11 @@ void test_Sockets_Connect_Fail_setsockopt( void )
         for( j = 0; j < 2; j++ )
         {
             expectSocketsConnectCalls( NUM_ADDR_INFO );
+
             if( j == 0 )
             {
                 setsockopt_ExpectAnyArgsAndReturn( -1 );
+
                 /* for ENOPROTOOPT case, Sockets_Connect continues
                  * despite setsockopt returning error. */
                 if( errno == ENOPROTOOPT )

--- a/platform/posix/transport/utest/sockets_utest.c
+++ b/platform/posix/transport/utest/sockets_utest.c
@@ -307,7 +307,7 @@ void test_Sockets_Connect_Fail_setsockopt( void )
 {
     SocketStatus_t socketStatus, expectedSocketStatus;
     int tcpSocket = 1;
-    uint16_t i = 1;
+    uint16_t i, j;
     int32_t allErrorCases[] =
     {
         EBADF,       EDOM,     EINVAL, EISCONN,
@@ -316,42 +316,51 @@ void test_Sockets_Connect_Fail_setsockopt( void )
 
     for( i = 0; i < ( sizeof( allErrorCases ) / sizeof( int32_t ) ); i++ )
     {
-        expectSocketsConnectCalls( NUM_ADDR_INFO );
         errno = allErrorCases[ i ];
 
-        if( i % 2 )
+        for( j = 0; j < 2; j++ )
         {
-            setsockopt_ExpectAnyArgsAndReturn( -1 );
-        }
-        else
-        {
-            setsockopt_ExpectAnyArgsAndReturn( 0 );
-            setsockopt_ExpectAnyArgsAndReturn( -1 );
-        }
+            expectSocketsConnectCalls( NUM_ADDR_INFO );
+            if( j == 0 )
+            {
+                setsockopt_ExpectAnyArgsAndReturn( -1 );
+                /* for ENOPROTOOPT case, Sockets_Connect continues
+                 * despite setsockopt returning error. */
+                if( errno == ENOPROTOOPT )
+                {
+                    setsockopt_ExpectAnyArgsAndReturn( -1 );
+                }
+            }
+            else
+            {
+                setsockopt_ExpectAnyArgsAndReturn( 0 );
+                setsockopt_ExpectAnyArgsAndReturn( -1 );
+            }
 
-        socketStatus = Sockets_Connect( &tcpSocket,
-                                        &serverInfo,
-                                        SEND_RECV_TIMEOUT,
-                                        SEND_RECV_TIMEOUT );
+            socketStatus = Sockets_Connect( &tcpSocket,
+                                            &serverInfo,
+                                            SEND_RECV_TIMEOUT,
+                                            SEND_RECV_TIMEOUT );
 
-        if( ( errno == ENOMEM ) || ( errno == ENOBUFS ) )
-        {
-            expectedSocketStatus = SOCKETS_INSUFFICIENT_MEMORY;
-        }
-        else if( ( errno == ENOTSOCK ) || ( errno == EDOM ) || ( errno == EBADF ) )
-        {
-            expectedSocketStatus = SOCKETS_INVALID_PARAMETER;
-        }
-        else if( errno == ENOPROTOOPT )
-        {
-            expectedSocketStatus = SOCKETS_SUCCESS;
-        }
-        else
-        {
-            expectedSocketStatus = SOCKETS_API_ERROR;
-        }
+            if( ( errno == ENOMEM ) || ( errno == ENOBUFS ) )
+            {
+                expectedSocketStatus = SOCKETS_INSUFFICIENT_MEMORY;
+            }
+            else if( ( errno == ENOTSOCK ) || ( errno == EDOM ) || ( errno == EBADF ) )
+            {
+                expectedSocketStatus = SOCKETS_INVALID_PARAMETER;
+            }
+            else if( errno == ENOPROTOOPT )
+            {
+                expectedSocketStatus = SOCKETS_SUCCESS;
+            }
+            else
+            {
+                expectedSocketStatus = SOCKETS_API_ERROR;
+            }
 
-        TEST_ASSERT_EQUAL( expectedSocketStatus, socketStatus );
+            TEST_ASSERT_EQUAL( expectedSocketStatus, socketStatus );
+        }
     }
 }
 

--- a/platform/posix/transport/utest/sockets_utest.c
+++ b/platform/posix/transport/utest/sockets_utest.c
@@ -342,6 +342,10 @@ void test_Sockets_Connect_Fail_setsockopt( void )
         {
             expectedSocketStatus = SOCKETS_INVALID_PARAMETER;
         }
+        else if( errno == ENOPROTOOPT )
+        {
+            expectedSocketStatus = SOCKETS_SUCCESS;
+        }
         else
         {
             expectedSocketStatus = SOCKETS_API_ERROR;


### PR DESCRIPTION
*Issue #1744 :*

*Description of changes:*
According to POSIX spec for setsockopt [1], SO_SNDTIMEO and SO_RCVTIMEO
options at the socket level are optional. A complaint implementation
shall set the errno to ENOPROTOOPT if they are not supported.

Currently Sockets_Connect() treats such case as an error and aborts the
connection. Update the codes to check the errno against ENOPROTOOPT and
skip it when unsupported.

[1] https://pubs.opengroup.org/onlinepubs/000095399/functions/setsockopt.html

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.