### PR TITLE
demos: Remove unneeded macros

### DIFF
--- a/demos/defender/defender_demo_json/CMakeLists.txt
+++ b/demos/defender/defender_demo_json/CMakeLists.txt
@@ -44,8 +44,6 @@ set_macro_definitions(TARGETS ${DEMO_NAME}
                         "CLIENT_PRIVATE_KEY_PATH"
                         "THING_NAME"
                         "CLIENT_IDENTIFIER"
-                        "CLIENT_USERNAME"
-                        "CLIENT_PASSWORD"
                         "OS_NAME"
                         "OS_VERSION"
                         "HARDWARE_PLATFORM_NAME")

--- a/demos/http/http_demo_mutual_auth/CMakeLists.txt
+++ b/demos/http/http_demo_mutual_auth/CMakeLists.txt
@@ -39,7 +39,6 @@ target_include_directories(
 
 set_macro_definitions(TARGETS ${DEMO_NAME}
                       REQUIRED
-                        "SERVER_HOST"
                         "AWS_HTTPS_PORT"
                         "ROOT_CA_CERT_PATH")
 set_macro_definitions(TARGETS ${DEMO_NAME}

--- a/demos/shadow/shadow_demo_main/CMakeLists.txt
+++ b/demos/shadow/shadow_demo_main/CMakeLists.txt
@@ -52,8 +52,6 @@ set_macro_definitions(TARGETS ${DEMO_NAME}
                         "CLIENT_PRIVATE_KEY_PATH"
                         "CLIENT_IDENTIFIER"
                         "THING_NAME"
-                        "CLIENT_USERNAME"
-                        "CLIENT_PASSWORD"
                         "OS_NAME"
                         "OS_VERSION"
                         "HARDWARE_PLATFORM_NAME")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The following macros are required in the CMakeLists.txt but are actually not used in the corresponding demo.

**defender_demo_json**:
_CLIENT_USERNAME_
_CLIENT_PASSWORD_

**http_demo_mutual_auth**:
_SERVER_HOST_

**shadow_demo_main**:
_CLIENT_USERNAME_
_CLIENT_PASSWORD_

Remove them.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
