### PR TITLE
3rdparty: Update tinycbor to require C99

### DIFF
--- a/libraries/3rdparty/CMakeLists.txt
+++ b/libraries/3rdparty/CMakeLists.txt
@@ -43,6 +43,11 @@ set_target_properties(tinycbor PROPERTIES
     POSITION_INDEPENDENT_CODE ON
 )
 
+# Use C99 for tinycbor as it is incompatible with C90
+if(CMAKE_C_STANDARD LESS 99)
+    set_target_properties(tinycbor PROPERTIES C_STANDARD 99)
+endif()
+
 target_include_directories(tinycbor PUBLIC
     "${ROOT_DIR}/libraries/3rdparty/tinycbor/src"
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The tinycbor codes use several macros from C99 math.h, like
FP_INFINITE, FP_NAN, INFINITE, NAN. Although it currently builds
fine with -std=gnu90 against Linux glibc, it fails to build with
a stricter C library. Update its make rules to require C99.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.