### PR TITLE
ota_demo_core_http: Fix a -Wenum-conversion build warning

### DIFF
--- a/demos/ota/ota_demo_core_http/ota_demo_core_http.c
+++ b/demos/ota/ota_demo_core_http/ota_demo_core_http.c
@@ -1613,7 +1613,7 @@ static OtaHttpStatus_t httpRequest( uint32_t rangeStart,
         /* Try establishing connection to S3 server again. */
         if( connectToS3Server( &networkContextHttp, NULL ) == EXIT_SUCCESS )
         {
-            ret = HTTPSuccess;
+            ret = OtaHttpSuccess;
         }
         else
         {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix the following -Wenum-conversion build warning:

```
warning: implicit conversion from enumeration type 'enum HTTPStatus' to
different enumeration type 'OtaHttpStatus_t' (aka 'enum OtaHttpStatus')
[-Wenum-conversion]
        ret = HTTPSuccess;
            ~ ^~~~~~~~~~~
```

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.