### PR TITLE
http_demo_s3_download: Use sizeof in designated initializers

### DIFF
--- a/demos/http/http_demo_s3_download/http_demo_s3_download.c
+++ b/demos/http/http_demo_s3_download/http_demo_s3_download.c
@@ -539,9 +539,9 @@ static SigV4Parameters_t sigv4Params =
     .pCredentials     = &sigvCreds,
     .pDateIso8601     = pDateISO8601,
     .pRegion          = AWS_S3_BUCKET_REGION,
-    .regionLen        = strlen( AWS_S3_BUCKET_REGION ),
+    .regionLen        = sizeof( AWS_S3_BUCKET_REGION ) - 1,
     .pService         = AWS_S3_SERVICE_NAME,
-    .serviceLen       = strlen( AWS_S3_SERVICE_NAME ),
+    .serviceLen       = sizeof( AWS_S3_SERVICE_NAME ) - 1,
     .pCryptoInterface = &cryptoInterface,
     .pHttpParameters  = NULL
 };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Clang seems to be stricter than GCC that an element value of a structure
must be a constant, otherwise an compile error of

`  "error: initializer element is not a compile-time constant"`

is thrown. Use sizeof instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.