### PR TITLE
http_demo_s3_download_multithreaded: Use LIB_RT in CMakeLists.txt

### DIFF
--- a/demos/http/http_demo_s3_download_multithreaded/CMakeLists.txt
+++ b/demos/http/http_demo_s3_download_multithreaded/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(
     PRIVATE
         clock_posix
         openssl_posix
-        rt
+        ${LIB_RT}
 )
 
 target_include_directories(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Avoid using hardcoded 'rt' in this demo's CMakeLists.txt, instead
use the LIB_RT defined in platform/CMakeLists.txt.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.