### PR TITLE
Add AWS Toolkit recommended extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"AmazonWebServices.aws-toolkit-vscode"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+		
+	]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,13 +1,9 @@
 {
-	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
-	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+    // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+    // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
 
-	// List of extensions which should be recommended for users of this workspace.
-	"recommendations": [
-		"AmazonWebServices.aws-toolkit-vscode"
-	],
-	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
-	"unwantedRecommendations": [
-		
-	]
+    // List of extensions which should be recommended for users of this workspace.
+    "recommendations": [
+        "AmazonWebServices.aws-toolkit-vscode"
+    ]
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Since the [AWS Toolkit for VS Code](https://github.com/aws/aws-toolkit-vscode) now has an explorer view for AWS IoT, this PR adds a recommendation for VS Code users to install it.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
