### PR TITLE
Update incorrect enum value in provisioningPublishCallback

### DIFF
--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/fleet_provisioning_with_csr_demo.c
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/fleet_provisioning_with_csr_demo.c
@@ -280,7 +280,7 @@ static void provisioningPublishCallback( MQTTPublishInfo_t * pPublishInfo,
 
             payloadLength = pPublishInfo->payloadLength;
         }
-        else if( api == FleetProvCborCreateCertFromCsrRejected )
+        else if( api == FleetProvCborRegisterThingRejected )
         {
             LogError( ( "Received rejected response from Fleet Provisioning RegisterThing API." ) );
 


### PR DESCRIPTION
provisioningPublishCallback rechecked the "FleetProvCborCreateCertFromCsrRejected" enum when it should have checked the "FleetProvCborRegisterThingRejected" topic.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
