### PR TITLE
demos: Detect fork and exclude demos if not found

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -15,6 +15,9 @@ foreach(demo_dir IN LISTS demo_dirs)
     endif()
 endforeach()
 
+# Check for function fork
+check_symbol_exists(fork "unistd.h" HAVE_FORK)
+
 # Filter demos based on what packages or library exist.
 if(${LIB_RT} STREQUAL "LIB_RT-NOTFOUND")
     set(librt_demos
@@ -54,6 +57,16 @@ if(NOT ${Threads_FOUND})
     )
     message( WARNING "Threads library could not be found. Demos that use it will be excluded from the default target." )
     foreach(demo_name ${thread_demos})
+        set_target_properties(${demo_name} PROPERTIES EXCLUDE_FROM_ALL true)
+    endforeach()
+endif()
+if(NOT HAVE_FORK)
+    set(fork_demos
+            "http_demo_s3_download_multithreaded"
+            "jobs_demo_mosquitto"
+    )
+    message( WARNING "fork() could not be found. Demos that use it will be excluded from the default target." )
+    foreach(demo_name ${fork_demos})
         set_target_properties(${demo_name} PROPERTIES EXCLUDE_FROM_ALL true)
     endforeach()
 endif()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
fork() may not be available on every platform, so let's detect it
using cmake's check_symbol_exists macro and exclude building demos
that call fork().

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
