### PR TITLE
Avoid hardcoded linking to libpthread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,10 @@ else()
 endif()
 install(DIRECTORY DESTINATION ${CSDK_LIB_INSTALL_PATH})
 
+# Find thread library.
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads)
+
 # Add libraries.
 add_subdirectory( libraries )
 

--- a/demos/ota/ota_demo_core_http/CMakeLists.txt
+++ b/demos/ota/ota_demo_core_http/CMakeLists.txt
@@ -29,7 +29,7 @@ target_link_libraries(
     PRIVATE
         ${LIB_RT}
         ota_pal
-        pthread
+        Threads::Threads
         clock_posix
         openssl_posix
 )

--- a/demos/ota/ota_demo_core_mqtt/CMakeLists.txt
+++ b/demos/ota/ota_demo_core_mqtt/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(
     PRIVATE
         ${LIB_RT}
         ota_pal
-        pthread
+        Threads::Threads
         clock_posix
         openssl_posix
 )

--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -8,11 +8,7 @@ if( ${OPENSSL_FOUND} AND ( OPENSSL_VERSION MATCHES "0.9$" OR OPENSSL_VERSION MAT
     message( WARNING "OpenSSL 1.1.0 or later required: OpenSSL ${OPENSSL_VERSION} found." )
 endif()
 
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads)
-
 set(OpenSSL_FOUND ${OpenSSL_FOUND} CACHE INTERNAL "Indicates whether OpenSSL library was found.")
-set(Threads_FOUND ${Threads_FOUND} CACHE INTERNAL "Indicates whether Threads library was found.")
 
 find_library(LIB_RT rt)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently ota_demo_core_http and ota_demo_core_mqtt make rules hardcode
linking to libpthread but VxWorks does not provide a separate pthread
library as a regular file, instead it's the libc that provides all the
pthread APIs.

We can certainly add the following logic in the CMakeLists.txt:

```
  if(VXWORKS)
      # remove pthread from the linking libraries
  else()
      # original linking libraries with pthread
  endif()
```

but that does not look very elegant. In fact, we don't have to use
VXWORKS to create a separate branch, the find_package(Threads) has
already provided Threads:Threads IMPORTED target [1] that holds the
thread library if found.

However by default the IMPORTED target does not have global scope
which means the target is only visible in the platform directory,
where find_package(Threads) is called. It's not possible to use it
in the demo directory where we want to replace the hardcoded pthread.
CMake 3.11 introduced the ability to promote an imported target to
global visibility by setting the target's IMPORTED_GLOBAL [2] property
to true, but that requires us to bump up the CMake minimum version
from current 3.2.0 to 3.11.0, which is not ideal as Ubuntu 18.04, a
still popular development host OS nowadays, is shipping CMake 3.10.

To keep current CMake minimum version requirement while promoting
the IMPORTED target scope to global, we need to move the call to
find_package(Threads) in the root directory. With that change, the
creation of Threads_FOUND as a cache variable is no longer needed.

[1] https://cmake.org/cmake/help/latest/module/FindThreads.html
[2] https://cmake.org/cmake/help/latest/prop_tgt/IMPORTED_GLOBAL.html

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.