### PR TITLE
Eliminate the CMake warning when PLATFORM_NAME is passed to CMake

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -5,6 +5,8 @@ if( NOT DEFINED PLATFORM_NAME )
     else()
         message( FATAL_ERROR "${CMAKE_SYSTEM_NAME} is not a supported platform." )
     endif()
+else()
+    set( PLATFORM_NAME ${PLATFORM_NAME} CACHE STRING "Port to use for building the SDK." )
 endif()
 
 # Include each subdirectory that has a CMakeLists.txt file in it


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If PLATFORM_NAME is given in the CMake command line, at the end of the
configure phase CMake throws a warning:

```
  CMake Warning:
    Manually-specified variables were not used by the project:

      PLATFORM_NAME
```

Add an else branch in the CMakeLists.txt to eliminate the warning.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.