### PR TITLE
Change OpenSSL libraries dependency to PUBLIC

### DIFF
--- a/platform/posix/transport/CMakeLists.txt
+++ b/platform/posix/transport/CMakeLists.txt
@@ -29,10 +29,10 @@ add_library( openssl_posix
 target_link_libraries( openssl_posix
                        PUBLIC
                           sockets_posix
-                       PRIVATE
                           # This variable is set by the built-in FindOpenSSL.cmake
                           # and contains the path to the actual library.
                           ${OPENSSL_LIBRARIES}
+                       PRIVATE
                           # SSL uses Threads and on some platforms require
                           # explicit linking.
                           Threads::Threads


### PR DESCRIPTION
*Issue #1761*

*Description of changes:*
As described in issue #1761, the failing case should be caused by a
CMake bug, and with the latest version it is still not fixed, hence
let's apply the workaround by moving OpenSSL libraries from PRIVATE
to PUBLIC for openssl_posix target.

Fixes: https://github.com/aws/aws-iot-device-sdk-embedded-C/issues/1761

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.