### PR TITLE
Make rt lib configurable

### DIFF
--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -10,7 +10,11 @@ endif()
 
 set(OpenSSL_FOUND ${OpenSSL_FOUND} CACHE INTERNAL "Indicates whether OpenSSL library was found.")
 
-find_library(LIB_RT rt)
+if( NOT DEFINED LIB_RT_NAME )
+    set( LIB_RT_NAME "rt" CACHE STRING "Name of the POSIX.1b Realtime Extensions library." )
+endif()
+
+find_library(LIB_RT ${LIB_RT_NAME})
 
 
 # Add the posix targets


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The libraries implementing the interfaces of the POSIX.1b Realtime Extension may differ across platforms, so this change allows the name of the library to be specified with the `-DLIB_RT_NAME=` CMake option.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
