### PR TITLE
update HTTP server root CA certificate

### DIFF
--- a/demos/ota/ota_demo_core_http/demo_config.h
+++ b/demos/ota/ota_demo_core_http/demo_config.h
@@ -110,7 +110,7 @@
  * @note This certificate should be PEM-encoded.
  */
 #ifndef ROOT_CA_CERT_PATH_HTTP
-    #define ROOT_CA_CERT_PATH_HTTP    "certificates/BaltimoreCyberTrustRoot.crt"
+    #define ROOT_CA_CERT_PATH_HTTP    "certificates/AmazonRootCA1.crt"
 #endif
 
 /**

--- a/demos/ota/ota_demo_core_http/demo_config.h
+++ b/demos/ota/ota_demo_core_http/demo_config.h
@@ -103,9 +103,13 @@
  * @brief Path of the file containing the server's root CA certificate for TLS
  * authentication.
  *
- * The Baltimore Cybertrust Root CA Certificate is automatically downloaded to
- * the certificates directory using the CMake build system, from @ref
- * https://cacerts.digicert.com/BaltimoreCyberTrustRoot.crt.pem.
+ * This certificate is used to identify the AWS IoT server and is publicly
+ * available. Refer to the AWS documentation available in the link below
+ * https://docs.aws.amazon.com/iot/latest/developerguide/server-authentication.html#server-authentication-certs
+ *
+ * Amazon's root CA certificate is automatically downloaded to the certificates
+ * directory from @ref https://www.amazontrust.com/repository/AmazonRootCA1.pem
+ * using the CMake build system.
  *
  * @note This certificate should be PEM-encoded.
  */


### PR DESCRIPTION
The HTTP server root CA certificate was modified from Baltimore trust CA certificate to Amazons root CA certificate because of this the OTA end to end tests were failing. 

*Description of changes:*
Updated the server root CA certificate path to the Amazon's root CA certificate. 

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
