### PR TITLE
Add automated doxygen deployment

### DIFF
--- a/.github/workflows/doxygen-generation.yml
+++ b/.github/workflows/doxygen-generation.yml
@@ -1,0 +1,31 @@
+name: Doxygen Generation
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+jobs:
+  doxygen-generation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Doxygen generation
+        uses: FreeRTOS/CI-CD-Github-Actions/doxygen-generation@main
+        with:
+          generate_command: |
+            git submodule update --init --depth 1
+            if python3 tools/doxygen/generate_docs.py --root . ; then
+              find * -type d -wholename '*/doxygen/output' -exec mkdir -p html/{} \; -exec mv {}/html html/{} \;
+              cat << END > html/index.html
+            <!DOCTYPE html>
+            <html>
+              <head>
+                <meta http-equiv="refresh" content="0; url='docs/doxygen/output/html'" />
+              </head>
+              <body>
+                <p><a href="docs/doxygen/output/html">Click here if page does not redirect.</a></p>
+              </body>
+            </html>
+            END
+            else
+              exit 1
+            fi
+          output_dir: html

--- a/.github/workflows/tag-and-zip.yml
+++ b/.github/workflows/tag-and-zip.yml
@@ -1,4 +1,4 @@
-name: Tag and Create ZIP
+name: Tag, Deploy Docs, and Create ZIP
 
 on:
   workflow_dispatch:
@@ -112,3 +112,32 @@ jobs:
         with:
           name: aws-iot-device-sdk-embedded-C-${{ github.event.inputs.version_number }}.zip
           path: zip-check/aws-iot-device-sdk-embedded-C-${{ github.event.inputs.version_number }}.zip
+  deploy-docs:
+    needs: tag-commit
+    name: Deploy doxygen docs
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Deploy doxygen for release tag
+        uses: FreeRTOS/CI-CD-Github-Actions/doxygen-generation@main
+        with:
+          ref: ${{ github.event.inputs.version_number }}
+          add_release: "true"
+          generate_command: |
+            git submodule update --init --depth 1
+            if python3 tools/doxygen/generate_docs.py --root . ; then
+              find * -type d -wholename '*/doxygen/output' -exec mkdir -p html/{} \; -exec mv {}/html html/{} \;
+              cat << END > html/index.html
+            <!DOCTYPE html>
+            <html>
+              <head>
+                <meta http-equiv="refresh" content="0; url='docs/doxygen/output/html'" />
+              </head>
+              <body>
+                <p><a href="docs/doxygen/output/html">Click here if page does not redirect.</a></p>
+              </body>
+            </html>
+            END
+            else
+              exit 1
+            fi
+          output_dir: html


### PR DESCRIPTION
Adds automated deployment of generated doxygen to Github Pages.

The `main` branch documentation is updated on every commits.

Releases add a new doxygen bundle for the release and add it to the index.

The index page is managed by the Github Action [here](https://github.com/FreeRTOS/CI-CD-Github-Actions/tree/main/doxygen-generation).

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
