### PR TITLE
return negative value when byteToSend/Recv is 0

### DIFF
--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -725,11 +725,23 @@ int32_t Openssl_Recv( NetworkContext_t * pNetworkContext,
     if( ( pNetworkContext == NULL ) || ( pNetworkContext->pParams == NULL ) )
     {
         LogError( ( "Parameter check failed: pNetworkContext is NULL." ) );
+        bytesReceived = -1;
     }
     else if( pNetworkContext->pParams->pSsl == NULL )
     {
         LogError( ( "Failed to receive data over network: "
                     "SSL object in network context is NULL." ) );
+        bytesReceived = -1;
+    }
+    else if( pBuffer == NULL )
+    {
+        LogError( ( "Failed to receive data over network: "
+                    "pBuffer is NULL." ) );
+        bytesReceived = -1;
+    }
+    else if( bytesToRecv == 0 )
+    {
+        LogError( ( "Parameter check failed: bytesToRecv is 0." ) );
     }
     else
     {
@@ -842,6 +854,16 @@ int32_t Openssl_Send( NetworkContext_t * pNetworkContext,
     if( ( pNetworkContext == NULL ) || ( pNetworkContext->pParams == NULL ) )
     {
         LogError( ( "Parameter check failed: pNetworkContext is NULL." ) );
+        bytesSent = -1;
+    }
+    else if( pBuffer == NULL )
+    {
+        LogError( ( "Parameter check failed: pBuffer is NULL." ) );
+        bytesSent = -1;
+    }
+    else if( bytesToSend == 0 )
+    {
+        LogError( ( "Parameter check failed: bytesToSend is 0." ) );
     }
     else if( pNetworkContext->pParams->pSsl != NULL )
     {

--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -559,21 +559,21 @@ static void setOptionalConfigurations( SSL * pSsl,
 
 static int32_t isValidNetworkContext( const NetworkContext_t * pNetworkContext )
 {
-    int32_t isValidNetworkContext = 1;
+    int32_t isValid = 1;
 
-    if( !pNetworkContext || !pNetworkContext->pParams )
+    if( ( pNetworkContext == NULL ) || ( pNetworkContext->pParams == NULL ) )
     {
         LogError( ( "Parameter check failed: pNetworkContext is NULL." ) );
-        isValidNetworkContext = 0;
+        isValid = 0;
     }
     else if( pNetworkContext->pParams->pSsl == NULL )
     {
         LogError( ( "Failed to receive data over network: "
                     "SSL object in network context is NULL." ) );
-        isValidNetworkContext = 0;
+        isValid = 0;
     }
 
-    return isValidNetworkContext;
+    return isValid;
 }
 /*-----------------------------------------------------------*/
 
@@ -754,11 +754,11 @@ int32_t Openssl_Recv( NetworkContext_t * pNetworkContext,
     {
         LogDebug( ( "bytesToRecv is 0." ) );
     }
-    else if( !isValidNetworkContext(pNetworkContext) || pBuffer == NULL )
+    else if( !isValidNetworkContext( pNetworkContext ) || ( pBuffer == NULL ) )
     {
         LogError( ( "Parameter check failed: invalid pNetworkContext or pBuffer is NULL." ) );
         bytesReceived = -1;
-    } 
+    }
     else
     {
         int32_t pollStatus = 1, readStatus = 1, sslError = 0;
@@ -870,8 +870,8 @@ int32_t Openssl_Send( NetworkContext_t * pNetworkContext,
     if( bytesToSend == 0 )
     {
         LogDebug( ( "bytesToSend is 0." ) );
-    } 
-    else if( !isValidNetworkContext(pNetworkContext) || pBuffer == NULL )
+    }
+    else if( !isValidNetworkContext( pNetworkContext ) || ( pBuffer == NULL ) )
     {
         LogError( ( "Parameter check failed: invalid pNetworkContext or pBuffer is NULL." ) );
         bytesSent = -1;

--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -84,7 +84,7 @@ struct NetworkContext
  * be added.
  * @param[in] pRootCaPath Filepath string to the trusted server root CA.
  *
- * @return 1 on success; -1, 0 on failure;
+ * @return 1 on success; -1, 0 on failure.
  */
 static int32_t setRootCa( const SSL_CTX * pSslContext,
                           const char * pRootCaPath );
@@ -97,7 +97,7 @@ static int32_t setRootCa( const SSL_CTX * pSslContext,
  * set.
  * @param[in] pClientCertPath Filepath string to the client certificate.
  *
- * @return 1 on success; 0 failure;
+ * @return 1 on success; 0 failure.
  */
 static int32_t setClientCertificate( SSL_CTX * pSslContext,
                                      const char * pClientCertPath );
@@ -108,7 +108,7 @@ static int32_t setClientCertificate( SSL_CTX * pSslContext,
  * @param[out] pSslContext SSL context to which the private key is to be added.
  * @param[in] pPrivateKeyPath Filepath string to the client private key.
  *
- * @return 1 on success; 0 on failure;
+ * @return 1 on success; 0 on failure.
  */
 static int32_t setPrivateKey( SSL_CTX * pSslContext,
                               const char * pPrivateKeyPath );
@@ -124,7 +124,7 @@ static int32_t setPrivateKey( SSL_CTX * pSslContext,
  * imported.
  * @param[in] pOpensslCredentials TLS credentials to be imported.
  *
- * @return 1 on success; -1, 0 on failure;
+ * @return 1 on success; -1, 0 on failure.
  */
 static int32_t setCredentials( SSL_CTX * pSslContext,
                                const OpensslCredentials_t * pOpensslCredentials );
@@ -165,11 +165,11 @@ static OpensslStatus_t tlsHandshake( const ServerInfo_t * pServerInfo,
                                      const OpensslCredentials_t * pOpensslCredentials );
 
 /**
- * @brief Check if the network context is valid
+ * @brief Check if the network context is valid.
  *
- * @param[in] pNetworkContext The network context created using Openssl_Connect API..
+ * @param[in] pNetworkContext The network context created using Openssl_Connect API.
  *
- * @return 1 on success; 0 on failure;
+ * @return 1 on success; 0 on failure.
  */
 static int32_t isValidNetworkContext( const NetworkContext_t * pNetworkContext );
 /*-----------------------------------------------------------*/
@@ -559,18 +559,20 @@ static void setOptionalConfigurations( SSL * pSsl,
 
 static int32_t isValidNetworkContext( const NetworkContext_t * pNetworkContext )
 {
-    int32_t isValid = 1;
+    int32_t isValid = 0;
 
     if( ( pNetworkContext == NULL ) || ( pNetworkContext->pParams == NULL ) )
     {
         LogError( ( "Parameter check failed: pNetworkContext is NULL." ) );
-        isValid = 0;
     }
     else if( pNetworkContext->pParams->pSsl == NULL )
     {
         LogError( ( "Failed to receive data over network: "
                     "SSL object in network context is NULL." ) );
-        isValid = 0;
+    }
+    else
+    {
+        isValid = 1;
     }
 
     return isValid;

--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -752,19 +752,11 @@ int32_t Openssl_Recv( NetworkContext_t * pNetworkContext,
     OpensslParams_t * pOpensslParams = NULL;
     int32_t bytesReceived = 0;
 
-    if( !isValidNetworkContext( pNetworkContext ) )
+    if( !isValidNetworkContext( pNetworkContext ) ||
+        ( pBuffer == NULL ) ||
+        ( bytesToRecv == 0 ) )
     {
-        LogError( ( "Parameter check failed: invalid pNetworkContext." ) );
-        bytesReceived = -1;
-    }
-    else if( pBuffer == NULL )
-    {
-        LogError( ( "pBuffer is NULL." ) );
-        bytesReceived = -1;
-    }
-    else if( bytesToRecv == 0 )
-    {
-        LogError( ( "bytesToRecv is 0." ) );
+        LogError( ( "Parameter check failed: invalid input, pNetworkContext is invalid or pBuffer = %p, bytesToRecv = %lu", pBuffer, bytesToRecv ) );
         bytesReceived = -1;
     }
     else
@@ -875,19 +867,11 @@ int32_t Openssl_Send( NetworkContext_t * pNetworkContext,
     OpensslParams_t * pOpensslParams = NULL;
     int32_t bytesSent = 0;
 
-    if( !isValidNetworkContext( pNetworkContext ) )
+    if( !isValidNetworkContext( pNetworkContext ) ||
+        ( pBuffer == NULL ) ||
+        ( bytesToSend == 0 ) )
     {
-        LogError( ( "Parameter check failed: invalid pNetworkContext." ) );
-        bytesSent = -1;
-    }
-    else if( pBuffer == NULL )
-    {
-        LogError( ( "pBuffer is NULL." ) );
-        bytesSent = -1;
-    }
-    else if( bytesToSend == 0 )
-    {
-        LogError( ( "bytesToSend is 0." ) );
+        LogError( ( "Parameter check failed: invalid input, pNetworkContext is invalid or pBuffer = %p, bytesToSend = %lu", pBuffer, bytesToSend ) );
         bytesSent = -1;
     }
     else

--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -752,11 +752,19 @@ int32_t Openssl_Recv( NetworkContext_t * pNetworkContext,
     OpensslParams_t * pOpensslParams = NULL;
     int32_t bytesReceived = 0;
 
-    if( !isValidNetworkContext( pNetworkContext ) ||
-        ( pBuffer == NULL ) ||
-        ( bytesToRecv == 0 ) )
+    if( !isValidNetworkContext( pNetworkContext ) )
     {
-        LogError( ( "Parameter check failed: invalid pNetworkContext or pBuffer is NULL or bytesToRecv is 0." ) );
+        LogError( ( "Parameter check failed: invalid pNetworkContext." ) );
+        bytesReceived = -1;
+    }
+    else if( pBuffer == NULL )
+    {
+        LogError( ( "pBuffer is NULL." ) );
+        bytesReceived = -1;
+    }
+    else if( bytesToRecv == 0 )
+    {
+        LogError( ( "bytesToRecv is 0." ) );
         bytesReceived = -1;
     }
     else
@@ -867,11 +875,19 @@ int32_t Openssl_Send( NetworkContext_t * pNetworkContext,
     OpensslParams_t * pOpensslParams = NULL;
     int32_t bytesSent = 0;
 
-    if( !isValidNetworkContext( pNetworkContext ) ||
-        ( pBuffer == NULL ) ||
-        ( bytesToSend == 0 ) )
+    if( !isValidNetworkContext( pNetworkContext ) )
     {
-        LogError( ( "Parameter check failed: invalid pNetworkContext or pBuffer is NULL or bytesToSend is 0." ) );
+        LogError( ( "Parameter check failed: invalid pNetworkContext." ) );
+        bytesSent = -1;
+    }
+    else if( pBuffer == NULL )
+    {
+        LogError( ( "pBuffer is NULL." ) );
+        bytesSent = -1;
+    }
+    else if( bytesToSend == 0 )
+    {
+        LogError( ( "bytesToSend is 0." ) );
         bytesSent = -1;
     }
     else

--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -752,13 +752,11 @@ int32_t Openssl_Recv( NetworkContext_t * pNetworkContext,
     OpensslParams_t * pOpensslParams = NULL;
     int32_t bytesReceived = 0;
 
-    if( bytesToRecv == 0 )
+    if( !isValidNetworkContext( pNetworkContext ) || 
+        ( pBuffer == NULL ) ||
+        ( bytesToRecv == 0 ) )
     {
-        LogDebug( ( "bytesToRecv is 0." ) );
-    }
-    else if( !isValidNetworkContext( pNetworkContext ) || ( pBuffer == NULL ) )
-    {
-        LogError( ( "Parameter check failed: invalid pNetworkContext or pBuffer is NULL." ) );
+        LogError( ( "Parameter check failed: invalid pNetworkContext or pBuffer is NULL or bytesToRecv is 0." ) );
         bytesReceived = -1;
     }
     else
@@ -869,13 +867,11 @@ int32_t Openssl_Send( NetworkContext_t * pNetworkContext,
     OpensslParams_t * pOpensslParams = NULL;
     int32_t bytesSent = 0;
 
-    if( bytesToSend == 0 )
+    if( !isValidNetworkContext( pNetworkContext ) || 
+        ( pBuffer == NULL ) ||
+        ( bytesToSend == 0 ) )
     {
-        LogDebug( ( "bytesToSend is 0." ) );
-    }
-    else if( !isValidNetworkContext( pNetworkContext ) || ( pBuffer == NULL ) )
-    {
-        LogError( ( "Parameter check failed: invalid pNetworkContext or pBuffer is NULL." ) );
+        LogError( ( "Parameter check failed: invalid pNetworkContext or pBuffer is NULL or bytesToSend is 0." ) );
         bytesSent = -1;
     }
     else

--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -752,7 +752,7 @@ int32_t Openssl_Recv( NetworkContext_t * pNetworkContext,
     OpensslParams_t * pOpensslParams = NULL;
     int32_t bytesReceived = 0;
 
-    if( !isValidNetworkContext( pNetworkContext ) || 
+    if( !isValidNetworkContext( pNetworkContext ) ||
         ( pBuffer == NULL ) ||
         ( bytesToRecv == 0 ) )
     {
@@ -867,7 +867,7 @@ int32_t Openssl_Send( NetworkContext_t * pNetworkContext,
     OpensslParams_t * pOpensslParams = NULL;
     int32_t bytesSent = 0;
 
-    if( !isValidNetworkContext( pNetworkContext ) || 
+    if( !isValidNetworkContext( pNetworkContext ) ||
         ( pBuffer == NULL ) ||
         ( bytesToSend == 0 ) )
     {

--- a/platform/posix/transport/utest/openssl_utest.c
+++ b/platform/posix/transport/utest/openssl_utest.c
@@ -754,7 +754,7 @@ void test_Openssl_Send_Invalid_Params( void )
     opensslParams.pSsl = &ssl;
 
     bytesSent = Openssl_Send( &networkContext, NULL, BYTES_TO_SEND );
-    TEST_ASSERT_EQUAL( -1, bytesSent ); 
+    TEST_ASSERT_EQUAL( -1, bytesSent );
 
     bytesSent = Openssl_Send( &networkContext, opensslBuffer, 0 );
     TEST_ASSERT_EQUAL( 0, bytesSent );

--- a/platform/posix/transport/utest/openssl_utest.c
+++ b/platform/posix/transport/utest/openssl_utest.c
@@ -757,7 +757,7 @@ void test_Openssl_Send_Invalid_Params( void )
     TEST_ASSERT_EQUAL( -1, bytesSent );
 
     bytesSent = Openssl_Send( &networkContext, opensslBuffer, 0 );
-    TEST_ASSERT_EQUAL( 0, bytesSent );
+    TEST_ASSERT_EQUAL( -1, bytesSent );
 }
 
 /**
@@ -845,7 +845,7 @@ void test_Openssl_Recv_Invalid_Params( void )
     TEST_ASSERT_EQUAL( -1, bytesReceived );
 
     bytesReceived = Openssl_Recv( &networkContext, opensslBuffer, 0 );
-    TEST_ASSERT_EQUAL( 0, bytesReceived );
+    TEST_ASSERT_EQUAL( -1, bytesReceived );
 }
 
 /**

--- a/platform/posix/transport/utest/openssl_utest.c
+++ b/platform/posix/transport/utest/openssl_utest.c
@@ -740,16 +740,23 @@ void test_Openssl_Send_Invalid_Params( void )
     int32_t bytesSent;
 
     bytesSent = Openssl_Send( NULL, opensslBuffer, BYTES_TO_SEND );
-    TEST_ASSERT_EQUAL( 0, bytesSent );
+    TEST_ASSERT_EQUAL( -1, bytesSent );
 
     networkContext.pParams = NULL;
     bytesSent = Openssl_Send( &networkContext, opensslBuffer, BYTES_TO_SEND );
-    TEST_ASSERT_EQUAL( 0, bytesSent );
+    TEST_ASSERT_EQUAL( -1, bytesSent );
     networkContext.pParams = &opensslParams;
 
     /* SSL object must not be NULL. Otherwise, no bytes are sent. */
     opensslParams.pSsl = NULL;
     bytesSent = Openssl_Send( &networkContext, opensslBuffer, BYTES_TO_SEND );
+    TEST_ASSERT_EQUAL( -1, bytesSent );
+    opensslParams.pSsl = &ssl;
+
+    bytesSent = Openssl_Send( &networkContext, NULL, BYTES_TO_SEND );
+    TEST_ASSERT_EQUAL( -1, bytesSent ); 
+
+    bytesSent = Openssl_Send( &networkContext, opensslBuffer, 0 );
     TEST_ASSERT_EQUAL( 0, bytesSent );
 }
 
@@ -821,16 +828,23 @@ void test_Openssl_Recv_Invalid_Params( void )
     int32_t bytesReceived;
 
     bytesReceived = Openssl_Recv( NULL, opensslBuffer, BYTES_TO_RECV );
-    TEST_ASSERT_EQUAL( 0, bytesReceived );
+    TEST_ASSERT_EQUAL( -1, bytesReceived );
 
     networkContext.pParams = NULL;
     bytesReceived = Openssl_Recv( &networkContext, opensslBuffer, BYTES_TO_RECV );
-    TEST_ASSERT_EQUAL( 0, bytesReceived );
+    TEST_ASSERT_EQUAL( -1, bytesReceived );
     networkContext.pParams = &opensslParams;
 
     /* SSL object must not be NULL. Otherwise, no bytes are sent. */
     opensslParams.pSsl = NULL;
     bytesReceived = Openssl_Recv( &networkContext, opensslBuffer, BYTES_TO_RECV );
+    TEST_ASSERT_EQUAL( -1, bytesReceived );
+    opensslParams.pSsl = &ssl;
+
+    bytesReceived = Openssl_Recv( &networkContext, NULL, BYTES_TO_RECV );
+    TEST_ASSERT_EQUAL( -1, bytesReceived );
+
+    bytesReceived = Openssl_Recv( &networkContext, opensslBuffer, 0 );
     TEST_ASSERT_EQUAL( 0, bytesReceived );
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
refer to [API reference](https://aws.github.io/aws-iot-device-sdk-embedded-C/202108.00/libraries/standard/coreMQTT/docs/doxygen/output/html/group__mqtt__callback__types.html)

Openssl_Recv should return negative value when byteToRecv is 0.
Openssl_Send should return negative value when byteToSend is 0.

TransportRecv_t:

If no data is available on the network to read and no error has occurred, zero MUST be the return value. A zero return value SHOULD represent that the read operation can be retried by calling the API function. Zero MUST NOT be returned if a network disconnection has occurred.

TransportSend_t:

If no data is transmitted over the network due to a full TX buffer and no network error has occurred, this MUST return zero as the return value. A zero return value SHOULD represent that the send operation can be retried by calling the API function. Zero MUST NOT be returned if a network disconnection has occurred.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
