### PR TITLE
demos: Define OTA file type for OTA demos

### DIFF
--- a/demos/ota/ota_demo_core_http/ota_config.h
+++ b/demos/ota/ota_demo_core_http/ota_config.h
@@ -174,4 +174,12 @@
  */
 #define configOTA_PRIMARY_DATA_PROTOCOL         ( OTA_DATA_OVER_HTTP )
 
+/**
+ * @brief Data type to represent a file.
+ *
+ * It is used to represent a file received via OTA. The file is declared as
+ * the pointer of this type: otaconfigOTA_FILE_TYPE * pFile.
+ */
+#define otaconfigOTA_FILE_TYPE                  FILE
+
 #endif /* OTA_CONFIG_H_ */

--- a/demos/ota/ota_demo_core_mqtt/ota_config.h
+++ b/demos/ota/ota_demo_core_mqtt/ota_config.h
@@ -175,4 +175,12 @@
  */
 #define configOTA_PRIMARY_DATA_PROTOCOL         ( OTA_DATA_OVER_MQTT )
 
+/**
+ * @brief Data type to represent a file.
+ *
+ * It is used to represent a file received via OTA. The file is declared as
+ * the pointer of this type: otaconfigOTA_FILE_TYPE * pFile.
+ */
+#define otaconfigOTA_FILE_TYPE                  FILE
+
 #endif /* OTA_CONFIG_H_ */


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Latest OTA codes [1] now support configurable OTA file type. As OTA
demos are supposed to run on POSIX platforms, we know 'FILE' should
be used, so per [2] the AWS IoT device SDK should be able to define
the following in its custom config file:

  #define otaconfigOTA_FILE_TYPE FILE

[1] https://github.com/aws/ota-for-aws-iot-embedded-sdk/pull/390/
[2] https://github.com/aws/ota-for-aws-iot-embedded-sdk/pull/388

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.