### PR TITLE
Update MbedTLS submodule pointer to v2.28.0

### DIFF
--- a/platform/posix/include/mbedtls_config.h
+++ b/platform/posix/include/mbedtls_config.h
@@ -114,10 +114,6 @@
 #define MBEDTLS_HAVE_TIME_DATE
 #define MBEDTLS_HAVE_TIME
 
-/* Include due to bug when building shared library:
- * See https://github.com/ARMmbed/mbedtls/issues/4411 */
-#define MBEDTLS_PSA_CRYPTO_C
-
 #include "mbedtls/check_config.h"
 
 #endif /* ifndef MBEDTLS_CONFIG_H_ */


### PR DESCRIPTION
Updating version of MbedTLS also removed the need to define MBEDTLS_PSA_CRYPTO_C

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
