### PR TITLE
Remove Baltimore certificate to fix S3 demos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,12 +163,6 @@ if(DOWNLOAD_CERTS)
         COMMAND curl --url https://www.amazontrust.com/repository/AmazonRootCA1.pem
         -o ${CERT_DOWNLOAD_DIR}/AmazonRootCA1.crt
     )
-    # Download the Baltimore Cybertrust Root CA certificate.
-    message( "Downloading the Baltimore Cybertrust Root CA certificate..." )
-    execute_process(
-        COMMAND curl --url https://cacerts.digicert.com/BaltimoreCyberTrustRoot.crt.pem
-        -o ${CERT_DOWNLOAD_DIR}/BaltimoreCyberTrustRoot.crt
-    )
     # Copy certificates to the build directory.
     file(COPY "${CERT_DOWNLOAD_DIR}"
          DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})

--- a/demos/http/http_demo_s3_download/demo_config.h
+++ b/demos/http/http_demo_s3_download/demo_config.h
@@ -62,7 +62,7 @@
 /**
  * @brief Path of the file containing the server's root CA certificate.
  *
- * This certificate is used to identify the AWS IoT server and is publicly
+ * This certificate is used to identify the AWS endpoints and is publicly
  * available. Refer to the AWS documentation available in the link below
  * https://docs.aws.amazon.com/iot/latest/developerguide/server-authentication.html#server-authentication-certs
  *

--- a/demos/http/http_demo_s3_download/demo_config.h
+++ b/demos/http/http_demo_s3_download/demo_config.h
@@ -60,27 +60,22 @@
 #endif
 
 /**
- * @brief Path of the file containing the AWS IOT Credential provider
- * server's root CA certificate for TLS authentication.
+ * @brief Path of the file containing the server's root CA certificate.
+ *
+ * This certificate is used to identify the AWS IoT server and is publicly
+ * available. Refer to the AWS documentation available in the link below
+ * https://docs.aws.amazon.com/iot/latest/developerguide/server-authentication.html#server-authentication-certs
+ *
+ * Amazon's root CA certificate is automatically downloaded to the certificates
+ * directory from @ref https://www.amazontrust.com/repository/AmazonRootCA1.pem
+ * using the CMake build system.
  *
  * @note This certificate should be PEM-encoded.
+ * @note This path is relative from the demo binary created. Update
+ * ROOT_CA_CERT_PATH to the absolute path if this demo is executed from elsewhere.
  */
-#ifndef AWS_IOT_CRED_PROVIDER_ROOT_CA_CERT_PATH
-    #define AWS_IOT_CRED_PROVIDER_ROOT_CA_CERT_PATH    "certificates/AmazonRootCA1.crt"
-#endif
-
-/**
- * @brief Path of the file containing the AWS S3 server's root CA certificate for TLS
- * authentication.
- *
- * The Baltimore Cybertrust Root CA Certificate is automatically downloaded to
- * the certificates directory using the CMake build system, from @ref
- * https://cacerts.digicert.com/BaltimoreCyberTrustRoot.crt.pem.
- *
- * @note This certificate should be PEM-encoded.
- */
-#ifndef AWS_S3_ROOT_CA_CERT_PATH
-    #define AWS_S3_ROOT_CA_CERT_PATH    "certificates/BaltimoreCyberTrustRoot.crt"
+#ifndef ROOT_CA_CERT_PATH
+    #define ROOT_CA_CERT_PATH    "certificates/AmazonRootCA1.crt"
 #endif
 
 /**

--- a/demos/http/http_demo_s3_download/http_demo_s3_download.c
+++ b/demos/http/http_demo_s3_download/http_demo_s3_download.c
@@ -60,7 +60,7 @@
 
 /* Check that a path for Root CA Certificate is defined. */
 #ifndef ROOT_CA_CERT_PATH
-    #error "Please define thr ROOT_CA_CERT_PATH macro in demo_config.h."
+    #error "Please define the ROOT_CA_CERT_PATH macro in demo_config.h."
 #endif
 
 /* Check that transport timeout for transport send and receive is defined. */

--- a/demos/http/http_demo_s3_download/http_demo_s3_download.c
+++ b/demos/http/http_demo_s3_download/http_demo_s3_download.c
@@ -58,14 +58,9 @@
     #error "Please define the HTTPS_PORT macro in demo_config.h ."
 #endif
 
-/* Check that a path for Root CA Certificate is defined for AWS IOT CREDENTIAL PROVIDER SERVICE. */
-#ifndef AWS_IOT_CRED_PROVIDER_ROOT_CA_CERT_PATH
-    #error "Please define thr AWS_IOT_CRED_PROVIDER_ROOT_CA_CERT_PATH macro in demo_config.h."
-#endif
-
-/* Check that a path for Root CA Certificate is defined for AWS S3 Service. */
-#ifndef AWS_S3_ROOT_CA_CERT_PATH
-    #error "Please define the AWS_S3_ROOT_CA_CERT_PATH macro for AWS S3 ROOT CA certificate in demo_config.h."
+/* Check that a path for Root CA Certificate is defined. */
+#ifndef ROOT_CA_CERT_PATH
+    #error "Please define thr ROOT_CA_CERT_PATH macro in demo_config.h."
 #endif
 
 /* Check that transport timeout for transport send and receive is defined. */
@@ -894,7 +889,7 @@ static int32_t connectToIotServer( NetworkContext_t * pNetworkContext )
         serverHost[ serverHostLength ] = '\0';
 
         /* Initialize TLS credentials. */
-        opensslCredentials.pRootCaPath = AWS_IOT_CRED_PROVIDER_ROOT_CA_CERT_PATH;
+        opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
         opensslCredentials.sniHostName = serverHost;
         opensslCredentials.pClientCertPath = CLIENT_CERT_PATH;
         opensslCredentials.pPrivateKeyPath = CLIENT_PRIVATE_KEY_PATH;
@@ -947,7 +942,7 @@ static int32_t connectToS3Server( NetworkContext_t * pNetworkContext )
         serverHost[ serverHostLength ] = '\0';
 
         /* Initialize TLS credentials. */
-        opensslCredentials.pRootCaPath = AWS_S3_ROOT_CA_CERT_PATH;
+        opensslCredentials.pRootCaPath = ROOT_CA_CERT_PATH;
         opensslCredentials.sniHostName = serverHost;
 
         /* Initialize server information. */

--- a/demos/http/http_demo_s3_download_multithreaded/demo_config.h
+++ b/demos/http/http_demo_s3_download_multithreaded/demo_config.h
@@ -61,13 +61,22 @@
 #endif
 
 /**
- * @brief Path of the file containing the server's root CA certificate for TLS authentication.
+ * @brief Path of the file containing the server's root CA certificate.
  *
- * @note S3 uses the Baltimore Cybertrust root CA certificate. To download this certificate, see
- * https://baltimore-cybertrust-root.chain-demos.digicert.com/info/index.html
+ * This certificate is used to identify the AWS IoT server and is publicly
+ * available. Refer to the AWS documentation available in the link below
+ * https://docs.aws.amazon.com/iot/latest/developerguide/server-authentication.html#server-authentication-certs
+ *
+ * Amazon's root CA certificate is automatically downloaded to the certificates
+ * directory from @ref https://www.amazontrust.com/repository/AmazonRootCA1.pem
+ * using the CMake build system.
+ *
+ * @note This certificate should be PEM-encoded.
+ * @note This path is relative from the demo binary created. Update
+ * ROOT_CA_CERT_PATH to the absolute path if this demo is executed from elsewhere.
  */
 #ifndef ROOT_CA_CERT_PATH
-    #define ROOT_CA_CERT_PATH    "certificates/BaltimoreCyberTrustRoot.crt"
+    #define ROOT_CA_CERT_PATH    "certificates/AmazonRootCA1.crt"
 #endif
 
 /**

--- a/demos/http/http_demo_s3_download_multithreaded/demo_config.h
+++ b/demos/http/http_demo_s3_download_multithreaded/demo_config.h
@@ -63,7 +63,7 @@
 /**
  * @brief Path of the file containing the server's root CA certificate.
  *
- * This certificate is used to identify the AWS IoT server and is publicly
+ * This certificate is used to identify the AWS endpoints and is publicly
  * available. Refer to the AWS documentation available in the link below
  * https://docs.aws.amazon.com/iot/latest/developerguide/server-authentication.html#server-authentication-certs
  *

--- a/demos/http/http_demo_s3_upload/demo_config.h
+++ b/demos/http/http_demo_s3_upload/demo_config.h
@@ -61,17 +61,22 @@
 #endif
 
 /**
- * @brief Path of the file containing the server's root CA certificate for TLS
- * authentication.
+ * @brief Path of the file containing the server's root CA certificate.
  *
- * The Baltimore Cybertrust Root CA Certificate is automatically downloaded to
- * the certificates directory using the CMake build system, from @ref
- * https://cacerts.digicert.com/BaltimoreCyberTrustRoot.crt.pem.
+ * This certificate is used to identify the AWS IoT server and is publicly
+ * available. Refer to the AWS documentation available in the link below
+ * https://docs.aws.amazon.com/iot/latest/developerguide/server-authentication.html#server-authentication-certs
+ *
+ * Amazon's root CA certificate is automatically downloaded to the certificates
+ * directory from @ref https://www.amazontrust.com/repository/AmazonRootCA1.pem
+ * using the CMake build system.
  *
  * @note This certificate should be PEM-encoded.
+ * @note This path is relative from the demo binary created. Update
+ * ROOT_CA_CERT_PATH to the absolute path if this demo is executed from elsewhere.
  */
 #ifndef ROOT_CA_CERT_PATH
-    #define ROOT_CA_CERT_PATH    "certificates/BaltimoreCyberTrustRoot.crt"
+    #define ROOT_CA_CERT_PATH    "certificates/AmazonRootCA1.crt"
 #endif
 
 /**

--- a/demos/http/http_demo_s3_upload/demo_config.h
+++ b/demos/http/http_demo_s3_upload/demo_config.h
@@ -63,7 +63,7 @@
 /**
  * @brief Path of the file containing the server's root CA certificate.
  *
- * This certificate is used to identify the AWS IoT server and is publicly
+ * This certificate is used to identify the AWS endpoints and is publicly
  * available. Refer to the AWS documentation available in the link below
  * https://docs.aws.amazon.com/iot/latest/developerguide/server-authentication.html#server-authentication-certs
  *


### PR DESCRIPTION
The Baltimore certificate is no longer needed for the S3 demos. Instead, the AmazonRootCA1 certificate is used. This PR removes the Baltimore certificate to fix the S3 demos.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
