### PR TITLE
Increase transport timeout in FP demo

### DIFF
--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/mqtt_operations.c
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/mqtt_operations.c
@@ -161,7 +161,7 @@
 /**
  * @brief Timeout in milliseconds for transport send and receive.
  */
-#define TRANSPORT_SEND_RECV_TIMEOUT_MS           ( 100U )
+#define TRANSPORT_SEND_RECV_TIMEOUT_MS           ( 1000U )
 
 /**
  * @brief The MQTT metrics string expected by AWS IoT MQTT Broker.


### PR DESCRIPTION
This PR increases the transport timeout in the Fleet Provisioning demo from 100ms to 1000ms. This avoids failures on networks with higher ping.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
