### PR TITLE
ota_demo_core_mqtt optional macros

### DIFF
--- a/demos/ota/ota_demo_core_mqtt/CMakeLists.txt
+++ b/demos/ota/ota_demo_core_mqtt/CMakeLists.txt
@@ -50,6 +50,7 @@ set_macro_definitions(TARGETS ${DEMO_NAME}
                         "CLIENT_CERT_PATH"
                         "CLIENT_PRIVATE_KEY_PATH"
                         "CLIENT_IDENTIFIER"
+                      OPTIONAL
                         "CLIENT_USERNAME"
                         "CLIENT_PASSWORD"
                         "OS_NAME"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I believe CLIENT_USERNAME, CLIENT_PASSWORD etc should be optional like ota_demo_core_http and mqtt_demo_mutual_auth. Otherwise we get a false warning when configuring the build.

> WARNING: ota_demo_core_mqtt missing definitions for macros: CLIENT_USERNAME, CLIENT_PASSWORD
> To run ota_demo_core_mqtt, define required macros in ota_demo_core_mqtt/demo_config.h.
> 

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
