### PR TITLE
Increase TRANSPORT_SEND_RECV_TIMEOUT_MS to minimum 1000ms in tests and demos

### DIFF
--- a/demos/defender/defender_demo_json/mqtt_operations.c
+++ b/demos/defender/defender_demo_json/mqtt_operations.c
@@ -167,7 +167,7 @@
 /**
  * @brief Timeout in milliseconds for transport send and receive.
  */
-#define TRANSPORT_SEND_RECV_TIMEOUT_MS           ( 100 )
+#define TRANSPORT_SEND_RECV_TIMEOUT_MS           ( 1000 )
 
 /**
  * @brief The MQTT metrics string expected by AWS IoT MQTT Broker.

--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -183,7 +183,7 @@
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
-#define TRANSPORT_SEND_RECV_TIMEOUT_MS           ( 500 )
+#define TRANSPORT_SEND_RECV_TIMEOUT_MS           ( 1000 )
 
 /*-----------------------------------------------------------*/
 

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
@@ -166,7 +166,7 @@
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
-#define TRANSPORT_SEND_RECV_TIMEOUT_MS      ( 500 )
+#define TRANSPORT_SEND_RECV_TIMEOUT_MS      ( 1000 )
 
 /*-----------------------------------------------------------*/
 

--- a/demos/mqtt/mqtt_demo_serializer/mqtt_demo_serializer.c
+++ b/demos/mqtt/mqtt_demo_serializer/mqtt_demo_serializer.c
@@ -124,7 +124,7 @@
 /**
  * @brief Socket layer transportTimeout in milliseconds.
  */
-#define TRANSPORT_SEND_RECV_TIMEOUT_MS       ( 500U )
+#define TRANSPORT_SEND_RECV_TIMEOUT_MS       ( 1000U )
 
 /**
  * @brief Number of time network receive will be attempted

--- a/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
+++ b/demos/mqtt/mqtt_demo_subscription_manager/mqtt_demo_subscription_manager.c
@@ -233,7 +233,7 @@
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
-#define TRANSPORT_SEND_RECV_TIMEOUT_MS          ( 500 )
+#define TRANSPORT_SEND_RECV_TIMEOUT_MS          ( 1000 )
 
 /*-----------------------------------------------------------*/
 

--- a/demos/ota/ota_demo_core_http/ota_demo_core_http.c
+++ b/demos/ota/ota_demo_core_http/ota_demo_core_http.c
@@ -124,7 +124,7 @@
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
-#define TRANSPORT_SEND_RECV_TIMEOUT_MS           ( 500U )
+#define TRANSPORT_SEND_RECV_TIMEOUT_MS           ( 1000U )
 
 /**
  * @brief Timeout for receiving CONNACK packet in milli seconds.

--- a/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
+++ b/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
@@ -115,7 +115,7 @@
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
-#define TRANSPORT_SEND_RECV_TIMEOUT_MS      ( 500U )
+#define TRANSPORT_SEND_RECV_TIMEOUT_MS      ( 1000U )
 
 /**
  * @brief Timeout for receiving CONNACK packet in milli seconds.

--- a/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
+++ b/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
@@ -167,7 +167,7 @@
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
-#define TRANSPORT_SEND_RECV_TIMEOUT_MS      ( 500 )
+#define TRANSPORT_SEND_RECV_TIMEOUT_MS      ( 1000 )
 
 /**
  * @brief The MQTT metrics string expected by AWS IoT.

--- a/integration-test/mqtt/mqtt_system_test.c
+++ b/integration-test/mqtt/mqtt_system_test.c
@@ -191,7 +191,7 @@
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
-#define TRANSPORT_SEND_RECV_TIMEOUT_MS          ( 200U )
+#define TRANSPORT_SEND_RECV_TIMEOUT_MS          ( 1000U )
 
 /**
  * @brief Timeout for receiving CONNACK packet in milli seconds.
@@ -210,7 +210,7 @@
  * PUBLISH message and ack responses for QoS 1 and QoS 2 communications
  * with the broker.
  */
-#define MQTT_PROCESS_LOOP_TIMEOUT_MS            ( 700U )
+#define MQTT_PROCESS_LOOP_TIMEOUT_MS            ( 1000U )
 
 /**
  * @brief The MQTT message published in this example.


### PR DESCRIPTION
Tests may encounter transient failures on slower network connections due to low timeouts. This PR reduces the likelihood of encountering transient connection issues by setting TRANSPORT_SEND_RECV_TIMEOUT_MS to a minimum of 1000ms in all tests and demos.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
