### PR TITLE
Add delay between setup and startPersistentSession

### DIFF
--- a/integration-test/mqtt/mqtt_system_test.c
+++ b/integration-test/mqtt/mqtt_system_test.c
@@ -1381,6 +1381,12 @@ TEST( coreMQTT_Integration, test_MQTT_Restore_Session_Incoming_Duplicate_PubRel 
  */
 void test_MQTT_Resend_Unacked_Publish_QoS1( void )
 {
+    if( testingAgainstAWS )
+    {
+        /* Add 30 seconds of delay */
+        Clock_SleepMs( 30000 );
+    }
+
     /* Start a persistent session with the broker. */
     startPersistentSession();
 
@@ -1409,6 +1415,12 @@ void test_MQTT_Resend_Unacked_Publish_QoS1( void )
 
     /* Reset the transport receive function in the context. */
     context.transportInterface.recv = Openssl_Recv;
+
+    if( testingAgainstAWS )
+    {
+        /* Add 30 seconds of delay */
+        Clock_SleepMs( 30000 );
+    }
 
     /* We will re-establish an MQTT over TLS connection with the broker to restore
      * the persistent session. */
@@ -1534,6 +1546,12 @@ TEST( coreMQTT_Integration, test_MQTT_Resend_Unacked_Publish_QoS2 )
  */
 void test_MQTT_Restore_Session_Duplicate_Incoming_Publish_Qos1( void )
 {
+    if( testingAgainstAWS )
+    {
+        /* Add 30 seconds of delay */
+        Clock_SleepMs( 30000 );
+    }
+
     /* Start a persistent session with the broker. */
     startPersistentSession();
 


### PR DESCRIPTION
*Issue #, if available:*
CSDK integration test has randomly failure on test_MQTT_Resend_Unacked_Publish_QoS1 and test_MQTT_Restore_Session_Duplicate_Incoming_Publish_Qos1 tests. The mqtt connect inside startPersistentSession in the beginning of the test might return status 4 instead of 0.

*Description of changes:*
- Add 30s delay between test setup and startPersistentSession
- Add 30s delay before resumePersistentSession in test_MQTT_Resend_Unacked_Publish_QoS1

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
