### PR TITLE
tls: Move alpn identifiers to a common header file

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -9,6 +9,8 @@ else()
     set( PLATFORM_NAME ${PLATFORM_NAME} CACHE STRING "Port to use for building the SDK." )
 endif()
 
+set(AWS_DEMO_INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}/include)
+
 # Include each subdirectory that has a CMakeLists.txt file in it
 file(GLOB demo_dirs "${DEMOS_DIR}/*/*")
 foreach(demo_dir IN LISTS demo_dirs)

--- a/demos/defender/defender_demo_json/CMakeLists.txt
+++ b/demos/defender/defender_demo_json/CMakeLists.txt
@@ -34,6 +34,7 @@ target_include_directories( ${DEMO_NAME} PUBLIC
                             ${BACKOFF_ALGORITHM_INCLUDE_PUBLIC_DIRS}
                             ${JSON_INCLUDE_PUBLIC_DIRS}
                             ${DEFENDER_INCLUDE_PUBLIC_DIRS}
+                            ${AWS_DEMO_INCLUDE_DIRS}
                             ${CMAKE_CURRENT_LIST_DIR} )
 
 set_macro_definitions(TARGETS ${DEMO_NAME}

--- a/demos/defender/defender_demo_json/mqtt_operations.c
+++ b/demos/defender/defender_demo_json/mqtt_operations.c
@@ -56,6 +56,9 @@
 /* Clock for timer. */
 #include "clock.h"
 
+/* AWS IoT Core TLS ALPN definitions for MQTT authentication */
+#include "aws_iot_alpn_defs.h"
+
 /**
  * These configurations are required. Throw compilation error if the below
  * configs are not defined.
@@ -96,25 +99,6 @@
  * @brief Length of the client identifier.
  */
 #define CLIENT_IDENTIFIER_LENGTH                 ( ( uint16_t ) ( sizeof( CLIENT_IDENTIFIER ) - 1 ) )
-
-/**
- * @brief ALPN protocol name for AWS IoT MQTT.
- *
- * This will be used if the AWS_MQTT_PORT is configured as 443 for AWS IoT MQTT
- * broker. Please see more details about the ALPN protocol for AWS IoT MQTT
- * endpoint in the link below.
- * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
- *
- * @note OpenSSL requires that the protocol string passed to it for configuration be encoded
- * with the prefix of 8-bit length information of the string. Thus, the 14 byte (0x0e) length
- * information is prefixed to the string.
- */
-#define ALPN_PROTOCOL_NAME                       "\x0ex-amzn-mqtt-ca"
-
-/**
- * @brief Length of ALPN protocol name.
- */
-#define ALPN_PROTOCOL_NAME_LENGTH                ( ( uint16_t ) ( sizeof( ALPN_PROTOCOL_NAME ) - 1 ) )
 
 /**
  * @brief The maximum number of retries for connecting to server.
@@ -378,8 +362,8 @@ static bool connectToBrokerWithBackoffRetries( NetworkContext_t * pNetworkContex
          * in the link below.
          * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
          */
-        opensslCredentials.pAlpnProtos = ALPN_PROTOCOL_NAME;
-        opensslCredentials.alpnProtosLen = ALPN_PROTOCOL_NAME_LENGTH;
+        opensslCredentials.pAlpnProtos = AWS_IOT_ALPN_MQTT_CA_AUTH_OPENSSL;
+        opensslCredentials.alpnProtosLen = AWS_IOT_ALPN_MQTT_CA_AUTH_OPENSSL_LEN;
     }
 
     /* Seed pseudo random number generator used in the demo for

--- a/demos/defender/defender_demo_json/mqtt_operations.c
+++ b/demos/defender/defender_demo_json/mqtt_operations.c
@@ -56,7 +56,7 @@
 /* Clock for timer. */
 #include "clock.h"
 
-/* AWS IoT Core TLS ALPN definitions for MQTT authentication */
+/* AWS IoT Core TLS ALPN definitions for MQTT authentication. */
 #include "aws_iot_alpn_defs.h"
 
 /**

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/CMakeLists.txt
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/CMakeLists.txt
@@ -47,6 +47,7 @@ target_include_directories( ${DEMO_NAME}
                               ${BACKOFF_ALGORITHM_INCLUDE_PUBLIC_DIRS}
                               ${PKCS_INCLUDE_PUBLIC_DIRS}
                               ${PKCS_PAL_INCLUDE_PUBLIC_DIRS}
+                              ${AWS_DEMO_INCLUDE_DIRS}
                               "${FLEET_PROVISIONING_INCLUDE_PUBLIC_DIRS}"
                               "${DEMOS_DIR}/pkcs11/common/include" # corePKCS11 config
                               "${CMAKE_SOURCE_DIR}/platform/include"

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/mqtt_operations.c
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/mqtt_operations.c
@@ -56,6 +56,9 @@
 /* Clock for timer. */
 #include "clock.h"
 
+/* AWS IoT Core TLS ALPN definitions for MQTT authentication */
+#include "aws_iot_alpn_defs.h"
+
 /**
  * These configurations are required. Throw compilation error if the below
  * configs are not defined.
@@ -90,25 +93,6 @@
  * @brief Length of the client identifier.
  */
 #define CLIENT_IDENTIFIER_LENGTH                 ( ( uint16_t ) ( sizeof( CLIENT_IDENTIFIER ) - 1 ) )
-
-/**
- * @brief ALPN protocol name for AWS IoT MQTT.
- *
- * This will be used if the AWS_MQTT_PORT is configured as 443 for AWS IoT MQTT
- * broker. Please see more details about the ALPN protocol for AWS IoT MQTT
- * endpoint in the link below.
- * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
- *
- * @note OpenSSL requires that the protocol string passed to it for configuration be encoded
- * with the prefix of 8-bit length information of the string. Thus, the 14 byte (0x0e) length
- * information is prefixed to the string.
- */
-#define ALPN_PROTOCOL_NAME                       "\x0ex-amzn-mqtt-ca"
-
-/**
- * @brief Length of ALPN protocol name.
- */
-#define ALPN_PROTOCOL_NAME_LENGTH                ( ( uint16_t ) ( sizeof( ALPN_PROTOCOL_NAME ) - 1 ) )
 
 /**
  * @brief The maximum number of retries for connecting to server.
@@ -356,7 +340,6 @@ static bool connectToBrokerWithBackoffRetries( NetworkContext_t * pNetworkContex
     BackoffAlgorithmContext_t reconnectParams;
     MbedtlsPkcs11Credentials_t tlsCredentials = { 0 };
     uint16_t nextRetryBackOff = 0U;
-    const char * alpn[] = { ALPN_PROTOCOL_NAME, NULL };
 
     /* Set the pParams member of the network context with desired transport. */
     pNetworkContext->pParams = &tlsContext;
@@ -377,12 +360,14 @@ static bool connectToBrokerWithBackoffRetries( NetworkContext_t * pNetworkContex
 
     if( AWS_MQTT_PORT == 443 )
     {
+        static const char * alpnProtoArray[] = AWS_IOT_ALPN_MQTT_CA_AUTH_MBEDTLS;
+
         /* Pass the ALPN protocol name depending on the port being used.
          * Please see more details about the ALPN protocol for AWS IoT MQTT endpoint
          * in the link below.
          * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
          */
-        tlsCredentials.pAlpnProtos = alpn;
+        tlsCredentials.pAlpnProtos = alpnProtoArray;
     }
 
     /* Initialize reconnect attempts and interval */

--- a/demos/http/http_demo_mutual_auth/CMakeLists.txt
+++ b/demos/http/http_demo_mutual_auth/CMakeLists.txt
@@ -40,8 +40,9 @@ target_include_directories(
         "${DEMOS_DIR}/http/common/include"
         ${HTTP_INCLUDE_PUBLIC_DIRS}
         ${BACKOFF_ALGORITHM_INCLUDE_PUBLIC_DIRS}
-        ${CMAKE_CURRENT_LIST_DIR}
         ${LOGGING_INCLUDE_DIRS}
+        ${AWS_DEMO_INCLUDE_DIRS}
+        ${CMAKE_CURRENT_LIST_DIR}
 )
 
 set_macro_definitions(TARGETS ${DEMO_NAME}

--- a/demos/http/http_demo_mutual_auth/http_demo_mutual_auth.c
+++ b/demos/http/http_demo_mutual_auth/http_demo_mutual_auth.c
@@ -40,6 +40,9 @@
 /* OpenSSL transport header. */
 #include "openssl_posix.h"
 
+/* AWS IoT Core TLS ALPN definitions for MQTT authentication */
+#include "aws_iot_alpn_defs.h"
+
 /* Check that AWS IoT Core endpoint is defined. */
 #ifndef AWS_IOT_ENDPOINT
     #error "AWS_IOT_ENDPOINT must be defined to your AWS IoT Core endpoint."
@@ -69,17 +72,6 @@
 #ifndef CLIENT_PRIVATE_KEY_PATH
     #error "Please define a CLIENT_PRIVATE_KEY_PATH."
 #endif
-
-/**
- * @brief ALPN protocol name to be sent as part of the ClientHello message.
- *
- * @note When using ALPN, port 443 must be used to connect to AWS IoT Core.
- *
- * @note OpenSSL requires that the protocol string passed to it for configuration be encoded
- * with the prefix of 8-bit length information of the string. Thus, the 14 byte (0x0e)
- * length information is prefixed to the string.
- */
-#define IOT_CORE_ALPN_PROTOCOL_NAME    "\x0ex-amzn-http-ca"
 
 /* Check that transport timeout for transport send and receive is defined. */
 #ifndef TRANSPORT_SEND_RECV_TIMEOUT_MS
@@ -185,8 +177,8 @@ static int32_t connectToServer( NetworkContext_t * pNetworkContext )
     /* ALPN is required when communicating to AWS IoT Core over port 443 through HTTP. */
     if( AWS_HTTPS_PORT == 443 )
     {
-        opensslCredentials.pAlpnProtos = IOT_CORE_ALPN_PROTOCOL_NAME;
-        opensslCredentials.alpnProtosLen = strlen( IOT_CORE_ALPN_PROTOCOL_NAME );
+        opensslCredentials.pAlpnProtos = AWS_IOT_ALPN_HTTP_CA_AUTH_OPENSSL;
+        opensslCredentials.alpnProtosLen = AWS_IOT_ALPN_MQTT_CA_AUTH_OPENSSL_LEN;
     }
 
     /* Initialize server information. */

--- a/demos/include/aws_iot_alpn_defs.h
+++ b/demos/include/aws_iot_alpn_defs.h
@@ -1,0 +1,65 @@
+/*
+ * AWS IoT Device SDK for Embedded C 202108.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef AWS_IOT_ALPN_DEFS_H_
+#define AWS_IOT_ALPN_DEFS_H_
+
+/*
+ * AWS IoT Core allows the use of HTTP or MQTT over TCP port 443. Connections
+ * to IoT Core endpoints on port 443 default to the HTTP protocol.
+ *
+ * Clients must use the TLS Application-Layer Protocol Negotiation extension
+ * to notify the service of it's desired protocol or authentication mode.
+ *
+ * For more information, please reference the following URL:
+ * https://docs.aws.amazon.com/iot/latest/developerguide/protocols.html
+ */
+
+#define AWS_IOT_ALPN_MQTT_CUSTOM_AUTH                "mqtt"
+#define AWS_IOT_ALPN_MQTT_CA_AUTH                    "x-amzn-mqtt-ca"
+#define AWS_IOT_ALPN_HTTP_CA_AUTH                    "x-amzn-http-ca"
+
+/*
+ * @note OpenSSL requires that ALPN identifiers be provided in protocol form.
+ *       This means that each alpn string be prepended with its length.
+ *       When multiple concurrent alpn identifiers are necessary,
+ *       each identifier should be prepended with it's respective length and
+ *       then concatenated together.
+ */
+#define AWS_IOT_ALPN_MQTT_CUSTOM_AUTH_OPENSSL        "\x04mqtt"
+#define AWS_IOT_ALPN_MQTT_CUSTOM_AUTH_OPENSSL_LEN    ( sizeof( AWS_IOT_ALPN_MQTT_CUSTOM_AUTH_OPENSSL ) - 1U )
+
+#define AWS_IOT_ALPN_MQTT_CA_AUTH_OPENSSL            "\x0ex-amzn-mqtt-ca"
+#define AWS_IOT_ALPN_MQTT_CA_AUTH_OPENSSL_LEN        ( sizeof( AWS_IOT_ALPN_MQTT_CA_AUTH_OPENSSL ) - 1U )
+
+#define AWS_IOT_ALPN_HTTP_CA_AUTH_OPENSSL            "\x0ex-amzn-http-ca"
+#define AWS_IOT_ALPN_HTTP_CA_AUTH_OPENSSL_LEN        ( sizeof( AWS_IOT_ALPN_HTTP_CA_AUTH_OPENSSL ) - 1U )
+
+/*
+ * @note MbedTLS requires alpn identifiers to be provided in a null terminated
+ *       array of null terminated c strings.
+ */
+#define AWS_IOT_ALPN_MQTT_CUSTOM_AUTH_MBEDTLS        { AWS_IOT_ALPN_MQTT_CUSTOM_AUTH, NULL }
+#define AWS_IOT_ALPN_MQTT_CA_AUTH_MBEDTLS            { AWS_IOT_ALPN_MQTT_CA_AUTH, NULL }
+#define AWS_IOT_ALPN_HTTP_CA_AUTH_MBEDTLS            { AWS_IOT_ALPN_HTTP_CA_AUTH, NULL }
+
+#endif /* AWS_IOT_ALPN_DEFS_H_ */

--- a/demos/mqtt/mqtt_demo_mutual_auth/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_mutual_auth/CMakeLists.txt
@@ -30,8 +30,9 @@ target_include_directories(
     PUBLIC
         ${MQTT_INCLUDE_PUBLIC_DIRS}
         ${BACKOFF_ALGORITHM_INCLUDE_PUBLIC_DIRS}
-        ${CMAKE_CURRENT_LIST_DIR}
         ${LOGGING_INCLUDE_DIRS}
+        ${AWS_DEMO_INCLUDE_DIRS}
+        ${CMAKE_CURRENT_LIST_DIR}
 )
 
 set_macro_definitions(TARGETS ${DEMO_NAME}

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -75,6 +75,9 @@
 /* Clock for timer. */
 #include "clock.h"
 
+/* AWS IoT Core TLS ALPN definitions for MQTT authentication */
+#include "aws_iot_alpn_defs.h"
+
 /**
  * These configuration settings are required to run the mutual auth demo.
  * Throw compilation error if the below configs are not defined.
@@ -139,47 +142,12 @@
 /**
  * @brief Length of MQTT server host name.
  */
-#define AWS_IOT_ENDPOINT_LENGTH         ( ( uint16_t ) ( sizeof( AWS_IOT_ENDPOINT ) - 1 ) )
+#define AWS_IOT_ENDPOINT_LENGTH                  ( ( uint16_t ) ( sizeof( AWS_IOT_ENDPOINT ) - 1 ) )
 
 /**
  * @brief Length of client identifier.
  */
-#define CLIENT_IDENTIFIER_LENGTH        ( ( uint16_t ) ( sizeof( CLIENT_IDENTIFIER ) - 1 ) )
-
-/**
- * @brief ALPN (Application-Layer Protocol Negotiation) protocol name for AWS IoT MQTT.
- *
- * This will be used if the AWS_MQTT_PORT is configured as 443 for AWS IoT MQTT broker.
- * Please see more details about the ALPN protocol for AWS IoT MQTT endpoint
- * in the link below.
- * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
- *
- * @note OpenSSL requires that the protocol string passed to it for configuration be encoded
- * with the prefix of 8-bit length information of the string. Thus, the 14 byte (0x0e) length
- * information is prefixed to the string.
- */
-#define AWS_IOT_MQTT_ALPN               "\x0ex-amzn-mqtt-ca"
-
-/**
- * @brief Length of ALPN protocol name.
- */
-#define AWS_IOT_MQTT_ALPN_LENGTH        ( ( uint16_t ) ( sizeof( AWS_IOT_MQTT_ALPN ) - 1 ) )
-
-/**
- * @brief This is the ALPN (Application-Layer Protocol Negotiation) string
- * required by AWS IoT for password-based authentication using TCP port 443.
- *
- * @note OpenSSL requires that the protocol string passed to it for configuration
- * be encoded with the prefix of 8-bit length information of the string. Thus, the
- * 4 byte (0x04) length information is prefixed to the string.
- */
-#define AWS_IOT_PASSWORD_ALPN           "\x04mqtt"
-
-/**
- * @brief Length of password ALPN.
- */
-#define AWS_IOT_PASSWORD_ALPN_LENGTH    ( ( uint16_t ) ( sizeof( AWS_IOT_PASSWORD_ALPN ) - 1 ) )
-
+#define CLIENT_IDENTIFIER_LENGTH                 ( ( uint16_t ) ( sizeof( CLIENT_IDENTIFIER ) - 1 ) )
 
 /**
  * @brief The maximum number of retries for connecting to server.
@@ -201,46 +169,45 @@
  */
 #define CONNACK_RECV_TIMEOUT_MS                  ( 1000U )
 
-
 /**
  * @brief The topic to subscribe and publish to in the example.
  *
  * The topic name starts with the client identifier to ensure that each demo
  * interacts with a unique topic name.
  */
-#define MQTT_EXAMPLE_TOPIC                  CLIENT_IDENTIFIER "/example/topic"
+#define MQTT_EXAMPLE_TOPIC                       CLIENT_IDENTIFIER "/example/topic"
 
 /**
  * @brief Length of client MQTT topic.
  */
-#define MQTT_EXAMPLE_TOPIC_LENGTH           ( ( uint16_t ) ( sizeof( MQTT_EXAMPLE_TOPIC ) - 1 ) )
+#define MQTT_EXAMPLE_TOPIC_LENGTH                ( ( uint16_t ) ( sizeof( MQTT_EXAMPLE_TOPIC ) - 1 ) )
 
 /**
  * @brief The MQTT message published in this example.
  */
-#define MQTT_EXAMPLE_MESSAGE                "Hello World!"
+#define MQTT_EXAMPLE_MESSAGE                     "Hello World!"
 
 /**
  * @brief The length of the MQTT message published in this example.
  */
-#define MQTT_EXAMPLE_MESSAGE_LENGTH         ( ( uint16_t ) ( sizeof( MQTT_EXAMPLE_MESSAGE ) - 1 ) )
+#define MQTT_EXAMPLE_MESSAGE_LENGTH              ( ( uint16_t ) ( sizeof( MQTT_EXAMPLE_MESSAGE ) - 1 ) )
 
 /**
  * @brief Maximum number of outgoing publishes maintained in the application
  * until an ack is received from the broker.
  */
-#define MAX_OUTGOING_PUBLISHES              ( 5U )
+#define MAX_OUTGOING_PUBLISHES                   ( 5U )
 
 /**
  * @brief Invalid packet identifier for the MQTT packets. Zero is always an
  * invalid packet identifier as per MQTT 3.1.1 spec.
  */
-#define MQTT_PACKET_ID_INVALID              ( ( uint16_t ) 0U )
+#define MQTT_PACKET_ID_INVALID                   ( ( uint16_t ) 0U )
 
 /**
  * @brief Timeout for MQTT_ProcessLoop function in milliseconds.
  */
-#define MQTT_PROCESS_LOOP_TIMEOUT_MS        ( 500U )
+#define MQTT_PROCESS_LOOP_TIMEOUT_MS             ( 500U )
 
 /**
  * @brief The maximum time interval in seconds which is allowed to elapse
@@ -251,37 +218,37 @@
  *  absence of sending any other Control Packets, the Client MUST send a
  *  PINGREQ Packet.
  */
-#define MQTT_KEEP_ALIVE_INTERVAL_SECONDS    ( 60U )
+#define MQTT_KEEP_ALIVE_INTERVAL_SECONDS         ( 60U )
 
 /**
  * @brief Delay between MQTT publishes in seconds.
  */
-#define DELAY_BETWEEN_PUBLISHES_SECONDS     ( 1U )
+#define DELAY_BETWEEN_PUBLISHES_SECONDS          ( 1U )
 
 /**
  * @brief Number of PUBLISH messages sent per iteration.
  */
-#define MQTT_PUBLISH_COUNT_PER_LOOP         ( 5U )
+#define MQTT_PUBLISH_COUNT_PER_LOOP              ( 5U )
 
 /**
  * @brief Delay in seconds between two iterations of subscribePublishLoop().
  */
-#define MQTT_SUBPUB_LOOP_DELAY_SECONDS      ( 5U )
+#define MQTT_SUBPUB_LOOP_DELAY_SECONDS           ( 5U )
 
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
-#define TRANSPORT_SEND_RECV_TIMEOUT_MS      ( 500 )
+#define TRANSPORT_SEND_RECV_TIMEOUT_MS           ( 500 )
 
 /**
  * @brief The MQTT metrics string expected by AWS IoT.
  */
-#define METRICS_STRING                      "?SDK=" OS_NAME "&Version=" OS_VERSION "&Platform=" HARDWARE_PLATFORM_NAME "&MQTTLib=" MQTT_LIB
+#define METRICS_STRING                           "?SDK=" OS_NAME "&Version=" OS_VERSION "&Platform=" HARDWARE_PLATFORM_NAME "&MQTTLib=" MQTT_LIB
 
 /**
  * @brief The length of the MQTT metrics string expected by AWS IoT.
  */
-#define METRICS_STRING_LENGTH               ( ( uint16_t ) ( sizeof( METRICS_STRING ) - 1 ) )
+#define METRICS_STRING_LENGTH                    ( ( uint16_t ) ( sizeof( METRICS_STRING ) - 1 ) )
 
 
 #ifdef CLIENT_USERNAME
@@ -605,22 +572,22 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
 
     if( AWS_MQTT_PORT == 443 )
     {
-        /* Pass the ALPN protocol name depending on the port being used.
+        /* Pass the ALPN protocol name depending on the port and auth type being used.
          * Please see more details about the ALPN protocol for the AWS IoT MQTT
          * endpoint in the link below.
          * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
          *
          * For username and password based authentication in AWS IoT,
-         * #AWS_IOT_PASSWORD_ALPN is used. More details can be found in the
+         * #AWS_IOT_ALPN_MQTT_CUSTOM_AUTH is used. More details can be found in the
          * link below.
          * https://docs.aws.amazon.com/iot/latest/developerguide/custom-authentication.html
          */
         #ifdef CLIENT_USERNAME
-            opensslCredentials.pAlpnProtos = AWS_IOT_PASSWORD_ALPN;
-            opensslCredentials.alpnProtosLen = AWS_IOT_PASSWORD_ALPN_LENGTH;
+            opensslCredentials.pAlpnProtos = AWS_IOT_ALPN_MQTT_CUSTOM_AUTH_OPENSSL;
+            opensslCredentials.alpnProtosLen = AWS_IOT_ALPN_MQTT_CUSTOM_AUTH_OPENSSL_LEN;
         #else
-            opensslCredentials.pAlpnProtos = AWS_IOT_MQTT_ALPN;
-            opensslCredentials.alpnProtosLen = AWS_IOT_MQTT_ALPN_LENGTH;
+            opensslCredentials.pAlpnProtos = AWS_IOT_ALPN_MQTT_CA_AUTH_OPENSSL;
+            opensslCredentials.alpnProtosLen = AWS_IOT_ALPN_MQTT_CA_AUTH_OPENSSL_LEN;
         #endif
     }
 

--- a/demos/ota/ota_demo_core_http/CMakeLists.txt
+++ b/demos/ota/ota_demo_core_http/CMakeLists.txt
@@ -54,6 +54,7 @@ target_include_directories(
         ${OTA_INCLUDE_OS_POSIX_DIRS}
         ${MQTT_INCLUDE_PUBLIC_DIRS}
         ${HTTP_INCLUDE_PUBLIC_DIRS}
+        ${AWS_DEMO_INCLUDE_DIRS}
 )
 
 set_macro_definitions(TARGETS ${DEMO_NAME}

--- a/demos/ota/ota_demo_core_http/ota_demo_core_http.c
+++ b/demos/ota/ota_demo_core_http/ota_demo_core_http.c
@@ -69,6 +69,9 @@
 /* Include firmware version struct definition. */
 #include "ota_appversion32.h"
 
+/* AWS IoT Core TLS ALPN definitions for MQTT authentication */
+#include "aws_iot_alpn_defs.h"
+
 /**
  * These configuration settings are required to run the OTA demo which uses mutual authentication.
  * Throw compilation error if the below configs are not defined.
@@ -91,25 +94,6 @@
 #ifndef CLIENT_PRIVATE_KEY_PATH
     #error "Please define path to client private key(CLIENT_PRIVATE_KEY_PATH) in demo_config.h."
 #endif
-
-/**
- * @brief ALPN (Application-Layer Protocol Negotiation) protocol name for AWS IoT MQTT.
- *
- * This will be used if the AWS_MQTT_PORT is configured as 443 for AWS IoT MQTT broker.
- * Please see more details about the ALPN protocol for AWS IoT MQTT endpoint
- * in the link below.
- * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
- *
- * @note OpenSSL requires that the protocol string passed to it for configuration be encoded
- * with the prefix of 8-bit length information of the string. Thus, the 14 byte (0x0e) length
- * information is prefixed to the string.
- */
-#define AWS_IOT_MQTT_ALPN                        "\x0ex-amzn-mqtt-ca"
-
-/**
- * @brief Length of ALPN protocol name.
- */
-#define AWS_IOT_MQTT_ALPN_LENGTH                 ( ( uint16_t ) ( sizeof( AWS_IOT_MQTT_ALPN ) - 1 ) )
 
 /**
  * @brief Length of MQTT server host name.
@@ -1089,11 +1073,11 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
          * https://docs.aws.amazon.com/iot/latest/developerguide/custom-authentication.html
          */
         #ifdef CLIENT_USERNAME
-            opensslCredentials.pAlpnProtos = AWS_IOT_PASSWORD_ALPN;
-            opensslCredentials.alpnProtosLen = AWS_IOT_PASSWORD_ALPN_LENGTH;
+            opensslCredentials.pAlpnProtos = AWS_IOT_ALPN_MQTT_CUSTOM_AUTH_OPENSSL;
+            opensslCredentials.alpnProtosLen = AWS_IOT_ALPN_MQTT_CUSTOM_AUTH_OPENSSL_LEN;
         #else
-            opensslCredentials.pAlpnProtos = AWS_IOT_MQTT_ALPN;
-            opensslCredentials.alpnProtosLen = AWS_IOT_MQTT_ALPN_LENGTH;
+            opensslCredentials.pAlpnProtos = AWS_IOT_ALPN_MQTT_CA_AUTH_OPENSSL;
+            opensslCredentials.alpnProtosLen = AWS_IOT_ALPN_MQTT_CA_AUTH_OPENSSL_LEN;
         #endif
     }
 

--- a/demos/ota/ota_demo_core_mqtt/CMakeLists.txt
+++ b/demos/ota/ota_demo_core_mqtt/CMakeLists.txt
@@ -41,6 +41,7 @@ target_include_directories(
         ${OTA_INCLUDE_PRIVATE_DIRS}
         ${OTA_INCLUDE_OS_POSIX_DIRS}
         ${MQTT_INCLUDE_PUBLIC_DIRS}
+        ${AWS_DEMO_INCLUDE_DIRS}
 )
 
 set_macro_definitions(TARGETS ${DEMO_NAME}

--- a/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
+++ b/demos/ota/ota_demo_core_mqtt/ota_demo_core_mqtt.c
@@ -63,6 +63,9 @@
 /* Include firmware version struct definition. */
 #include "ota_appversion32.h"
 
+/* AWS IoT Core TLS ALPN definitions for MQTT authentication */
+#include "aws_iot_alpn_defs.h"
+
 /**
  * These configuration settings are required to run the OTA demo which uses mutual authentication.
  * Throw compilation error if the below configs are not defined.
@@ -82,25 +85,6 @@
 #ifndef CLIENT_PRIVATE_KEY_PATH
     #error "Please define path to client private key(CLIENT_PRIVATE_KEY_PATH) in demo_config.h."
 #endif
-
-/**
- * @brief ALPN (Application-Layer Protocol Negotiation) protocol name for AWS IoT MQTT.
- *
- * This will be used if the AWS_MQTT_PORT is configured as 443 for AWS IoT MQTT broker.
- * Please see more details about the ALPN protocol for AWS IoT MQTT endpoint
- * in the link below.
- * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
- *
- * @note OpenSSL requires that the protocol string passed to it for configuration be encoded
- * with the prefix of 8-bit length information of the string. Thus, the 14 byte (0x0e) length
- * information is prefixed to the string.
- */
-#define AWS_IOT_MQTT_ALPN                   "\x0ex-amzn-mqtt-ca"
-
-/**
- * @brief Length of ALPN protocol name.
- */
-#define AWS_IOT_MQTT_ALPN_LENGTH            ( ( uint16_t ) ( sizeof( AWS_IOT_MQTT_ALPN ) - 1 ) )
 
 /**
  * @brief Length of MQTT server host name.
@@ -958,11 +942,11 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
          * https://docs.aws.amazon.com/iot/latest/developerguide/custom-authentication.html
          */
         #ifdef CLIENT_USERNAME
-            opensslCredentials.pAlpnProtos = AWS_IOT_PASSWORD_ALPN;
-            opensslCredentials.alpnProtosLen = AWS_IOT_PASSWORD_ALPN_LENGTH;
+            opensslCredentials.pAlpnProtos = AWS_IOT_ALPN_MQTT_CUSTOM_AUTH_OPENSSL;
+            opensslCredentials.alpnProtosLen = AWS_IOT_ALPN_MQTT_CUSTOM_AUTH_OPENSSL_LEN;
         #else
-            opensslCredentials.pAlpnProtos = AWS_IOT_MQTT_ALPN;
-            opensslCredentials.alpnProtosLen = AWS_IOT_MQTT_ALPN_LENGTH;
+            opensslCredentials.pAlpnProtos = AWS_IOT_ALPN_MQTT_CA_AUTH_OPENSSL;
+            opensslCredentials.alpnProtosLen = AWS_IOT_ALPN_MQTT_CA_AUTH_OPENSSL_LEN;
         #endif
     }
 

--- a/demos/shadow/shadow_demo_main/CMakeLists.txt
+++ b/demos/shadow/shadow_demo_main/CMakeLists.txt
@@ -40,8 +40,9 @@ target_include_directories(
         ${MQTT_INCLUDE_PUBLIC_DIRS}
         ${BACKOFF_ALGORITHM_INCLUDE_PUBLIC_DIRS}
         ${SHADOW_INCLUDE_PUBLIC_DIRS}
-        ${CMAKE_CURRENT_LIST_DIR}
         ${JSON_INCLUDE_PUBLIC_DIRS}
+        ${AWS_DEMO_INCLUDE_DIRS}
+        ${CMAKE_CURRENT_LIST_DIR}
 )
 
 set_macro_definitions(TARGETS ${DEMO_NAME}

--- a/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
+++ b/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
@@ -53,6 +53,8 @@
 /* Clock for timer. */
 #include "clock.h"
 
+/* AWS IoT Core TLS ALPN definitions for MQTT authentication */
+#include "aws_iot_alpn_defs.h"
 
 /**
  * These configuration settings are required to run the shadow demo.
@@ -88,32 +90,12 @@
 /**
  * @brief Length of MQTT server host name.
  */
-#define AWS_IOT_ENDPOINT_LENGTH      ( ( uint16_t ) ( sizeof( AWS_IOT_ENDPOINT ) - 1 ) )
+#define AWS_IOT_ENDPOINT_LENGTH                  ( ( uint16_t ) ( sizeof( AWS_IOT_ENDPOINT ) - 1 ) )
 
 /**
  * @brief Length of client identifier.
  */
-#define CLIENT_IDENTIFIER_LENGTH     ( ( uint16_t ) ( sizeof( CLIENT_IDENTIFIER ) - 1 ) )
-
-/**
- * @brief ALPN protocol name for AWS IoT MQTT.
- *
- * This will be used if the AWS_MQTT_PORT is configured as 443 for AWS IoT MQTT broker.
- * Please see more details about the ALPN protocol for AWS IoT MQTT endpoint
- * in the link below.
- * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
- *
- * @note OpenSSL requires that the protocol string passed to it for configuration be encoded
- * with the prefix of 8-bit length information of the string. Thus, the 14 byte (0x0e) length
- * information is prefixed to the string.
- */
-#define ALPN_PROTOCOL_NAME           "\x0ex-amzn-mqtt-ca"
-
-/**
- * @brief Length of ALPN protocol name.
- */
-#define ALPN_PROTOCOL_NAME_LENGTH    ( ( uint16_t ) ( sizeof( ALPN_PROTOCOL_NAME ) - 1 ) )
-
+#define CLIENT_IDENTIFIER_LENGTH                 ( ( uint16_t ) ( sizeof( CLIENT_IDENTIFIER ) - 1 ) )
 
 /**
  * @brief The maximum number of retries for connecting to server.
@@ -361,8 +343,8 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
          * in the link below.
          * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
          */
-        opensslCredentials.pAlpnProtos = ALPN_PROTOCOL_NAME;
-        opensslCredentials.alpnProtosLen = ALPN_PROTOCOL_NAME_LENGTH;
+        opensslCredentials.pAlpnProtos = AWS_IOT_ALPN_MQTT_CA_AUTH_OPENSSL;
+        opensslCredentials.alpnProtosLen = AWS_IOT_ALPN_MQTT_CA_AUTH_OPENSSL_LEN;
     }
 
     /* Seed pseudo random number generator used in the demo for


### PR DESCRIPTION
Fixes #1811

Use the same alpn identifier definitions for all demos.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
