### PR TITLE
Update github apt repository signing key id

### DIFF
--- a/.github/workflows/version-updater.yml
+++ b/.github/workflows/version-updater.yml
@@ -37,7 +37,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key 23F3D4EA75716059
           sudo apt-add-repository https://cli.github.com/packages
           sudo apt update
           sudo apt-get install gh


### PR DESCRIPTION
Update github apt repository signing key id

C99B11DEB97541F0 -> 23F3D4EA75716059

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
