### PR TITLE
Use additional OpensslCredentials_t parameter for hostname checking.

### DIFF
--- a/platform/posix/transport/include/openssl_posix.h
+++ b/platform/posix/transport/include/openssl_posix.h
@@ -119,6 +119,11 @@ typedef struct OpensslCredentials
     const char * sniHostName;
 
     /**
+     * @brief If non-zero, don't compare hostname to server certificate subject.
+     */
+    uint8_t disableHostnameCheck;
+
+    /**
      * @brief Set the value for the TLS max fragment length (TLS MFLN)
      *
      * OpenSSL allows this value to be in the range of:

--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -244,12 +244,15 @@ static OpensslStatus_t tlsHandshake( const ServerInfo_t * pServerInfo,
     int32_t sslStatus = -1;
 
     /* Validate the hostname against the server's certificate. */
-    sslStatus = SSL_set1_host( pOpensslParams->pSsl, pServerInfo->pHostName );
-
-    if( sslStatus != 1 )
+    if( pOpensslCredentials->disableHostnameCheck == 0U )
     {
-        LogError( ( "SSL_set1_host failed to set the hostname to validate." ) );
-        returnStatus = OPENSSL_API_ERROR;
+        sslStatus = SSL_set1_host( pOpensslParams->pSsl, pServerInfo->pHostName );
+
+        if( sslStatus != 1 )
+        {
+            LogError( ( "SSL_set1_host failed to set the hostname to validate." ) );
+            returnStatus = OPENSSL_API_ERROR;
+        }
     }
 
     /* Enable SSL peer verification. */

--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -241,7 +241,7 @@ static OpensslStatus_t tlsHandshake( const ServerInfo_t * pServerInfo,
                                      const OpensslCredentials_t * pOpensslCredentials )
 {
     OpensslStatus_t returnStatus = OPENSSL_SUCCESS;
-    int32_t sslStatus = -1;
+    int32_t sslStatus = -1, verifyPeerCertStatus = X509_V_OK;
 
     /* Validate the hostname against the server's certificate. */
     if( pOpensslCredentials->disableHostnameCheck == 0U )
@@ -281,6 +281,19 @@ static OpensslStatus_t tlsHandshake( const ServerInfo_t * pServerInfo,
         if( sslStatus != 1 )
         {
             LogError( ( "SSL_connect failed to perform TLS handshake." ) );
+            returnStatus = OPENSSL_HANDSHAKE_FAILED;
+        }
+    }
+
+    /* Verify X509 certificate from peer. */
+    if( returnStatus == OPENSSL_SUCCESS )
+    {
+        verifyPeerCertStatus = ( int32_t ) SSL_get_verify_result( pOpensslParams->pSsl );
+
+        if( verifyPeerCertStatus != X509_V_OK )
+        {
+            LogError( ( "SSL_get_verify_result failed to verify X509 "
+                        "certificate from peer." ) );
             returnStatus = OPENSSL_HANDSHAKE_FAILED;
         }
     }

--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -241,7 +241,7 @@ static OpensslStatus_t tlsHandshake( const ServerInfo_t * pServerInfo,
                                      const OpensslCredentials_t * pOpensslCredentials )
 {
     OpensslStatus_t returnStatus = OPENSSL_SUCCESS;
-    int32_t sslStatus = -1, verifyPeerCertStatus = X509_V_OK;
+    int32_t sslStatus = -1;
 
     /* Validate the hostname against the server's certificate. */
     sslStatus = SSL_set1_host( pOpensslParams->pSsl, pServerInfo->pHostName );
@@ -278,19 +278,6 @@ static OpensslStatus_t tlsHandshake( const ServerInfo_t * pServerInfo,
         if( sslStatus != 1 )
         {
             LogError( ( "SSL_connect failed to perform TLS handshake." ) );
-            returnStatus = OPENSSL_HANDSHAKE_FAILED;
-        }
-    }
-
-    /* Verify X509 certificate from peer. */
-    if( returnStatus == OPENSSL_SUCCESS )
-    {
-        verifyPeerCertStatus = ( int32_t ) SSL_get_verify_result( pOpensslParams->pSsl );
-
-        if( verifyPeerCertStatus != X509_V_OK )
-        {
-            LogError( ( "SSL_get_verify_result failed to verify X509 "
-                        "certificate from peer." ) );
             returnStatus = OPENSSL_HANDSHAKE_FAILED;
         }
     }


### PR DESCRIPTION
This will allow demos to disable hostname checking, allowing them to be used with Greengrass or other endpoints that do not have the hostname in their certificate subject.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
