### PR TITLE
Add multiple topic sub/unsub test

### DIFF
--- a/integration-test/mqtt/mqtt_system_test.c
+++ b/integration-test/mqtt/mqtt_system_test.c
@@ -1893,7 +1893,7 @@ void test_MQTT_Subscribe_Unsubscribe_Multiple_Topics( void )
 
         TEST_ASSERT_EQUAL( MQTTSuccess, publishToTopic(
                                &context,
-                               TEST_MQTT_TOPIC,
+                               topicList[ i ],
                                false,     /* setRetainFlag */
                                false,     /* isDuplicate */
                                qos,       /* QoS */

--- a/integration-test/mqtt/mqtt_system_test.c
+++ b/integration-test/mqtt/mqtt_system_test.c
@@ -1850,7 +1850,6 @@ void test_MQTT_Publish_With_Retain_Flag( void )
 void test_MQTT_Subscribe_Unsubscribe_Multiple_Topics( void )
 {
     MQTTSubscribeInfo_t subscribeParams[ 5 ];
-    uint16_t usPacketID;
     char * topicList[ 5 ];
     size_t i;
     const size_t topicCount = 5U;
@@ -1868,16 +1867,16 @@ void test_MQTT_Subscribe_Unsubscribe_Multiple_Topics( void )
         subscribeParams[ i ].qos = ( i % 2 );
     }
 
-    usPacketID = MQTT_GetPacketId( &context );
+    globalSubscribePacketIdentifier = MQTT_GetPacketId( &context );
     /* Check that the packet ID is valid according to the MQTT spec. */
-    TEST_ASSERT_NOT_EQUAL( MQTT_PACKET_ID_INVALID, usPacketID );
-    TEST_ASSERT_NOT_EQUAL( 0U, usPacketID );
+    TEST_ASSERT_NOT_EQUAL( MQTT_PACKET_ID_INVALID, globalSubscribePacketIdentifier );
+    TEST_ASSERT_NOT_EQUAL( 0U, globalSubscribePacketIdentifier );
 
     /* Subscribe to all topics. */
     TEST_ASSERT_EQUAL( MQTTSuccess, MQTT_Subscribe( &context,
                                                     subscribeParams,
                                                     topicCount,
-                                                    usPacketID ) );
+                                                    globalSubscribePacketIdentifier ) );
 
     /* Expect a SUBACK from the broker for the subscribe operation. */
     TEST_ASSERT_FALSE( receivedSubAck );
@@ -1919,14 +1918,14 @@ void test_MQTT_Subscribe_Unsubscribe_Multiple_Topics( void )
                                   incomingInfo.payloadLength );
     }
 
-    usPacketID = MQTT_GetPacketId( &context );
+    globalUnsubscribePacketIdentifier = MQTT_GetPacketId( &context );
     /* Check that the packet ID is valid according to the MQTT spec. */
-    TEST_ASSERT_NOT_EQUAL( MQTT_PACKET_ID_INVALID, usPacketID );
-    TEST_ASSERT_NOT_EQUAL( 0U, usPacketID );
+    TEST_ASSERT_NOT_EQUAL( MQTT_PACKET_ID_INVALID, globalUnsubscribePacketIdentifier );
+    TEST_ASSERT_NOT_EQUAL( 0U, globalUnsubscribePacketIdentifier );
 
     /* Un-subscribe from all the topics. */
     TEST_ASSERT_EQUAL( MQTTSuccess, MQTT_Unsubscribe(
-                           &context, subscribeParams, topicCount, usPacketID ) );
+                           &context, subscribeParams, topicCount, globalUnsubscribePacketIdentifier ) );
 
     receivedUnsubAck = false;
 

--- a/integration-test/mqtt/mqtt_system_test.c
+++ b/integration-test/mqtt/mqtt_system_test.c
@@ -1021,6 +1021,7 @@ TEST_GROUP_RUNNER( coreMQTT_Integration_AWS_IoT_Compatible )
     RUN_TEST_CASE( coreMQTT_Integration_AWS_IoT_Compatible, test_MQTT_ProcessLoop_KeepAlive );
     RUN_TEST_CASE( coreMQTT_Integration_AWS_IoT_Compatible, test_MQTT_Resend_Unacked_Publish_QoS1 );
     RUN_TEST_CASE( coreMQTT_Integration_AWS_IoT_Compatible, test_MQTT_Restore_Session_Duplicate_Incoming_Publish_Qos1 );
+    RUN_TEST_CASE( coreMQTT_Integration_AWS_IoT_Compatible, test_MQTT_SubUnsub_Multiple_Topics );
     RUN_TEST_CASE( coreMQTT_Integration_AWS_IoT_Compatible, test_MQTT_Publish_With_Retain_Flag );
 }
 
@@ -1042,6 +1043,7 @@ TEST_GROUP_RUNNER( coreMQTT_Integration )
     RUN_TEST_CASE( coreMQTT_Integration, test_MQTT_Resend_Unacked_Publish_QoS2 );
     RUN_TEST_CASE( coreMQTT_Integration, test_MQTT_Restore_Session_Duplicate_Incoming_Publish_Qos2 );
     RUN_TEST_CASE( coreMQTT_Integration, test_MQTT_Publish_With_Retain_Flag );
+    RUN_TEST_CASE( coreMQTT_Integration, test_MQTT_SubUnsub_Multiple_Topics );
 }
 
 /* ========================== Test Cases ============================ */

--- a/integration-test/mqtt/mqtt_system_test.c
+++ b/integration-test/mqtt/mqtt_system_test.c
@@ -1894,9 +1894,9 @@ void test_MQTT_Subscribe_Unsubscribe_Multiple_Topics( void )
         TEST_ASSERT_EQUAL( MQTTSuccess, publishToTopic(
                                &context,
                                topicList[ i ],
-                               false,     /* setRetainFlag */
-                               false,     /* isDuplicate */
-                               qos,       /* QoS */
+                               false, /* setRetainFlag */
+                               false, /* isDuplicate */
+                               qos,   /* QoS */
                                MQTT_GetPacketId( &context ) ) );
 
         /* Reset the PUBACK flag. */

--- a/integration-test/mqtt/mqtt_system_test.c
+++ b/integration-test/mqtt/mqtt_system_test.c
@@ -1895,15 +1895,19 @@ void test_MQTT_Subscribe_Unsubscribe_Multiple_Topics( void )
                                ( i % 2 ), /* QoS */
                                MQTT_GetPacketId( &context ) ) );
 
-        /* Reset the PUBACK flag. */
-        receivedPubAck = false;
+        /* Only wait for PUBACK if QoS is not QoS0. */
+        if( ( i % 2 ) !=  0 )
+        {
+            /* Reset the PUBACK flag. */
+            receivedPubAck = false;
 
-        /* Expect a PUBACK response for the PUBLISH and an incoming PUBLISH for the
-         * same message that we published (as we have subscribed to the same topic). */
-        TEST_ASSERT_EQUAL( MQTTSuccess,
-                           processLoopWithTimeout( &context, MQTT_PROCESS_LOOP_TIMEOUT_MS ) );
-        /* Make sure we have received PUBACK response. */
-        TEST_ASSERT_TRUE( receivedPubAck );
+            /* Expect a PUBACK response for the PUBLISH and an incoming PUBLISH for the
+             * same message that we published (as we have subscribed to the same topic). */
+            TEST_ASSERT_EQUAL( MQTTSuccess,
+                               processLoopWithTimeout( &context, MQTT_PROCESS_LOOP_TIMEOUT_MS ) );
+            /* Make sure we have received PUBACK response. */
+            TEST_ASSERT_TRUE( receivedPubAck );
+        }
 
         /* Make sure that we have received the same message from the server,
          * that was published (as we have subscribed to the same topic). */


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds a test to verify multiple subscription and unsubscribe requests succeed when done through a single API call.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
