### PR TITLE
Update doxygen version for Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,7 @@ jobs:
           submodules: recursive
       - name: Install Doxygen
         run: |
-          wget -qO- "https://sourceforge.net/projects/doxygen/files/rel-1.9.2/doxygen-1.9.2.linux.bin.tar.gz/download" | sudo tar --strip-components=1 -xz -C /usr/local
+          wget -qO- "https://sourceforge.net/projects/doxygen/files/rel-1.9.5/doxygen-1.9.5.linux.bin.tar.gz/download" | sudo tar --strip-components=1 -xz -C /usr/local
           sudo apt-get install -y libclang-9-dev libclang-cpp9 graphviz
       - name: Install Python3
         uses: actions/setup-python@v2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR updates the version of doxygen to 1.9.5 which is the latest version supported by the new LTS version of Ubuntu 22.04.

_**NOTE: This PR will fail multiple CI checks as the latest version of ubuntu has changed from 20.04 to 22.04. This has led to multiple tools being deprecated/updated in the latest version of ubuntu.
The CI repository cannot be updated as well directly since there is a dependency on this repository (forming a circular dependency). The CI checks will continue to fail till this repository is not updated and then the CI repository will need to be updated.**_


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
