### PR TITLE
Fixing a typo in thing name header field

### DIFF
--- a/demos/http/http_demo_s3_download/http_demo_s3_download.c
+++ b/demos/http/http_demo_s3_download/http_demo_s3_download.c
@@ -182,7 +182,7 @@
 /**
  * @brief HTTP header name for specifying the IOT Thing resource name in request to AWS S3.
  */
-#define AWS_IOT_THING_NAME_HEADER_FIELD               "x-amz-iot-thing-name"
+#define AWS_IOT_THING_NAME_HEADER_FIELD               "x-amzn-iot-thingname"
 
 /**
  * @brief Field name of the HTTP date header to read from the AWS IOT credential provider server response.


### PR DESCRIPTION
The header field for passing thing name in AWS IoT Credential Provider was incorrect. As per documentation, the header should be 'x-amz-iot-thingname'

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
