### PR TITLE
demos: Fix unbounded write in sscanf call

### DIFF
--- a/demos/defender/defender_demo_json/metrics_collector.c
+++ b/demos/defender/defender_demo_json/metrics_collector.c
@@ -612,7 +612,7 @@ MetricsCollectorStatus_t GetNetworkInferfaceInfo( char ( *pOutNetworkInterfaceNa
                 LogDebug( ( "File: /proc/net/arp, Content: %s.", &( lineBuffer[ 0 ] ) ) );
 
                 filledVariables = sscanf( lineBuffer,
-                                          "%u.%u.%u.%u %*s %*s %*s %*s %s",
+                                          "%u.%u.%u.%u %*s %*s %*s %*s %15s",
                                           &ipPart1,
                                           &ipPart2,
                                           &ipPart3,


### PR DESCRIPTION
Buffer write operations that do not control the length of data written may overflow.

*Description of changes:*
Change format specifier from "%s" to "%15s".

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
