### PR TITLE
Update hyperlink for version 202211.00 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
     * [Sending metrics to AWS IoT](#sending-metrics-to-aws-iot)
 * [Versioning](#versioning)
 * [Releases and Documentation](#releases-and-documentation)
-    * [202211.00](#20210800)
+    * [202211.00](#20221100)
     * [202108.00](#20210800)
     * [202103.00](#20210300)
     * [202012.01](#20201201)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
     * [Sending metrics to AWS IoT](#sending-metrics-to-aws-iot)
 * [Versioning](#versioning)
 * [Releases and Documentation](#releases-and-documentation)
-    * [202211.00](#20221100)
+    * [202211.00](#20210800)
     * [202108.00](#20210800)
     * [202103.00](#20210300)
     * [202012.01](#20201201)


### PR DESCRIPTION
The current 202210.00 hyperlink point to 202108.00;
This PR is submitted to update the hyperlink.