### PR TITLE
OTA HTTP demo, default ROOT_CA_CERT_PATH_HTTP to ROOT_CA_CERT_PATH

### DIFF
--- a/demos/ota/ota_demo_core_http/demo_config.h
+++ b/demos/ota/ota_demo_core_http/demo_config.h
@@ -114,7 +114,7 @@
  * @note This certificate should be PEM-encoded.
  */
 #ifndef ROOT_CA_CERT_PATH_HTTP
-    #define ROOT_CA_CERT_PATH_HTTP    "certificates/AmazonRootCA1.crt"
+    #define ROOT_CA_CERT_PATH_HTTP    ROOT_CA_CERT_PATH
 #endif
 
 /**


### PR DESCRIPTION
*Description of changes:*

For OTA HTTP demo, wouldn't make sense to default ROOT_CA_CERT_PATH_HTTP  to ROOT_CA_CERT_PATH rather than ROOT_CA_CERT_PATH's default?

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
