### PR TITLE
Fix mqtt_demo_mutual_auth username parameters for client authentication

### DIFF
--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -1122,7 +1122,10 @@ static int establishMqttSession( MQTTContext_t * pMqttContext,
     int returnStatus = EXIT_SUCCESS;
     MQTTStatus_t mqttStatus;
     MQTTConnectInfo_t connectInfo = { 0 };
-    void * pMemchrPtr;
+
+    #ifdef CLIENT_USERNAME
+        void * pMemchrPtr;
+    #endif
 
     assert( pMqttContext != NULL );
     assert( pSessionPresent != NULL );
@@ -1181,7 +1184,7 @@ static int establishMqttSession( MQTTContext_t * pMqttContext,
 
         connectInfo.pPassword = CLIENT_PASSWORD;
         connectInfo.passwordLength = strlen( CLIENT_PASSWORD );
-    #else  /* ifdef CLIENT_USERNAME */
+    #else /* ifdef CLIENT_USERNAME */
         connectInfo.pUserName = METRICS_STRING;
         connectInfo.userNameLength = METRICS_STRING_LENGTH;
         /* Password for authentication is not used. */

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -387,17 +387,6 @@ struct NetworkContext
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Check if client username contains parameter.
- *
- * @param[in] pClientUsername Pointer to client username.
- * @param[in] clientUsernameLength Length of client username pointed by pClientUsername;
- *
- * @return ture if client username contains parameter. Otherwise, false.
- */
-static bool checkUsernameParameter( const char * pClientUsername,
-                                    size_t clientUsernameLength );
-
-/**
  * @brief The random number generator to use for exponential backoff with
  * jitter retry logic.
  *
@@ -619,6 +608,7 @@ static int waitForPacketAck( MQTTContext_t * pMqttContext,
  */
 static MQTTStatus_t processLoopWithTimeout( MQTTContext_t * pMqttContext,
                                             uint32_t ulTimeoutMs );
+
 
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
Support parameters in CLIENT_USERNAME

**Description**
Before this PR, CLIENT_USERNAME can't be appended with extra parameters. These parameters are used in client authentication to specify token, signature and authorizer.


**Test**
Specify the authorizer in CLIENT_USERNAME should be able to connect to AWS IoT core.
For example,
```
#define CLIENT_USERNAME    "Test?x-amz-customauthorizer-name=test_nodejs"
```

**Issue**
#1885 


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
