### PR TITLE
Use ROOT_DIR variable instead of CMAKE_SOURCE_DIR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,7 @@ jobs:
         uses: FreeRTOS/CI-CD-GitHub-Actions/link-verifier@main
         with:
           path: ./
-          exclude-dirs: cmock,unity,cbmc,third-party,3rdparty,libmosquitto
+          exclude-dirs: cmock,unity,cbmc,third-party,3rdparty,libmosquitto,libraries
           include-file-types: .c,.h,.dox
           allowlist-file: ./.github/links_allowlist.txt
   verify-manifest:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
           fi
       - name: Upload doxygen artifact if main branch
         if: success() && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: doxygen.zip
           path: ./doxygen.zip

--- a/.github/workflows/localhost_demo_runner.yml
+++ b/.github/workflows/localhost_demo_runner.yml
@@ -205,7 +205,7 @@ jobs:
 
       - name: 'Upload demo logs'
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: demo_run_logs
           path: demo_run_logs

--- a/.github/workflows/tag-and-zip.yml
+++ b/.github/workflows/tag-and-zip.yml
@@ -110,7 +110,7 @@ jobs:
           ctest -E system --output-on-failure
           cd ..
       - name: Create artifact of ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: aws-iot-device-sdk-embedded-C-${{ github.event.inputs.version_number }}.zip
           path: zip-check/aws-iot-device-sdk-embedded-C-${{ github.event.inputs.version_number }}.zip

--- a/demos/defender/defender_demo_json/CMakeLists.txt
+++ b/demos/defender/defender_demo_json/CMakeLists.txt
@@ -1,16 +1,16 @@
 set( DEMO_NAME "defender_demo" )
 
 # Include MQTT library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 
 # Include backoffAlgorithm library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
 # Include JSON library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreJSON/jsonFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreJSON/jsonFilePaths.cmake )
 
 # Include Defender library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/aws/device-defender-for-aws-iot-embedded-sdk/defenderFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/aws/device-defender-for-aws-iot-embedded-sdk/defenderFilePaths.cmake )
 
 # CPP files are searched for supporting CI build checks that verify C++ linkage of the Device Defender library
 file( GLOB DEMO_SRCS "*.c*" )

--- a/demos/fleet_provisioning/fleet_provisioning_keys_cert/CMakeLists.txt
+++ b/demos/fleet_provisioning/fleet_provisioning_keys_cert/CMakeLists.txt
@@ -1,17 +1,17 @@
 set( DEMO_NAME "fleet_provisioning_keys_cert_demo" )
 
 # Include MQTT library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 
 # Include backoffAlgorithm library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
 # Include Fleet Provisioning library's source and header path variables.
 include(
-    ${CMAKE_SOURCE_DIR}/libraries/aws/fleet-provisioning-for-aws-iot-embedded-sdk/fleetprovisioningFilePaths.cmake )
+    ${ROOT_DIR}/libraries/aws/fleet-provisioning-for-aws-iot-embedded-sdk/fleetprovisioningFilePaths.cmake )
 
 # Set path to corePKCS11 and it's third party libraries.
-set(COREPKCS11_LOCATION "${CMAKE_SOURCE_DIR}/libraries/standard/corePKCS11")
+set(COREPKCS11_LOCATION "${ROOT_DIR}/libraries/standard/corePKCS11")
 set(CORE_PKCS11_3RDPARTY_LOCATION "${COREPKCS11_LOCATION}/source/dependency/3rdparty")
 
 # Include PKCS #11 library's source and header path variables.
@@ -50,7 +50,7 @@ target_include_directories( ${DEMO_NAME}
                               ${AWS_DEMO_INCLUDE_DIRS}
                               "${FLEET_PROVISIONING_INCLUDE_PUBLIC_DIRS}"
                               "${DEMOS_DIR}/pkcs11/common/include" # corePKCS11 config
-                              "${CMAKE_SOURCE_DIR}/platform/include"
+                              "${ROOT_DIR}/platform/include"
                               "${CMAKE_CURRENT_LIST_DIR}"
                             PRIVATE
                               "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils" )

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/CMakeLists.txt
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/CMakeLists.txt
@@ -1,17 +1,17 @@
 set( DEMO_NAME "fleet_provisioning_with_csr_demo" )
 
 # Include MQTT library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 
 # Include backoffAlgorithm library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
 # Include Fleet Provisioning library's source and header path variables.
 include(
-    ${CMAKE_SOURCE_DIR}/libraries/aws/fleet-provisioning-for-aws-iot-embedded-sdk/fleetprovisioningFilePaths.cmake )
+    ${ROOT_DIR}/libraries/aws/fleet-provisioning-for-aws-iot-embedded-sdk/fleetprovisioningFilePaths.cmake )
 
 # Set path to corePKCS11 and it's third party libraries.
-set(COREPKCS11_LOCATION "${CMAKE_SOURCE_DIR}/libraries/standard/corePKCS11")
+set(COREPKCS11_LOCATION "${ROOT_DIR}/libraries/standard/corePKCS11")
 set(CORE_PKCS11_3RDPARTY_LOCATION "${COREPKCS11_LOCATION}/source/dependency/3rdparty")
 
 # Include PKCS #11 library's source and header path variables.
@@ -50,7 +50,7 @@ target_include_directories( ${DEMO_NAME}
                               ${AWS_DEMO_INCLUDE_DIRS}
                               "${FLEET_PROVISIONING_INCLUDE_PUBLIC_DIRS}"
                               "${DEMOS_DIR}/pkcs11/common/include" # corePKCS11 config
-                              "${CMAKE_SOURCE_DIR}/platform/include"
+                              "${ROOT_DIR}/platform/include"
                               "${CMAKE_CURRENT_LIST_DIR}"
                             PRIVATE
                               "${CORE_PKCS11_3RDPARTY_LOCATION}/mbedtls_utils" )

--- a/demos/greengrass/greengrass_demo_local_auth/CMakeLists.txt
+++ b/demos/greengrass/greengrass_demo_local_auth/CMakeLists.txt
@@ -1,10 +1,10 @@
 set( DEMO_NAME "greengrass_demo_local_auth" )
 
 # Include MQTT library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 
 # Include backoffAlgorithm library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
 # CPP files are searched for supporting CI build checks that verify C++ linkage of the coreMQTT library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )

--- a/demos/http/http_demo_basic_tls/CMakeLists.txt
+++ b/demos/http/http_demo_basic_tls/CMakeLists.txt
@@ -1,10 +1,10 @@
 set( DEMO_NAME "http_demo_basic_tls" )
 
 # Include HTTP library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 
 # Include backoffAlgorithm library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
 # CPP files are searched for supporting CI build checks that verify C++ linkage of the coreHTTP library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )

--- a/demos/http/http_demo_mutual_auth/CMakeLists.txt
+++ b/demos/http/http_demo_mutual_auth/CMakeLists.txt
@@ -1,10 +1,10 @@
 set( DEMO_NAME "http_demo_mutual_auth" )
 
 # Include HTTP library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 
 # Include backoffAlgorithm library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
 # CPP files are searched for supporting CI build checks that verify C++ linkage of the coreHTTP library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )

--- a/demos/http/http_demo_plaintext/CMakeLists.txt
+++ b/demos/http/http_demo_plaintext/CMakeLists.txt
@@ -1,10 +1,10 @@
 set( DEMO_NAME "http_demo_plaintext" )
 
 # Include HTTP library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 
 # Include backoffAlgorithm library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
 # CPP files are searched for supporting CI build checks that verify C++ linkage of the coreHTTP library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )

--- a/demos/http/http_demo_s3_download/CMakeLists.txt
+++ b/demos/http/http_demo_s3_download/CMakeLists.txt
@@ -1,16 +1,16 @@
 set( DEMO_NAME "http_demo_s3_download" )
 
 # Include HTTP library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 
 # Include backoffAlgorithm library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
 # Include coreJSON library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreJSON/jsonFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreJSON/jsonFilePaths.cmake )
 
 # Include sigV4 library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/aws/sigv4-for-aws-iot-embedded-sdk/sigv4FilePaths.cmake )
+include( ${ROOT_DIR}/libraries/aws/sigv4-for-aws-iot-embedded-sdk/sigv4FilePaths.cmake )
 
 # CPP files are searched for supporting CI build checks that verify C++ linkage of the coreHTTP library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )

--- a/demos/http/http_demo_s3_download_multithreaded/CMakeLists.txt
+++ b/demos/http/http_demo_s3_download_multithreaded/CMakeLists.txt
@@ -1,10 +1,10 @@
 set( DEMO_NAME "http_demo_s3_download_multithreaded" )
 
 # Include HTTP library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 
 # Include backoffAlgorithm library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
 # CPP files are searched for supporting CI build checks that verify C++ linkage of the coreHTTP library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )

--- a/demos/http/http_demo_s3_generate_presigned_url/CMakeLists.txt
+++ b/demos/http/http_demo_s3_generate_presigned_url/CMakeLists.txt
@@ -1,16 +1,16 @@
 set( DEMO_NAME "http_demo_s3_generate_presigned_url" )
 
 # Include HTTP library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 
 # Include backoffAlgorithm library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
 # Include coreJSON library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreJSON/jsonFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreJSON/jsonFilePaths.cmake )
 
 # Include sigV4 library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/aws/sigv4-for-aws-iot-embedded-sdk/sigv4FilePaths.cmake )
+include( ${ROOT_DIR}/libraries/aws/sigv4-for-aws-iot-embedded-sdk/sigv4FilePaths.cmake )
 
 # CPP files are searched for supporting CI build checks that verify C++ linkage of the coreHTTP library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )

--- a/demos/http/http_demo_s3_upload/CMakeLists.txt
+++ b/demos/http/http_demo_s3_upload/CMakeLists.txt
@@ -1,10 +1,10 @@
 set( DEMO_NAME "http_demo_s3_upload" )
 
 # Include HTTP library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 
 # Include backoffAlgorithm library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
 # CPP files are searched for supporting CI build checks that verify C++ linkage of the coreHTTP library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )

--- a/demos/jobs/jobs_demo_mosquitto/CMakeLists.txt
+++ b/demos/jobs/jobs_demo_mosquitto/CMakeLists.txt
@@ -4,8 +4,8 @@ set( DEMO_NAME "jobs_demo_mosquitto" )
 set_source_files_properties( "${DEMO_NAME}.c" PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter" )
 
 # Include library source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreJSON/jsonFilePaths.cmake )
-include( ${CMAKE_SOURCE_DIR}/libraries/aws/jobs-for-aws-iot-embedded-sdk/jobsFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreJSON/jsonFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/aws/jobs-for-aws-iot-embedded-sdk/jobsFilePaths.cmake )
 
 # Demo target.
 add_executable(

--- a/demos/mqtt/mqtt_demo_basic_tls/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_basic_tls/CMakeLists.txt
@@ -1,10 +1,10 @@
 set( DEMO_NAME "mqtt_demo_basic_tls" )
 
 # Include MQTT library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 
 # Include backoffAlgorithm library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
 # CPP files are searched for supporting CI build checks that verify C++ linkage of the coreMQTT library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )

--- a/demos/mqtt/mqtt_demo_mutual_auth/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_mutual_auth/CMakeLists.txt
@@ -1,10 +1,10 @@
 set( DEMO_NAME "mqtt_demo_mutual_auth" )
 
 # Include MQTT library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 
 # Include backoffAlgorithm library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
 # CPP files are searched for supporting CI build checks that verify C++ linkage of the coreMQTT library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )

--- a/demos/mqtt/mqtt_demo_plaintext/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_plaintext/CMakeLists.txt
@@ -1,10 +1,10 @@
 set( DEMO_NAME "mqtt_demo_plaintext" )
 
 # Include MQTT library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 
 # Include backoffAlgorithm library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
 # CPP files are searched for supporting CI build checks that verify C++ linkage of the coreMQTT library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )

--- a/demos/mqtt/mqtt_demo_serializer/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_serializer/CMakeLists.txt
@@ -1,10 +1,10 @@
 set( DEMO_NAME "mqtt_demo_serializer" )
 
 # Include MQTT library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 
 # Include backoffAlgorithm library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
 # CPP files are searched for supporting CI build checks that verify C++ linkage of the coreMQTT library
 file( GLOB DEMO_FILE "${DEMO_NAME}.c*" )

--- a/demos/mqtt/mqtt_demo_subscription_manager/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_subscription_manager/CMakeLists.txt
@@ -2,10 +2,10 @@
 add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/subscription-manager )
 
 # Include MQTT library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 
 # Include backoffAlgorithm library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
 set( DEMO_NAME "mqtt_demo_subscription_manager" )
 

--- a/demos/mqtt/mqtt_demo_subscription_manager/subscription-manager/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_subscription_manager/subscription-manager/CMakeLists.txt
@@ -1,8 +1,8 @@
 # Include MQTT library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 
 # Include backoffAlgorithm library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
 set( LIBRARY_NAME "mqtt_subscription_manager" )
 

--- a/demos/ota/ota_demo_core_http/CMakeLists.txt
+++ b/demos/ota/ota_demo_core_http/CMakeLists.txt
@@ -1,12 +1,12 @@
 set( DEMO_NAME "ota_demo_core_http" )
 
 # Include required library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/aws/ota-for-aws-iot-embedded-sdk/otaFilePaths.cmake )
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/aws/ota-for-aws-iot-embedded-sdk/otaFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 
 # Include backoffAlgorithm library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
 # Disable some warnings for llhttp sources.
 set_source_files_properties(

--- a/demos/ota/ota_demo_core_mqtt/CMakeLists.txt
+++ b/demos/ota/ota_demo_core_mqtt/CMakeLists.txt
@@ -1,11 +1,11 @@
 set( DEMO_NAME "ota_demo_core_mqtt" )
 
 # Include required library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/aws/ota-for-aws-iot-embedded-sdk/otaFilePaths.cmake )
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/aws/ota-for-aws-iot-embedded-sdk/otaFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 
 # Include backoffAlgorithm library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
 # Demo target.
 add_executable(

--- a/demos/pkcs11/pkcs11_demo_management_and_rng/CMakeLists.txt
+++ b/demos/pkcs11/pkcs11_demo_management_and_rng/CMakeLists.txt
@@ -1,7 +1,7 @@
 set( DEMO_NAME "pkcs11_demo_management_and_rng" )
 
 # Set path to corePKCS11 and it's third party libraries.
-set(COREPKCS11_LOCATION "${CMAKE_SOURCE_DIR}/libraries/standard/corePKCS11")
+set(COREPKCS11_LOCATION "${ROOT_DIR}/libraries/standard/corePKCS11")
 set(CORE_PKCS11_3RDPARTY_LOCATION "${COREPKCS11_LOCATION}/source/dependency/3rdparty")
 
 # Include PKCS #11 library's source and header path variables.

--- a/demos/pkcs11/pkcs11_demo_mechanisms_and_digests/CMakeLists.txt
+++ b/demos/pkcs11/pkcs11_demo_mechanisms_and_digests/CMakeLists.txt
@@ -1,7 +1,7 @@
 set( DEMO_NAME "pkcs11_demo_mechanisms_and_digests" )
 
 # Set path to corePKCS11 and its third party libraries.
-set(COREPKCS11_LOCATION "${CMAKE_SOURCE_DIR}/libraries/standard/corePKCS11")
+set(COREPKCS11_LOCATION "${ROOT_DIR}/libraries/standard/corePKCS11")
 set(CORE_PKCS11_3RDPARTY_LOCATION "${COREPKCS11_LOCATION}/source/dependency/3rdparty")
 
 # Include PKCS #11 library's source and header path variables.

--- a/demos/pkcs11/pkcs11_demo_objects/CMakeLists.txt
+++ b/demos/pkcs11/pkcs11_demo_objects/CMakeLists.txt
@@ -1,7 +1,7 @@
 set( DEMO_NAME "pkcs11_demo_objects" )
 
 # Set path to corePKCS11 and it's third party libraries.
-set(COREPKCS11_LOCATION "${CMAKE_SOURCE_DIR}/libraries/standard/corePKCS11")
+set(COREPKCS11_LOCATION "${ROOT_DIR}/libraries/standard/corePKCS11")
 set(CORE_PKCS11_3RDPARTY_LOCATION "${COREPKCS11_LOCATION}/source/dependency/3rdparty")
 
 # Include PKCS #11 library's source and header path variables.

--- a/demos/pkcs11/pkcs11_demo_sign_and_verify/CMakeLists.txt
+++ b/demos/pkcs11/pkcs11_demo_sign_and_verify/CMakeLists.txt
@@ -1,7 +1,7 @@
 set( DEMO_NAME "pkcs11_demo_sign_and_verify" )
 
 # Set path to corePKCS11 and it's third party libraries.
-set(COREPKCS11_LOCATION "${CMAKE_SOURCE_DIR}/libraries/standard/corePKCS11")
+set(COREPKCS11_LOCATION "${ROOT_DIR}/libraries/standard/corePKCS11")
 set(CORE_PKCS11_3RDPARTY_LOCATION "${COREPKCS11_LOCATION}/source/dependency/3rdparty")
 
 # Include PKCS #11 library's source and header path variables.

--- a/demos/shadow/shadow_demo_main/CMakeLists.txt
+++ b/demos/shadow/shadow_demo_main/CMakeLists.txt
@@ -1,16 +1,16 @@
 set( DEMO_NAME "shadow_demo_main" )
 
 # Include MQTT library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake )
 
 # Include backoffAlgorithm library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
 # Include Shadow library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/aws/device-shadow-for-aws-iot-embedded-sdk/shadowFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/aws/device-shadow-for-aws-iot-embedded-sdk/shadowFilePaths.cmake )
 
 # Include JSON library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreJSON/jsonFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreJSON/jsonFilePaths.cmake )
 
 # CPP files are searched for supporting CI build checks that verify C++ linkage of the Device Shadow library
 file( GLOB DEMO_SRCS "shadow_demo_helpers.c" "*.c*" )

--- a/integration-test/http/CMakeLists.txt
+++ b/integration-test/http/CMakeLists.txt
@@ -2,10 +2,10 @@ project ("http system test")
 cmake_minimum_required (VERSION 3.2.0)
 
 # Include HTTP library's source and header path variables.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/coreHTTP/httpFilePaths.cmake )
 
 # Include backoffAlgorithm library file path configuration.
-include( ${CMAKE_SOURCE_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
+include( ${ROOT_DIR}/libraries/standard/backoffAlgorithm/backoffAlgorithmFilePaths.cmake )
 
 # ====================  Define your project name (edit) ========================
 set(project_name "http_system")

--- a/integration-test/mqtt/CMakeLists.txt
+++ b/integration-test/mqtt/CMakeLists.txt
@@ -2,7 +2,7 @@ project ("mqtt system test")
 cmake_minimum_required (VERSION 3.2.0)
 
 # Include MQTT library's source and header path variables.
-include("${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake")
+include("${ROOT_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake")
 
 # ====================  Define your project name (edit) ========================
 set(project_name "mqtt_system")

--- a/integration-test/shadow/CMakeLists.txt
+++ b/integration-test/shadow/CMakeLists.txt
@@ -2,9 +2,9 @@ project ("shadow system test")
 cmake_minimum_required (VERSION 3.2.0)
 
 # Include MQTT library's source and header path variables.
-include("${CMAKE_SOURCE_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake")
+include("${ROOT_DIR}/libraries/standard/coreMQTT/mqttFilePaths.cmake")
 
-include("${CMAKE_SOURCE_DIR}/libraries/aws/device-shadow-for-aws-iot-embedded-sdk/shadowFilePaths.cmake")
+include("${ROOT_DIR}/libraries/aws/device-shadow-for-aws-iot-embedded-sdk/shadowFilePaths.cmake")
 
 # ====================  Define your project name (edit) ========================
 set(project_name "shadow_system")

--- a/platform/posix/transport/CMakeLists.txt
+++ b/platform/posix/transport/CMakeLists.txt
@@ -41,7 +41,7 @@ target_link_libraries( openssl_posix
                           ${CMAKE_DL_LIBS} )
 
 # Set path to corePKCS11 and it's third party libraries.
-set(COREPKCS11_LOCATION "${CMAKE_SOURCE_DIR}/libraries/standard/corePKCS11")
+set(COREPKCS11_LOCATION "${ROOT_DIR}/libraries/standard/corePKCS11")
 set(CORE_PKCS11_3RDPARTY_LOCATION "${COREPKCS11_LOCATION}/source/dependency/3rdparty")
 
 # Include PKCS #11 library's source and header path variables.

--- a/tools/cmock/coverage.cmake
+++ b/tools/cmock/coverage.cmake
@@ -37,7 +37,7 @@ endforeach()
 
 # generate Junit style xml output
 execute_process(COMMAND ruby
-    ${CMAKE_SOURCE_DIR}/../libraries/3rdparty/CMock/vendor/unity/auto/parse_output.rb
+    ${ROOT_DIR}/libraries/3rdparty/CMock/vendor/unity/auto/parse_output.rb
                     -xml ${REPORT_FILE}
                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
             )

--- a/tools/cmock/create_test.cmake
+++ b/tools/cmock/create_test.cmake
@@ -11,8 +11,8 @@ function(create_test test_name
     get_filename_component(test_src_absolute ${test_src} ABSOLUTE)
     add_custom_command(OUTPUT ${test_name}_runner.c
                   COMMAND ruby
-                    ${CMAKE_SOURCE_DIR}/libraries/3rdparty/CMock/vendor/unity/auto/generate_test_runner.rb
-                    ${CMAKE_SOURCE_DIR}/tools/cmock/project.yml
+                    ${ROOT_DIR}/libraries/3rdparty/CMock/vendor/unity/auto/generate_test_runner.rb
+                    ${ROOT_DIR}/tools/cmock/project.yml
                     ${test_src_absolute}
                     ${test_name}_runner.c
                   DEPENDS ${test_src}
@@ -26,10 +26,10 @@ function(create_test test_name
     if((DEFINED VARGS_USE_CUSTOM_RUNNER) AND (${VARGS_USE_CUSTOM_RUNNER}))
         add_executable(${test_name}
                          ${test_src}
-                         ${CMAKE_SOURCE_DIR}/integration-test/custom_test_runner/custom_unity_runner.c)
+                         ${ROOT_DIR}/integration-test/custom_test_runner/custom_unity_runner.c)
         target_include_directories(${test_name}
                                      PUBLIC
-                                     ${CMAKE_SOURCE_DIR}/integration-test/custom_test_runner)
+                                     ${ROOT_DIR}/integration-test/custom_test_runner)
         target_compile_definitions(${test_name} PUBLIC -DUSE_CUSTOM_RUNNER=1)
     else()
         add_executable(${test_name} ${test_src} ${test_name}_runner.c)
@@ -123,7 +123,7 @@ function(create_mock_list mock_name
         add_custom_command (
                   OUTPUT ${mocks_dir}/mock_${mock_file_name}.c
                   COMMAND ruby
-                  ${CMAKE_SOURCE_DIR}/libraries/3rdparty/CMock/lib/cmock.rb
+                  ${ROOT_DIR}/libraries/3rdparty/CMock/lib/cmock.rb
                   -o${cmock_config} ${mock_file_abs}
                   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                 )


### PR DESCRIPTION
*Issue #1916*

*Description of changes:*
Using CMAKE_SOURCE_DIR breaks everything when the SDK is not the top directory in the source tree.
The SDK's top CMakeLists file defines the ROOT_DIR variable which can be used instead.
This way the SDK can be integrated as a git submodule or using CMake's FetchContent.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
