### PR TITLE
Fix OTA_Shutdown() not releasing resources

### DIFF
--- a/demos/ota/ota_demo_core_http/ota_demo_core_http.c
+++ b/demos/ota/ota_demo_core_http/ota_demo_core_http.c
@@ -1944,6 +1944,8 @@ static void * otaThread( void * pParam )
     /* Calling OTA agent task. */
     OTA_EventProcessingTask( pParam );
     LogInfo( ( "OTA Agent stopped." ) );
+    pthread_detach(pthread_self());
+    pthread_exit(NULL);
     return NULL;
 }
 

--- a/demos/ota/ota_demo_core_http/ota_demo_core_http.c
+++ b/demos/ota/ota_demo_core_http/ota_demo_core_http.c
@@ -1944,8 +1944,8 @@ static void * otaThread( void * pParam )
     /* Calling OTA agent task. */
     OTA_EventProcessingTask( pParam );
     LogInfo( ( "OTA Agent stopped." ) );
-    pthread_detach(pthread_self());
-    pthread_exit(NULL);
+    pthread_detach( pthread_self() );
+    pthread_exit( NULL );
     return NULL;
 }
 


### PR DESCRIPTION
Related to #1910

Modify `otaThread` function in `demos/ota/ota_demo_core_http/ota_demo_core_http.c` to release resources properly.

* Add `pthread_detach(pthread_self());` to detach the thread.
* Add `pthread_exit(NULL);` to exit the thread.

