### PR TITLE
Fix/openssl connect close socket on error

### DIFF
--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -586,7 +586,7 @@ OpensslStatus_t Openssl_Connect( NetworkContext_t * pNetworkContext,
                                  uint32_t recvTimeoutMs )
 {
     OpensslParams_t * pOpensslParams = NULL;
-    SocketStatus_t socketStatus = SOCKETS_SUCCESS;
+    SocketStatus_t socketStatus = SOCKETS_CONNECT_FAILURE;
     OpensslStatus_t returnStatus = OPENSSL_SUCCESS;
     int32_t sslStatus = 0;
     uint8_t sslObjectCreated = 0;

--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -694,6 +694,9 @@ OpensslStatus_t Openssl_Connect( NetworkContext_t * pNetworkContext,
     if( returnStatus != OPENSSL_SUCCESS )
     {
         LogError( ( "Failed to establish a TLS connection." ) );
+        if( socketStatus == SOCKETS_SUCCESS ) {
+            Sockets_Disconnect( pOpensslParams->socketDescriptor );
+        }
     }
     else
     {

--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -694,6 +694,7 @@ OpensslStatus_t Openssl_Connect( NetworkContext_t * pNetworkContext,
     if( returnStatus != OPENSSL_SUCCESS )
     {
         LogError( ( "Failed to establish a TLS connection." ) );
+
         if( socketStatus == SOCKETS_SUCCESS )
         {
             Sockets_Disconnect( pOpensslParams->socketDescriptor );

--- a/platform/posix/transport/src/openssl_posix.c
+++ b/platform/posix/transport/src/openssl_posix.c
@@ -694,7 +694,8 @@ OpensslStatus_t Openssl_Connect( NetworkContext_t * pNetworkContext,
     if( returnStatus != OPENSSL_SUCCESS )
     {
         LogError( ( "Failed to establish a TLS connection." ) );
-        if( socketStatus == SOCKETS_SUCCESS ) {
+        if( socketStatus == SOCKETS_SUCCESS )
+        {
             Sockets_Disconnect( pOpensslParams->socketDescriptor );
         }
     }


### PR DESCRIPTION
*Issue #, if available:*
#1938 

*Description of changes:*

This pull request addresses the issue where the `Openssl_Connect` function fails to close the socket on error, leading to a file descriptor leak. The following changes have been made:
- Added logic to ensure that the socket is properly closed when an error occurs during the connection process.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
