### PR TITLE
Fix: change subscription QoS to 1 in mqtt_demo_basic_tls demo for AWS IoT Core compatibility

### DIFF
--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -1093,7 +1093,8 @@ static int subscribeToTopic( MQTTContext_t * pMqttContext )
     ( void ) memset( ( void * ) pGlobalSubscriptionList, 0x00, sizeof( pGlobalSubscriptionList ) );
 
     /* This example subscribes to only one topic and uses QOS2. */
-    pGlobalSubscriptionList[ 0 ].qos = MQTTQoS2;
+    /* AWS IoT Core does not support QoS2. Use QoS1 instead to avoid SSL_read failure. */
+    pGlobalSubscriptionList[ 0 ].qos = MQTTQoS1;
     pGlobalSubscriptionList[ 0 ].pTopicFilter = MQTT_EXAMPLE_TOPIC;
     pGlobalSubscriptionList[ 0 ].topicFilterLength = MQTT_EXAMPLE_TOPIC_LENGTH;
 
@@ -1135,8 +1136,9 @@ static int unsubscribeFromTopic( MQTTContext_t * pMqttContext )
     ( void ) memset( ( void * ) pGlobalSubscriptionList, 0x00, sizeof( pGlobalSubscriptionList ) );
 
     /* This example subscribes to and unsubscribes from only one topic
-     * and uses QOS2. */
-    pGlobalSubscriptionList[ 0 ].qos = MQTTQoS2;
+     * and uses QOS2. */    
+    /* AWS IoT Core does not support QoS2. Use QoS1 instead to avoid SSL_read failure. */
+    pGlobalSubscriptionList[ 0 ].qos = MQTTQoS1;
     pGlobalSubscriptionList[ 0 ].pTopicFilter = MQTT_EXAMPLE_TOPIC;
     pGlobalSubscriptionList[ 0 ].topicFilterLength = MQTT_EXAMPLE_TOPIC_LENGTH;
 
@@ -1188,7 +1190,8 @@ static int publishToTopic( MQTTContext_t * pMqttContext )
     else
     {
         /* This example publishes to only one topic and uses QOS2. */
-        outgoingPublishPackets[ publishIndex ].pubInfo.qos = MQTTQoS2;
+        /* AWS IoT Core does not support QoS2. Use QoS1 instead to avoid SSL_read failure. */
+        outgoingPublishPackets[ publishIndex ].pubInfo.qos = MQTTQoS1;
         outgoingPublishPackets[ publishIndex ].pubInfo.pTopicName = MQTT_EXAMPLE_TOPIC;
         outgoingPublishPackets[ publishIndex ].pubInfo.topicNameLength = MQTT_EXAMPLE_TOPIC_LENGTH;
         outgoingPublishPackets[ publishIndex ].pubInfo.pPayload = MQTT_EXAMPLE_MESSAGE;


### PR DESCRIPTION
### Problem:
The mqtt_demo_basic_tls demo sets subscription QoS to `MQTTQoS2` by default, which is not supported by AWS IoT Core.
Attempting to subscribe with QoS2 causes the TLS session to close, resulting in `SSL_read failed`.
The same error happened for publishing if using QoS2.

debug log:
[INFO] [DEMO] [mqtt_demo_basic_tls.c:573] Establishing a TLS session to afi154mel0eud-ats.iot.us-east-1.amazonaws.com:8883.
[INFO] [MQTT] [core_mqtt.c:2999] MQTT connection established with the broker.
[INFO] [DEMO] [mqtt_demo_basic_tls.c:1059] MQTT connection successfully established with broker.

[INFO] [DEMO] [mqtt_demo_basic_tls.c:1575] A clean MQTT connection is established. Cleaning up all the stored outgoing publishes.

[INFO] [DEMO] [mqtt_demo_basic_tls.c:1310] Subscribing to the MQTT topic sdk/test/python.
[INFO] [DEMO] [mqtt_demo_basic_tls.c:1127] SUBSCRIBE sent for topic sdk/test/python to broker.


[ERROR] [Transport_OpenSSL_Sockets] [openssl_posix.c:850] Failed to receive data over network: SSL_read failed: ErrorStatus=EVP lib.
[ERROR] [MQTT] [core_mqtt.c:1803] Call to receiveSingleIteration failed. Status=MQTTRecvFailed
[ERROR] [DEMO] [mqtt_demo_basic_tls.c:1456] MQTT_ProcessLoop failed to receive ACK packet: Expected ACK Packet ID=01, LoopDuration=486, Status=MQTTRecvFailed
[INFO] [DEMO] [mqtt_demo_basic_tls.c:1399] Disconnecting the MQTT connection with afi154mel0eud-ats.iot.us-east-1.amazonaws.com.
[INFO] [MQTT] [core_mqtt.c:3404] Disconnected from the broker.
[ERROR] [MQTT] [core_mqtt.c:3411] MQTT Connection Disconnected Successfully
[INFO] [DEMO] [mqtt_demo_basic_tls.c:1595] Short delay before starting the next iteration ....


### Fix:
Changed the subscription QoS to `MQTTQoS1`, which works correctly with AWS IoT Core.

### Tested on:
- STM32MP157 with Buildroot Linux

This fix ensures out-of-box demo compatibility with AWS IoT Core.