### PR TITLE
Upgrade MQTT demos to v5 

### DIFF
--- a/demos/defender/defender_demo_json/demo_config.h
+++ b/demos/defender/defender_demo_json/demo_config.h
@@ -85,6 +85,7 @@
  * @note This path is relative from the demo binary created. Update
  * ROOT_CA_CERT_PATH to the absolute path if this demo is executed from elsewhere.
  */
+
 #ifndef ROOT_CA_CERT_PATH
     #define ROOT_CA_CERT_PATH    "certificates/AmazonRootCA1.crt"
 #endif
@@ -97,7 +98,7 @@
  * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
  *
  * @note This certificate should be PEM-encoded.
- *
+ *m 
  * #define CLIENT_CERT_PATH    "...insert here..."
  */
 

--- a/demos/defender/defender_demo_json/mqtt_operations.c
+++ b/demos/defender/defender_demo_json/mqtt_operations.c
@@ -343,7 +343,10 @@ static void cleanupOutgoingPublishWithPacketID( uint16_t packetId );
  */
 static void mqttCallback( MQTTContext_t * pMqttContext,
                           MQTTPacketInfo_t * pPacketInfo,
-                          MQTTDeserializedInfo_t * pDeserializedInfo );
+                          MQTTDeserializedInfo_t * pDeserializedInfo, 
+                          MQTTSuccessFailReasonCode_t * pReasonCode,
+                          MQTTPropBuilder_t * sendPropsBuffer,
+                          MQTTPropBuilder_t * getPropsBuffer ); 
 
 /**
  * @brief Resend the publishes if a session is re-established with the broker.
@@ -555,7 +558,10 @@ static void cleanupOutgoingPublishWithPacketID( uint16_t packetId )
 
 static void mqttCallback( MQTTContext_t * pMqttContext,
                           MQTTPacketInfo_t * pPacketInfo,
-                          MQTTDeserializedInfo_t * pDeserializedInfo )
+                          MQTTDeserializedInfo_t * pDeserializedInfo, 
+                          MQTTSuccessFailReasonCode_t * pReasonCode,
+                          MQTTPropBuilder_t * sendPropsBuffer,
+                          MQTTPropBuilder_t * getPropsBuffer )
 {
     uint16_t packetIdentifier;
 
@@ -659,7 +665,7 @@ static bool handlePublishResend( MQTTContext_t * pMqttContext )
                         outgoingPublishPackets[ index ].packetId ) );
             mqttStatus = MQTT_Publish( pMqttContext,
                                        &outgoingPublishPackets[ index ].pubInfo,
-                                       outgoingPublishPackets[ index ].packetId );
+                                       outgoingPublishPackets[ index ].packetId , NULL);
 
             if( mqttStatus != MQTTSuccess )
             {
@@ -799,7 +805,7 @@ bool EstablishMqttSession( MQTTPublishCallback_t publishCallback )
                                                pOutgoingPublishRecords,
                                                OUTGOING_PUBLISH_RECORD_LEN,
                                                pIncomingPublishRecords,
-                                               INCOMING_PUBLISH_RECORD_LEN );
+                                               INCOMING_PUBLISH_RECORD_LEN, NULL, 0 );
 
             if( mqttStatus != MQTTSuccess )
             {
@@ -842,7 +848,7 @@ bool EstablishMqttSession( MQTTPublishCallback_t publishCallback )
                                            &connectInfo,
                                            NULL,
                                            CONNACK_RECV_TIMEOUT_MS,
-                                           &sessionPresent );
+                                           &sessionPresent, NULL, NULL );
 
                 if( mqttStatus != MQTTSuccess )
                 {
@@ -908,7 +914,7 @@ bool DisconnectMqttSession( void )
     if( mqttSessionEstablished == true )
     {
         /* Send DISCONNECT. */
-        mqttStatus = MQTT_Disconnect( pMqttContext );
+        mqttStatus = MQTT_Disconnect( pMqttContext , NULL, MQTT_REASON_DISCONNECT_NORMAL_DISCONNECTION);
 
         if( mqttStatus != MQTTSuccess )
         {
@@ -956,7 +962,7 @@ bool SubscribeToTopic( const char * pTopicFilter,
     mqttStatus = MQTT_Subscribe( pMqttContext,
                                  pSubscriptionList,
                                  sizeof( pSubscriptionList ) / sizeof( MQTTSubscribeInfo_t ),
-                                 globalSubscribePacketIdentifier );
+                                 globalSubscribePacketIdentifier, NULL);
 
     if( mqttStatus != MQTTSuccess )
     {
@@ -1012,7 +1018,7 @@ bool UnsubscribeFromTopic( const char * pTopicFilter,
     mqttStatus = MQTT_Unsubscribe( pMqttContext,
                                    pSubscriptionList,
                                    sizeof( pSubscriptionList ) / sizeof( MQTTSubscribeInfo_t ),
-                                   globalUnsubscribePacketIdentifier );
+                                   globalUnsubscribePacketIdentifier, NULL);
 
     if( mqttStatus != MQTTSuccess )
     {
@@ -1080,7 +1086,7 @@ bool PublishToTopic( const char * pTopicFilter,
         /* Send PUBLISH packet. */
         mqttStatus = MQTT_Publish( pMqttContext,
                                    &outgoingPublishPackets[ publishIndex ].pubInfo,
-                                   outgoingPublishPackets[ publishIndex ].packetId );
+                                   outgoingPublishPackets[ publishIndex ].packetId , NULL );
 
         if( mqttStatus != MQTTSuccess )
         {

--- a/demos/fleet_provisioning/fleet_provisioning_keys_cert/demo_config.h
+++ b/demos/fleet_provisioning/fleet_provisioning_keys_cert/demo_config.h
@@ -85,6 +85,7 @@
  * @note This path is relative from the demo binary created. Update
  * ROOT_CA_CERT_PATH to the absolute path if this demo is executed from elsewhere.
  */
+
 #ifndef ROOT_CA_CERT_PATH
     #define ROOT_CA_CERT_PATH    "certificates/AmazonRootCA1.crt"
 #endif

--- a/demos/fleet_provisioning/fleet_provisioning_keys_cert/mqtt_operations.c
+++ b/demos/fleet_provisioning/fleet_provisioning_keys_cert/mqtt_operations.c
@@ -343,7 +343,10 @@ static void cleanupOutgoingPublishWithPacketID( uint16_t packetId );
  */
 static void mqttCallback( MQTTContext_t * pMqttContext,
                           MQTTPacketInfo_t * pPacketInfo,
-                          MQTTDeserializedInfo_t * pDeserializedInfo );
+                          MQTTDeserializedInfo_t * pDeserializedInfo,
+                          MQTTSuccessFailReasonCode_t * pReasonCode,
+                          MQTTPropBuilder_t * sendPropsBuffer,
+                          MQTTPropBuilder_t * getPropsBuffer  ); 
 
 /**
  * @brief Resend the publishes if a session is re-established with the broker.
@@ -548,7 +551,10 @@ static void cleanupOutgoingPublishWithPacketID( uint16_t packetId )
 
 static void mqttCallback( MQTTContext_t * pMqttContext,
                           MQTTPacketInfo_t * pPacketInfo,
-                          MQTTDeserializedInfo_t * pDeserializedInfo )
+                          MQTTDeserializedInfo_t * pDeserializedInfo,
+                          MQTTSuccessFailReasonCode_t * pReasonCode,
+                          MQTTPropBuilder_t * sendPropsBuffer,
+                          MQTTPropBuilder_t * getPropsBuffer  )
 {
     uint16_t packetIdentifier;
 
@@ -652,7 +658,7 @@ static bool handlePublishResend( MQTTContext_t * pMqttContext )
                         outgoingPublishPackets[ index ].packetId ) );
             mqttStatus = MQTT_Publish( pMqttContext,
                                        &outgoingPublishPackets[ index ].pubInfo,
-                                       outgoingPublishPackets[ index ].packetId );
+                                       outgoingPublishPackets[ index ].packetId, NULL);
 
             if( mqttStatus != MQTTSuccess )
             {
@@ -798,7 +804,7 @@ bool EstablishMqttSession( MQTTPublishCallback_t publishCallback,
                                                pOutgoingPublishRecords,
                                                OUTGOING_PUBLISH_RECORD_LEN,
                                                pIncomingPublishRecords,
-                                               INCOMING_PUBLISH_RECORD_LEN );
+                                               INCOMING_PUBLISH_RECORD_LEN, NULL, 0);
 
             if( mqttStatus != MQTTSuccess )
             {
@@ -841,7 +847,7 @@ bool EstablishMqttSession( MQTTPublishCallback_t publishCallback,
                                            &connectInfo,
                                            NULL,
                                            CONNACK_RECV_TIMEOUT_MS,
-                                           &sessionPresent );
+                                           &sessionPresent, NULL, NULL );
 
                 if( mqttStatus != MQTTSuccess )
                 {
@@ -908,7 +914,7 @@ bool DisconnectMqttSession( void )
     if( mqttSessionEstablished == true )
     {
         /* Send DISCONNECT. */
-        mqttStatus = MQTT_Disconnect( pMqttContext );
+        mqttStatus = MQTT_Disconnect( pMqttContext, NULL, 0 );
 
         if( mqttStatus != MQTTSuccess )
         {
@@ -956,7 +962,7 @@ bool SubscribeToTopic( const char * pTopicFilter,
     mqttStatus = MQTT_Subscribe( pMqttContext,
                                  pSubscriptionList,
                                  sizeof( pSubscriptionList ) / sizeof( MQTTSubscribeInfo_t ),
-                                 globalSubscribePacketIdentifier );
+                                 globalSubscribePacketIdentifier, NULL);
 
     if( mqttStatus != MQTTSuccess )
     {
@@ -1012,7 +1018,7 @@ bool UnsubscribeFromTopic( const char * pTopicFilter,
     mqttStatus = MQTT_Unsubscribe( pMqttContext,
                                    pSubscriptionList,
                                    sizeof( pSubscriptionList ) / sizeof( MQTTSubscribeInfo_t ),
-                                   globalUnsubscribePacketIdentifier );
+                                   globalUnsubscribePacketIdentifier, NULL );
 
     if( mqttStatus != MQTTSuccess )
     {
@@ -1080,7 +1086,7 @@ bool PublishToTopic( const char * pTopicFilter,
         /* Send PUBLISH packet. */
         mqttStatus = MQTT_Publish( pMqttContext,
                                    &outgoingPublishPackets[ publishIndex ].pubInfo,
-                                   outgoingPublishPackets[ publishIndex ].packetId );
+                                   outgoingPublishPackets[ publishIndex ].packetId, NULL );
 
         if( mqttStatus != MQTTSuccess )
         {

--- a/demos/fleet_provisioning/fleet_provisioning_with_csr/mqtt_operations.c
+++ b/demos/fleet_provisioning/fleet_provisioning_with_csr/mqtt_operations.c
@@ -343,7 +343,10 @@ static void cleanupOutgoingPublishWithPacketID( uint16_t packetId );
  */
 static void mqttCallback( MQTTContext_t * pMqttContext,
                           MQTTPacketInfo_t * pPacketInfo,
-                          MQTTDeserializedInfo_t * pDeserializedInfo );
+                          MQTTDeserializedInfo_t * pDeserializedInfo, 
+                          MQTTSuccessFailReasonCode_t * pReasonCode,
+                          MQTTPropBuilder_t * sendPropsBuffer,
+                          MQTTPropBuilder_t * getPropsBuffer ); 
 
 /**
  * @brief Resend the publishes if a session is re-established with the broker.
@@ -548,7 +551,10 @@ static void cleanupOutgoingPublishWithPacketID( uint16_t packetId )
 
 static void mqttCallback( MQTTContext_t * pMqttContext,
                           MQTTPacketInfo_t * pPacketInfo,
-                          MQTTDeserializedInfo_t * pDeserializedInfo )
+                          MQTTDeserializedInfo_t * pDeserializedInfo, 
+                          MQTTSuccessFailReasonCode_t * pReasonCode,
+                          MQTTPropBuilder_t * sendPropsBuffer,
+                          MQTTPropBuilder_t * getPropsBuffer )
 {
     uint16_t packetIdentifier;
 
@@ -652,7 +658,8 @@ static bool handlePublishResend( MQTTContext_t * pMqttContext )
                         outgoingPublishPackets[ index ].packetId ) );
             mqttStatus = MQTT_Publish( pMqttContext,
                                        &outgoingPublishPackets[ index ].pubInfo,
-                                       outgoingPublishPackets[ index ].packetId );
+                                       outgoingPublishPackets[ index ].packetId,
+                                       NULL );
 
             if( mqttStatus != MQTTSuccess )
             {
@@ -798,7 +805,7 @@ bool EstablishMqttSession( MQTTPublishCallback_t publishCallback,
                                                pOutgoingPublishRecords,
                                                OUTGOING_PUBLISH_RECORD_LEN,
                                                pIncomingPublishRecords,
-                                               INCOMING_PUBLISH_RECORD_LEN );
+                                               INCOMING_PUBLISH_RECORD_LEN, NULL, 0);
 
             if( mqttStatus != MQTTSuccess )
             {
@@ -841,7 +848,9 @@ bool EstablishMqttSession( MQTTPublishCallback_t publishCallback,
                                            &connectInfo,
                                            NULL,
                                            CONNACK_RECV_TIMEOUT_MS,
-                                           &sessionPresent );
+                                           &sessionPresent,
+                                           NULL, 
+                                           NULL);
 
                 if( mqttStatus != MQTTSuccess )
                 {
@@ -908,7 +917,7 @@ bool DisconnectMqttSession( void )
     if( mqttSessionEstablished == true )
     {
         /* Send DISCONNECT. */
-        mqttStatus = MQTT_Disconnect( pMqttContext );
+        mqttStatus = MQTT_Disconnect( pMqttContext, NULL, 0 );
 
         if( mqttStatus != MQTTSuccess )
         {
@@ -956,7 +965,8 @@ bool SubscribeToTopic( const char * pTopicFilter,
     mqttStatus = MQTT_Subscribe( pMqttContext,
                                  pSubscriptionList,
                                  sizeof( pSubscriptionList ) / sizeof( MQTTSubscribeInfo_t ),
-                                 globalSubscribePacketIdentifier );
+                                 globalSubscribePacketIdentifier,
+                                 NULL );
 
     if( mqttStatus != MQTTSuccess )
     {
@@ -1012,7 +1022,8 @@ bool UnsubscribeFromTopic( const char * pTopicFilter,
     mqttStatus = MQTT_Unsubscribe( pMqttContext,
                                    pSubscriptionList,
                                    sizeof( pSubscriptionList ) / sizeof( MQTTSubscribeInfo_t ),
-                                   globalUnsubscribePacketIdentifier );
+                                   globalUnsubscribePacketIdentifier,
+                                   NULL );
 
     if( mqttStatus != MQTTSuccess )
     {
@@ -1080,7 +1091,8 @@ bool PublishToTopic( const char * pTopicFilter,
         /* Send PUBLISH packet. */
         mqttStatus = MQTT_Publish( pMqttContext,
                                    &outgoingPublishPackets[ publishIndex ].pubInfo,
-                                   outgoingPublishPackets[ publishIndex ].packetId );
+                                   outgoingPublishPackets[ publishIndex ].packetId,
+                                   NULL );
 
         if( mqttStatus != MQTTSuccess )
         {

--- a/demos/greengrass/greengrass_demo_local_auth/README.md
+++ b/demos/greengrass/greengrass_demo_local_auth/README.md
@@ -99,7 +99,7 @@ openssl x509 -req \
 
 Deploy the following components to your Greengrass core:
 - aws.greengrass.clientdevices.Auth
-- aws.greengrass.clientdevices.mqtt.Moquette
+- aws.greengrass.clientdevices.mqtt.EMQX
 - aws.greengrass.clientdevices.mqtt.Bridge
 - aws.greengrass.clientdevices.IPDetector
 

--- a/demos/greengrass/greengrass_demo_local_auth/greengrass_demo_local_auth.c
+++ b/demos/greengrass/greengrass_demo_local_auth/greengrass_demo_local_auth.c
@@ -227,7 +227,10 @@ static void handleIncomingPublish( MQTTPublishInfo_t * pPublishInfo,
  */
 static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           MQTTDeserializedInfo_t * pDeserializedInfo );
+                           MQTTDeserializedInfo_t * pDeserializedInfo,
+                           MQTTSuccessFailReasonCode_t * pReasonCode,
+                           MQTTPropBuilder_t * sendPropsBuffer,
+                           MQTTPropBuilder_t * getPropsBuffer );
 
 /**
  * @brief Initializes the MQTT library.
@@ -433,7 +436,10 @@ static void updateSubAckStatus( MQTTPacketInfo_t * pPacketInfo )
 
 static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           MQTTDeserializedInfo_t * pDeserializedInfo )
+                           MQTTDeserializedInfo_t * pDeserializedInfo,
+                           MQTTSuccessFailReasonCode_t * pReasonCode,
+                           MQTTPropBuilder_t * sendPropsBuffer,
+                           MQTTPropBuilder_t * getPropsBuffer )
 {
     uint16_t packetId;
 
@@ -514,7 +520,7 @@ static int establishMqttSession( MQTTContext_t * pMqttContext )
     connectInfo.cleanSession = true;
 
     mqttStatus = MQTT_Connect( pMqttContext, &connectInfo, NULL,
-                               CONNACK_RECV_TIMEOUT_MS, &sessionPresent );
+                               CONNACK_RECV_TIMEOUT_MS, &sessionPresent, NULL, NULL );
 
     if( mqttStatus != MQTTSuccess )
     {
@@ -540,7 +546,7 @@ static int disconnectMqttSession( MQTTContext_t * pMqttContext )
     assert( pMqttContext != NULL );
 
     /* Send DISCONNECT. */
-    mqttStatus = MQTT_Disconnect( pMqttContext );
+    mqttStatus = MQTT_Disconnect( pMqttContext, NULL, 0 );
 
     if( mqttStatus != MQTTSuccess )
     {
@@ -571,7 +577,7 @@ static int subscribeToTopic( MQTTContext_t * pMqttContext )
     mqttStatus = MQTT_Subscribe( pMqttContext,
                                  &subInfo,
                                  1U,
-                                 MQTT_GetPacketId( pMqttContext ) );
+                                 MQTT_GetPacketId( pMqttContext ), NULL );
 
     if( mqttStatus != MQTTSuccess )
     {
@@ -607,7 +613,7 @@ static int unsubscribeFromTopic( MQTTContext_t * pMqttContext )
     mqttStatus = MQTT_Unsubscribe( pMqttContext,
                                    &unsubInfo,
                                    1U,
-                                   MQTT_GetPacketId( pMqttContext ) );
+                                   MQTT_GetPacketId( pMqttContext ), NULL );
 
     if( mqttStatus != MQTTSuccess )
     {
@@ -648,7 +654,7 @@ static int publishToTopic( MQTTContext_t * pMqttContext )
 
     mqttStatus = MQTT_Publish( pMqttContext,
                                &publish,
-                               packetId );
+                               packetId , NULL);
 
     if( mqttStatus != MQTTSuccess )
     {

--- a/demos/mqtt/mqtt_demo_basic_tls/demo_config.h
+++ b/demos/mqtt/mqtt_demo_basic_tls/demo_config.h
@@ -60,13 +60,12 @@
  *
  * #define BROKER_ENDPOINT               "...insert here..."
  */
-#define BROKER_ENDPOINT    "test.mosquitto.org"
+
 /**
  * @brief MQTT server port number.
  *
  * In general, port 8883 is for secured MQTT connections.
  */
-#define BROKER_PORT    ( 8883 )
 
 /**
  * @brief Path of the file containing the server's root CA certificate.
@@ -75,7 +74,7 @@
  *
  * #define ROOT_CA_CERT_PATH         ".....insert here...."
  */
-#define ROOT_CA_CERT_PATH    "/home/ubuntu/aws-iot-device-sdk-embedded-C/certs/mosquitto_rootCA.crt"
+
 /**
  * @brief MQTT client identifier.
  *

--- a/demos/mqtt/mqtt_demo_basic_tls/demo_config.h
+++ b/demos/mqtt/mqtt_demo_basic_tls/demo_config.h
@@ -60,7 +60,7 @@
  *
  * #define BROKER_ENDPOINT               "...insert here..."
  */
-
+#define BROKER_ENDPOINT    "test.mosquitto.org"
 /**
  * @brief MQTT server port number.
  *
@@ -75,7 +75,7 @@
  *
  * #define ROOT_CA_CERT_PATH         ".....insert here...."
  */
-
+#define ROOT_CA_CERT_PATH    "/home/ubuntu/aws-iot-device-sdk-embedded-C/certs/mosquitto_rootCA.crt"
 /**
  * @brief MQTT client identifier.
  *

--- a/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
+++ b/demos/mqtt/mqtt_demo_basic_tls/mqtt_demo_basic_tls.c
@@ -363,8 +363,8 @@ static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
                            MQTTDeserializedInfo_t * pDeserializedInfo ,
                            MQTTSuccessFailReasonCode_t * pReasonCode,
-                           MqttPropBuilder_t * sendPropsBuffer,
-                           MqttPropBuilder_t * getPropsBuffer); 
+                           MQTTPropBuilder_t * sendPropsBuffer,
+                           MQTTPropBuilder_t * getPropsBuffer); 
 
 /**
  * @brief Initializes the MQTT library.
@@ -914,8 +914,8 @@ static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
                            MQTTDeserializedInfo_t * pDeserializedInfo ,
                            MQTTSuccessFailReasonCode_t * pReasonCode,
-                           MqttPropBuilder_t * sendPropsBuffer,
-                           MqttPropBuilder_t * getPropsBuffer)
+                           MQTTPropBuilder_t * sendPropsBuffer,
+                           MQTTPropBuilder_t * getPropsBuffer)
 {
     uint16_t packetIdentifier;
 

--- a/demos/mqtt/mqtt_demo_mutual_auth/demo_config.h
+++ b/demos/mqtt/mqtt_demo_mutual_auth/demo_config.h
@@ -57,7 +57,7 @@
  *
  * #define AWS_IOT_ENDPOINT               "...insert here..."
  */
-#define AWS_IOT_ENDPOINT    "arfk9u1wy8ods-ats.iot.ap-south-1.amazonaws.com"
+
 /**
  * @brief AWS IoT MQTT broker port number.
  *
@@ -86,7 +86,7 @@
  * ROOT_CA_CERT_PATH to the absolute path if this demo is executed from elsewhere.
  */
 #ifndef ROOT_CA_CERT_PATH
-    #define ROOT_CA_CERT_PATH    "/home/ubuntu/aws-iot-device-sdk-embedded-C/certs/AmazonRootCA1.crt"
+    #define ROOT_CA_CERT_PATH    "build/bin/certificates/AmazonRootCA1.crt"
 #endif
 
 /**
@@ -100,7 +100,7 @@
  *
  * #define CLIENT_CERT_PATH    "...insert here..."
  */
-#define CLIENT_CERT_PATH    "/home/ubuntu/aws-iot-device-sdk-embedded-C/certs/cert.crt"
+
 /**
  * @brief Path of the file containing the client's private key.
  *
@@ -112,7 +112,7 @@
  *
  * #define CLIENT_PRIVATE_KEY_PATH    "...insert here..."
  */
-#define CLIENT_PRIVATE_KEY_PATH    "/home/ubuntu/aws-iot-device-sdk-embedded-C/certs/private_key.key"
+
 /**
  * @brief The username value for authenticating client to MQTT broker when
  * username/password based client authentication is used.

--- a/demos/mqtt/mqtt_demo_mutual_auth/demo_config.h
+++ b/demos/mqtt/mqtt_demo_mutual_auth/demo_config.h
@@ -57,7 +57,7 @@
  *
  * #define AWS_IOT_ENDPOINT               "...insert here..."
  */
-
+#define AWS_IOT_ENDPOINT    "arfk9u1wy8ods-ats.iot.ap-south-1.amazonaws.com"
 /**
  * @brief AWS IoT MQTT broker port number.
  *
@@ -86,7 +86,7 @@
  * ROOT_CA_CERT_PATH to the absolute path if this demo is executed from elsewhere.
  */
 #ifndef ROOT_CA_CERT_PATH
-    #define ROOT_CA_CERT_PATH    "certificates/AmazonRootCA1.crt"
+    #define ROOT_CA_CERT_PATH    "/home/ubuntu/aws-iot-device-sdk-embedded-C/certs/AmazonRootCA1.crt"
 #endif
 
 /**
@@ -100,7 +100,7 @@
  *
  * #define CLIENT_CERT_PATH    "...insert here..."
  */
-
+#define CLIENT_CERT_PATH    "/home/ubuntu/aws-iot-device-sdk-embedded-C/certs/cert.crt"
 /**
  * @brief Path of the file containing the client's private key.
  *
@@ -112,7 +112,7 @@
  *
  * #define CLIENT_PRIVATE_KEY_PATH    "...insert here..."
  */
-
+#define CLIENT_PRIVATE_KEY_PATH    "/home/ubuntu/aws-iot-device-sdk-embedded-C/certs/private_key.key"
 /**
  * @brief The username value for authenticating client to MQTT broker when
  * username/password based client authentication is used.

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -448,8 +448,8 @@ static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
                            MQTTDeserializedInfo_t * pDeserializedInfo,
                            MQTTSuccessFailReasonCode_t * pReasonCode,
-                           MqttPropBuilder_t * sendPropsBuffer,
-                           MqttPropBuilder_t * getPropsBuffer  );
+                           MQTTPropBuilder_t * sendPropsBuffer,
+                           MQTTPropBuilder_t * getPropsBuffer  );
 
 /**
  * @brief Initializes the MQTT library.
@@ -1028,8 +1028,8 @@ static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
                            MQTTDeserializedInfo_t * pDeserializedInfo,
                            MQTTSuccessFailReasonCode_t * pReasonCode,
-                           MqttPropBuilder_t * sendPropsBuffer,
-                           MqttPropBuilder_t * getPropsBuffer  )
+                           MQTTPropBuilder_t * sendPropsBuffer,
+                           MQTTPropBuilder_t * getPropsBuffer  )
 {
     uint16_t packetIdentifier;
 

--- a/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
+++ b/demos/mqtt/mqtt_demo_mutual_auth/mqtt_demo_mutual_auth.c
@@ -446,7 +446,10 @@ static void handleIncomingPublish( MQTTPublishInfo_t * pPublishInfo,
  */
 static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           MQTTDeserializedInfo_t * pDeserializedInfo );
+                           MQTTDeserializedInfo_t * pDeserializedInfo,
+                           MQTTSuccessFailReasonCode_t * pReasonCode,
+                           MqttPropBuilder_t * sendPropsBuffer,
+                           MqttPropBuilder_t * getPropsBuffer  );
 
 /**
  * @brief Initializes the MQTT library.
@@ -851,7 +854,7 @@ static int handlePublishResend( MQTTContext_t * pMqttContext )
                            outgoingPublishPackets[ index ].packetId ) );
                 mqttStatus = MQTT_Publish( pMqttContext,
                                            &outgoingPublishPackets[ index ].pubInfo,
-                                           outgoingPublishPackets[ index ].packetId );
+                                           outgoingPublishPackets[ index ].packetId , NULL);
 
                 if( mqttStatus != MQTTSuccess )
                 {
@@ -968,7 +971,7 @@ static int handleResubscribe( MQTTContext_t * pMqttContext )
         mqttStatus = MQTT_Subscribe( pMqttContext,
                                      pGlobalSubscriptionList,
                                      sizeof( pGlobalSubscriptionList ) / sizeof( MQTTSubscribeInfo_t ),
-                                     globalSubscribePacketIdentifier );
+                                     globalSubscribePacketIdentifier, NULL );
 
         if( mqttStatus != MQTTSuccess )
         {
@@ -1023,7 +1026,10 @@ static int handleResubscribe( MQTTContext_t * pMqttContext )
 
 static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           MQTTDeserializedInfo_t * pDeserializedInfo )
+                           MQTTDeserializedInfo_t * pDeserializedInfo,
+                           MQTTSuccessFailReasonCode_t * pReasonCode,
+                           MqttPropBuilder_t * sendPropsBuffer,
+                           MqttPropBuilder_t * getPropsBuffer  )
 {
     uint16_t packetIdentifier;
 
@@ -1193,7 +1199,7 @@ static int establishMqttSession( MQTTContext_t * pMqttContext,
     #endif /* ifdef CLIENT_USERNAME */
 
     /* Send MQTT CONNECT packet to broker. */
-    mqttStatus = MQTT_Connect( pMqttContext, &connectInfo, NULL, CONNACK_RECV_TIMEOUT_MS, pSessionPresent );
+    mqttStatus = MQTT_Connect( pMqttContext, &connectInfo, NULL, CONNACK_RECV_TIMEOUT_MS, pSessionPresent, NULL,NULL );
 
     if( mqttStatus != MQTTSuccess )
     {
@@ -1219,7 +1225,7 @@ static int disconnectMqttSession( MQTTContext_t * pMqttContext )
     assert( pMqttContext != NULL );
 
     /* Send DISCONNECT. */
-    mqttStatus = MQTT_Disconnect( pMqttContext );
+    mqttStatus = MQTT_Disconnect( pMqttContext, NULL, 0x00 );
 
     if( mqttStatus != MQTTSuccess )
     {
@@ -1255,7 +1261,7 @@ static int subscribeToTopic( MQTTContext_t * pMqttContext )
     mqttStatus = MQTT_Subscribe( pMqttContext,
                                  pGlobalSubscriptionList,
                                  sizeof( pGlobalSubscriptionList ) / sizeof( MQTTSubscribeInfo_t ),
-                                 globalSubscribePacketIdentifier );
+                                 globalSubscribePacketIdentifier, NULL );
 
     if( mqttStatus != MQTTSuccess )
     {
@@ -1298,7 +1304,7 @@ static int unsubscribeFromTopic( MQTTContext_t * pMqttContext )
     mqttStatus = MQTT_Unsubscribe( pMqttContext,
                                    pGlobalSubscriptionList,
                                    sizeof( pGlobalSubscriptionList ) / sizeof( MQTTSubscribeInfo_t ),
-                                   globalUnsubscribePacketIdentifier );
+                                   globalUnsubscribePacketIdentifier , NULL);
 
     if( mqttStatus != MQTTSuccess )
     {
@@ -1351,7 +1357,7 @@ static int publishToTopic( MQTTContext_t * pMqttContext )
         /* Send PUBLISH packet. */
         mqttStatus = MQTT_Publish( pMqttContext,
                                    &outgoingPublishPackets[ publishIndex ].pubInfo,
-                                   outgoingPublishPackets[ publishIndex ].packetId );
+                                   outgoingPublishPackets[ publishIndex ].packetId , NULL);
 
         if( mqttStatus != MQTTSuccess )
         {
@@ -1415,7 +1421,7 @@ static int initializeMqtt( MQTTContext_t * pMqttContext,
                                            pOutgoingPublishRecords,
                                            OUTGOING_PUBLISH_RECORD_LEN,
                                            pIncomingPublishRecords,
-                                           INCOMING_PUBLISH_RECORD_LEN );
+                                           INCOMING_PUBLISH_RECORD_LEN , NULL, 0);
 
         if( mqttStatus != MQTTSuccess )
         {

--- a/demos/mqtt/mqtt_demo_plaintext/demo_config.h
+++ b/demos/mqtt/mqtt_demo_plaintext/demo_config.h
@@ -60,7 +60,7 @@
  *
  * #define BROKER_ENDPOINT               "...insert here..."
  */
-
+#define BROKER_ENDPOINT    "test.mosquitto.org"
 /**
  * @brief MQTT server port number.
  *

--- a/demos/mqtt/mqtt_demo_plaintext/demo_config.h
+++ b/demos/mqtt/mqtt_demo_plaintext/demo_config.h
@@ -60,13 +60,12 @@
  *
  * #define BROKER_ENDPOINT               "...insert here..."
  */
-#define BROKER_ENDPOINT    "test.mosquitto.org"
+
 /**
  * @brief MQTT server port number.
  *
  * In general, port 1883 is for unsecured MQTT connections.
  */
-#define BROKER_PORT    ( 1883 )
 
 /**
  * @brief MQTT client identifier.

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
@@ -304,8 +304,8 @@ static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
                            MQTTDeserializedInfo_t * pDeserializedInfo ,
                            MQTTSuccessFailReasonCode_t * pReasonCode,
-                           MqttPropBuilder_t * sendPropsBuffer,
-                           MqttPropBuilder_t * getPropsBuffer); 
+                           MQTTPropBuilder_t * sendPropsBuffer,
+                           MQTTPropBuilder_t * getPropsBuffer); 
 
 /**
  * @brief Sends an MQTT CONNECT packet over the already connected TCP socket.
@@ -635,8 +635,8 @@ static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
                            MQTTDeserializedInfo_t * pDeserializedInfo ,
                            MQTTSuccessFailReasonCode_t * pReasonCode,
-                           MqttPropBuilder_t * sendPropsBuffer,
-                           MqttPropBuilder_t * getPropsBuffer)
+                           MQTTPropBuilder_t * sendPropsBuffer,
+                           MQTTPropBuilder_t * getPropsBuffer)
 {
     uint16_t packetIdentifier;
 

--- a/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
+++ b/demos/mqtt/mqtt_demo_plaintext/mqtt_demo_plaintext.c
@@ -302,7 +302,10 @@ static void handleIncomingPublish( MQTTPublishInfo_t * pPublishInfo,
  */
 static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           MQTTDeserializedInfo_t * pDeserializedInfo );
+                           MQTTDeserializedInfo_t * pDeserializedInfo ,
+                           MQTTSuccessFailReasonCode_t * pReasonCode,
+                           MqttPropBuilder_t * sendPropsBuffer,
+                           MqttPropBuilder_t * getPropsBuffer); 
 
 /**
  * @brief Sends an MQTT CONNECT packet over the already connected TCP socket.
@@ -575,7 +578,7 @@ static int handleResubscribe( MQTTContext_t * pMqttContext )
         mqttStatus = MQTT_Subscribe( pMqttContext,
                                      pGlobalSubscriptionList,
                                      sizeof( pGlobalSubscriptionList ) / sizeof( MQTTSubscribeInfo_t ),
-                                     globalSubscribePacketIdentifier );
+                                     globalSubscribePacketIdentifier, NULL );
 
         if( mqttStatus != MQTTSuccess )
         {
@@ -630,7 +633,10 @@ static int handleResubscribe( MQTTContext_t * pMqttContext )
 
 static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           MQTTDeserializedInfo_t * pDeserializedInfo )
+                           MQTTDeserializedInfo_t * pDeserializedInfo ,
+                           MQTTSuccessFailReasonCode_t * pReasonCode,
+                           MqttPropBuilder_t * sendPropsBuffer,
+                           MqttPropBuilder_t * getPropsBuffer)
 {
     uint16_t packetIdentifier;
 
@@ -755,7 +761,7 @@ static int establishMqttSession( MQTTContext_t * pMqttContext,
                                            pOutgoingPublishRecords,
                                            OUTGOING_PUBLISH_RECORD_LEN,
                                            pIncomingPublishRecords,
-                                           INCOMING_PUBLISH_RECORD_LEN );
+                                           INCOMING_PUBLISH_RECORD_LEN, NULL, 0 );
 
         if( mqttStatus != MQTTSuccess )
         {
@@ -793,7 +799,7 @@ static int establishMqttSession( MQTTContext_t * pMqttContext,
             connectInfo.passwordLength = 0U;
 
             /* Send MQTT CONNECT packet to broker. */
-            mqttStatus = MQTT_Connect( pMqttContext, &connectInfo, NULL, CONNACK_RECV_TIMEOUT_MS, &sessionPresent );
+            mqttStatus = MQTT_Connect( pMqttContext, &connectInfo, NULL, CONNACK_RECV_TIMEOUT_MS, &sessionPresent , NULL, NULL);
 
             if( mqttStatus != MQTTSuccess )
             {
@@ -821,7 +827,7 @@ static int disconnectMqttSession( MQTTContext_t * pMqttContext )
     assert( pMqttContext != NULL );
 
     /* Send DISCONNECT. */
-    mqttStatus = MQTT_Disconnect( pMqttContext );
+    mqttStatus = MQTT_Disconnect( pMqttContext, NULL, MQTT_REASON_DISCONNECT_NORMAL_DISCONNECTION );
 
     if( mqttStatus != MQTTSuccess )
     {
@@ -857,7 +863,7 @@ static int subscribeToTopic( MQTTContext_t * pMqttContext )
     mqttStatus = MQTT_Subscribe( pMqttContext,
                                  pGlobalSubscriptionList,
                                  sizeof( pGlobalSubscriptionList ) / sizeof( MQTTSubscribeInfo_t ),
-                                 globalSubscribePacketIdentifier );
+                                 globalSubscribePacketIdentifier, NULL );
 
     if( mqttStatus != MQTTSuccess )
     {
@@ -900,7 +906,7 @@ static int unsubscribeFromTopic( MQTTContext_t * pMqttContext )
     mqttStatus = MQTT_Unsubscribe( pMqttContext,
                                    pGlobalSubscriptionList,
                                    sizeof( pGlobalSubscriptionList ) / sizeof( MQTTSubscribeInfo_t ),
-                                   globalUnsubscribePacketIdentifier );
+                                   globalUnsubscribePacketIdentifier, NULL );
 
     if( mqttStatus != MQTTSuccess )
     {
@@ -940,7 +946,7 @@ static int publishToTopic( MQTTContext_t * pMqttContext )
 
     /* Send PUBLISH packet. Packet Id is not used for a QoS0 publish.
      * Hence 0 is passed as packet id. */
-    mqttStatus = MQTT_Publish( pMqttContext, &publishInfo, 0U );
+    mqttStatus = MQTT_Publish( pMqttContext, &publishInfo, 0U, NULL );
 
     if( mqttStatus != MQTTSuccess )
     {

--- a/demos/mqtt/mqtt_demo_serializer/CMakeLists.txt
+++ b/demos/mqtt/mqtt_demo_serializer/CMakeLists.txt
@@ -17,6 +17,8 @@ add_executable(
         ${BACKOFF_ALGORITHM_SOURCES}
 )
 
+target_sources(${DEMO_NAME} PRIVATE ${ROOT_DIR}/libraries/standard/coreMQTT/source/core_mqtt_utils.c)
+
 target_link_libraries(
     ${DEMO_NAME}
     PRIVATE

--- a/demos/mqtt/mqtt_demo_serializer/demo_config.h
+++ b/demos/mqtt/mqtt_demo_serializer/demo_config.h
@@ -60,7 +60,7 @@
  *
  * #define BROKER_ENDPOINT               "...insert here..."
  */
-
+#define BROKER_ENDPOINT    "test.mosquitto.org"
 /**
  * @brief MQTT server port number.
  *

--- a/demos/mqtt/mqtt_demo_serializer/demo_config.h
+++ b/demos/mqtt/mqtt_demo_serializer/demo_config.h
@@ -60,13 +60,12 @@
  *
  * #define BROKER_ENDPOINT               "...insert here..."
  */
-#define BROKER_ENDPOINT    "test.mosquitto.org"
+
 /**
  * @brief MQTT server port number.
  *
  * In general, port 1883 is for unsecured MQTT connections.
  */
-#define BROKER_PORT    1883
 
 /**
  * @brief MQTT client identifier.

--- a/demos/mqtt/mqtt_demo_serializer/mqtt_demo_serializer.c
+++ b/demos/mqtt/mqtt_demo_serializer/mqtt_demo_serializer.c
@@ -51,6 +51,7 @@
 
 /* MQTT Serializer Serializer API header. */
 #include "core_mqtt_serializer.h"
+#include "core_mqtt_utils.h"
 
 /* Plaintext transport implementation. */
 #include "plaintext_posix.h"
@@ -142,6 +143,11 @@
  * @brief Delay between two demo iterations.
  */
 #define MQTT_DEMO_ITERATION_DELAY_SECONDS    ( 5U )
+
+/**
+ * @brief Per the MQTT spec, the max packet size  can be of  max remaining length + 5 bytes
+ */
+#define MQTT_MAX_PACKET_SIZE                        ( 268435460U )
 
 /*-----------------------------------------------------------*/
 
@@ -486,14 +492,14 @@ static int createMQTTConnectionWithBroker( NetworkContext_t * pNetworkContext,
     mqttConnectInfo.keepAliveSeconds = MQTT_KEEP_ALIVE_INTERVAL_SECONDS;
 
     /* Get size requirement for the connect packet */
-    result = MQTT_GetConnectPacketSize( &mqttConnectInfo, NULL, &remainingLength, &packetSize );
+    result = MQTT_GetConnectPacketSize( &mqttConnectInfo, NULL, NULL, NULL, &remainingLength, &packetSize );
 
     /* Make sure the packet size is less than static buffer size. */
     assert( result == MQTTSuccess );
     assert( packetSize < pFixedBuffer->size );
 
     /* Serialize MQTT connect packet into the provided buffer. */
-    result = MQTT_SerializeConnect( &mqttConnectInfo, NULL, remainingLength, pFixedBuffer );
+    result = MQTT_SerializeConnect( &mqttConnectInfo, NULL, NULL, NULL, remainingLength, pFixedBuffer );
     assert( result == MQTTSuccess );
 
     /* Send the serialized connect packet to the MQTT broker */
@@ -531,7 +537,11 @@ static int createMQTTConnectionWithBroker( NetworkContext_t * pNetworkContext,
 
     /* Deserialize the received packet to make sure the content of the CONNACK
      * is valid. Note that the packetId is not present in the connection ack. */
-    result = MQTT_DeserializeAck( &incomingPacket, &packetId, &sessionPresent );
+    MQTTConnectProperties_t  connackProperties = {0} ;
+    connackProperties.maxPacketSize = MQTT_MAX_PACKET_SIZE;
+
+    MQTTPropBuilder_t propBuffer = {0} ;
+    result = MQTT_DeserializeConnack( &connackProperties, &incomingPacket, &sessionPresent, &propBuffer );
 
     if( result != MQTTSuccess )
     {
@@ -578,7 +588,8 @@ static void mqttSubscribeToTopic( NetworkContext_t * pNetworkContext,
 
     result = MQTT_GetSubscribePacketSize( mqttSubscription,
                                           sizeof( mqttSubscription ) / sizeof( MQTTSubscribeInfo_t ),
-                                          &remainingLength, &packetSize );
+                                          NULL,
+                                          &remainingLength, &packetSize, MQTT_MAX_PACKET_SIZE );
 
     /* Make sure the packet size is less than static buffer size. */
     assert( result == MQTTSuccess );
@@ -586,8 +597,10 @@ static void mqttSubscribeToTopic( NetworkContext_t * pNetworkContext,
     subscribePacketIdentifier = getNextPacketIdentifier();
 
     /* Serialize subscribe into statically allocated buffer. */
+
     result = MQTT_SerializeSubscribe( mqttSubscription,
                                       sizeof( mqttSubscription ) / sizeof( MQTTSubscribeInfo_t ),
+                                      NULL,
                                       subscribePacketIdentifier,
                                       remainingLength,
                                       pFixedBuffer );
@@ -631,7 +644,7 @@ static void mqttPublishToTopic( NetworkContext_t * pNetworkContext,
     mqttPublishInfo.payloadLength = strlen( MQTT_EXAMPLE_MESSAGE );
 
     /* Find out length of Publish packet size. */
-    result = MQTT_GetPublishPacketSize( &mqttPublishInfo, &remainingLength, &packetSize );
+    result = MQTT_GetPublishPacketSize( &mqttPublishInfo, NULL, &remainingLength, &packetSize, MQTT_MAX_PACKET_SIZE );
     assert( result == MQTTSuccess );
 
     /* Make sure the packet size is less than static buffer size. */
@@ -641,6 +654,7 @@ static void mqttPublishToTopic( NetworkContext_t * pNetworkContext,
      * be sent directly in order to avoid copying it into the buffer.
      * QOS0 does not make use of packet identifier, therefore value of 0 is used */
     result = MQTT_SerializePublishHeader( &mqttPublishInfo,
+                                          NULL, 
                                           0,
                                           remainingLength,
                                           pFixedBuffer,
@@ -680,8 +694,10 @@ static void mqttUnsubscribeFromTopic( NetworkContext_t * pNetworkContext,
 
     result = MQTT_GetUnsubscribePacketSize( mqttSubscription,
                                             sizeof( mqttSubscription ) / sizeof( MQTTSubscribeInfo_t ),
+                                            NULL, 
                                             &remainingLength,
-                                            &packetSize );
+                                            &packetSize,
+                                            MQTT_MAX_PACKET_SIZE);
     assert( result == MQTTSuccess );
     /* Make sure the packet size is less than static buffer size */
     assert( packetSize < pFixedBuffer->size );
@@ -691,6 +707,7 @@ static void mqttUnsubscribeFromTopic( NetworkContext_t * pNetworkContext,
 
     result = MQTT_SerializeUnsubscribe( mqttSubscription,
                                         sizeof( mqttSubscription ) / sizeof( MQTTSubscribeInfo_t ),
+                                        NULL,
                                         unsubscribePacketIdentifier,
                                         remainingLength,
                                         pFixedBuffer );
@@ -734,17 +751,18 @@ static void mqttDisconnect( NetworkContext_t * pNetworkContext,
 {
     MQTTStatus_t result;
     int32_t status;
+    size_t remainingLength ; 
     size_t packetSize = 0;
 
     /* Suppress unused variable warnings when asserts are disabled in build. */
     ( void ) status;
     ( void ) result;
-
-    status = MQTT_GetDisconnectPacketSize( &packetSize );
+    
+    status = MQTT_GetDisconnectPacketSize( NULL, &remainingLength, &packetSize, MQTT_MAX_PACKET_SIZE, MQTT_REASON_DISCONNECT_NORMAL_DISCONNECTION );
 
     assert( packetSize <= pFixedBuffer->size );
 
-    result = MQTT_SerializeDisconnect( pFixedBuffer );
+    result = MQTT_SerializeDisconnect( NULL, MQTT_REASON_DISCONNECT_NORMAL_DISCONNECTION, remainingLength, pFixedBuffer );
     assert( result == MQTTSuccess );
 
     /* Send disconnect packet to the broker */
@@ -882,30 +900,37 @@ static void mqttProcessIncomingPacket( NetworkContext_t * pNetworkContext,
 
     if( ( incomingPacket.type & 0xf0 ) == MQTT_PACKET_TYPE_PUBLISH )
     {
-        result = MQTT_DeserializePublish( &incomingPacket, &packetId, &publishInfo );
+        result = MQTT_DeserializePublish( &incomingPacket, &packetId, &publishInfo , NULL, MQTT_MAX_PACKET_SIZE);
         assert( result == MQTTSuccess );
 
         /* Process incoming Publish message. */
         mqttProcessIncomingPublish( &publishInfo, packetId );
     }
+    else if( ( incomingPacket.type == MQTT_PACKET_TYPE_SUBACK ) || ( incomingPacket.type == MQTT_PACKET_TYPE_UNSUBACK ) )
+    {
+        MQTTReasonCodeInfo_t reasonCodes ; 
+        result = MQTT_DeserializeSuback( &reasonCodes, &incomingPacket, &packetId, NULL, MQTT_MAX_PACKET_SIZE );
+        globalSubAckStatus = ( result == MQTTSuccess );
+        assert( result == MQTTSuccess || result == MQTTServerRefused );
+
+        /* Process the response. */
+        mqttProcessResponse( &incomingPacket, packetId );
+    }
+    else if( (incomingPacket.type == MQTT_PACKET_TYPE_PUBACK) ||
+             (incomingPacket.type == MQTT_PACKET_TYPE_PUBREC) ||
+             (incomingPacket.type == MQTT_PACKET_TYPE_PUBREL) ||
+             (incomingPacket.type == MQTT_PACKET_TYPE_PUBCOMP) )
+    {
+        MQTTReasonCodeInfo_t reasonCode ; 
+        result = MQTT_DeserializePublishAck( &incomingPacket, &packetId, &reasonCode, 0 , MQTT_MAX_PACKET_SIZE, NULL );
+        assert( result == MQTTSuccess );
+        /* Process the response. */
+        mqttProcessResponse( &incomingPacket, packetId );
+    }
     else
     {
-        /* If the received packet is not a Publish message, then it is an ACK for one
-         * of the messages we sent out, verify that the ACK packet is a valid MQTT
-         * packet. Since CONNACK is already processed, session present parameter is
-         * to NULL */
-        result = MQTT_DeserializeAck( &incomingPacket, &packetId, &sessionPresent );
-
-        if( incomingPacket.type == MQTT_PACKET_TYPE_SUBACK )
-        {
-            globalSubAckStatus = ( result == MQTTSuccess );
-            assert( result == MQTTSuccess || result == MQTTServerRefused );
-        }
-        else
-        {
-            assert( result == MQTTSuccess );
-        }
-
+        result = MQTT_DeserializePing(&incomingPacket); 
+        assert( result == MQTTSuccess );
         /* Process the response. */
         mqttProcessResponse( &incomingPacket, packetId );
     }

--- a/demos/mqtt/mqtt_demo_subscription_manager/demo_config.h
+++ b/demos/mqtt/mqtt_demo_subscription_manager/demo_config.h
@@ -60,13 +60,12 @@
  *
  * #define BROKER_ENDPOINT               "...insert here..."
  */
-#define BROKER_ENDPOINT "test.mosquitto.org"
+
 /**
  * @brief MQTT server port number.
  *
  * In general, port 8883 is for secured MQTT connections.
  */
-#define BROKER_PORT    ( 8883 )
 
 /**
  * @brief Path of the file containing the server's root CA certificate.
@@ -75,7 +74,7 @@
  *
  * #define ROOT_CA_CERT_PATH               "....insert here...."
  */
-#define ROOT_CA_CERT_PATH    "/home/ubuntu/aws-iot-device-sdk-embedded-C/certs/mosquitto_rootCA.crt"
+
 /**
  * @brief MQTT client identifier.
  *

--- a/demos/mqtt/mqtt_demo_subscription_manager/demo_config.h
+++ b/demos/mqtt/mqtt_demo_subscription_manager/demo_config.h
@@ -60,7 +60,7 @@
  *
  * #define BROKER_ENDPOINT               "...insert here..."
  */
-
+#define BROKER_ENDPOINT "test.mosquitto.org"
 /**
  * @brief MQTT server port number.
  *
@@ -75,7 +75,7 @@
  *
  * #define ROOT_CA_CERT_PATH               "....insert here...."
  */
-
+#define ROOT_CA_CERT_PATH    "/home/ubuntu/aws-iot-device-sdk-embedded-C/certs/mosquitto_rootCA.crt"
 /**
  * @brief MQTT client identifier.
  *

--- a/demos/shadow/shadow_demo_main/demo_config.h
+++ b/demos/shadow/shadow_demo_main/demo_config.h
@@ -68,7 +68,6 @@
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. When using port 8883, ALPN is not required.
  */
-#define AWS_MQTT_PORT    ( 8883 )
 
 /**
  * @brief Path of the file containing the server's root CA certificate.

--- a/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
+++ b/demos/shadow/shadow_demo_main/shadow_demo_helpers.c
@@ -686,7 +686,7 @@ static int handlePublishResend( MQTTContext_t * pMqttContext )
                        outgoingPublishPackets[ index ].packetId ) );
             mqttStatus = MQTT_Publish( pMqttContext,
                                        &outgoingPublishPackets[ index ].pubInfo,
-                                       outgoingPublishPackets[ index ].packetId );
+                                       outgoingPublishPackets[ index ].packetId, NULL );
 
             if( mqttStatus != MQTTSuccess )
             {
@@ -770,7 +770,7 @@ int EstablishMqttSession( MQTTEventCallback_t eventCallback )
                                                pOutgoingPublishRecords,
                                                OUTGOING_PUBLISH_RECORD_LEN,
                                                pIncomingPublishRecords,
-                                               INCOMING_PUBLISH_RECORD_LEN );
+                                               INCOMING_PUBLISH_RECORD_LEN, NULL, 0 );
 
             if( mqttStatus != MQTTSuccess )
             {
@@ -812,7 +812,7 @@ int EstablishMqttSession( MQTTEventCallback_t eventCallback )
                                            &connectInfo,
                                            NULL,
                                            CONNACK_RECV_TIMEOUT_MS,
-                                           &sessionPresent );
+                                           &sessionPresent, NULL, NULL );
 
                 if( mqttStatus != MQTTSuccess )
                 {
@@ -877,7 +877,7 @@ int32_t DisconnectMqttSession( void )
     if( mqttSessionEstablished == true )
     {
         /* Send DISCONNECT. */
-        mqttStatus = MQTT_Disconnect( pMqttContext );
+        mqttStatus = MQTT_Disconnect( pMqttContext, NULL, MQTT_REASON_DISCONNECT_NORMAL_DISCONNECTION );
 
         if( mqttStatus != MQTTSuccess )
         {
@@ -922,7 +922,7 @@ int32_t SubscribeToTopic( const char * pTopicFilter,
     mqttStatus = MQTT_Subscribe( pMqttContext,
                                  pSubscriptionList,
                                  sizeof( pSubscriptionList ) / sizeof( MQTTSubscribeInfo_t ),
-                                 globalSubscribePacketIdentifier );
+                                 globalSubscribePacketIdentifier, NULL );
 
     if( mqttStatus != MQTTSuccess )
     {
@@ -980,7 +980,7 @@ int32_t UnsubscribeFromTopic( const char * pTopicFilter,
     mqttStatus = MQTT_Unsubscribe( pMqttContext,
                                    pSubscriptionList,
                                    sizeof( pSubscriptionList ) / sizeof( MQTTSubscribeInfo_t ),
-                                   globalUnsubscribePacketIdentifier );
+                                   globalUnsubscribePacketIdentifier, NULL );
 
     if( mqttStatus != MQTTSuccess )
     {
@@ -1051,7 +1051,7 @@ int32_t PublishToTopic( const char * pTopicFilter,
         /* Send PUBLISH packet. */
         mqttStatus = MQTT_Publish( pMqttContext,
                                    &outgoingPublishPackets[ publishIndex ].pubInfo,
-                                   outgoingPublishPackets[ publishIndex ].packetId );
+                                   outgoingPublishPackets[ publishIndex ].packetId, NULL );
 
         if( mqttStatus != MQTTSuccess )
         {

--- a/demos/shadow/shadow_demo_main/shadow_demo_main.c
+++ b/demos/shadow/shadow_demo_main/shadow_demo_main.c
@@ -237,7 +237,10 @@ static bool shadowDeleted = false;
  */
 static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           MQTTDeserializedInfo_t * pDeserializedInfo );
+                           MQTTDeserializedInfo_t * pDeserializedInfo, 
+                           MQTTSuccessFailReasonCode_t * pReasonCode,
+                           MQTTPropBuilder_t * sendPropsBuffer,
+                           MQTTPropBuilder_t * getPropsBuffer); 
 
 /**
  * @brief Process payload from /update/delta topic.
@@ -558,7 +561,10 @@ static void updateAcceptedHandler( MQTTPublishInfo_t * pPublishInfo )
  */
 static void eventCallback( MQTTContext_t * pMqttContext,
                            MQTTPacketInfo_t * pPacketInfo,
-                           MQTTDeserializedInfo_t * pDeserializedInfo )
+                           MQTTDeserializedInfo_t * pDeserializedInfo, 
+                           MQTTSuccessFailReasonCode_t * pReasonCode,
+                           MQTTPropBuilder_t * sendPropsBuffer,
+                           MQTTPropBuilder_t * getPropsBuffer)
 {
     ShadowMessageType_t messageType = ShadowMessageTypeMaxNum;
     const char * pThingName = NULL;


### PR DESCRIPTION
Upgrading MQTT Library to support v5 features

*Description of changes:*
This PR updates all demo applications in the repository that use MQTT to use MQTT v5.0 instead of MQTT v3.1.1. The goal is to align the demo code with the newer version of the MQTT protocol.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
