### PR TITLE
Add artifact backup action

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -159,6 +159,8 @@ jobs:
             fi
           output_dir: html
   create-release:
+    permissions:
+      id-token: write
     needs:
       - create-zip
       - deploy-docs
@@ -190,3 +192,8 @@ jobs:
           asset_path: ./aws-iot-device-sdk-embedded-C-${{ github.event.inputs.version_number }}.zip
           asset_name: aws-iot-device-sdk-embedded-C-${{ github.event.inputs.version_number }}.zip
           asset_content_type: application/zip
+      - name: Backup Release Asset
+        uses: FreeRTOS/CI-CD-Github-Actions/artifact-backup@main
+        with:
+          artifact_path: ./aws-iot-device-sdk-embedded-C-${{ github.event.inputs.version_number }}.zip
+          release_tag: ${{ github.event.inputs.version_number }}


### PR DESCRIPTION
This PR updates the release workflow to use artifact backup action for storing release artifacts.