### PR TITLE
Add openssl include path for sockets_posix target

### DIFF
--- a/platform/posix/transport/CMakeLists.txt
+++ b/platform/posix/transport/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library( sockets_posix
 
 target_include_directories( sockets_posix
                             PUBLIC
+                                ${OPENSSL_INCLUDE_DIR}
                                 ${COMMON_TRANSPORT_INCLUDE_PUBLIC_DIRS}
                                 ${LOGGING_INCLUDE_DIRS}
                                 ${TRANSPORT_INTERFACE_INCLUDE_DIR} )


### PR DESCRIPTION
*Issue #, if available:*
When compile device sdk as shared library, compiler complaining `openssl/ssl.h` header file not found, in the cmakelists.txt, it has `find_package(OpenSSL)`, but the `OPENSSL_INCLUDE_DIR` is not used anywhere, it only linked `OPENSSL_LIBRARIES`

The cmake configure and compile command I used:
```
cmake -DCMAKE_TOOLCHAIN_FILE=$IOTMI_TOOLCHAIN_PATH/toolchain.cmake \                                                                                                                                            
  -DCMAKE_INSTALL_PREFIX=$SYSROOT_PATH/usr/local \
  -DCMAKE_PREFIX_PATH=$SYSROOT_PATH/usr/local \
  -DCMAKE_BUILD_TYPE=Release \
  -DBUILD_DEMOS=OFF \
  -DBUILD_CLONE_SUBMODULES=OFF \
  -DDOWNLOAD_CERTS=OFF \
  -DINSTALL_TO_SYSTEM=ON \
  -DBUILD_SHARED_LIBS=ON \
  ..

cmake --build . --target install
```

*Description of changes:*
Add `OPENSSL_INCLUDE_DIR` to include directories for target `sockets_posix`

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
